### PR TITLE
Call fs.readFileSync with __dirname

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -148,7 +148,8 @@ impl Bindgen {
         }
 
         shim.push_str(&format!("
-            const bytes = require('fs').readFileSync('{}');
+            const join = require('path').join;
+            const bytes = require('fs').readFileSync(join(__dirname, '{}'));
             const wasmModule = new WebAssembly.Module(bytes);
             const wasmInstance = new WebAssembly.Instance(wasmModule, imports);
             module.exports = wasmInstance.exports;


### PR DESCRIPTION
Node's fs APIs resolve relative paths relative to the current working directory: https://nodejs.org/api/fs.html#fs_file_paths

This creates a problem if you try to require the wasm-bindgen-generated JavaScript from a different directory. For example, if you have

* build/foo.js
* build/foo_bg.js
* build/foo_bg.wasm

and another script, script/index.js, that requires build/foo.js. We can instead use __dirname to get the correct path to the file.