### PR TITLE
Overhaul the conversion traits

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -57,8 +57,8 @@ pub struct ImportType {
 
 pub struct Function {
     pub name: syn::Ident,
-    pub arguments: Vec<Type>,
-    pub ret: Option<Type>,
+    pub arguments: Vec<syn::Type>,
+    pub ret: Option<syn::Type>,
     pub opts: BindgenAttrs,
     pub rust_attrs: Vec<syn::Attribute>,
     pub rust_decl: Box<syn::FnDecl>,
@@ -77,12 +77,6 @@ pub struct Enum {
 pub struct Variant {
     pub name: syn::Ident,
     pub value: u32,
-}
-
-pub struct Type {
-    pub ty: syn::Type,
-    pub kind: TypeKind,
-    pub loc: TypeLocation,
 }
 
 #[derive(Copy, Clone)]
@@ -210,7 +204,6 @@ impl Program {
             opts,
             method.vis,
             true,
-            false,
         );
         self.exports.push(Export {
             class: Some(class),
@@ -305,7 +298,6 @@ impl Program {
             opts,
             f.vis,
             false,
-            true,
         ).0;
         if wasm.opts.catch() {
             // TODO: this assumes a whole bunch:
@@ -323,7 +315,15 @@ impl Program {
             let class = wasm.arguments
                 .get(0)
                 .expect("methods must have at least one argument");
-            let class_name = match class.ty {
+            let class = match *class {
+                syn::Type::Reference(syn::TypeReference {
+                    mutability: None,
+                    ref elem,
+                    ..
+                }) => &**elem,
+                _ => panic!("first argument of method must be a shared reference"),
+            };
+            let class_name = match *class {
                 syn::Type::Path(syn::TypePath {
                     qself: None,
                     ref path,
@@ -335,11 +335,11 @@ impl Program {
 
             ImportFunctionKind::Method {
                 class: class_name.as_ref().to_string(),
-                ty: class.ty.clone(),
+                ty: class.clone(),
             }
         } else if wasm.opts.constructor() {
             let class = match wasm.ret {
-                Some(Type { ref ty, kind: TypeKind::ByValue, .. }) => ty,
+                Some(ref ty) => ty,
                 _ => panic!("constructor returns must be bare types"),
             };
             let class_name = match *class {
@@ -433,7 +433,6 @@ impl Function {
             opts,
             input.vis,
             false,
-            false,
         ).0
     }
 
@@ -444,7 +443,6 @@ impl Function {
         opts: BindgenAttrs,
         vis: syn::Visibility,
         allow_self: bool,
-        import: bool,
     ) -> (Function, Option<bool>) {
         if decl.variadic.is_some() {
             panic!("can't bindgen variadic functions")
@@ -452,6 +450,8 @@ impl Function {
         if decl.generics.params.len() > 0 {
             panic!("can't bindgen functions with lifetime or type parameters")
         }
+
+        assert_no_lifetimes(&decl);
 
         let mut mutable = None;
         let arguments = decl.inputs
@@ -468,24 +468,12 @@ impl Function {
                 }
                 _ => panic!("arguments cannot be `self` or ignored"),
             })
-            .map(|arg| {
-                Type::from(&arg.ty, if import {
-                    TypeLocation::ImportArgument
-                } else {
-                    TypeLocation::ExportArgument
-                })
-            })
+            .map(|arg| arg.ty.clone())
             .collect::<Vec<_>>();
 
         let ret = match decl.output {
             syn::ReturnType::Default => None,
-            syn::ReturnType::Type(_, ref t) => {
-                Some(Type::from(t, if import {
-                    TypeLocation::ImportRet
-                } else {
-                    TypeLocation::ExportRet
-                }))
-            }
+            syn::ReturnType::Type(_, ref t) => Some((**t).clone()),
         };
 
         (
@@ -660,22 +648,6 @@ impl ImportType {
 impl Struct {
     fn from(s: syn::ItemStruct, _opts: BindgenAttrs) -> Struct {
         Struct { name: s.ident }
-    }
-}
-
-impl Type {
-    pub fn from(ty: &syn::Type, loc: TypeLocation) -> Type {
-        let (ty, kind) = match *ty {
-            syn::Type::Reference(ref r) => {
-                if r.mutability.is_some() {
-                    ((*r.elem).clone(), TypeKind::ByMutRef)
-                } else {
-                    ((*r.elem).clone(), TypeKind::ByRef)
-                }
-            }
-            _ => (ty.clone(), TypeKind::ByValue),
-        };
-        Type { loc, ty, kind }
     }
 }
 
@@ -857,16 +829,12 @@ impl syn::synom::Synom for BindgenAttr {
     ));
 }
 
-fn extract_first_ty_param(ty: Option<&Type>) -> Option<Option<Type>> {
+fn extract_first_ty_param(ty: Option<&syn::Type>) -> Option<Option<syn::Type>> {
     let t = match ty {
         Some(t) => t,
         None => return Some(None),
     };
-    let ty = match *t {
-        Type { ref ty, kind: TypeKind::ByValue, .. } => ty,
-        _ => return None,
-    };
-    let path = match *ty {
+    let path = match *t {
         syn::Type::Path(syn::TypePath {
             qself: None,
             ref path,
@@ -886,11 +854,7 @@ fn extract_first_ty_param(ty: Option<&Type>) -> Option<Option<Type>> {
         syn::Type::Tuple(ref t) if t.elems.len() == 0 => return Some(None),
         _ => {}
     }
-    Some(Some(Type {
-        ty: ty.clone(),
-        kind: TypeKind::ByValue,
-        loc: t.loc,
-    }))
+    Some(Some(ty.clone()))
 }
 
 fn term<'a>(cursor: syn::buffer::Cursor<'a>, name: &str) -> syn::synom::PResult<'a, ()> {
@@ -900,4 +864,17 @@ fn term<'a>(cursor: syn::buffer::Cursor<'a>, name: &str) -> syn::synom::PResult<
         }
     }
     syn::parse_error()
+}
+
+fn assert_no_lifetimes(decl: &syn::FnDecl) {
+    struct Walk;
+
+    impl<'ast> syn::visit::Visit<'ast> for Walk {
+        fn visit_lifetime(&mut self, _i: &'ast syn::Lifetime) {
+            panic!("it is currently not sound to use lifetimes in function \
+                    signatures");
+        }
+    }
+
+    syn::visit::Visit::visit_fn_decl(&mut Walk, decl);
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -2,7 +2,6 @@
 //! at your own risk.
 
 use std::mem::{self, ManuallyDrop};
-use std::ops::{Deref, DerefMut};
 use std::slice;
 use std::str;
 
@@ -15,37 +14,22 @@ pub struct Descriptor {
     pub __x: [u8; 4],
 }
 
-pub trait WasmBoundary: WasmDescribe {
+pub trait IntoWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
-
     fn into_abi(self, extra: &mut Stack) -> Self::Abi;
-    unsafe fn from_abi(js: Self::Abi, extra: &mut Stack) -> Self;
 }
 
-pub trait FromRefWasmBoundary: WasmDescribe {
+pub trait FromWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
-    type RefAnchor: Deref<Target = Self>;
+    type Temp;
 
-    unsafe fn from_abi_ref(js: Self::Abi, extra: &mut Stack) -> Self::RefAnchor;
-}
+    // SUPER UNSAFE
+    //
+    // Many types implement `FromWasmAbi` which have a lifetime parameter and
+    // the lifetime isn't connected to the lifetime of `js` itself.
+    unsafe fn from_abi(js: Self::Abi, extra: &mut Stack) -> Self::Temp;
+    unsafe fn from_temp(temp: &mut Self::Temp) -> Self;
 
-pub trait FromRefMutWasmBoundary: WasmDescribe {
-    type Abi: WasmAbi;
-    type RefAnchor: DerefMut<Target = Self>;
-
-    unsafe fn from_abi_ref_mut(js: Self::Abi, extra: &mut Stack) -> Self::RefAnchor;
-}
-
-pub trait ToRefWasmBoundary: WasmDescribe {
-    type Abi: WasmAbi;
-
-    fn to_abi_ref(&self, extra: &mut Stack) -> u32;
-}
-
-pub trait ToRefMutWasmBoundary: WasmDescribe {
-    type Abi: WasmAbi;
-
-    fn to_abi_ref_mut(&mut self, extra: &mut Stack) -> u32;
 }
 
 pub trait Stack {
@@ -70,11 +54,16 @@ unsafe impl WasmAbi for f64 {}
 
 macro_rules! simple {
     ($($t:tt)*) => ($(
-        impl WasmBoundary for $t {
+        impl IntoWasmAbi for $t {
             type Abi = $t;
-
             fn into_abi(self, _extra: &mut Stack) -> $t { self }
+        }
+
+        impl FromWasmAbi for $t {
+            type Abi = $t;
+            type Temp = $t;
             unsafe fn from_abi(js: $t, _extra: &mut Stack) -> $t { js }
+            unsafe fn from_temp(temp: &mut $t) -> $t { *temp }
         }
     )*)
 }
@@ -83,41 +72,71 @@ simple!(u32 u64 i32 i64 f32 f64);
 
 macro_rules! as_u32 {
     ($($t:tt)*) => ($(
-        impl WasmBoundary for $t {
+        impl IntoWasmAbi for $t {
             type Abi = u32;
-
             fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
+        }
+
+        impl FromWasmAbi for $t {
+            type Abi = u32;
+            type Temp = $t;
             unsafe fn from_abi(js: u32, _extra: &mut Stack) -> $t { js as $t }
+            unsafe fn from_temp(temp: &mut $t) -> $t { *temp }
         }
     )*)
 }
 
 as_u32!(i8 u8 i16 u16 isize usize);
 
-impl WasmBoundary for bool {
+impl IntoWasmAbi for bool {
     type Abi = u32;
 
     fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
+}
+
+impl FromWasmAbi for bool {
+    type Abi = u32;
+    type Temp = bool;
+
     unsafe fn from_abi(js: u32, _extra: &mut Stack) -> bool { js != 0 }
+    unsafe fn from_temp(temp: &mut bool) -> bool { *temp }
 }
 
-impl<T> WasmBoundary for *const T {
+impl<T> IntoWasmAbi for *const T {
     type Abi = u32;
 
     fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
-    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> *const T { js as *const T }
 }
 
-impl<T> WasmBoundary for *mut T {
+impl<T> FromWasmAbi for *const T {
+    type Abi = u32;
+    type Temp = *const T;
+
+    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> *const T {
+        js as *const T
+    }
+    unsafe fn from_temp(temp: &mut *const T) -> *const T { *temp }
+}
+
+impl<T> IntoWasmAbi for *mut T {
     type Abi = u32;
 
     fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
-    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> *mut T { js as *mut T }
+}
+
+impl<T> FromWasmAbi for *mut T {
+    type Abi = u32;
+    type Temp = *mut T;
+
+    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> *mut T {
+        js as *mut T
+    }
+    unsafe fn from_temp(temp: &mut *mut T) -> *mut T { *temp }
 }
 
 macro_rules! vectors {
     ($($t:ident)*) => ($(
-        impl WasmBoundary for Box<[$t]> {
+        impl IntoWasmAbi for Box<[$t]> {
             type Abi = u32;
 
             fn into_abi(self, extra: &mut Stack) -> u32 {
@@ -127,19 +146,27 @@ macro_rules! vectors {
                 extra.push(len as u32);
                 ptr.into_abi(extra)
             }
-
-            unsafe fn from_abi(js: u32, extra: &mut Stack) -> Box<[$t]> {
-                let ptr = <*mut $t>::from_abi(js, extra);
-                let len = extra.pop() as usize;
-                Vec::from_raw_parts(ptr, len, len).into_boxed_slice()
-            }
-
         }
 
-        impl ToRefWasmBoundary for [$t] {
+        impl FromWasmAbi for Box<[$t]> {
+            type Abi = u32;
+            type Temp = (*mut $t, usize);
+
+            unsafe fn from_abi(js: u32, extra: &mut Stack) -> Self::Temp {
+                let ptr = <*mut $t>::from_abi(js, extra);
+                let len = extra.pop() as usize;
+                (ptr, len)
+            }
+
+            unsafe fn from_temp(temp: &mut Self::Temp) -> Box<[$t]> {
+                Vec::from_raw_parts(temp.0, temp.1, temp.1).into_boxed_slice()
+            }
+        }
+
+        impl<'a> IntoWasmAbi for &'a [$t] {
             type Abi = u32;
 
-            fn to_abi_ref(&self, extra: &mut Stack) -> u32 {
+            fn into_abi(self, extra: &mut Stack) -> u32 {
                 let ptr = self.as_ptr();
                 let len = self.len();
                 extra.push(len as u32);
@@ -147,90 +174,86 @@ macro_rules! vectors {
             }
         }
 
-        impl FromRefWasmBoundary for [$t] {
+        impl<'a> FromWasmAbi for &'a [$t] {
             type Abi = u32;
-            type RefAnchor = SliceAnchor<$t>;
+            type Temp = &'a [$t];
 
-            unsafe fn from_abi_ref(js: u32, extra: &mut Stack) -> SliceAnchor<$t> {
-                SliceAnchor {
-                    ptr: <*mut $t>::from_abi(js, extra),
-                    len: extra.pop() as usize,
-                }
+            unsafe fn from_abi(js: u32, extra: &mut Stack) -> &'a [$t] {
+                slice::from_raw_parts(
+                    <*const $t>::from_abi(js, extra),
+                    extra.pop() as usize,
+                )
             }
+            unsafe fn from_temp(temp: &mut &'a [$t]) -> &'a [$t] { *temp }
         }
     )*)
-}
-
-pub struct SliceAnchor<T> {
-    ptr: *mut T,
-    len: usize,
-}
-
-impl<T> Deref for SliceAnchor<T> {
-    type Target = [T];
-    fn deref(&self) -> &[T] {
-        unsafe { slice::from_raw_parts(self.ptr, self.len) }
-    }
 }
 
 vectors! {
     u8 i8 u16 i16 u32 i32 f32 f64
 }
 
-impl<T> WasmBoundary for Vec<T> where Box<[T]>: WasmBoundary {
-    type Abi = <Box<[T]> as WasmBoundary>::Abi;
-
+impl<T> IntoWasmAbi for Vec<T> where Box<[T]>: IntoWasmAbi {
+    type Abi = <Box<[T]> as IntoWasmAbi>::Abi;
     fn into_abi(self, extra: &mut Stack) -> Self::Abi {
         self.into_boxed_slice().into_abi(extra)
     }
+}
 
-    unsafe fn from_abi(js: Self::Abi, extra: &mut Stack) -> Self {
-        <Box<[T]>>::from_abi(js, extra).into()
+impl<T> FromWasmAbi for Vec<T> where Box<[T]>: FromWasmAbi {
+    type Abi = <Box<[T]> as FromWasmAbi>::Abi;
+    type Temp = <Box<[T]> as FromWasmAbi>::Temp;
+    unsafe fn from_abi(js: Self::Abi, extra: &mut Stack) -> Self::Temp {
+        <Box<[T]>>::from_abi(js, extra)
+    }
+
+    unsafe fn from_temp(temp: &mut Self::Temp) -> Self {
+        <Box<[T]>>::from_temp(temp).into()
     }
 }
 
-impl WasmBoundary for String {
+impl IntoWasmAbi for String {
     type Abi = u32;
 
     fn into_abi(self, extra: &mut Stack) -> u32 {
         self.into_bytes().into_abi(extra)
     }
+}
 
-    unsafe fn from_abi(js: u32, extra: &mut Stack) -> String {
-        String::from_utf8_unchecked(Vec::from_abi(js, extra))
+impl FromWasmAbi for String {
+    type Abi = u32;
+    type Temp = <Vec<u8> as FromWasmAbi>::Temp;
+
+    unsafe fn from_abi(js: u32, extra: &mut Stack) -> Self::Temp {
+        <Vec<u8>>::from_abi(js, extra)
+    }
+
+    unsafe fn from_temp(temp: &mut Self::Temp) -> Self {
+        String::from_utf8_unchecked(Vec::from_temp(temp))
     }
 }
 
-impl ToRefWasmBoundary for str {
-    type Abi = <[u8] as ToRefWasmBoundary>::Abi;
+impl<'a> IntoWasmAbi for &'a str {
+    type Abi = <&'a [u8] as IntoWasmAbi>::Abi;
 
-    fn to_abi_ref(&self, extra: &mut Stack) -> Self::Abi {
-        self.as_bytes().to_abi_ref(extra)
+    fn into_abi(self, extra: &mut Stack) -> Self::Abi {
+        self.as_bytes().into_abi(extra)
     }
 }
 
-impl FromRefWasmBoundary for str {
-    type Abi = <[u8] as ToRefWasmBoundary>::Abi;
-    type RefAnchor = StrAnchor;
+impl<'a> FromWasmAbi for &'a str {
+    type Abi = <&'a [u8] as FromWasmAbi>::Abi;
+    type Temp = <&'a [u8] as FromWasmAbi>::Temp;
 
-    unsafe fn from_abi_ref(js: Self::Abi, extra: &mut Stack) -> Self::RefAnchor {
-        StrAnchor { inner: <[u8]>::from_abi_ref(js, extra) }
+    unsafe fn from_abi(js: Self::Abi, extra: &mut Stack) -> Self::Temp {
+        <&'a [u8]>::from_abi(js, extra)
+    }
+    unsafe fn from_temp(temp: &mut Self::Temp) -> Self {
+        str::from_utf8_unchecked(<&'a [u8]>::from_temp(temp))
     }
 }
 
-pub struct StrAnchor {
-    inner: SliceAnchor<u8>,
-}
-
-impl Deref for StrAnchor {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        unsafe { str::from_utf8_unchecked(&self.inner) }
-    }
-}
-
-impl WasmBoundary for JsValue {
+impl IntoWasmAbi for JsValue {
     type Abi = u32;
 
     fn into_abi(self, _extra: &mut Stack) -> u32 {
@@ -238,29 +261,39 @@ impl WasmBoundary for JsValue {
         mem::forget(self);
         return ret
     }
+}
 
-    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> JsValue {
-        JsValue { idx: js }
+impl FromWasmAbi for JsValue {
+    type Abi = u32;
+    type Temp = u32;
+    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> u32 { js }
+
+    unsafe fn from_temp(temp: &mut u32) -> JsValue {
+        JsValue { idx: *temp }
     }
 }
 
-impl ToRefWasmBoundary for JsValue {
+impl<'a> IntoWasmAbi for &'a JsValue {
     type Abi = u32;
-    fn to_abi_ref(&self, _extra: &mut Stack) -> u32 {
+    fn into_abi(self, _extra: &mut Stack) -> u32 {
         self.idx
     }
 }
 
-impl FromRefWasmBoundary for JsValue {
+impl<'a> FromWasmAbi for &'a JsValue {
     type Abi = u32;
-    type RefAnchor = ManuallyDrop<JsValue>;
+    type Temp = ManuallyDrop<JsValue>;
 
-    unsafe fn from_abi_ref(js: u32, _extra: &mut Stack) -> ManuallyDrop<JsValue> {
+    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> Self::Temp {
         ManuallyDrop::new(JsValue { idx: js })
+    }
+
+    unsafe fn from_temp(temp: &mut ManuallyDrop<JsValue>) -> Self {
+        &*(&**temp as *const JsValue)
     }
 }
 
-impl WasmBoundary for Box<[JsValue]> {
+impl IntoWasmAbi for Box<[JsValue]> {
     type Abi = u32;
 
     fn into_abi(self, extra: &mut Stack) -> u32 {
@@ -270,11 +303,20 @@ impl WasmBoundary for Box<[JsValue]> {
         extra.push(len as u32);
         ptr.into_abi(extra)
     }
+}
 
-    unsafe fn from_abi(js: u32, extra: &mut Stack) -> Box<[JsValue]> {
+impl FromWasmAbi for Box<[JsValue]> {
+    type Abi = u32;
+    type Temp = (*mut JsValue, usize);
+
+    unsafe fn from_abi(js: u32, extra: &mut Stack) -> Self::Temp {
         let ptr = <*mut JsValue>::from_abi(js, extra);
         let len = extra.pop() as usize;
-        Vec::from_raw_parts(ptr, len, len).into_boxed_slice()
+        (ptr ,len)
+    }
+
+    unsafe fn from_temp(temp: &mut Self::Temp) -> Box<[JsValue]> {
+        Vec::from_raw_parts(temp.0, temp.1, temp.1).into_boxed_slice()
     }
 }
 
@@ -316,13 +358,13 @@ pub unsafe extern fn __wbindgen_global_argument_ptr() -> *mut u32 {
 
 macro_rules! stack_closures {
     ($( ($($var:ident)*) )*) => ($(
-        impl<'a, $($var,)* R> ToRefWasmBoundary for Fn($($var),*) -> R + 'a
+        impl<'a, $($var,)* R> IntoWasmAbi for &'a (Fn($($var),*) -> R + 'a)
             where $($var: WasmAbi + WasmDescribe,)*
                   R: WasmAbi + WasmDescribe
         {
             type Abi = u32;
 
-            fn to_abi_ref(&self, extra: &mut Stack) -> u32 {
+            fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
                 unsafe extern fn invoke<$($var,)* R>(
                     a: usize,
@@ -344,12 +386,12 @@ macro_rules! stack_closures {
             }
         }
 
-        impl<'a, $($var,)*> ToRefWasmBoundary for Fn($($var),*) + 'a
+        impl<'a, $($var,)*> IntoWasmAbi for &'a (Fn($($var),*) + 'a)
             where $($var: WasmAbi + WasmDescribe,)*
         {
             type Abi = u32;
 
-            fn to_abi_ref(&self, extra: &mut Stack) -> u32 {
+            fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
                 unsafe extern fn invoke<$($var,)* >(
                     a: usize,
@@ -371,13 +413,13 @@ macro_rules! stack_closures {
             }
         }
 
-        impl<'a, $($var,)* R> ToRefMutWasmBoundary for FnMut($($var),*) -> R + 'a
+        impl<'a, $($var,)* R> IntoWasmAbi for &'a mut (FnMut($($var),*) -> R + 'a)
             where $($var: WasmAbi + WasmDescribe,)*
                   R: WasmAbi + WasmDescribe
         {
             type Abi = u32;
 
-            fn to_abi_ref_mut(&mut self, extra: &mut Stack) -> u32 {
+            fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
                 unsafe extern fn invoke<$($var,)* R>(
                     a: usize,
@@ -399,12 +441,12 @@ macro_rules! stack_closures {
             }
         }
 
-        impl<'a, $($var,)*> ToRefMutWasmBoundary for FnMut($($var),*) + 'a
+        impl<'a, $($var,)*> IntoWasmAbi for &'a mut (FnMut($($var),*) + 'a)
             where $($var: WasmAbi + WasmDescribe,)*
         {
             type Abi = u32;
 
-            fn to_abi_ref_mut(&mut self, extra: &mut Stack) -> u32 {
+            fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
                 unsafe extern fn invoke<$($var,)* >(
                     a: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::cell::UnsafeCell;
 use std::ops::Deref;
 use std::ptr;
 
-use convert::WasmBoundary;
+use convert::FromWasmAbi;
 
 /// A module which is typically glob imported from:
 ///
@@ -295,7 +295,7 @@ pub struct JsStatic<T> {
 unsafe impl<T: Sync> Sync for JsStatic<T> {}
 unsafe impl<T: Send> Send for JsStatic<T> {}
 
-impl<T: WasmBoundary> Deref for JsStatic<T> {
+impl<T: FromWasmAbi + 'static> Deref for JsStatic<T> {
     type Target = T;
     fn deref(&self) -> &T {
         unsafe {


### PR DESCRIPTION
This commit overhauls the conversion traits used for types crossing the Rust/JS
boundary. Previously there were a few ad-hoc traits but now there's only two.
One is for converting JS values to Rust values, `FromWasmAbi`, and the other is
for converting Rust values into JS values, `IntoWasmAbi`. These two traits are
now uniformly used for all operations such as creating references and such.

The `IntoWasmAbi` trait is pretty straightforward but `FromWasmAbi` is much
trickier. We need to be able to create references which necessitates a good deal
of funkiness with the API, but it in general should work out alright.

The goal of this commit is to reduce the number of traits in play so it's more
straightforward which traits are used for closures.