### PR TITLE
Don't use the global stack for string lengths

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1318,21 +1318,6 @@ impl<'a> Context<'a> {
         }
     }
 
-    fn expose_set_global_argument(&mut self) -> Result<(), Error> {
-        if !self.exposed_globals.insert("set_global_argument") {
-            return Ok(());
-        }
-        self.expose_uint32_memory();
-        self.expose_global_argument_ptr()?;
-        self.global("
-            function setGlobalArgument(arg, i) {
-                const idx = globalArgumentPtr() / 4 + i;
-                getUint32Memory()[idx] = arg;
-            }
-        ");
-        Ok(())
-    }
-
     fn expose_get_global_argument(&mut self) -> Result<(), Error> {
         if !self.exposed_globals.insert("get_global_argument") {
             return Ok(());

--- a/tests/all/imports.rs
+++ b/tests/all/imports.rs
@@ -114,6 +114,40 @@ fn unused() {
 }
 
 #[test]
+fn string_ret() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen(module = "./test")]
+            extern {
+                fn foo() -> String;
+            }
+
+            #[wasm_bindgen]
+            pub fn run() {
+                assert_eq!(foo(), "bar");
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as wasm from "./out";
+
+            export function foo(): string {
+                return 'bar';
+            }
+
+            export function test() {
+                wasm.run();
+            }
+        "#)
+        .test();
+}
+
+#[test]
 fn strings() {
     project()
         .file("src/lib.rs", r#"


### PR DESCRIPTION
This commit updates the `Abi` associated type for all slice types to a
`WasmSlice` type, an aggregate of two `u32` integers. This translates to an ABI
where when passed as a function argument it expands to two integer arguments,
and when passed as a return value it passes a return pointer as the first
argument to get filled in.

This is hopefully more forwards-compatible with the host bindings proposal which
uses this strategy for passing string arguments at least. It's a little sketchy
what we're doing as there's not really a stable ABI yet, but hopefully this'll
all be relatively stable for awhile!