### PR TITLE
allows using &JsValue as an arg to Object's has_own_property

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -84,7 +84,7 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
     #[wasm_bindgen(method, js_name = hasOwnProperty)]
-    pub fn has_own_property(this: &Object, property: &str) -> bool;
+    pub fn has_own_property(this: &Object, property: &JsValue) -> bool;
 
     /// The toString() method returns a string representing the object.
     ///

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -39,8 +39,8 @@ fn has_own_property() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn has_own_foo_property(obj: &js::Object) -> bool {
-                obj.has_own_property("foo")
+            pub fn has_own_foo_property(obj: &js::Object, property: &JsValue) -> bool {
+                obj.has_own_property(&property)
             }
         "#)
         .file("test.ts", r#"
@@ -48,8 +48,12 @@ fn has_own_property() {
             import * as wasm from "./out";
 
             export function test() {
-                assert.ok(wasm.has_own_foo_property({ foo: 42 }));
-                assert.ok(!wasm.has_own_foo_property({}));
+                assert(wasm.has_own_foo_property({ foo: 42 }, "foo"));
+                assert(wasm.has_own_foo_property({ 42: "foo" }, 42));
+                assert(!wasm.has_own_foo_property({ foo: 42 }, "bar"));
+
+                const s = Symbol();
+                assert(wasm.has_own_foo_property({ [s]: "foo" }, s));
             }
         "#)
         .test()


### PR DESCRIPTION
The binding for `Object`'s `has_own_property` should expect a property argument of type `&JsValue`. In JavaScript, a property can be of type `String`, `Number` and even `Symbol`. The previous implementation allowed `&str` only.