### PR TITLE
Adds valueOf and toString to Number

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -213,6 +213,13 @@ extern {
 extern {
     pub type Number;
 
+    /// The toLocaleString() method returns a string with a language sensitive
+    /// representation of this number.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
+    #[wasm_bindgen(method, js_name = toLocaleString)]
+    pub fn to_locale_string(this: &Number, locale: String) -> String;
+
     /// The toPrecision() method returns a string representing the Number
     /// object to the specified precision.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -213,6 +213,13 @@ extern {
 extern {
     pub type Number;
 
+    /// The toPrecision() method returns a string representing the Number
+    /// object to the specified precision.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision
+    #[wasm_bindgen(catch, method, js_name = toPrecision)]
+    pub fn to_precision(this: &Number, precision: u8) -> Result<String, JsValue>;
+
     /// The toString() method returns a string representing the
     /// specified Number object.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -208,6 +208,20 @@ extern {
     pub fn entries(this: &Array) -> ArrayIterator;
 }
 
+// Number.
+#[wasm_bindgen]
+extern {
+    pub type Number;
+
+    /// The valueOf() method returns the wrapped primitive value of
+    /// a Number object.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf
+    #[wasm_bindgen(method, js_name = valueOf)]
+    pub fn value_of(this: &Number) -> Number;
+
+}
+
 // Object.
 #[wasm_bindgen]
 extern {

--- a/src/js.rs
+++ b/src/js.rs
@@ -213,6 +213,13 @@ extern {
 extern {
     pub type Number;
 
+    /// The toString() method returns a string representing the
+    /// specified Number object.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString
+    #[wasm_bindgen(catch, method, js_name = toString)]
+    pub fn to_string(this: &Number, radix: u8) -> Result<String, JsValue>;
+
     /// The valueOf() method returns the wrapped primitive value of
     /// a Number object.
     ///

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -4,6 +4,40 @@ use super::project;
 
 
 #[test]
+fn to_string() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn to_string(this: &js::Number, radix: u8) -> String {
+                let result = this.to_string(radix);
+                let result = match result {
+                    Ok(num) => num,
+                    Err(_err) => "RangeError".to_string()
+                };
+                result
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let number = 42;
+                assert.equal(wasm.to_string(number, 10), "42");
+                assert.equal(wasm.to_string(233, 16), "e9");
+                assert.equal(wasm.to_string(number, 100), "RangeError");
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn value_of() {
     project()
         .file("src/lib.rs", r#"

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -1,0 +1,32 @@
+#![allow(non_snake_case)]
+
+use super::project;
+
+
+#[test]
+fn value_of() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn js_value_of(this: &js::Number) -> js::Number {
+                this.value_of()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let number = 42;
+                assert.equal(wasm.js_value_of(number), 42);
+                assert.equal(typeof wasm.js_value_of(number), "number");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -2,6 +2,37 @@
 
 use super::project;
 
+#[test]
+fn to_precision() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn to_precision(this: &js::Number, precision: u8) -> String {
+                let result = this.to_precision(precision);
+                let result = match result {
+                    Ok(num) => num,
+                    Err(_err) => "RangeError".to_string()
+                };
+                result
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.to_precision(0.1, 3), "0.100");
+                assert.equal(wasm.to_precision(10, 101), "RangeError");
+            }
+        "#)
+        .test()
+}
 
 #[test]
 fn to_string() {

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -2,6 +2,36 @@
 
 use super::project;
 
+
+#[test]
+fn to_locale_string() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn to_locale_string(this: &js::Number, locale: String) -> String {
+                this.to_locale_string(locale)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let number = 1234.45;
+                assert.equal(wasm.to_locale_string(number, "de-DE"), "1,234.45");
+                assert.equal(wasm.to_locale_string(number, "en-US"), "1,234.45");
+                assert.equal(wasm.to_locale_string(number, "zh-Hans-CN-u-nu-hanidec"), "1,234.45");
+            }
+        "#)
+        .test()
+}
+
 #[test]
 fn to_precision() {
     project()

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -6,6 +6,7 @@ mod Object;
 mod Array;
 mod ArrayIterator;
 mod JsString;
+mod Number;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
While doing this I saw that `Result<String, JsValue>` can't cross the javascript boundary. As it isn't described in wasmdescribe. Would it be desirable to ever have that described in wasmdescribe, or should you explicitly handle any errors in Rust code. 