### PR TITLE
Attribute for static methods

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -813,7 +813,7 @@ impl Struct {
                     ty: field.ty.clone(),
                     getter: Ident::new(&getter, Span::call_site()),
                     setter: Ident::new(&setter, Span::call_site()),
-                    comments
+                    comments,
                 });
             }
         }
@@ -912,7 +912,7 @@ impl BindgenAttrs {
             .iter()
             .filter_map(|a| match a {
                 BindgenAttr::StaticMethodOf(c) => Some(c),
-                _ => None
+                _ => None,
             })
             .next()
     }

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -1,8 +1,8 @@
 use proc_macro2::{Ident, Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use shared;
-use std::iter::FromIterator;
 use syn;
+use util;
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 #[derive(Default)]
@@ -416,20 +416,7 @@ impl Program {
         } else if let Some(cls) = wasm.opts.static_method_of() {
             let class = cls.to_string();
             let kind = MethodKind::Static;
-
-            let segments = syn::punctuated::Punctuated::from_iter(Some(syn::PathSegment {
-                ident: cls.clone(),
-                arguments: syn::PathArguments::None,
-            }));
-
-            let ty = syn::Type::Path(syn::TypePath {
-                qself: None,
-                path: syn::Path {
-                    leading_colon: None,
-                    segments,
-                },
-            });
-
+            let ty = util::ident_ty(cls.clone());
             ImportFunctionKind::Method { class, ty, kind }
         } else if wasm.opts.constructor() {
             let class = match wasm.ret {

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -12,3 +12,4 @@ extern crate wasm_bindgen_shared as shared;
 
 pub mod ast;
 mod codegen;
+pub mod util;

--- a/crates/backend/src/util.rs
+++ b/crates/backend/src/util.rs
@@ -1,0 +1,69 @@
+use std::iter::FromIterator;
+
+use ast;
+use proc_macro2::{self, Ident};
+use syn;
+
+fn is_rust_keyword(name: &str) -> bool {
+    match name {
+        "abstract" | "alignof" | "as" | "become" | "box" | "break" | "const" | "continue"
+        | "crate" | "do" | "else" | "enum" | "extern" | "false" | "final" | "fn" | "for" | "if"
+        | "impl" | "in" | "let" | "loop" | "macro" | "match" | "mod" | "move" | "mut"
+        | "offsetof" | "override" | "priv" | "proc" | "pub" | "pure" | "ref" | "return"
+        | "Self" | "self" | "sizeof" | "static" | "struct" | "super" | "trait" | "true"
+        | "type" | "typeof" | "unsafe" | "unsized" | "use" | "virtual" | "where" | "while"
+        | "yield" | "bool" | "_" => true,
+        _ => false,
+    }
+}
+
+// Create an `Ident`, possibly mangling it if it conflicts with a Rust keyword.
+pub fn rust_ident(name: &str) -> Ident {
+    if is_rust_keyword(name) {
+        Ident::new(&format!("{}_", name), proc_macro2::Span::call_site())
+    } else {
+        raw_ident(name)
+    }
+}
+
+// Create an `Ident` without checking to see if it conflicts with a Rust
+// keyword.
+pub fn raw_ident(name: &str) -> Ident {
+    Ident::new(name, proc_macro2::Span::call_site())
+}
+
+/// Create a path type from the given segments. For example an iterator yielding
+/// the idents `[foo, bar, baz]` will result in the path type `foo::bar::baz`.
+pub fn simple_path_ty<I>(segments: I) -> syn::Type
+where
+    I: IntoIterator<Item = Ident>,
+{
+    let segments: Vec<_> = segments
+        .into_iter()
+        .map(|i| syn::PathSegment {
+            ident: i,
+            arguments: syn::PathArguments::None,
+        })
+        .collect();
+
+    syn::TypePath {
+        qself: None,
+        path: syn::Path {
+            leading_colon: None,
+            segments: syn::punctuated::Punctuated::from_iter(segments),
+        },
+    }.into()
+}
+
+pub fn ident_ty(ident: Ident) -> syn::Type {
+    simple_path_ty(Some(ident))
+}
+
+pub fn wrap_import_function(function: ast::ImportFunction) -> ast::Import {
+    ast::Import {
+        module: None,
+        version: None,
+        js_namespace: None,
+        kind: ast::ImportKind::Function(function),
+    }
+}

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -18,19 +18,19 @@ extern crate syn;
 extern crate wasm_bindgen_backend as backend;
 extern crate webidl;
 
+mod util;
+
 use std::fs;
 use std::io::{self, Read};
-use std::iter;
 use std::path::Path;
 
+use backend::util::{ident_ty, rust_ident, wrap_import_function};
 use failure::ResultExt;
 use quote::ToTokens;
 
-mod util;
-
 use util::{
-    create_basic_method, create_function, create_getter, create_setter, ident_ty, rust_ident,
-    webidl_ty_to_syn_ty, wrap_import_function, TypePosition,
+    create_basic_method, create_function, create_getter, create_setter, webidl_ty_to_syn_ty,
+    TypePosition,
 };
 
 /// Either `Ok(t)` or `Err(failure::Error)`.

--- a/src/js.rs
+++ b/src/js.rs
@@ -293,6 +293,13 @@ extern {
     #[wasm_bindgen(method, js_name = isPrototypeOf)]
     pub fn is_prototype_of(this: &Object, value: &JsValue) -> bool;
 
+    /// The Object.keys() method returns an array of a given object's property
+    /// names, in the same order as we get with a normal loop.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+    #[wasm_bindgen(static_method_of = Object)]
+    pub fn keys(object: &Object) -> Array;
+
     /// The Object constructor creates an object wrapper.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object

--- a/src/js.rs
+++ b/src/js.rs
@@ -278,12 +278,6 @@ extern {
 extern {
     pub type Object;
 
-    /// The Object constructor creates an object wrapper.
-    ///
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> Object;
-
     /// The `hasOwnProperty()` method returns a boolean indicating whether the
     /// object has the specified property as its own property (as opposed to
     /// inheriting it).
@@ -291,6 +285,26 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
     #[wasm_bindgen(method, js_name = hasOwnProperty)]
     pub fn has_own_property(this: &Object, property: &JsValue) -> bool;
+
+    /// The isPrototypeOf() method checks if an object exists in another
+    /// object's prototype chain.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf
+    #[wasm_bindgen(method, js_name = isPrototypeOf)]
+    pub fn is_prototype_of(this: &Object, value: &JsValue) -> bool;
+
+    /// The Object constructor creates an object wrapper.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Object;
+
+    /// The propertyIsEnumerable() method returns a Boolean indicating
+    /// whether the specified property is enumerable.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable
+    #[wasm_bindgen(method, js_name = propertyIsEnumerable)]
+    pub fn property_is_enumerable(this: &Object, property: &JsValue) -> bool;
 
     /// The toLocaleString() method returns a string representing the object.
     /// This method is meant to be overridden by derived objects for locale-specific
@@ -305,20 +319,6 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
     #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(this: &Object) -> JsString;
-
-    /// The isPrototypeOf() method checks if an object exists in another
-    /// object's prototype chain.
-    ///
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf
-    #[wasm_bindgen(method, js_name = isPrototypeOf)]
-    pub fn is_prototype_of(this: &Object, value: &JsValue) -> bool;
-
-    /// The propertyIsEnumerable() method returns a Boolean indicating
-    /// whether the specified property is enumerable.
-    ///
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable
-    #[wasm_bindgen(method, js_name = propertyIsEnumerable)]
-    pub fn property_is_enumerable(this: &Object, property: &JsValue) -> bool;
 
     /// The valueOf() method returns the primitive value of the
     /// specified object.

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -124,6 +124,33 @@ fn is_prototype_of() {
 }
 
 #[test]
+fn keys() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn keys(obj: &js::Object) -> js::Array {
+                js::Object::keys(obj)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const obj = { a: 1, b: 2, c: 3 };
+                assert.deepStrictEqual(wasm.keys(obj), ["a", "b", "c"]);
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn property_is_enumerable() {
     project()
         .file("src/lib.rs", r#"


### PR DESCRIPTION
This hooks up the existing support for static methods that @ohanar added for WebIDL to a `#[wasm_bindgen(static_method_of = Class)]` attribute, and implements bindings to `Object.keys` to exercise the code path during tests.