### PR TITLE
Implement Array.length binding

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -112,6 +112,13 @@ extern {
 extern {
     pub type Array;
 
+    /// The length property of an object which is an instance of type Array sets or returns the number of elements in that array.
+    /// The value is an unsigned, 32-bit integer that is always numerically greater than the highest index in the array.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length
+    #[wasm_bindgen(method, getter, structural)]
+    pub fn length(this: &Array) -> u32;
+
     /// The indexOf() method returns the first index at which a given element can be found in the array, or -1 if it is not present.
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -422,3 +422,37 @@ fn includes() {
         "#)
         .test()
 }
+
+
+#[test]
+fn length() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn array_length(this: &js::Array) -> u32 {
+                this.length()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+                let charactersLength = wasm.array_length(characters);
+                assert.equal(charactersLength, 6);
+
+                var empty : number[] = [];
+                let emptyLength = wasm.array_length(empty);
+                assert.equal(emptyLength, 0);
+            }
+        "#)
+        .test()
+}


### PR DESCRIPTION
Based on the example property in the **Design** section of the `wasm_bindgen` book, I reasoned that the `Array.length` property must be a `method, getter, structural`.

Also, I learned today that there is in fact a way to trigger an exception with `Array.length`.

```javascript
var namelistA = new Array(4294967296); //2 to the 32nd power = 4294967296 
var namelistC = new Array(-100) //negative sign

console.log(namelistA.length); //RangeError: Invalid array length 
console.log(namelistC.length); //RangeError: Invalid array length 
```

Should I account for this?

I played around with `catch` however it said `Result<u32, JsValue>` in not implemented for `IntoWasmAbi`. Should I implement this? I began to but didn't want to go overboard or do anything too ambitious for my first pr 😅 