### PR TITLE
Add support for mutable stack closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ you can do are:
 ```rust
 #[wasm_bindgen]
 extern {
-    fn foo(a: &Fn()); // must be `Fn`, not `FnMut`
+    fn foo(a: &Fn()); // could also be `&mut FnMut()`
 }
 ```
 
@@ -452,7 +452,7 @@ returns, and the validity of the JS closure is tied to the lifetime of the
 `Closure` in Rust. Once `Closure` is dropped it will deallocate its internal
 memory and invalidate the corresponding JS function.
 
-Unlike stack closures a `Closure` supports `FnMut`:
+Like stack closures a `Closure` also supports `FnMut`:
 
 ```rust
 use wasm_bindgen::prelude::*;

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -495,7 +495,14 @@ impl ToTokens for ast::ImportFunction {
                             ::into_abi(#var, &mut __stack);
                     });
                 }
-                ast::TypeKind::ByMutRef => panic!("urgh mut"),
+                ast::TypeKind::ByMutRef => {
+                    abi_argument_names.push(name);
+                    abi_arguments.push(quote! { #name: u32 });
+                    arg_conversions.push(quote! {
+                        let #name = <#t as ::wasm_bindgen::convert::ToRefMutWasmBoundary>
+                            ::to_abi_ref_mut(#name, &mut __stack);
+                    });
+                }
                 ast::TypeKind::ByRef => {
                     abi_argument_names.push(name);
                     abi_arguments.push(quote! { #name: u32 });

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -212,13 +212,14 @@ impl Descriptor {
         }
     }
 
-    pub fn stack_closure(&self) -> Option<&Function> {
-        let inner = match *self {
-            Descriptor::Ref(ref d) => &**d,
+    pub fn stack_closure(&self) -> Option<(&Function, bool)> {
+        let (inner, mutable) = match *self {
+            Descriptor::Ref(ref d) => (&**d, false),
+            Descriptor::RefMut(ref d) => (&**d, true),
             _ => return None,
         };
         match *inner {
-            Descriptor::Function(ref f) => Some(f),
+            Descriptor::Function(ref f) => Some((f, mutable)),
             _ => None,
         }
     }


### PR DESCRIPTION
This commit adds support for passing `&mut FnMut(..)` to JS via imports. These
closures cannot be invoked recursively in JS (they invalidate themselves while
they're being invoked) and otherwise work the same as `&Fn(..)` closures.

Closes #123