### PR TITLE
js globals: return JsString rather than String

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -45,9 +45,8 @@ extern {
     /// previously created by `encodeURI` or by a similar routine.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI
-    #[cfg(feature = "std")]
     #[wasm_bindgen(catch, js_name = decodeURI)]
-    pub fn decode_uri(encoded: &str) -> Result<String, JsValue>;
+    pub fn decode_uri(encoded: &str) -> Result<JsString, JsValue>;
 
     /// The `encodeURI()` function encodes a Uniform Resource Identifier (URI)
     /// by replacing each instance of certain characters by one, two, three, or
@@ -56,9 +55,8 @@ extern {
     /// "surrogate" characters).
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-    #[cfg(feature = "std")]
     #[wasm_bindgen(js_name = encodeURI)]
-    pub fn encode_uri(decoded: &str) -> String;
+    pub fn encode_uri(decoded: &str) -> JsString;
 
     /// The `eval()` function evaluates JavaScript code represented as a string.
     ///
@@ -119,7 +117,7 @@ extern {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/join
     #[wasm_bindgen(method)]
-    pub fn join(this: &Array, delimiter: &str) -> String;
+    pub fn join(this: &Array, delimiter: &str) -> JsString;
 
     /// The lastIndexOf() method returns the last index at which a given element can
     /// be found in the array, or -1 if it is not present. The array is searched
@@ -180,7 +178,7 @@ extern {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toString
     #[wasm_bindgen(method, js_name = toString)]
-    pub fn to_string(this: &Array) -> String;
+    pub fn to_string(this: &Array) -> JsString;
 
     /// The unshift() method adds one or more elements to the beginning of an array
     /// and returns the new length of the array.
@@ -224,7 +222,7 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
     #[wasm_bindgen(method, getter, structural)]
-    pub fn name(this: &JsFunction) -> String;
+    pub fn name(this: &JsFunction) -> JsString;
 }
 
 // Number.
@@ -237,21 +235,21 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
     #[wasm_bindgen(method, js_name = toLocaleString)]
-    pub fn to_locale_string(this: &Number, locale: String) -> String;
+    pub fn to_locale_string(this: &Number, locale: &str) -> JsString;
 
     /// The toPrecision() method returns a string representing the Number
     /// object to the specified precision.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision
     #[wasm_bindgen(catch, method, js_name = toPrecision)]
-    pub fn to_precision(this: &Number, precision: u8) -> Result<String, JsValue>;
+    pub fn to_precision(this: &Number, precision: u8) -> Result<JsString, JsValue>;
 
     /// The toString() method returns a string representing the
     /// specified Number object.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString
     #[wasm_bindgen(catch, method, js_name = toString)]
-    pub fn to_string(this: &Number, radix: u8) -> Result<String, JsValue>;
+    pub fn to_string(this: &Number, radix: u8) -> Result<JsString, JsValue>;
 
     /// The valueOf() method returns the wrapped primitive value of
     /// a Number object.
@@ -286,13 +284,13 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString
     #[wasm_bindgen(method, js_name = toLocaleString)]
-    pub fn to_locale_string(this: &Object) -> String;
+    pub fn to_locale_string(this: &Object) -> JsString;
 
     /// The toString() method returns a string representing the object.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
     #[wasm_bindgen(method, js_name = toString)]
-    pub fn to_string(this: &Object) -> String;
+    pub fn to_string(this: &Object) -> JsString;
 
     /// The isPrototypeOf() method checks if an object exists in another
     /// object's prototype chain.
@@ -310,16 +308,16 @@ extern {
 
     /// The valueOf() method returns the primitive value of the
     /// specified object.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf
     #[wasm_bindgen(method, js_name = valueOf)]
     pub fn value_of(this: &Object) -> Object;
 }
 
-// String
+// JsString
 #[wasm_bindgen]
 extern {
-    #[wasm_bindgen(js_name = String)]
+    #[wasm_bindgen(js_name = JsString)]
     pub type JsString;
 
     /// The slice() method extracts a section of a string and returns it as a
@@ -328,4 +326,32 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
     #[wasm_bindgen(method, js_class = "String")]
     pub fn slice(this: &JsString, start: u32, end: u32) -> JsString;
+}
+
+impl<'a> From<&'a str> for JsString {
+    fn from(s: &'a str) -> Self {
+        JsString {
+            obj: JsValue::from_str(s),
+        }
+    }
+}
+
+if_std! {
+    impl From<String> for JsString {
+        fn from(s: String) -> Self {
+            From::from(&*s)
+        }
+    }
+
+    impl<'a> From<&'a JsString> for String {
+        fn from(s: &'a JsString) -> Self {
+            s.obj.as_string().unwrap()
+        }
+    }
+
+    impl From<JsString> for String {
+        fn from(s: JsString) -> Self {
+            From::from(&s)
+        }
+    }
 }

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -119,7 +119,7 @@ fn join() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn join_array(this: &js::Array, delimiter: &str) -> String {
+            pub fn join_array(this: &js::Array, delimiter: &str) -> js::JsString {
                 this.join(delimiter)
             }
 
@@ -398,7 +398,7 @@ fn to_string() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn array_to_string(this: &js::Array) -> String {
+            pub fn array_to_string(this: &js::Array) -> js::JsString {
                 this.to_string()
             }
 

--- a/tests/all/js_globals/JsFunction.rs
+++ b/tests/all/js_globals/JsFunction.rs
@@ -53,7 +53,7 @@ fn name() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn fn_name(this: &js::JsFunction) -> String {
+            pub fn fn_name(this: &js::JsFunction) -> js::JsString {
                 this.name()
             }
         "#)

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -14,7 +14,7 @@ fn to_locale_string() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn to_locale_string(this: &js::Number, locale: String) -> String {
+            pub fn to_locale_string(this: &js::Number, locale: js::JsString) -> js::JsString {
                 this.to_locale_string(locale)
             }
         "#)
@@ -43,11 +43,11 @@ fn to_precision() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn to_precision(this: &js::Number, precision: u8) -> String {
+            pub fn to_precision(this: &js::Number, precision: u8) -> js::JsString {
                 let result = this.to_precision(precision);
                 let result = match result {
                     Ok(num) => num,
-                    Err(_err) => "RangeError".to_string()
+                    Err(_err) => "RangeError".into()
                 };
                 result
             }
@@ -75,11 +75,11 @@ fn to_string() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn to_string(this: &js::Number, radix: u8) -> String {
+            pub fn to_string(this: &js::Number, radix: u8) -> js::JsString {
                 let result = this.to_string(radix);
                 let result = match result {
                     Ok(num) => num,
-                    Err(_err) => "RangeError".to_string()
+                    Err(_err) => "RangeError".into()
                 };
                 result
             }

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -3,9 +3,7 @@
 use super::project;
 
 
-// TODO: test seems to be system dependent, disable for now
-// #[test]
-#[allow(dead_code)]
+#[test]
 fn to_locale_string() {
     project()
         .file("src/lib.rs", r#"
@@ -26,9 +24,10 @@ fn to_locale_string() {
 
             export function test() {
                 let number = 1234.45;
-                assert.equal(wasm.to_locale_string(number, "de-DE"), "1,234.45");
                 assert.equal(wasm.to_locale_string(number, "en-US"), "1,234.45");
-                assert.equal(wasm.to_locale_string(number, "zh-Hans-CN-u-nu-hanidec"), "1,234.45");
+                // TODO: these tests seems to be system dependent, disable for now
+                // assert.equal(wasm.to_locale_string(number, "de-DE"), "1,234.45");
+                // assert.equal(wasm.to_locale_string(number, "zh-Hans-CN-u-nu-hanidec"), "1,234.45");
             }
         "#)
         .test()

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -3,7 +3,9 @@
 use super::project;
 
 
-#[test]
+// TODO: test seems to be system dependent, disable for now
+// #[test]
+#[allow(dead_code)]
 fn to_locale_string() {
     project()
         .file("src/lib.rs", r#"
@@ -14,7 +16,7 @@ fn to_locale_string() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn to_locale_string(this: &js::Number, locale: js::JsString) -> js::JsString {
+            pub fn to_locale_string(this: &js::Number, locale: &str) -> js::JsString {
                 this.to_locale_string(locale)
             }
         "#)

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -70,14 +70,14 @@ fn to_string() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn to_string(obj: &js::Object) -> String {
+            pub fn to_string(obj: &js::Object) -> js::JsString {
                 obj.to_string()
             }
 
             #[wasm_bindgen]
             pub fn test() {
                 let object = js::Object::new();
-                assert_eq!(object.to_string(), "[object Object]");
+                assert_eq!(String::from(object.to_string()), "[object Object]");
             }
         "#)
         .file("test.ts", r#"
@@ -169,7 +169,7 @@ fn to_locale_string() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn to_locale_string() -> String {
+            pub fn to_locale_string() -> js::JsString {
                 let object = js::Object::new();
                 object.to_locale_string()
             }

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -25,7 +25,7 @@ fn decode_uri() {
                 let x = js::decode_uri("https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B")
                     .ok()
                     .expect("should decode URI OK");
-                assert_eq!(x, "https://mozilla.org/?x=шеллы");
+                assert_eq!(String::from(x), "https://mozilla.org/?x=шеллы");
 
                 assert!(js::decode_uri("%E0%A4%A").is_err());
             }
@@ -47,7 +47,7 @@ fn encode_uri() {
             #[wasm_bindgen]
             pub fn test() {
                 let x = js::encode_uri("ABC abc 123");
-                assert_eq!(x, "ABC%20abc%20123");
+                assert_eq!(String::from(x), "ABC%20abc%20123");
             }
         "#)
         .test();


### PR DESCRIPTION
This reduces the need to copy strings in and out of wasm memory. We should also potentially consider doing the same for arguments (rather than taking `&str`).