### PR TITLE
Support `new Foo(...)` to fix #115

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -538,21 +538,13 @@ code for this we'll see:
 ```js
 import * as wasm from './js_hello_world_bg';
 
+export class Foo {
+    static __construct(ptr) {
+        return new Foo(ptr);
+    }
 
-class ConstructorToken {
     constructor(ptr) {
         this.ptr = ptr;
-    }
-}
-
-export class Foo {
-
-    constructor(...args) {
-        if (args.length === 1 && args[0] instanceof ConstructorToken) {
-            this.ptr = args[0].ptr;
-            return;
-        }
-        throw new Error('you cannot invoke `new` directly without having a method annotated a constructor');
     }
 
     free() {
@@ -563,7 +555,7 @@ export class Foo {
 
     static new(arg0) {
         const ret = wasm.foo_new(arg0);
-        return new Foo(new ConstructorToken(ret));
+        return Foo.__construct(ret)
     }
 
     get() {

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -203,23 +203,13 @@ impl Program {
             panic!("can only bindgen safe functions");
         }
 
-        let mut opts = BindgenAttrs::find(&mut method.attrs);
+        let opts = BindgenAttrs::find(&mut method.attrs);
         let is_constructor = opts.constructor();
         let constructor = if is_constructor {
             Some(method.sig.ident.to_string())
         } else {
             None
         };
-
-        if is_constructor {
-            let pos = opts.attrs
-                .iter()
-                .enumerate()
-                .find(|(_, a)| **a == BindgenAttr::Constructor)
-                .unwrap()
-                .0;
-            opts.attrs.remove(pos);
-        }
 
         let (function, mutable) = Function::from_decl(
             method.sig.ident,

--- a/crates/cli-support/src/js.rs
+++ b/crates/cli-support/src/js.rs
@@ -1338,8 +1338,8 @@ impl<'a, 'b> SubContext<'a, 'b> {
         self.cx.typescript.push_str("\n");
     }
 
-    pub fn generate_export_for_class(&mut self, class: &str, export: &shared::Export) {
-        let wasm_name = shared::struct_function_export_name(class, &export.function.name);
+    pub fn generate_export_for_class(&mut self, class_name: &str, export: &shared::Export) {
+        let wasm_name = shared::struct_function_export_name(class_name, &export.function.name);
         let descriptor = self.cx.describe(&wasm_name);
         let (js, ts) = self.generate_function(
             "",

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -110,7 +110,7 @@ impl Bindgen {
         // execute a shim function which informs us about its type so we can
         // then generate the appropriate bindings.
         let instance = wasmi::Module::from_parity_wasm_module(module.clone())?;
-        let instance = wasmi::ModuleInstance::new(&imodule, &MyResolver)?;
+        let instance = wasmi::ModuleInstance::new(&instance, &MyResolver)?;
         let instance = instance.not_started_instance();
 
         let (js, ts) = {
@@ -128,7 +128,7 @@ impl Bindgen {
                 function_table_needed: false,
                 run_descriptor: &|name| {
                     let mut v = MyExternals(Vec::new());
-                    let ret = imodulei
+                    let ret = instance
                         .invoke_export(name, &[], &mut v)
                         .expect("failed to run export");
                     assert!(ret.is_none());

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -54,7 +54,7 @@ pub struct ImportType {
 pub struct Export {
     pub class: Option<String>,
     pub method: bool,
-    pub constructor: bool,
+    pub constructor: Option<String>,
     pub function: Function,
 }
 

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -54,6 +54,7 @@ pub struct ImportType {
 pub struct Export {
     pub class: Option<String>,
     pub method: bool,
+    pub constructor: bool,
     pub function: Function,
 }
 

--- a/tests/all/classes.rs
+++ b/tests/all/classes.rs
@@ -380,6 +380,11 @@ fn constructors() {
             use wasm_bindgen::prelude::*;
 
             #[wasm_bindgen]
+            pub fn cross_item_construction() -> Bar {
+                Bar::other_name(7, 8)
+            }
+
+            #[wasm_bindgen]
             pub struct Foo {
                 number: u32,
             }
@@ -416,7 +421,7 @@ fn constructors() {
         "#)
         .file("test.ts", r#"
             import * as assert from "assert";
-            import { Foo, Bar } from "./out";
+            import { Foo, Bar, cross_item_construction } from "./out";
 
             export function test() {
                 const foo = new Foo(1);
@@ -434,6 +439,8 @@ fn constructors() {
                 const bar2 = Bar.other_name(5, 6);
                 assert.strictEqual(bar2.get_sum(), 11);
                 bar2.free();
+
+                assert.strictEqual(cross_item_construction().get_sum(), 15);
             }
         "#)
         .test();

--- a/tests/all/classes.rs
+++ b/tests/all/classes.rs
@@ -405,7 +405,7 @@ fn constructors() {
             #[wasm_bindgen]
             impl Bar {
                 #[wasm_bindgen(constructor)]
-                pub fn new(number: u32, number2: u32) -> Bar {
+                pub fn other_name(number: u32, number2: u32) -> Bar {
                     Bar { number, number2 }
                 }
 
@@ -431,7 +431,7 @@ fn constructors() {
                 assert.strictEqual(bar.get_sum(), 7);
                 bar.free();
 
-                const bar2 = Bar.new(5, 6);
+                const bar2 = Bar.other_name(5, 6);
                 assert.strictEqual(bar2.get_sum(), 11);
                 bar2.free();
             }


### PR DESCRIPTION
When there is a function is annotated `#[wasm_bindgen(constructor)]` in an impl block for `Foo`, you can  use `new Foo()` in the javascript directly. The `constructors::classes` test should give a good impression on how this looks in practice.

~~A nice side effect is that constructors are now independent of debug.~~ I haven't tested for perfomance implications though as mentioned in https://github.com/rustwasm/wasm-bindgen/issues/115#issuecomment-380119274. I also refrained from replacing `Foo.new()` with `new Foo()` in the docs and examples.

[The user facing constructor variant](https://github.com/rustwasm/wasm-bindgen/compare/describe...konstin:new?expand=1#diff-8e501067c51f03c3db3c9d1286f71da5R335) is currently a hack. I couldn't think of a better way to do that, so suggestions are welcome.

This pull request is based on the describe branch from #124 to avoid merge conflicts.