### PR TITLE
Implement Array.prototype.filter and Array.prototype.find

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -188,6 +188,13 @@ extern {
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift
     #[wasm_bindgen(method)]
     pub fn unshift(this: &Array, value: JsValue) -> u32;
+
+    /// The filter() method creates a new array with all elements that pass the test implemented 
+    /// by the provided function.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
+    #[wasm_bindgen(method)]
+    pub fn filter(this: &Array, function: JsValue) -> Array;
 }
 
 // Array Iterator

--- a/src/js.rs
+++ b/src/js.rs
@@ -195,6 +195,14 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
     #[wasm_bindgen(method)]
     pub fn filter(this: &Array, function: JsValue) -> Array;
+
+    /// The find() method returns the value of the first element in the array that satisfies the
+    /// provided testing function. Otherwise undefined is returned.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+    #[wasm_bindgen(method)]
+    pub fn find(this: &Array, function: JsValue) -> JsValue;
+
 }
 
 // Array Iterator

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -516,3 +516,43 @@ fn length() {
         "#)
         .test()
 }
+
+#[test]
+fn filter() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn array_filter(this: &js::Array, function: JsValue) -> js::Array {
+                this.filter(function)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+
+                // filters by element
+                let filteredArray1 = wasm.array_filter(characters, function(element: number) {
+                    return element > 4;
+                });
+                assert.equal(filteredArray1.length, 2)
+                assert.equal(filteredArray1[1], 5)
+
+                // filters by index and element
+                let filteredArray2 = wasm.array_filter(characters, function(element: number, index: number) {
+                    return index < 3 && element > 7;
+                });
+                assert.equal(filteredArray2.length, 1)
+                assert.equal(filteredArray2[0], 8)
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -556,3 +556,47 @@ fn filter() {
         "#)
         .test()
 }
+
+#[test]
+fn find() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn array_find(this: &js::Array, function: JsValue) -> JsValue {
+                this.find(function)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = [8, 5, 4, 3, 1, 2]
+
+                // finds item
+                let foundElement = wasm.array_find(characters, function(element: number) {
+                    return element > 6;
+                });
+                assert.equal(foundElement, 8);
+
+                // if unfound returns undefined
+                let unfoundElement1 = wasm.array_find(characters, function(element: number) {
+                    return element > 8;
+                });
+                assert.equal(unfoundElement1, undefined);
+
+                // if incorrect type returns undefined
+                let unfoundElement2 = wasm.array_find(characters, function(element: string) {
+                    return element > "a";
+                });
+                assert.equal(unfoundElement2, undefined);
+            }
+        "#)
+        .test()
+}


### PR DESCRIPTION
For both of these, I use `JsValue` to capture a function as input -- which is possible since functions are values in JS. However, these fail if the user does not input a function. What is the recommended way to safe guard against this? Should I use the `#[wasm_bindgen(catch)]` with ` -> Result<JsValue, JsValue>`?