### PR TITLE
Add `spans` feature to control `proc-macro2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ test = false
 doctest = false
 
 [features]
-default = ["std"]
+default = ["spans", "std"]
+spans = ["wasm-bindgen-macro/spans"]
 std = []
 
 [dependencies]

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -10,9 +10,12 @@ description = """
 Backend code generation of the wasm-bindgen tool
 """
 
+[features]
+spans = ["proc-macro2/nightly"]
+
 [dependencies]
 quote = '0.5'
-proc-macro2 = { version = "0.3", features = ["nightly"] }
+proc-macro2 = "0.3"
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.5" }
 syn = { version = '0.13', features = ['full', 'visit-mut'] }
 serde_json = "1.0"

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -13,10 +13,13 @@ Definition of the `#[wasm_bindgen]` attribute, an internal dependency
 [lib]
 proc-macro = true
 
+[features]
+spans = ["proc-macro2/nightly", "wasm-bindgen-backend/spans"]
+
 [dependencies]
 syn = { version = '0.13', features = ['full'] }
 quote = '0.5'
-proc-macro2 = { version = "0.3", features = ["nightly"] }
+proc-macro2 = "0.3"
 serde_json = "1"
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.5" }
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.5" }


### PR DESCRIPTION
Using `proc-macro2`'s `nightly` feature is a good default for most use cases.
However, it causes a build error if used together with crates such as
`cssparser` that also use `proc-macro2` from a build script.

This change adds a default enabled feature `spans` that users can disable if
they need to work around this conflict.

Fixes #160.