### PR TITLE
Enabling amd builds 

### DIFF
--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -1622,6 +1622,10 @@ impl<'a, 'b> SubContext<'a, 'b> {
 
     fn import_name(&mut self, import: &shared::Import, item: &str) -> String {
         if let Some(ref module) = import.module {
+            if self.cx.config.no_modules {
+                panic!("import from `{}` module not allowed in `--no-modules`. use `--nodejs` or `--browser` instead", module);
+            }
+
             let name = import.js_namespace.as_ref().map(|s| &**s).unwrap_or(item);
 
             if self.cx.imported_names.insert(name.to_string()) {

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -47,7 +47,7 @@ impl<'a> Context<'a> {
         let contents = contents.trim();
         let global = if self.config.nodejs {
             format!("module.exports.{} = {};\n", name, contents)
-        } else if self.config.umd {
+        } else if self.config.amd {
             format!("__exports.{} = {}\n", name, contents)
         } else {
             if contents.starts_with("function") {
@@ -66,7 +66,7 @@ impl<'a> Context<'a> {
         {
             let mut bind = |name: &str, f: &Fn(&mut Self) -> String| {
                 if !self.wasm_import_needed(name) {
-                    return
+                    return;
                 }
                 let contents = f(self);
                 let contents = contents.trim();
@@ -229,61 +229,39 @@ impl<'a> Context<'a> {
             self.footer.push_str(&format!("wasm = require('./{}_bg');",
                                           module_name));
             format!("var wasm;")
-        } else if self.config.umd {
+        } else if self.config.amd {
             format!("
-                if(typeof window === 'undefined' && typeof process === 'object') {{
-                    const fs = require('fs');
-                    const path = require('path');
-                    const wasm_path = path.join(__dirname, '{module}_bg.wasm');
-                    const buffer = fs.readFileSync(wasm_path);
-                    const mod = new WebAssembly.Module(buffer);
-
-                    return __initialize(mod, false);
-                }} else {{
-                    return fetch('{module}_bg.wasm')
-                        .then(response => response.arrayBuffer())
-                        .then(bytes => WebAssembly.compile(bytes))
-                        .then(mod => __initialize(mod, true));
-                }}", module = module_name)
+                return fetch('{module}_bg.wasm')
+                    .then(response => response.arrayBuffer())
+                    .then(buffer => WebAssembly.instantiate(buffer, __js_exports))
+                    .then(({{instance}}) => {{
+                        wasm = instance.exports;
+                        return wasm;
+                    }})
+                    .catch(error => {{
+                        console.log('Error loading wasm module `{module}`:', error);
+                        throw error;
+                    }});
+            ", module = module_name)
         } else {
             format!("import * as wasm from './{}_bg';", module_name)
         };
 
-        let js = if self.config.umd {
+        let js = if self.config.amd {
             format!("
                 (function (root, factory) {{
                     if (typeof define === 'function' && define.amd) {{
                         define([], factory);
-                    }} else if (typeof module === 'object' && module.exports) {{
-                        module.exports = factory();
                     }} else {{
                         root.{module} = factory();
                     }}
                 }}(typeof self !== 'undefined' ? self : this, function() {{
                     let wasm;
+                    const __js_exports = {{}};
+                    const __exports = {{}};
+                    {globals}
+                    __js_exports['./{module}'] = __exports;
                     {import_wasm}
-                    function __initialize(__mod, __load_async) {{
-                        const __js_exports = {{}};
-                        const __exports = {{}};
-                        {globals}
-                        __js_exports['./{module}'] = __exports;
-
-                        if (__load_async) {{
-                            return WebAssembly.instantiate(__mod, __js_exports)
-                                .then(instance => {{
-                                    wasm = instance.exports;
-                                    return instance.exports;
-                                }})
-                                .catch(error => {{
-                                    console.log('Error loading wasm module `{module}`:', error);
-                                    throw error;
-                                }});
-                        }} else {{
-                            const instance = new WebAssembly.Instance(__mod, __js_exports);
-                            wasm = instance.exports;
-                            return instance.exports;
-                        }}
-                    }}
                 }}))
             ",
                     module = module_name,
@@ -380,7 +358,7 @@ impl<'a> Context<'a> {
     }
 
     fn _rewrite_imports(&mut self, module_name: &str)
-        -> Vec<(String, String)>
+                        -> Vec<(String, String)>
     {
         let mut math_imports = Vec::new();
         let imports = self.module.sections_mut()
@@ -398,11 +376,11 @@ impl<'a> Context<'a> {
                 import.module_mut().truncate(0);
                 import.module_mut().push_str("./");
                 import.module_mut().push_str(module_name);
-                continue
+                continue;
             }
 
             if import.module() != "env" {
-                continue
+                continue;
             }
 
             let renamed_import = format!("__wbindgen_{}", import.field());
@@ -477,7 +455,7 @@ impl<'a> Context<'a> {
 
     fn expose_drop_ref(&mut self) {
         if !self.exposed_globals.insert("drop_ref") {
-            return
+            return;
         }
         self.expose_global_slab();
         self.expose_global_slab_next();
@@ -520,7 +498,7 @@ impl<'a> Context<'a> {
 
     fn expose_global_stack(&mut self) {
         if !self.exposed_globals.insert("stack") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             let stack = [];
@@ -529,14 +507,14 @@ impl<'a> Context<'a> {
 
     fn expose_global_slab(&mut self) {
         if !self.exposed_globals.insert("slab") {
-            return
+            return;
         }
         self.globals.push_str(&format!("let slab = [];"));
     }
 
     fn expose_global_slab_next(&mut self) {
         if !self.exposed_globals.insert("slab_next") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             let slab_next = 0;
@@ -545,7 +523,7 @@ impl<'a> Context<'a> {
 
     fn expose_get_object(&mut self) {
         if !self.exposed_globals.insert("get_object") {
-            return
+            return;
         }
         self.expose_global_stack();
         self.expose_global_slab();
@@ -575,7 +553,7 @@ impl<'a> Context<'a> {
 
     fn expose_check_token(&mut self) {
         if !self.exposed_globals.insert("check_token") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             const token = Symbol('foo');
@@ -588,7 +566,7 @@ impl<'a> Context<'a> {
 
     fn expose_assert_num(&mut self) {
         if !self.exposed_globals.insert("assert_num") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function _assertNum(n) {{
@@ -600,7 +578,7 @@ impl<'a> Context<'a> {
 
     fn expose_assert_bool(&mut self) {
         if !self.exposed_globals.insert("assert_bool") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function _assertBoolean(n) {{
@@ -612,7 +590,7 @@ impl<'a> Context<'a> {
 
     fn expose_pass_string_to_wasm(&mut self) {
         if !self.exposed_globals.insert("pass_string_to_wasm") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_malloc");
         self.expose_text_encoder();
@@ -638,7 +616,7 @@ impl<'a> Context<'a> {
 
     fn expose_pass_array8_to_wasm(&mut self) {
         if !self.exposed_globals.insert("pass_array8_to_wasm") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_malloc");
         self.expose_uint8_memory();
@@ -653,7 +631,7 @@ impl<'a> Context<'a> {
 
     fn expose_pass_array16_to_wasm(&mut self) {
         if !self.exposed_globals.insert("pass_array16_to_wasm") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_malloc");
         self.expose_uint16_memory();
@@ -668,7 +646,7 @@ impl<'a> Context<'a> {
 
     fn expose_pass_array32_to_wasm(&mut self) {
         if !self.exposed_globals.insert("pass_array32_to_wasm") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_malloc");
         self.expose_uint32_memory();
@@ -683,7 +661,7 @@ impl<'a> Context<'a> {
 
     fn expose_pass_array_f32_to_wasm(&mut self) {
         if !self.exposed_globals.insert("pass_array_f32_to_wasm") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_malloc");
         self.globals.push_str(&format!("
@@ -697,7 +675,7 @@ impl<'a> Context<'a> {
 
     fn expose_pass_array_f64_to_wasm(&mut self) {
         if !self.exposed_globals.insert("pass_array_f64_to_wasm") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_malloc");
         self.globals.push_str(&format!("
@@ -711,7 +689,7 @@ impl<'a> Context<'a> {
 
     fn expose_text_encoder(&mut self) {
         if !self.exposed_globals.insert("text_encoder") {
-            return
+            return;
         }
         if self.config.nodejs {
             self.globals.push_str(&format!("
@@ -731,7 +709,7 @@ impl<'a> Context<'a> {
 
     fn expose_text_decoder(&mut self) {
         if !self.exposed_globals.insert("text_decoder") {
-            return
+            return;
         }
         if self.config.nodejs {
             self.globals.push_str(&format!("
@@ -751,7 +729,7 @@ impl<'a> Context<'a> {
 
     fn expose_get_string_from_wasm(&mut self) {
         if !self.exposed_globals.insert("get_string_from_wasm") {
-            return
+            return;
         }
         self.expose_text_decoder();
         self.expose_uint8_memory();
@@ -764,7 +742,7 @@ impl<'a> Context<'a> {
 
     fn expose_get_array_js_value_from_wasm(&mut self) {
         if !self.exposed_globals.insert("get_array_js_value_from_wasm") {
-            return
+            return;
         }
         self.expose_get_array_u32_from_wasm();
         self.expose_get_object();
@@ -784,7 +762,7 @@ impl<'a> Context<'a> {
     fn expose_get_array_i8_from_wasm(&mut self) {
         self.expose_uint8_memory();
         if !self.exposed_globals.insert("get_array_i8_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayI8FromWasm(ptr, len) {{
@@ -798,7 +776,7 @@ impl<'a> Context<'a> {
     fn expose_get_array_u8_from_wasm(&mut self) {
         self.expose_uint8_memory();
         if !self.exposed_globals.insert("get_array_u8_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayU8FromWasm(ptr, len) {{
@@ -812,7 +790,7 @@ impl<'a> Context<'a> {
     fn expose_get_array_i16_from_wasm(&mut self) {
         self.expose_uint16_memory();
         if !self.exposed_globals.insert("get_array_i16_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayI16FromWasm(ptr, len) {{
@@ -826,7 +804,7 @@ impl<'a> Context<'a> {
     fn expose_get_array_u16_from_wasm(&mut self) {
         self.expose_uint16_memory();
         if !self.exposed_globals.insert("get_array_u16_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayU16FromWasm(ptr, len) {{
@@ -840,7 +818,7 @@ impl<'a> Context<'a> {
     fn expose_get_array_i32_from_wasm(&mut self) {
         self.expose_uint32_memory();
         if !self.exposed_globals.insert("get_array_i32_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayI32FromWasm(ptr, len) {{
@@ -854,7 +832,7 @@ impl<'a> Context<'a> {
     fn expose_get_array_u32_from_wasm(&mut self) {
         self.expose_uint32_memory();
         if !self.exposed_globals.insert("get_array_u32_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayU32FromWasm(ptr, len) {{
@@ -867,7 +845,7 @@ impl<'a> Context<'a> {
 
     fn expose_get_array_f32_from_wasm(&mut self) {
         if !self.exposed_globals.insert("get_array_f32_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayF32FromWasm(ptr, len) {{
@@ -880,7 +858,7 @@ impl<'a> Context<'a> {
 
     fn expose_get_array_f64_from_wasm(&mut self) {
         if !self.exposed_globals.insert("get_array_f64_from_wasm") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function getArrayF64FromWasm(ptr, len) {{
@@ -893,7 +871,7 @@ impl<'a> Context<'a> {
 
     fn expose_uint8_memory(&mut self) {
         if !self.exposed_globals.insert("uint8_memory") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             let cachedUint8Memory = null;
@@ -908,7 +886,7 @@ impl<'a> Context<'a> {
 
     fn expose_uint16_memory(&mut self) {
         if !self.exposed_globals.insert("uint16_memory") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             let cachedUint16Memory = null;
@@ -923,7 +901,7 @@ impl<'a> Context<'a> {
 
     fn expose_uint32_memory(&mut self) {
         if !self.exposed_globals.insert("uint32_memory") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             let cachedUint32Memory = null;
@@ -938,7 +916,7 @@ impl<'a> Context<'a> {
 
     fn expose_assert_class(&mut self) {
         if !self.exposed_globals.insert("assert_class") {
-            return
+            return;
         }
         self.globals.push_str(&format!("
             function _assertClass(instance, klass) {{
@@ -951,7 +929,7 @@ impl<'a> Context<'a> {
 
     fn expose_borrowed_objects(&mut self) {
         if !self.exposed_globals.insert("borrowed_objects") {
-            return
+            return;
         }
         self.expose_global_stack();
         self.globals.push_str(&format!("
@@ -964,7 +942,7 @@ impl<'a> Context<'a> {
 
     fn expose_take_object(&mut self) {
         if !self.exposed_globals.insert("take_object") {
-            return
+            return;
         }
         self.expose_get_object();
         self.expose_drop_ref();
@@ -979,7 +957,7 @@ impl<'a> Context<'a> {
 
     fn expose_add_heap_object(&mut self) {
         if !self.exposed_globals.insert("add_heap_object") {
-            return
+            return;
         }
         self.expose_global_slab();
         self.expose_global_slab_next();
@@ -1100,7 +1078,7 @@ impl<'a> Context<'a> {
 
     fn expose_set_global_argument(&mut self) {
         if !self.exposed_globals.insert("set_global_argument") {
-            return
+            return;
         }
         self.expose_uint32_memory();
         self.expose_global_argument_ptr();
@@ -1114,7 +1092,7 @@ impl<'a> Context<'a> {
 
     fn expose_get_global_argument(&mut self) {
         if !self.exposed_globals.insert("get_global_argument") {
-            return
+            return;
         }
         self.expose_uint32_memory();
         self.expose_global_argument_ptr();
@@ -1128,7 +1106,7 @@ impl<'a> Context<'a> {
 
     fn expose_global_argument_ptr(&mut self) {
         if !self.exposed_globals.insert("global_argument_ptr") {
-            return
+            return;
         }
         self.required_internal_exports.insert("__wbindgen_global_argument_ptr");
         self.globals.push_str("
@@ -1157,7 +1135,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
 
     pub fn generate_export(&mut self, export: &shared::Export) {
         if let Some(ref class) = export.class {
-            return self.generate_export_for_class(class, export)
+            return self.generate_export_for_class(class, export);
         }
         let (js, ts) = self.generate_function("function",
                                               &export.function.name,
@@ -1237,8 +1215,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                         arg_conversions.push_str(&format!("\
                             _assertBoolean({name});
                         ", name = name));
-                    } else {
-                    }
+                    } else {}
                     pass(&format!("arg{i} ? 1 : 0", i = i))
                 }
                 shared::TYPE_JS_OWNED => {
@@ -1381,9 +1358,9 @@ impl<'a, 'b> SubContext<'a, 'b> {
                 const ret = wasm.{}({passed});
                 {convert_ret}
             ",
-                f = wasm_name,
-                passed = passed_args,
-                convert_ret = convert_ret,
+                                  f = wasm_name,
+                                  passed = passed_args,
+                                  convert_ret = convert_ret,
             ));
         } else {
             dst.push_str(&format!("\
@@ -1394,10 +1371,10 @@ impl<'a, 'b> SubContext<'a, 'b> {
                     {destructors}
                 }}
             ",
-                f = wasm_name,
-                passed = passed_args,
-                destructors = destructors,
-                convert_ret = convert_ret,
+                                  f = wasm_name,
+                                  passed = passed_args,
+                                  destructors = destructors,
+                                  convert_ret = convert_ret,
             ));
         }
         dst.push_str("}");

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -695,7 +695,7 @@ impl<'a> Context<'a> {
             self.globals.push_str(&format!("
                 const TextEncoder = require('util').TextEncoder;
             "));
-        } else if !self.config.browser {
+        } else if !(self.config.browser && self.config.amd) {
             self.globals.push_str(&format!("
                 const TextEncoder = typeof window === 'object' && window.TextEncoder
                     ? window.TextEncoder
@@ -715,7 +715,7 @@ impl<'a> Context<'a> {
             self.globals.push_str(&format!("
                 const TextDecoder = require('util').TextDecoder;
             "));
-        } else if !self.config.browser {
+        } else if !(self.config.browser && self.config.amd) {
             self.globals.push_str(&format!("
                 const TextDecoder = typeof window === 'object' && window.TextDecoder
                     ? window.TextDecoder

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -284,6 +284,7 @@ impl<'a> Context<'a> {
                 }}))
             ",
                     module = module_name,
+                    globals = self.globals,
                     import_wasm = import_wasm,
             )
         } else {

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -47,7 +47,7 @@ impl<'a> Context<'a> {
         let contents = contents.trim();
         let global = if self.config.nodejs {
             format!("module.exports.{} = {};\n", name, contents)
-        } else if self.config.amd {
+        } else if self.config.no_modules {
             format!("__exports.{} = {}\n", name, contents)
         } else {
             if contents.starts_with("function") {
@@ -229,7 +229,7 @@ impl<'a> Context<'a> {
             self.footer.push_str(&format!("wasm = require('./{}_bg');",
                                           module_name));
             format!("var wasm;")
-        } else if self.config.amd {
+        } else if self.config.no_modules {
             format!("
                 return fetch('{module}_bg.wasm')
                     .then(response => response.arrayBuffer())
@@ -247,7 +247,7 @@ impl<'a> Context<'a> {
             format!("import * as wasm from './{}_bg';", module_name)
         };
 
-        let js = if self.config.amd {
+        let js = if self.config.no_modules {
             format!("
                 (function (root, factory) {{
                     if (typeof define === 'function' && define.amd) {{
@@ -695,7 +695,7 @@ impl<'a> Context<'a> {
             self.globals.push_str(&format!("
                 const TextEncoder = require('util').TextEncoder;
             "));
-        } else if !(self.config.browser || self.config.amd) {
+        } else if !(self.config.browser || self.config.no_modules) {
             self.globals.push_str(&format!("
                 const TextEncoder = typeof window === 'object' && window.TextEncoder
                     ? window.TextEncoder
@@ -715,7 +715,7 @@ impl<'a> Context<'a> {
             self.globals.push_str(&format!("
                 const TextDecoder = require('util').TextDecoder;
             "));
-        } else if !(self.config.browser || self.config.amd) {
+        } else if !(self.config.browser || self.config.no_modules) {
             self.globals.push_str(&format!("
                 const TextDecoder = typeof window === 'object' && window.TextDecoder
                     ? window.TextDecoder

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -695,7 +695,7 @@ impl<'a> Context<'a> {
             self.globals.push_str(&format!("
                 const TextEncoder = require('util').TextEncoder;
             "));
-        } else if !(self.config.browser && self.config.amd) {
+        } else if !(self.config.browser || self.config.amd) {
             self.globals.push_str(&format!("
                 const TextEncoder = typeof window === 'object' && window.TextEncoder
                     ? window.TextEncoder
@@ -715,7 +715,7 @@ impl<'a> Context<'a> {
             self.globals.push_str(&format!("
                 const TextDecoder = require('util').TextDecoder;
             "));
-        } else if !(self.config.browser && self.config.amd) {
+        } else if !(self.config.browser || self.config.amd) {
             self.globals.push_str(&format!("
                 const TextDecoder = typeof window === 'object' && window.TextDecoder
                     ? window.TextDecoder

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Bindgen {
     path: Option<PathBuf>,
     nodejs: bool,
     browser: bool,
-    amd: bool,
+    no_modules: bool,
     debug: bool,
     typescript: bool,
 }
@@ -37,7 +37,7 @@ impl Bindgen {
             path: None,
             nodejs: false,
             browser: false,
-            amd: false,
+            no_modules: false,
             debug: false,
             typescript: false,
         }
@@ -58,8 +58,8 @@ impl Bindgen {
         self
     }
 
-    pub fn amd(&mut self, amd: bool) -> &mut Bindgen {
-        self.amd = amd;
+    pub fn no_modules(&mut self, no_modules: bool) -> &mut Bindgen {
+        self.no_modules = no_modules;
         self
     }
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -17,6 +17,7 @@ pub struct Bindgen {
     path: Option<PathBuf>,
     nodejs: bool,
     browser: bool,
+    umd: bool,
     debug: bool,
     typescript: bool,
 }
@@ -36,6 +37,7 @@ impl Bindgen {
             path: None,
             nodejs: false,
             browser: false,
+            umd: false,
             debug: false,
             typescript: false,
         }
@@ -53,6 +55,11 @@ impl Bindgen {
 
     pub fn browser(&mut self, browser: bool) -> &mut Bindgen {
         self.browser = browser;
+        self
+    }
+
+    pub fn umd(&mut self, umd: bool) -> &mut Bindgen {
+        self.umd = umd;
         self
     }
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Bindgen {
     path: Option<PathBuf>,
     nodejs: bool,
     browser: bool,
-    umd: bool,
+    amd: bool,
     debug: bool,
     typescript: bool,
 }
@@ -37,7 +37,7 @@ impl Bindgen {
             path: None,
             nodejs: false,
             browser: false,
-            umd: false,
+            amd: false,
             debug: false,
             typescript: false,
         }
@@ -58,8 +58,8 @@ impl Bindgen {
         self
     }
 
-    pub fn umd(&mut self, umd: bool) -> &mut Bindgen {
-        self.umd = umd;
+    pub fn amd(&mut self, amd: bool) -> &mut Bindgen {
+        self.amd = amd;
         self
     }
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,7 +22,7 @@ Options:
     --out-dir DIR            Output directory
     --nodejs                 Generate output that only works in node.js
     --browser                Generate output that only works in a browser
-    --umd                    Generate output that works both in browser and node.js
+    --amd                    Generate output that only works in a browser
     --typescript             Output a TypeScript definition file
     --debug                  Include otherwise-extraneous debug checks in output
     -V --version             Print the version number of wasm-bindgen

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,6 +22,7 @@ Options:
     --out-dir DIR            Output directory
     --nodejs                 Generate output that only works in node.js
     --browser                Generate output that only works in a browser
+    --umd                    Generate output that works both in browser and node.js
     --typescript             Output a TypeScript definition file
     --debug                  Include otherwise-extraneous debug checks in output
     -V --version             Print the version number of wasm-bindgen
@@ -31,6 +32,7 @@ Options:
 struct Args {
     flag_nodejs: bool,
     flag_browser: bool,
+    flag_umd: bool,
     flag_typescript: bool,
     flag_out_dir: Option<PathBuf>,
     flag_debug: bool,
@@ -45,7 +47,7 @@ fn main() {
 
     if args.flag_version {
         println!("wasm-bindgen {}", wasm_bindgen_shared::version());
-        return
+        return;
     }
 
     let input = match args.arg_input {
@@ -55,10 +57,11 @@ fn main() {
 
     let mut b = Bindgen::new();
     b.input_path(&input)
-     .nodejs(args.flag_nodejs)
-     .browser(args.flag_browser)
-     .debug(args.flag_debug)
-     .typescript(args.flag_typescript);
+        .nodejs(args.flag_nodejs)
+        .browser(args.flag_browser)
+        .umd(args.flag_umd)
+        .debug(args.flag_debug)
+        .typescript(args.flag_typescript);
 
     let out_dir = match args.flag_out_dir {
         Some(ref p) => p,

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -32,7 +32,7 @@ Options:
 struct Args {
     flag_nodejs: bool,
     flag_browser: bool,
-    flag_umd: bool,
+    flag_amd: bool,
     flag_typescript: bool,
     flag_out_dir: Option<PathBuf>,
     flag_debug: bool,
@@ -59,7 +59,7 @@ fn main() {
     b.input_path(&input)
         .nodejs(args.flag_nodejs)
         .browser(args.flag_browser)
-        .umd(args.flag_umd)
+        .amd(args.flag_amd)
         .debug(args.flag_debug)
         .typescript(args.flag_typescript);
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,7 +22,7 @@ Options:
     --out-dir DIR            Output directory
     --nodejs                 Generate output that only works in node.js
     --browser                Generate output that only works in a browser
-    --amd                    Generate output that only works in a browser
+    --no-modules             Generate output that only works in a browser (without modules)
     --typescript             Output a TypeScript definition file
     --debug                  Include otherwise-extraneous debug checks in output
     -V --version             Print the version number of wasm-bindgen
@@ -32,7 +32,7 @@ Options:
 struct Args {
     flag_nodejs: bool,
     flag_browser: bool,
-    flag_amd: bool,
+    flag_no_modules: bool,
     flag_typescript: bool,
     flag_out_dir: Option<PathBuf>,
     flag_debug: bool,
@@ -59,7 +59,7 @@ fn main() {
     b.input_path(&input)
         .nodejs(args.flag_nodejs)
         .browser(args.flag_browser)
-        .amd(args.flag_amd)
+        .no_modules(args.flag_no_modules)
         .debug(args.flag_debug)
         .typescript(args.flag_typescript);
 


### PR DESCRIPTION
Before I describe what I have done here. Here's why I want it to be included?

My usecase is that I wanted to  create a cli without any dependency on webpack. For that I could use `--browser` but it required `type="module"` which is behind flags in firefox and testing in chrome is weird. 

Seeing what `stdweb` did, I wanted to emulate the same here using `--umd` builds. The implementation is very simple. Only proper js is accessible in exports.

You could directly import and use as is.
```
<script src="sample.js"></script>
<script>
sample.then(m => m.run());
</script>
```

As you can tell, this commit is incomplete. I don't know how to handle `SubContext::import_name`? As far as I know, it handles the `js_namespace` values and would I need to skip through the imports?

Also, where are custom js library imports handled? Because resolving their dependency tree would require `webpack`. And I would not want to use that, so panicking when js libs are used would be best in this usecase.