### PR TITLE
Work with `#![no_std]` contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ Easy support for interacting between JS and Rust.
 test = false
 doctest = false
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.4" }
 

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -119,9 +119,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 self.finally(&format!("\
                     wasm.__wbindgen_free(ptr{i}, len{i} * {size});\n\
                 ", i = i, size = kind.size()));
-                self.cx.required_internal_exports.insert(
-                    "__wbindgen_free",
-                );
+                self.cx.require_internal_export("__wbindgen_free");
             }
             self.rust_arguments.push(format!("ptr{}", i));
             return
@@ -216,7 +214,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             self.ret_ty = ty.js_ty().to_string();
             let f = self.cx.expose_get_vector_from_wasm(ty);
             self.cx.expose_get_global_argument();
-            self.cx.required_internal_exports.insert("__wbindgen_free");
+            self.cx.require_internal_export("__wbindgen_free");
             self.ret_expr = format!("\
                 const ret = RET;\n\
                 const len = getGlobalArgument(0);\n\

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -91,9 +91,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 self.prelude(&format!("\
                     wasm.__wbindgen_free(arg{0}, len{0} * {size});\
                 ", i, size = ty.size()));
-                self.cx.required_internal_exports.insert(
-                    "__wbindgen_free"
-                );
+                self.cx.require_internal_export("__wbindgen_free");
             }
             self.js_arguments.push(format!("v{}", i));
             return

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -7,6 +7,7 @@
 use std::cell::UnsafeCell;
 use std::marker::Unsize;
 use std::mem::{self, ManuallyDrop};
+use std::prelude::v1::*;
 
 use JsValue;
 use convert::*;

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -72,7 +72,6 @@ simple! {
     f64 => F64
     bool => BOOLEAN
     str => STRING
-    String => STRING
     JsValue => ANYREF
 }
 
@@ -105,16 +104,24 @@ impl<'a, T: WasmDescribe + ?Sized> WasmDescribe for &'a mut T {
     }
 }
 
-impl<T: WasmDescribe> WasmDescribe for Box<[T]> {
-    fn describe() {
-        inform(VECTOR);
-        T::describe();
-    }
-}
+if_std! {
+    use std::prelude::v1::*;
 
-impl<T> WasmDescribe for Vec<T> where Box<[T]>: WasmDescribe {
-    fn describe() {
-        <Box<[T]>>::describe();
+    impl WasmDescribe for String {
+        fn describe() { inform(STRING) }
+    }
+
+    impl<T: WasmDescribe> WasmDescribe for Box<[T]> {
+        fn describe() {
+            inform(VECTOR);
+            T::describe();
+        }
+    }
+
+    impl<T> WasmDescribe for Vec<T> where Box<[T]>: WasmDescribe {
+        fn describe() {
+            <Box<[T]>>::describe();
+        }
     }
 }
 

--- a/tests/all/simple.rs
+++ b/tests/all/simple.rs
@@ -201,3 +201,89 @@ fn other_exports() {
         "#)
         .test();
 }
+
+#[test]
+fn no_std() {
+    project()
+        .no_std(true)
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+            #![no_std]
+            #![allow(dead_code)]
+
+            extern crate wasm_bindgen;
+            extern crate std as _some_other_name;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            extern {
+                fn test(a: &str);
+
+                type Js;
+                #[wasm_bindgen(constructor)]
+                fn new() -> Js;
+                #[wasm_bindgen(method)]
+                fn init(this: &Js);
+            }
+
+            #[wasm_bindgen]
+            pub fn foo(_a: u32) {}
+        "#)
+        .file("test.ts", r#"
+            import * as wasm from "./out_bg";
+
+            export function test() {
+                // mostly just testing the project compiles here
+                wasm.foo(1);
+            }
+        "#)
+        .test();
+}
+
+#[test]
+fn no_std_class() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+            #![no_std]
+            #![allow(dead_code)]
+
+            extern crate wasm_bindgen;
+            extern crate std as _some_other_name;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            extern {
+                fn test(a: &str);
+
+                type Js;
+                #[wasm_bindgen(constructor)]
+                fn new() -> Js;
+                #[wasm_bindgen(method, structural)]
+                fn init(this: &Js);
+            }
+
+            #[wasm_bindgen]
+            pub fn foo(_a: u32) {}
+
+            #[wasm_bindgen]
+            pub struct A {}
+
+            #[wasm_bindgen]
+            impl A {
+                pub fn foo(&self) {}
+                pub fn bar(&mut self) {}
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as wasm from "./out_bg";
+
+            export function test() {
+                // mostly just testing the project compiles here
+                wasm.foo(1);
+            }
+        "#)
+        .test();
+}


### PR DESCRIPTION
This commit adds support for both `#![no_std]` in the wasm-bindgen runtime
support (disabled by default with an on-by-default `std` feature). This also
adds support to work and compile in the context of `#![no_std]` crates.

Closes #146