### PR TITLE
Non closure array bindings

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -139,4 +139,10 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin
     #[wasm_bindgen(method, js_name = copyWithin)]
     pub fn copy_within(this: &Array, target: i32, start: i32, end: i32) -> Array;
+
+    /// The pop() method removes the last element from an array and returns that element. This method changes the length of the array.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop
+    #[wasm_bindgen(method)]
+    pub fn pop(this: &Array) -> JsValue;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -126,4 +126,11 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
     #[wasm_bindgen(method)]
     pub fn slice(this: &Array, start: u32, end: u32) -> Array;
+
+    /// The fill() method fills all the elements of an array from a start index to an end index with a static value.
+    /// The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Array, value: JsValue, start: u32, end: u32) -> Array;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -118,4 +118,12 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
     #[wasm_bindgen(method)]
     pub fn join(this: &Array, delimiter: &str) -> String;
+
+    /// The slice() method returns a shallow copy of a portion of an array into a new array
+    /// object selected from begin to end (end not included).
+    /// The original array will not be modified.
+    /// 
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
+    #[wasm_bindgen(method)]
+    pub fn slice(this: &Array, start: u32, end: u32) -> Array;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -171,4 +171,10 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift
     #[wasm_bindgen(method)]
     pub fn unshift(this: &Array, value: JsValue) -> u32;
+
+    /// The toString() method returns a string representing the specified array and its elements.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
+    #[wasm_bindgen(method, js_name = toString)]
+    pub fn to_string(this: &Array) -> String;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -158,4 +158,11 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse
     #[wasm_bindgen(method)]
     pub fn reverse(this: &Array) -> Array;
+
+    /// The shift() method removes the first element from an array and returns that removed element.
+    /// This method changes the length of the array.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift
+    #[wasm_bindgen(method)]
+    pub fn shift(this: &Array) -> JsValue;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -165,4 +165,10 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift
     #[wasm_bindgen(method)]
     pub fn shift(this: &Array) -> JsValue;
+
+    /// The unshift() method adds one or more elements to the beginning of an array and returns the new length of the array.
+    /// 
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift
+    #[wasm_bindgen(method)]
+    pub fn unshift(this: &Array, value: JsValue) -> u32;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -145,4 +145,10 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop
     #[wasm_bindgen(method)]
     pub fn pop(this: &Array) -> JsValue;
+
+    /// The push() method adds one or more elements to the end of an array and returns the new length of the array.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push
+    #[wasm_bindgen(method)]
+    pub fn push(this: &Array, value: JsValue) -> u32;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -112,4 +112,10 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
     #[wasm_bindgen(method, js_name = lastIndexOf)]
     pub fn last_index_of(this: &Array, value: JsValue, from_index: i32) -> i32;
+
+    /// The join() method joins all elements of an array (or an array-like object) into a string and returns this string.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
+    #[wasm_bindgen(method)]
+    pub fn join(this: &Array, delimiter: &str) -> String;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -151,4 +151,11 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push
     #[wasm_bindgen(method)]
     pub fn push(this: &Array, value: JsValue) -> u32;
+
+    /// The reverse() method reverses an array in place.
+    /// The first array element becomes the last, and the last array element becomes the first.
+    /// 
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse
+    #[wasm_bindgen(method)]
+    pub fn reverse(this: &Array) -> Array;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -105,4 +105,11 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
     #[wasm_bindgen(method, js_name = indexOf)]
     pub fn index_of(this: &Array, value: JsValue, from_index: i32) -> i32;
+
+    /// The lastIndexOf() method returns the last index at which a given element can be found in the array, or -1 if it is not present.
+    /// The array is searched backwards, starting at fromIndex.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf
+    #[wasm_bindgen(method, js_name = lastIndexOf)]
+    pub fn last_index_of(this: &Array, value: JsValue, from_index: i32) -> i32;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -94,3 +94,15 @@ extern {
 
 
 }
+
+// Array
+#[wasm_bindgen]
+extern {
+    pub type Array;
+
+    /// The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
+    #[wasm_bindgen(method, js_name = indexOf)]
+    pub fn index_of(this: &Array, value: JsValue, from_index: i32) -> i32;
+}

--- a/src/js.rs
+++ b/src/js.rs
@@ -177,4 +177,11 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
     #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(this: &Array) -> String;
+
+    /// The includes() method determines whether an array includes a certain element, returning true or false as appropriate.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
+    #[wasm_bindgen(method)]
+    pub fn includes(this: &Array, value: JsValue, from_index: i32) -> bool;
+
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -133,4 +133,10 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
     #[wasm_bindgen(method)]
     pub fn fill(this: &Array, value: JsValue, start: u32, end: u32) -> Array;
+
+    /// The copyWithin() method shallow copies part of an array to another location in the same array and returns it, without modifying its size.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin
+    #[wasm_bindgen(method, js_name = copyWithin)]
+    pub fn copy_within(this: &Array, target: i32, start: i32, end: i32) -> Array;
 }

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -77,3 +77,35 @@ fn last_index_of() {
         "#)
         .test()
 }
+
+#[test]
+fn join() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn join_array(this: &js::Array, delimiter: &str) -> String {
+                this.join(delimiter)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = ["a", "c", "x", "n"];
+                let stringValue = wasm.join_array(characters, ", ");
+
+                assert.equal("a, c, x, n", stringValue);
+                let withForwardSlash = wasm.join_array(characters, "/");
+                assert.equal("a/c/x/n", withForwardSlash);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -294,3 +294,34 @@ fn reverse() {
         "#)
         .test()
 }
+
+#[test]
+fn shift() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn shift_item(this: &js::Array) -> JsValue {
+                this.shift()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let shiftedItem = wasm.shift_item(characters);
+
+                assert.equal(shiftedItem, 8);
+                assert.equal(characters.length, 5);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -1,0 +1,41 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn index_of() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn get_index_of(this: &js::Array, value: JsValue, from_index: i32) -> i32 {
+                this.index_of(value, from_index)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = ["a", "c", "x", "n"];
+                let index = wasm.get_index_of(characters, "x", 0);
+                let notFoundIndex = wasm.get_index_of(characters, "z", 0);
+
+                assert.equal(index, 2);
+                assert.equal(notFoundIndex, -1);
+
+                let withFromIndex = wasm.get_index_of(characters, "x", -3);
+                let withFromIndexNotFound = wasm.get_index_of(characters, "a", -2);
+
+                assert.equal(withFromIndex, 2);
+                assert.equal(withFromIndexNotFound, -1);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -264,3 +264,33 @@ fn push() {
         "#)
         .test()
 }
+
+#[test]
+fn reverse() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn reverse_array(this: &js::Array) -> js::Array {
+                this.reverse()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let reversed = wasm.reverse_array(characters);
+                assert.equal(reversed[0], 2);
+                assert.equal(reversed[5], 8);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -386,3 +386,39 @@ fn to_string() {
         "#)
         .test()
 }
+
+
+#[test]
+fn includes() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn array_includes(this: &js::Array, value: JsValue, from_index: i32) -> bool {
+                this.includes(value, from_index)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let isTwoIncluded = wasm.array_includes(characters, 2, 0);
+                let isNineIncluded = wasm.array_includes(characters, 9, 0);
+
+                assert.ok(isTwoIncluded);
+                assert.ok(!isNineIncluded);
+
+                let isThreeIncluded = wasm.array_includes(characters, 3, 4);
+                assert.ok(!isThreeIncluded);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -39,3 +39,41 @@ fn index_of() {
         "#)
         .test()
 }
+
+#[test]
+fn last_index_of() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn get_last_index_of(this: &js::Array, value: JsValue, from_index: i32) -> i32 {
+                this.last_index_of(value, from_index)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = ["a", "x", "c", "x", "n"];
+                let index = wasm.get_last_index_of(characters, "x", 5);
+                let notFoundIndex = wasm.get_last_index_of(characters, "z", 5);
+
+                assert.equal(index, 3);
+                assert.equal(notFoundIndex, -1);
+
+                let withFromIndex = wasm.get_last_index_of(characters, "x", 2);
+                let withFromIndexNotFound = wasm.get_last_index_of(characters, "x", 0);
+
+                assert.equal(withFromIndex, 1);
+                assert.equal(withFromIndexNotFound, -1);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -203,3 +203,33 @@ fn copy_within() {
         "#)
         .test()
 }
+
+#[test]
+fn pop() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn pop_in_it(this: &js::Array) -> JsValue {
+                this.pop()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let item = wasm.pop_in_it(characters);
+                assert.equal(item, 2);
+                assert.equal(characters.length, 5);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -139,3 +139,33 @@ fn slice() {
         "#)
         .test()
 }
+
+#[test]
+fn fill() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn fill_with(this: &js::Array, value: JsValue, start: u32, end: u32) -> js::Array {
+                this.fill(value, start, end)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = ["a", "c", "x", "n", 1, "8"];
+                let subset = wasm.fill_with(characters, 0, 0, 3);
+
+                assert.equal(subset[0], 0);
+                assert.equal(subset[4], 1);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -109,3 +109,33 @@ fn join() {
         "#)
         .test()
 }
+
+#[test]
+fn slice() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn create_slice(this: &js::Array, start: u32, end: u32) -> js::Array {
+                this.slice(start, end)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = ["a", "c", "x", "n", 1, "8"];
+                let subset = wasm.create_slice(characters, 1, 3);
+
+                assert.equal(subset[0], "c");
+                assert.equal(subset[1], "x");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -325,3 +325,34 @@ fn shift() {
         "#)
         .test()
 }
+
+#[test]
+fn unshift() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn unshift_item(this: &js::Array, value: JsValue) -> u32 {
+                this.unshift(value)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let length = wasm.unshift_item(characters, "abba");
+
+                assert.equal(length, 7);
+                assert.equal(characters[0], "abba");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -356,3 +356,33 @@ fn unshift() {
         "#)
         .test()
 }
+
+#[test]
+fn to_string() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn array_to_string(this: &js::Array) -> String {
+                this.to_string()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let arrayString = wasm.array_to_string(characters);
+
+                assert.equal(arrayString, "8,5,4,3,1,2");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -233,3 +233,34 @@ fn pop() {
         "#)
         .test()
 }
+
+
+#[test]
+fn push() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn push_it_along(this: &js::Array, value: JsValue) -> u32 {
+                this.push(value)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let length = wasm.push_it_along(characters, "a");
+                assert.equal(length, 7);
+                assert.equal(characters[6], "a");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -169,3 +169,37 @@ fn fill() {
         "#)
         .test()
 }
+
+#[test]
+fn copy_within() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn copy_values_within_array(this: &js::Array, target: i32, start: i32, end: i32) -> js::Array {
+                this.copy_within(target, start, end)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                wasm.copy_values_within_array(characters, 1, 4, 5);
+
+                assert.equal(characters[1], 1);
+
+                // if negatives were used
+                wasm.copy_values_within_array(characters, -1, -3, -2);
+                assert.equal(characters[5], 3);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -3,6 +3,7 @@
 use super::project;
 
 mod Object;
+mod Array;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
Here's a few of `Array` for today. I tried to include `toSource` but it's not implemented in any browser except Firefox and I assume there aren't any typescript declarations for it either.

I'll continue working on some more non-closure related items in the checklist - as much as I would love to figure the callback issue out, I'll wait until the rest is done first. Please let me know if there's anything I can do to enhance the tests or got the signatures wrong (or add a missing test - pretty sure I got them all). 

And please note that I decided to go with including all optional arguments for those that had them. Never knew that `indexOf` allows you to look in reverse.