### PR TITLE
Map u64/i64 to BigInt in JS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
       DEPLOY: 1
 
 install:
-  - ps: Install-Product node 9
+  - ps: Install-Product node 10
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain nightly
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
 install:
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
   - source ~/.nvm/nvm.sh
-  - nvm install 9
+  - nvm install 10
   - yarn
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ All structs referenced through arguments to functions should be defined in the
 macro itself. Arguments allowed implement the `WasmBoundary` trait, and examples
 are:
 
-* Integers (not u64/i64)
+* Integers (u64/i64 require `BigInt` support)
 * Floats
 * Borrowed strings (`&str`)
 * Owned strings (`String`)

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -79,6 +79,8 @@ pub enum VectorKind {
     U16,
     I32,
     U32,
+    I64,
+    U64,
     F32,
     F64,
     String,
@@ -139,12 +141,18 @@ impl Descriptor {
             Descriptor::U16 |
             Descriptor::I32 |
             Descriptor::U32 |
-            Descriptor::I64 |
-            Descriptor::U64 |
             Descriptor::F32 |
             Descriptor::F64 |
             Descriptor::Enum => true,
             _ => return false,
+        }
+    }
+
+    pub fn get_64bit(&self) -> Option<bool> {
+        match *self {
+            Descriptor::I64 => Some(true),
+            Descriptor::U64 => Some(false),
+            _ => None,
         }
     }
 
@@ -199,9 +207,11 @@ impl Descriptor {
             Descriptor::I8 => Some(VectorKind::I8),
             Descriptor::I16 => Some(VectorKind::I16),
             Descriptor::I32 => Some(VectorKind::I32),
+            Descriptor::I64 => Some(VectorKind::I64),
             Descriptor::U8 => Some(VectorKind::U8),
             Descriptor::U16 => Some(VectorKind::U16),
             Descriptor::U32 => Some(VectorKind::U32),
+            Descriptor::U64 => Some(VectorKind::U64),
             Descriptor::F32 => Some(VectorKind::F32),
             Descriptor::F64 => Some(VectorKind::F64),
             Descriptor::Anyref => Some(VectorKind::Anyref),
@@ -290,6 +300,8 @@ impl VectorKind {
             VectorKind::U16 => "Uint16Array",
             VectorKind::I32 => "Int32Array",
             VectorKind::U32 => "Uint32Array",
+            VectorKind::I64 => "BigInt64Array",
+            VectorKind::U64 => "BigUint64Array",
             VectorKind::F32 => "Float32Array",
             VectorKind::F64 => "Float64Array",
             VectorKind::Anyref => "any[]",
@@ -305,6 +317,8 @@ impl VectorKind {
             VectorKind::U16 => 2,
             VectorKind::I32 => 4,
             VectorKind::U32 => 4,
+            VectorKind::I64 => 8,
+            VectorKind::U64 => 8,
             VectorKind::F32 => 4,
             VectorKind::F64 => 8,
             VectorKind::Anyref => 4,

--- a/tests/all/u64.rs
+++ b/tests/all/u64.rs
@@ -1,0 +1,100 @@
+use super::project;
+
+#[test]
+fn works() {
+    project()
+        .requires_bigint()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen(module = "./test")]
+            extern {
+                fn js_i64_round(a: i64) -> i64;
+                fn js_u64_round(a: u64) -> u64;
+            }
+
+            #[wasm_bindgen]
+            pub fn zero() -> u64 { 0 }
+            #[wasm_bindgen]
+            pub fn one() -> u64 { 1 }
+            #[wasm_bindgen]
+            pub fn neg_one() -> i64 { -1 }
+            #[wasm_bindgen]
+            pub fn u32_max() -> u64 { u32::max_value() as u64 }
+            #[wasm_bindgen]
+            pub fn i32_min() -> i64 { i32::min_value() as i64 }
+            #[wasm_bindgen]
+            pub fn u64_max() -> u64 { u64::max_value() }
+            #[wasm_bindgen]
+            pub fn i64_min() -> i64 { i64::min_value() }
+
+            #[wasm_bindgen]
+            pub fn i64_round(a: i64) -> i64 { js_i64_round(a) }
+            #[wasm_bindgen]
+            pub fn u64_round(a: u64) -> u64 { js_u64_round(a) }
+
+            #[wasm_bindgen]
+            pub fn i64_slice(a: &[i64]) -> Vec<i64> { a.to_vec() }
+
+            #[wasm_bindgen]
+            pub fn u64_slice(a: &[u64]) -> Vec<u64> { a.to_vec() }
+        "#)
+        .file("test.js", r#"
+            import * as wasm from './out';
+
+            function assertEq(a, b) {
+              console.log(a, '?=', b);
+              if (a === b)
+                return;
+              throw new Error('not equal');
+            }
+
+            function assertArrayEq(a, b) {
+              console.log(a, '?=', b);
+              if (a.length !== b.length)
+                throw new Error('not equal');
+              for (let i = 0; i < a.length; i++)
+                assertEq(a[i], b[i]);
+            }
+
+            export function test() {
+              assertEq(wasm.zero(), BigInt(0));
+              assertEq(wasm.one(), BigInt(1));
+              assertEq(wasm.neg_one(), BigInt(-1));
+              assertEq(wasm.u32_max(), BigInt(4294967295));
+              assertEq(wasm.i32_min(), BigInt(-2147483648));
+              assertEq(wasm.u64_max(), BigInt('18446744073709551615'));
+              assertEq(wasm.i64_min(), BigInt('-9223372036854775808'));
+
+              assertEq(wasm.i64_round(BigInt(0)), BigInt(0));
+              assertEq(wasm.i64_round(BigInt(1)), BigInt(1));
+              assertEq(wasm.i64_round(BigInt(-1)), BigInt(-1));
+              assertEq(wasm.u64_round(BigInt(0)), BigInt(0));
+              assertEq(wasm.u64_round(BigInt(1)), BigInt(1));
+              assertEq(wasm.u64_round(BigInt(1) << BigInt(64)), BigInt(0));
+
+              const u64_max = BigInt('18446744073709551615');
+              const i64_min = BigInt('-9223372036854775808');
+              assertEq(wasm.i64_round(i64_min), i64_min);
+              assertEq(wasm.u64_round(u64_max), u64_max);
+
+              assertArrayEq(wasm.u64_slice([]), new BigUint64Array());
+              assertArrayEq(wasm.i64_slice([]), new BigInt64Array());
+              const arr1 = new BigUint64Array([BigInt(1), BigInt(2)]);
+              assertArrayEq(wasm.u64_slice([BigInt(1), BigInt(2)]), arr1);
+              const arr2 = new BigInt64Array([BigInt(1), BigInt(2)]);
+              assertArrayEq(wasm.i64_slice([BigInt(1), BigInt(2)]), arr2);
+
+              assertArrayEq(wasm.i64_slice([i64_min]), new BigInt64Array([i64_min]));
+              assertArrayEq(wasm.u64_slice([u64_max]), new BigUint64Array([u64_max]));
+            }
+
+            export function js_i64_round(a) { return a; }
+            export function js_u64_round(a) { return a; }
+        "#)
+        .test();
+}


### PR DESCRIPTION
This commit is an implementation of mapping u64/i64 to `BigInt` in JS through
the unstable BigInt APIs. The BigInt type will ship soon in Chrome and so this
commit builds out the necessary support for wasm-bindgen to use it!

Closes https://github.com/rustwasm/wasm-bindgen/issues/35