### PR TITLE
Add JsValue::{from_serde, into_serde}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,12 @@ doctest = false
 default = ["spans", "std"]
 spans = ["wasm-bindgen-macro/spans"]
 std = []
+serde-serialize = ["serde", "serde_json", "std"]
 
 [dependencies]
 wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.6" }
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-cli-support = { path = "crates/cli-support", version = '=0.2.6' }

--- a/tests/all/jsobjects.rs
+++ b/tests/all/jsobjects.rs
@@ -244,3 +244,90 @@ fn another_vector_return() {
         "#)
         .test();
 }
+
+#[test]
+fn serde() {
+    project()
+        .serde(true)
+        .depend("serde = '1.0'")
+        .depend("serde_derive = '1.0'")
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+            #[macro_use]
+            extern crate serde_derive;
+
+            use wasm_bindgen::prelude::*;
+
+            #[derive(Deserialize, Serialize)]
+            pub struct Foo {
+                a: u32,
+                b: String,
+                c: Option<Bar>,
+                d: Bar,
+            }
+
+            #[derive(Deserialize, Serialize)]
+            pub struct Bar {
+                a: u32,
+            }
+
+            #[wasm_bindgen(module = "./test")]
+            extern {
+                fn verify(a: JsValue) -> JsValue;
+            }
+
+            #[wasm_bindgen]
+            pub fn run() {
+                let js = JsValue::from_serde("foo").unwrap();
+                assert_eq!(js.as_string(), Some("foo".to_string()));
+
+                let ret = verify(JsValue::from_serde(&Foo {
+                    a: 0,
+                    b: "foo".to_string(),
+                    c: None,
+                    d: Bar { a: 1 },
+                }).unwrap());
+
+                let foo = ret.into_serde::<Foo>().unwrap();
+                assert_eq!(foo.a, 2);
+                assert_eq!(foo.b, "bar");
+                assert!(foo.c.is_some());
+                assert_eq!(foo.c.as_ref().unwrap().a, 3);
+                assert_eq!(foo.d.a, 4);
+            }
+
+            #[wasm_bindgen]
+            pub fn parse(j: &JsValue) {
+                let s = j.into_serde::<String>().unwrap();
+                assert_eq!(s, "bar");
+            }
+        "#)
+        .file("test.ts", r#"
+            import { run, parse } from "./out";
+            import * as assert from "assert";
+
+            export function verify(a: any) {
+                assert.deepStrictEqual(a, {
+                    a: 0,
+                    b: 'foo',
+                    c: null,
+                    d: { a: 1 }
+                });
+
+                return {
+                    a: 2,
+                    b: 'bar',
+                    c: { a: 3 },
+                    d: { a: 4 },
+                }
+            }
+
+            export function test() {
+                run();
+                parse('bar');
+            }
+        "#)
+        .test();
+}


### PR DESCRIPTION
These functions are activated with the `serde-serialization` feature of the
`wasm-bindgen` crate. When activated they will allow passing any arbitrary value
into JS that implements the `Serialize` trait and receiving any value from JS
using the `Deserialize` trait. The interchange between JS and Rust is JSON.

Closes #96