### PR TITLE
Add support for version specifications

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -886,6 +886,34 @@ controlling precisely how imports are imported and what they map to in JS. This
 section is intended to hopefully be an exhaustive reference of the
 possibilities!
 
+* `module` and `version` - we've seen `module` so far indicating where we can
+  import items from but `version` is also allowed:
+
+  ```rust
+  #[wasm_bindgen(module = "moment", version = "2.0.0")]
+  extern {
+      type Moment;
+      fn moment() -> Moment;
+      #[wasm_bindgen(method)]
+      fn format(this: &Moment) -> String;
+  }
+  ```
+
+  The `module` key is used to configure the module that each item is imported
+  from. The `version` key does not affect the generated wasm itself but rather
+  it's an informative directive for tools like [wasm-pack]. Tools like wasm-pack
+  will generate a `package.json` for you and the `version` listed here, when
+  `module` is also an NPM package, will correspond to what to write down in
+  `package.json`.
+
+  In other words the usage of `module` as the name of an NPM package and
+  `version` as the version requirement allows you to, inline in Rust, depend on
+  the NPM ecosystem and import functionality from those packages. When bundled
+  with a tool like [wasm-pack] everything will automatically get wired up with
+  bundlers and you should be good to go!
+
+[wasm-pack]: https://github.com/ashleygwilliams/wasm-pack
+
 * `catch` - as we saw before the `catch` attribute allows catching a JS
   exception. This can be attached to any imported function and the function must
   return a `Result` where the `Err` payload is a `JsValue`, like so:

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -20,6 +20,7 @@ pub struct Export {
 
 pub struct Import {
     pub module: Option<String>,
+    pub version: Option<String>,
     pub js_namespace: Option<syn::Ident>,
     pub kind: ImportKind,
 }
@@ -294,6 +295,7 @@ impl Program {
                 BindgenAttrs::find(attrs)
             };
             let module = item_opts.module().or(opts.module()).map(|s| s.to_string());
+            let version = item_opts.version().or(opts.version()).map(|s| s.to_string());
             let js_namespace = item_opts.js_namespace().or(opts.js_namespace());
             let mut kind = match item {
                 syn::ForeignItem::Fn(f) => self.push_foreign_fn(f, item_opts),
@@ -304,6 +306,7 @@ impl Program {
 
             self.imports.push(Import {
                 module,
+                version,
                 js_namespace,
                 kind,
             });
@@ -586,6 +589,7 @@ impl Import {
     fn shared(&self) -> shared::Import {
         shared::Import {
             module: self.module.clone(),
+            version: self.version.clone(),
             js_namespace: self.js_namespace.map(|s| s.as_ref().to_string()),
             kind: self.kind.shared(),
         }
@@ -746,6 +750,16 @@ impl BindgenAttrs {
             .next()
     }
 
+    fn version(&self) -> Option<&str> {
+        self.attrs
+            .iter()
+            .filter_map(|a| match *a {
+                BindgenAttr::Version(ref s) => Some(&s[..]),
+                _ => None,
+            })
+            .next()
+    }
+
     pub fn catch(&self) -> bool {
         self.attrs.iter().any(|a| match *a {
             BindgenAttr::Catch => true,
@@ -844,6 +858,7 @@ enum BindgenAttr {
     Method,
     JsNamespace(syn::Ident),
     Module(String),
+    Version(String),
     Getter(Option<syn::Ident>),
     Setter(Option<syn::Ident>),
     Structural,
@@ -896,6 +911,13 @@ impl syn::synom::Synom for BindgenAttr {
             s: syn!(syn::LitStr) >>
             (s.value())
         )=> { BindgenAttr::Module }
+        |
+        do_parse!(
+            call!(term, "version") >>
+            punct!(=) >>
+            s: syn!(syn::LitStr) >>
+            (s.value())
+        )=> { BindgenAttr::Version }
         |
         do_parse!(
             call!(term, "js_name") >>

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -13,6 +13,8 @@ Shared support for the wasm-bindgen-cli package, an internal dependency
 [dependencies]
 base64 = "0.9"
 parity-wasm = "0.27"
+serde = "1.0"
+serde_derive = "1.0"
 serde_json = "1.0"
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.5' }
 wasm-gc-api = "0.1"

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -1,5 +1,7 @@
 extern crate parity_wasm;
 extern crate wasm_bindgen_shared as shared;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate wasm_gc;
 extern crate wasmi;
@@ -133,6 +135,7 @@ impl Bindgen {
                 config: &self,
                 module: &mut module,
                 function_table_needed: false,
+                module_versions: Default::default(),
                 run_descriptor: &|name| {
                     let mut v = MyExternals(Vec::new());
                     let ret = instance

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -22,6 +22,7 @@ pub struct Program {
 #[derive(Deserialize, Serialize)]
 pub struct Import {
     pub module: Option<String>,
+    pub version: Option<String>,
     pub js_namespace: Option<String>,
     pub kind: ImportKind,
 }

--- a/tests/all/imports.rs
+++ b/tests/all/imports.rs
@@ -350,3 +350,47 @@ fn rename() {
         "#)
         .test();
 }
+
+#[test]
+fn versions() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen(module = "a_module", version = "0.2.0")]
+            extern {
+                fn foo();
+            }
+
+            #[wasm_bindgen]
+            pub fn run() {
+                foo();
+            }
+        "#)
+        .file("test.js", r#"
+            const fs = require("fs");
+            const assert = require("assert");
+
+            exports.test = function() {
+                const bytes = fs.readFileSync('out_bg.wasm');
+                const m = new WebAssembly.Module(bytes);
+                const name = '__wasm_pack_unstable';
+                const sections = WebAssembly.Module.customSections(m, name);
+                assert.strictEqual(sections.length, 1);
+                const b = new Uint8Array(sections[0]);
+                const buf = new Buffer(b);
+                const map = JSON.parse(buf.toString());
+                assert.deepStrictEqual(map, {
+                    version: '0.0.1',
+                    modules: [
+                        ['a_module', '0.2.0']
+                    ]
+                });
+            };
+        "#)
+        .test();
+}


### PR DESCRIPTION
This commit adds a `#[wasm_bindgen(version = "...")]` attribute support. This
information is eventually written into a `__wasm_pack_unstable` section.
Currently this is a strawman for the proposal in ashleygwilliams/wasm-pack#101