### PR TITLE
Mark JsValue idx as NonZeroU32

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -631,7 +631,7 @@ impl<'a> Context<'a> {
         if !self.exposed_globals.insert("slab") {
             return;
         }
-        self.global(&format!("let slab = [];"));
+        self.global(&format!("let slab = [null];"));
     }
 
     fn expose_global_slab_next(&mut self) {
@@ -639,7 +639,8 @@ impl<'a> Context<'a> {
             return;
         }
         self.global(&format!("
-            let slab_next = 0;
+            // Avoid 0 as an index to enable optimizing Option<JsValue> layout
+            let slab_next = 1;
         "));
     }
 

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -2,6 +2,7 @@
 //! at your own risk.
 
 use core::mem::{self, ManuallyDrop};
+use core::num::NonZeroU32;
 use core::ops::{Deref, DerefMut};
 use core::slice;
 use core::str;
@@ -242,7 +243,7 @@ impl IntoWasmAbi for JsValue {
     type Abi = u32;
 
     fn into_abi(self, _extra: &mut Stack) -> u32 {
-        let ret = self.idx;
+        let ret = self.idx.get();
         mem::forget(self);
         return ret
     }
@@ -252,14 +253,14 @@ impl FromWasmAbi for JsValue {
     type Abi = u32;
 
     unsafe fn from_abi(js: u32, _extra: &mut Stack) -> JsValue {
-        JsValue { idx: js }
+        JsValue { idx: NonZeroU32::new_unchecked(js) }
     }
 }
 
 impl<'a> IntoWasmAbi for &'a JsValue {
     type Abi = u32;
     fn into_abi(self, _extra: &mut Stack) -> u32 {
-        self.idx
+        self.idx.get()
     }
 }
 
@@ -268,7 +269,7 @@ impl RefFromWasmAbi for JsValue {
     type Anchor = ManuallyDrop<JsValue>;
 
     unsafe fn ref_from_abi(js: u32, _extra: &mut Stack) -> Self::Anchor {
-        ManuallyDrop::new(JsValue { idx: js })
+        ManuallyDrop::new(JsValue { idx: NonZeroU32::new_unchecked(js) })
     }
 }
 


### PR DESCRIPTION
I noticed in the generated wasm for examples/dom that `JsStatic` takes two words of storage (for its `Option<JsValue>`) when it would seem to only need one, if we mandate that `0` is not a valid heap index. Changing the `.idx` type to `NonZeroU32` fixes this.

However, LLVM doesn't know that these values are non-zero yet (https://github.com/rust-lang/rust/issues/49572) which means in the implementation of Option's `get_or_insert_with` (https://doc.rust-lang.org/nightly/src/core/option.rs.html#774) LLVM is no longer able to prove that the `unreachable!()` branch is never hit and thus JsStatic ends up pulling in all the panic infrastructure where it previously didn't. This results in the examples/dom output being much larger, rather than smaller as I had hoped. Probably makes sense to wait for the upstream issue to be fixed so that this can be landed without regressing anything.