### PR TITLE
attempts to implement Promise constructor

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -16,6 +16,7 @@
 //! example, `decodeURI` in JavaScript is exposed as `decode_uri` in these
 //! bindings.
 
+use closure::*;
 use wasm_bindgen_macro::*;
 use JsValue;
 if_std! {
@@ -85,4 +86,22 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
     #[wasm_bindgen(method, js_name = hasOwnProperty)]
     pub fn has_own_property(this: &Object, property: &str) -> bool;
+}
+
+// Promise.
+#[wasm_bindgen]
+extern {
+    pub type Promise;
+
+    /// A Promise object is created using the new keyword and its constructor.
+    /// This constructor takes as its argument a function, called the "executor
+    /// function". This function should take two functions as parameters.
+    /// The first of these functions (resolve) is called when the asynchronous
+    /// task completes successfully and returns the results of the task as a value.
+    /// The second (reject) is called when the task fails, and returns the reason
+    /// for failure, which is typically an error object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+    #[wasm_bindgen(constructor)]
+    pub fn new(executor: &Closure<FnMut(Box<Fn(JsValue)>, Box<Fn(JsValue)>)>) -> Promise;
 }

--- a/tests/all/js_globals/Promise.rs
+++ b/tests/all/js_globals/Promise.rs
@@ -1,0 +1,30 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn new() {
+  project()
+    .file("src/lib.rs", r#"
+      #![feature(proc_macro, wasm_custom_section)]
+
+      extern crate wasm_bindgen;
+      use wasm_bindgen::prelude::*;
+      use wasm_bindgen::js;
+
+      #[wasm_bindgen]
+      pub fn new_promise() -> js::Promise {
+        let closure = Closure::new(|resolve, _reject| { resolve(42) });
+        js::Promise::new(&closure)
+      }
+    "#)
+    .file("test.ts", r#"
+      import * as assert from "assert";
+      import * as wasm from "./out";
+
+      export function test() {
+          assert.equal(wasm.new_promise() instanceof Promise, true);
+      }
+    "#)
+    .test();
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -3,6 +3,7 @@
 use super::project;
 
 mod Object;
+mod Promise;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
The closure-taking functions/constructors seem to be quite difficult to deal with; especially in `Promise` constructor, where a closure takes a form of:
```js
new Promise( /* executor */ function(resolve, reject) { ... } );
```
where `resolve` and `reject` are callable.