### PR TITLE
Optimize JsValue::{from_bool, undefined, null} constructors

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -690,17 +690,23 @@ impl<'a> Context<'a> {
         if !self.exposed_globals.insert("slab") {
             return;
         }
-        self.global(&format!("let slab = [];"));
+        let initial_values = [
+            "{ obj: null }",
+            "{ obj: undefined }",
+            "{ obj: true }",
+            "{ obj: false }",
+        ];
+        self.global(&format!("let slab = [{}];", initial_values.join(", ")));
         if self.config.debug {
-            self.export("assertSlabEmpty", "
-                function() {
-                    for (let i = 0; i < slab.length; i++) {
+            self.export("assertSlabEmpty", &format!("
+                function() {{
+                    for (let i = {}; i < slab.length; i++) {{
                         if (typeof(slab[i]) === 'number')
                             continue;
                         throw new Error('slab is not currently empty');
-                    }
-                }
-            ");
+                    }}
+                }}
+            ", initial_values.len()));
         }
     }
 
@@ -708,8 +714,9 @@ impl<'a> Context<'a> {
         if !self.exposed_globals.insert("slab_next") {
             return;
         }
+        self.expose_global_slab();
         self.global(&format!("
-            let slab_next = 0;
+            let slab_next = slab.length;
         "));
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2717,8 +2717,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2739,14 +2738,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2761,20 +2758,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2891,8 +2885,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2904,7 +2897,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2919,7 +2911,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2927,14 +2918,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2953,7 +2942,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3034,8 +3022,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3047,7 +3034,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3133,8 +3119,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3170,7 +3155,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3190,7 +3174,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3234,14 +3217,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },


### PR DESCRIPTION
This commit optimizes constructing an instance of `JsValue` which is one of
`null`, `undefined`, `true`, or `false`. These are commonly created on the Rust
side of things and since there's only a limited set of values we can easily
prepopulate the global slab with a few entries and use hardcoded indices to
refer to these constants. This should avoid the need to travel into JS to insert
a `null` or and `undefined` into the global slab.