### PR TITLE
Generate accessors for public struct fields

### DIFF
--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate serde_derive;
 
-pub const SCHEMA_VERSION: &str = "2";
+pub const SCHEMA_VERSION: &str = "3";
 
 #[derive(Deserialize)]
 pub struct ProgramOnlySchema {
@@ -14,7 +14,7 @@ pub struct Program {
     pub exports: Vec<Export>,
     pub enums: Vec<Enum>,
     pub imports: Vec<Import>,
-    pub structs: Vec<String>,
+    pub structs: Vec<Struct>,
     pub version: String,
     pub schema_version: String,
 }
@@ -82,6 +82,17 @@ pub struct Function {
     pub name: String,
 }
 
+#[derive(Deserialize, Serialize)]
+pub struct Struct {
+    pub name: String,
+    pub fields: Vec<StructField>,
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct StructField {
+    pub name: String,
+}
+
 pub fn new_function(struct_name: &str) -> String {
     let mut name = format!("__wbg_");
     name.extend(struct_name
@@ -109,6 +120,26 @@ pub fn struct_function_export_name(struct_: &str, f: &str) -> String {
         .chars()
         .flat_map(|s| s.to_lowercase())
         .collect::<String>();
+    name.push_str("_");
+    name.push_str(f);
+    return name
+}
+
+pub fn struct_field_get(struct_: &str, f: &str) -> String {
+    let mut name = String::from("__wbg_get_");
+    name.extend(struct_
+        .chars()
+        .flat_map(|s| s.to_lowercase()));
+    name.push_str("_");
+    name.push_str(f);
+    return name
+}
+
+pub fn struct_field_set(struct_: &str, f: &str) -> String {
+    let mut name = String::from("__wbg_set_");
+    name.extend(struct_
+        .chars()
+        .flat_map(|s| s.to_lowercase()));
     name.push_str("_");
     name.push_str(f);
     return name

--- a/tests/all/classes.rs
+++ b/tests/all/classes.rs
@@ -473,3 +473,56 @@ fn empty_structs() {
         "#)
         .test();
 }
+
+#[test]
+fn public_fields() {
+    project()
+        .debug(false)
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            #[derive(Default)]
+            pub struct Foo {
+                pub a: u32,
+                pub b: f32,
+                pub c: f64,
+                pub d: i32,
+            }
+
+            #[wasm_bindgen]
+            impl Foo {
+                pub fn new() -> Foo {
+                    Foo::default()
+                }
+            }
+        "#)
+        .file("test.ts", r#"
+            import { Foo } from "./out";
+            import * as assert from "assert";
+
+            export function test() {
+                const a = Foo.new();
+                assert.strictEqual(a.a, 0);
+                a.a = 3;
+                assert.strictEqual(a.a, 3);
+
+                assert.strictEqual(a.b, 0);
+                a.b = 7;
+                assert.strictEqual(a.b, 7);
+
+                assert.strictEqual(a.c, 0);
+                a.c = 8;
+                assert.strictEqual(a.c, 8);
+
+                assert.strictEqual(a.d, 0);
+                a.d = 3.3;
+                assert.strictEqual(a.d, 3);
+            }
+        "#)
+        .test();
+}


### PR DESCRIPTION
Automatically infer public struct fields as "JS wants to access this" and
generate appropriate getters/setters for the field. At this time the field is
required to implement `Copy`, but we will probably want to relax that in the
future to at least encompass `JsValue` and maybe other `Clone` values as well.

Closes #121