### PR TITLE
Enable `cargo test` where possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,10 +275,27 @@ macro_rules! numbers {
 
 numbers! { i8 u8 i16 u16 i32 u32 f32 f64 }
 
-#[wasm_import_module = "__wbindgen_placeholder__"]
-extern {
+macro_rules! externs {
+    ($(fn $name:ident($($args:tt)*) -> $ret:ty;)*) => (
+        #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+        #[wasm_import_module = "__wbindgen_placeholder__"]
+        extern {
+            $(fn $name($($args)*) -> $ret;)*
+        }
+
+        $(
+            #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+            #[allow(unused_variables)]
+            unsafe extern fn $name($($args)*) -> $ret {
+                panic!("function not implemented on non-wasm32 targets")
+            }
+        )*
+    )
+}
+
+externs! {
     fn __wbindgen_object_clone_ref(idx: u32) -> u32;
-    fn __wbindgen_object_drop_ref(idx: u32);
+    fn __wbindgen_object_drop_ref(idx: u32) -> ();
     fn __wbindgen_string_new(ptr: *const u8, len: usize) -> u32;
     fn __wbindgen_number_new(f: f64) -> u32;
     fn __wbindgen_number_get(idx: u32, invalid: *mut u8) -> f64;
@@ -293,10 +310,10 @@ extern {
     fn __wbindgen_string_get(idx: u32, len: *mut usize) -> *mut u8;
     fn __wbindgen_throw(a: *const u8, b: usize) -> !;
 
-    fn __wbindgen_cb_drop(idx: u32);
-    fn __wbindgen_cb_forget(idx: u32);
+    fn __wbindgen_cb_drop(idx: u32) -> ();
+    fn __wbindgen_cb_forget(idx: u32) -> ();
 
-    fn __wbindgen_describe(v: u32);
+    fn __wbindgen_describe(v: u32) -> ();
 
     fn __wbindgen_json_parse(ptr: *const u8, len: usize) -> u32;
     fn __wbindgen_json_serialize(idx: u32, ptr: *mut *mut u8) -> usize;

--- a/tests/all/non_wasm.rs
+++ b/tests/all/non_wasm.rs
@@ -1,0 +1,86 @@
+use std::process::Command;
+use super::{run, project};
+
+#[test]
+fn works() {
+    let mut p = project();
+    let name = p.crate_name();
+    p
+        .rlib(true)
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub struct A {
+                x: u32,
+            }
+
+            #[wasm_bindgen]
+            impl A {
+                pub fn new() -> A {
+                    A { x: 3 }
+                }
+
+                pub fn foo(&self) {
+                }
+            }
+
+            #[wasm_bindgen]
+            pub fn foo(x: bool) {
+                A::new().foo();
+
+                if x {
+                    bar("test");
+                    baz(JsValue::from(3));
+                }
+            }
+
+            #[wasm_bindgen]
+            extern {
+                fn some_import();
+                static A: JsValue;
+            }
+
+            #[wasm_bindgen]
+            pub fn bar(_: &str) -> JsValue {
+                some_import();
+                A.clone()
+            }
+
+            #[wasm_bindgen]
+            pub fn baz(_: JsValue) {
+            }
+        "#)
+        .file("tests/foo.rs", &format!("
+            extern crate {} as mytest;
+
+            #[test]
+            fn foo() {{
+                mytest::foo(false);
+                mytest::A::new().foo();
+            }}
+        ", name))
+        .file("benches/foo.rs", &format!("
+            #![feature(test)]
+            extern crate test;
+            extern crate {} as mytest;
+
+            #[bench]
+            fn foo(b: &mut test::Bencher) {{
+                b.iter(|| mytest::foo(false));
+            }}
+        ", name));
+    let (root, target_dir) = p.build();
+    let mut cmd = Command::new("cargo");
+    cmd.arg("test")
+        .arg("--test").arg("foo")
+        .arg("--bench").arg("foo")
+        .current_dir(&root)
+        .env("CARGO_TARGET_DIR", &target_dir);
+    run(&mut cmd, "cargo");
+}
+


### PR DESCRIPTION
Currently `#[wasm_bindgen]` generates a bunch of references to symbols that
don't actually exist on non-wasm targets, making it more difficult to get a
crate working across multiple platforms. This commit updates the symbol
references to be dummy ones that panic on non-wasm targets to allow simple
testing/benchmarking to work on native targets.

While this isn't a perfect solution for #114 it's probably as good as we can do
for now pending upstream Cargo features, so I'm gonna say that it...

Closes #114