### PR TITLE
Add support for mutable slices

### DIFF
--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -187,6 +187,12 @@ impl Descriptor {
                     _ => return None,
                 }
             }
+            Descriptor::RefMut(ref d) => {
+                match **d {
+                    Descriptor::Slice(ref d) => &**d,
+                    _ => return None,
+                }
+            }
             _ => return None,
         };
         match *inner {
@@ -230,6 +236,13 @@ impl Descriptor {
     pub fn is_by_ref(&self) -> bool {
         match *self {
             Descriptor::Ref(_) |
+            Descriptor::RefMut(_) => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_mut_ref(&self) -> bool {
+        match *self {
             Descriptor::RefMut(_) => true,
             _ => false,
         }

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -118,6 +118,15 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 setGlobalArgument(len{i}, {global_idx});\n\
             ", i = i, func = func, arg = name, global_idx = global_idx));
             if arg.is_by_ref() {
+                if arg.is_mut_ref() {
+                    let get = self.cx.memview_function(kind);
+                    self.finally(&format!("\
+                        {arg}.set({get}().subarray(\
+                            ptr{i} / {size}, \
+                            ptr{i} / {size} + len{i}\
+                        ));\n\
+                    ", i = i, arg = name, get = get, size = kind.size()));
+                }
                 self.finally(&format!("\
                     wasm.__wbindgen_free(ptr{i}, len{i} * {size});\n\
                 ", i = i, size = kind.size()));

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -92,6 +92,9 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                     wasm.__wbindgen_free(arg{0}, len{0} * {size});\
                 ", i, size = ty.size()));
                 self.cx.require_internal_export("__wbindgen_free")?;
+            } else if arg.is_mut_ref() {
+                let f = self.cx.expose_commit_slice_to_wasm(ty)?;
+                self.finally(&format!("{}(arg{i}, v{i});", f, i = i));
             }
             self.js_arguments.push(format!("v{}", i));
             return Ok(())

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -170,6 +170,14 @@ macro_rules! vectors {
             }
         }
 
+        impl<'a> IntoWasmAbi for &'a mut [$t] {
+            type Abi = u32;
+
+            fn into_abi(self, extra: &mut Stack) -> u32 {
+                (&*self).into_abi(extra)
+            }
+        }
+
         impl RefFromWasmAbi for [$t] {
             type Abi = u32;
             type Anchor = &'static [$t];
@@ -177,6 +185,18 @@ macro_rules! vectors {
             unsafe fn ref_from_abi(js: u32, extra: &mut Stack) -> &'static [$t] {
                 slice::from_raw_parts(
                     <*const $t>::from_abi(js, extra),
+                    extra.pop() as usize,
+                )
+            }
+        }
+
+        impl RefMutFromWasmAbi for [$t] {
+            type Abi = u32;
+            type Anchor = &'static mut [$t];
+
+            unsafe fn ref_mut_from_abi(js: u32, extra: &mut Stack) -> &'static mut [$t] {
+                slice::from_raw_parts_mut(
+                    <*mut $t>::from_abi(js, extra),
                     extra.pop() as usize,
                 )
             }

--- a/tests/all/slice.rs
+++ b/tests/all/slice.rs
@@ -278,3 +278,225 @@ fn pass_array_works() {
         "#)
         .test();
 }
+
+#[test]
+fn import_mut() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            macro_rules! doit {
+                ($(($rust:ident, $js:ident, $i:ident))*) => (
+                    $(
+                        #[wasm_bindgen(module = "./test")]
+                        extern {
+                            fn $js(a: &mut [$i]);
+                        }
+
+                        fn $rust() {
+                            let mut buf = [
+                                1 as $i,
+                                2 as $i,
+                                3 as $i,
+                            ];
+                            $js(&mut buf);
+                            assert_eq!(buf[0], 4 as $i);
+                            assert_eq!(buf[1], 5 as $i);
+                            assert_eq!(buf[2], 3 as $i);
+                        }
+                    )*
+
+                    #[wasm_bindgen]
+                    pub fn run() {
+                        $($rust();)*
+                    }
+                )
+            }
+
+
+            doit! {
+                (rust_i8, js_i8, i8)
+                (rust_u8, js_u8, u8)
+                (rust_i16, js_i16, i16)
+                (rust_u16, js_u16, u16)
+                (rust_i32, js_i32, i32)
+                (rust_u32, js_u32, u32)
+                (rust_f32, js_f32, f32)
+                (rust_f64, js_f64, f64)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            function foo(a: any) {
+                assert.strictEqual(a.length, 3);
+                assert.strictEqual(a[0], 1);
+                assert.strictEqual(a[1], 2);
+                a[0] = 4;
+                a[1] = 5;
+            }
+
+            export const js_i8 = foo;
+            export const js_u8 = foo;
+            export const js_i16 = foo;
+            export const js_u16 = foo;
+            export const js_i32 = foo;
+            export const js_u32 = foo;
+            export const js_f32 = foo;
+            export const js_f64 = foo;
+
+            export function test() {
+                wasm.run();
+            }
+        "#)
+        .test();
+}
+
+#[test]
+fn import_mut_realloc_middle() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            macro_rules! doit {
+                ($(($rust:ident, $js:ident, $i:ident))*) => (
+                    $(
+                        #[wasm_bindgen(module = "./test")]
+                        extern {
+                            fn $js(a: &mut [$i]);
+                        }
+
+                        fn $rust() {
+                            let mut buf = [
+                                1 as $i,
+                                2 as $i,
+                                3 as $i,
+                            ];
+                            $js(&mut buf);
+                            assert_eq!(buf[0], 4 as $i);
+                            assert_eq!(buf[1], 5 as $i);
+                            assert_eq!(buf[2], 3 as $i);
+                        }
+                    )*
+
+                    #[wasm_bindgen]
+                    pub fn run() {
+                        $($rust();)*
+                    }
+
+                    #[wasm_bindgen]
+                    pub fn allocate() {
+                        std::mem::forget(Vec::<u8>::with_capacity(128 * 1024));
+                    }
+                )
+            }
+
+
+            doit! {
+                (rust_i8, js_i8, i8)
+                (rust_u8, js_u8, u8)
+                (rust_i16, js_i16, i16)
+                (rust_u16, js_u16, u16)
+                (rust_i32, js_i32, i32)
+                (rust_u32, js_u32, u32)
+                (rust_f32, js_f32, f32)
+                (rust_f64, js_f64, f64)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            function foo(a: any) {
+                wasm.allocate();
+                assert.strictEqual(a.length, 3);
+                assert.strictEqual(a[0], 1);
+                assert.strictEqual(a[1], 2);
+                a[0] = 4;
+                a[1] = 5;
+            }
+
+            export const js_i8 = foo;
+            export const js_u8 = foo;
+            export const js_i16 = foo;
+            export const js_u16 = foo;
+            export const js_i32 = foo;
+            export const js_u32 = foo;
+            export const js_f32 = foo;
+            export const js_f64 = foo;
+
+            export function test() {
+                wasm.run();
+            }
+        "#)
+        .test();
+}
+
+#[test]
+fn export_mut() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            macro_rules! doit {
+                ($($i:ident)*) => ($(
+                    #[wasm_bindgen]
+                    pub fn $i(a: &mut [$i])  {
+                        assert_eq!(a.len(), 3);
+                        assert_eq!(a[0], 1 as $i);
+                        assert_eq!(a[1], 2 as $i);
+                        assert_eq!(a[2], 3 as $i);
+                        a[0] = 4 as $i;
+                        a[1] = 5 as $i;
+                    }
+                )*)
+            }
+
+
+            doit! { i8 u8 i16 u16 i32 u32 f32 f64 }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            function run(a: any, rust: any) {
+                assert.strictEqual(a.length, 3);
+                a[0] = 1;
+                a[1] = 2;
+                a[2] = 3;
+                console.log(a);
+                rust(a);
+                console.log(a);
+                assert.strictEqual(a.length, 3);
+                assert.strictEqual(a[0], 4);
+                assert.strictEqual(a[1], 5);
+                assert.strictEqual(a[2], 3);
+            }
+
+            export function test() {
+                run(new Int8Array(3), wasm.i8);
+                run(new Uint8Array(3), wasm.u8);
+                run(new Int16Array(3), wasm.i16);
+                run(new Uint16Array(3), wasm.u16);
+                run(new Int32Array(3), wasm.i32);
+                run(new Uint32Array(3), wasm.u32);
+                run(new Float32Array(3), wasm.f32);
+                run(new Float64Array(3), wasm.f64);
+          }
+      "#)
+        .test();
+}
+


### PR DESCRIPTION
This commit adds support for mutable slices to pass the boundary between JS and
Rust. While mutable slices cannot be used as return values they can be listed as
arguments to both exported functions as well as imported functions.

When passing a mutable slice into a Rust function (aka having it as an argument
to an exported Rust function) then like before with a normal slice it's copied
into the wasm memory. Afterwards, however, the updates in the wasm memory will
be reflected back into the original slice. This does require a lot of copying
and probably isn't the most efficient, but it should at least work for the time
being.

The real nifty part happens when Rust passes a mutable slice out to JS. When
doing this it's a very cheap operation that just gets a subarray of the main
wasm memory. Now the wasm memory's buffer can change over time which can produce
surprising results where memory is modified in JS but it may not be reflected
back into Rust. To accomodate this when a JS imported function returns any
updates to the buffer are copied back to Rust if Rust's memory buffer has
changed in the meantime.

Along the way this fixes usage of `slice` to instead use `subarray` as that's
what we really want, no copying. All methods have been updated to use `subarray`
accessors instead of `slice` or constructing new arrays.

Closes #53