### PR TITLE
webidl: add features necessary to support Event.initEvent

### DIFF
--- a/crates/webidl/tests/expected/Event.rs
+++ b/crates/webidl/tests/expected/Event.rs
@@ -171,6 +171,59 @@ impl Event {
         );
     }
 }
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "C" fn __wbindgen_describe___wbg_f_initEvent_initEvent_Event() {
+    use wasm_bindgen::describe::*;
+    inform(FUNCTION);
+    inform(4u32);
+    <&Event as WasmDescribe>::describe();
+    <&str as WasmDescribe>::describe();
+    <bool as WasmDescribe>::describe();
+    <bool as WasmDescribe>::describe();
+    inform(0);
+}
+impl Event {
+    #[allow(bad_style)]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+    pub extern "C" fn initEvent(&self, type_: &str, bubbles: bool, cancelable: bool) {
+        ::wasm_bindgen::__rt::link_this_library();
+        #[wasm_import_module = "__wbindgen_placeholder__"]
+        extern "C" {
+            fn __wbg_f_initEvent_initEvent_Event(
+                self_: <&Event as ::wasm_bindgen::convert::IntoWasmAbi>::Abi,
+                type_: <&str as ::wasm_bindgen::convert::IntoWasmAbi>::Abi,
+                bubbles: <bool as ::wasm_bindgen::convert::IntoWasmAbi>::Abi,
+                cancelable: <bool as ::wasm_bindgen::convert::IntoWasmAbi>::Abi,
+            ) -> ();
+        }
+        unsafe {
+            let _ret = {
+                let mut __stack = ::wasm_bindgen::convert::GlobalStack::new();
+                let self_ =
+                    <&Event as ::wasm_bindgen::convert::IntoWasmAbi>::into_abi(self, &mut __stack);
+                let type_ =
+                    <&str as ::wasm_bindgen::convert::IntoWasmAbi>::into_abi(type_, &mut __stack);
+                let bubbles =
+                    <bool as ::wasm_bindgen::convert::IntoWasmAbi>::into_abi(bubbles, &mut __stack);
+                let cancelable = <bool as ::wasm_bindgen::convert::IntoWasmAbi>::into_abi(
+                    cancelable,
+                    &mut __stack,
+                );
+                __wbg_f_initEvent_initEvent_Event(self_, type_, bubbles, cancelable)
+            };
+            ()
+        }
+    }
+    #[allow(bad_style, unused_variables)]
+    #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+    pub extern "C" fn initEvent(&self, type_: &str, bubbles: bool, cancelable: bool) {
+        panic!(
+            "cannot call wasm-bindgen imported functions on \
+             non-wasm targets"
+        );
+    }
+}
 #[allow(non_upper_case_globals)]
 #[wasm_custom_section = "__wasm_bindgen_unstable"]
 const __WASM_BINDGEN_GENERATED_wasm_bindgen_webidl_0_1_0_0 : [ u8 ; 180usize ] = * b"\xB0\0\0\0{\"exports\":[],\"enums\":[],\"imports\":[{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"type\"}}],\"structs\":[],\"version\":\"0.2.11 (3879f6f42)\",\"schema_version\":\"4\"}" ;


### PR DESCRIPTION
1. Adds support for binding `DOMString` arguments to `&str`.

2. Ignore whether an argument is optional, and just always emit bindings for it.