### PR TITLE
Add basic support for String.prototype.char_at()

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -190,3 +190,15 @@ extern {
     pub fn includes(this: &Array, value: JsValue, from_index: i32) -> bool;
 
 }
+
+// String
+#[wasm_bindgen]
+extern {
+    pub type String;
+
+    /// The String object's charAt() method returns a new string consisting of the single UTF-16 code unit located at the specified offset into the string.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt
+    #[wasm_bindgen(method, js_name = charAt)]
+    pub fn char_at(this: &String, index: i32) -> String;
+}

--- a/tests/all/js_globals/String.rs
+++ b/tests/all/js_globals/String.rs
@@ -1,0 +1,32 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn char_at() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn string_char_at(string: &js::String, index: i32) -> js::String {
+                string.char_at(index)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            var anyString = 'Brave new world';
+
+            export function test() {
+                assert.equal(wasm.string_char_at(anyString, 0), "B");
+                assert.equal(wasm.string_char_at(anyString, 999), "");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -4,6 +4,7 @@ use super::project;
 
 mod Object;
 mod Array;
+mod String;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
I really would love to get some feedback.
Also one question I couldn't answer myself - what about optional parameters?
`char_at()` has index, which by default should be 0, but in Rust there is no way to do it and I am not quite sure I understand the `wasn-bindgen` enough for that. Also some other implementations with optional value don't have it yet, e.g. `Array.prototype.includes()`

I hope I can fully finish this PR.

PS: Currently the Array and Object are not in Alphabetical order as in the Guidelines.