### PR TITLE
add js_class attribute for defining what class an imported method is for

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -405,9 +405,11 @@ impl Program {
             };
             let class_name = extract_path_ident(class_name)
                 .expect("first argument of method must be a bare type");
+            let class_name = wasm.opts.js_class().map(Into::into)
+                .unwrap_or_else(|| class_name.to_string());
 
             ImportFunctionKind::Method {
-                class: class_name.to_string(),
+                class: class_name,
                 ty: class.clone(),
                 kind: MethodKind::Normal,
             }
@@ -947,6 +949,16 @@ impl BindgenAttrs {
             })
             .next()
     }
+
+    fn js_class(&self) -> Option<&str> {
+        self.attrs
+            .iter()
+            .filter_map(|a| match a {
+                BindgenAttr::JsClass(s) => Some(&s[..]),
+                _ => None,
+            })
+            .next()
+    }
 }
 
 impl syn::synom::Synom for BindgenAttrs {
@@ -977,6 +989,7 @@ pub enum BindgenAttr {
     Structural,
     Readonly,
     JsName(Ident),
+    JsClass(String),
 }
 
 impl syn::synom::Synom for BindgenAttr {
@@ -1038,6 +1051,13 @@ impl syn::synom::Synom for BindgenAttr {
             ns: call!(term2ident) >>
             (ns)
         )=> { BindgenAttr::JsName }
+        |
+        do_parse!(
+            call!(term, "js_class") >>
+            punct!(=) >>
+            s: syn!(syn::LitStr) >>
+            (s.value())
+        )=> { BindgenAttr::JsClass }
     ));
 }
 

--- a/src/js.rs
+++ b/src/js.rs
@@ -255,3 +255,17 @@ extern {
     #[wasm_bindgen(method, js_name = propertyIsEnumerable)]
     pub fn property_is_enumerable(this: &Object, property: &JsValue) -> bool;
 }
+
+// String
+#[wasm_bindgen]
+extern {
+    #[wasm_bindgen(js_name = String)]
+    pub type JsString;
+
+    /// The slice() method extracts a section of a string and returns it as a
+    /// new string, without modifying the original string.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
+    #[wasm_bindgen(method, js_class = "String")]
+    pub fn slice(this: &JsString, start: u32, end: u32) -> JsString;
+}

--- a/tests/all/js_globals/JsString.rs
+++ b/tests/all/js_globals/JsString.rs
@@ -1,0 +1,32 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn slice() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn create_slice(this: &js::JsString, start: u32, end: u32) -> js::JsString {
+                this.slice(start, end)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = "acxn18";
+                let subset = wasm.create_slice(characters, 1, 3);
+
+                assert.equal(subset, "cx");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -5,6 +5,7 @@ use super::project;
 mod Object;
 mod Array;
 mod ArrayIterator;
+mod JsString;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
Allows this to work:

```rust
#[wasm_bindgen]
extern {
    #[wasm_bindgen(js_name = String)]
    pub type JsString;

    #[wasm_bindgen(method, js_class = "String")] // <-- here
    pub fn slice(this: &JsString, start: u32, end: u32) -> JsString;
}


#[wasm_bindgen]
pub fn f(x: JsString) -> JsString {
    x.slice(1, 3)
}
```