### PR TITLE
Add missing docs to make cargo test work

### DIFF
--- a/guide/src/contributing.md
+++ b/guide/src/contributing.md
@@ -9,6 +9,7 @@ development.
 
     ```shell
     rustup default nightly
+    rustup target add wasm32-unknown-unknown
     ```
 
 [install Rust]: https://www.rust-lang.org/en-US/install.html


### PR DESCRIPTION
When I was trying to make cargo test work, I discovered that wasm32-unknown-unknown is necessary to make the test compile properly. 

So I've added that to the documentation. 