### PR TITLE
Adds an example of using a native node module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "examples/wasm-in-wasm",
   "examples/closures",
   "examples/no_modules",
+  "examples/node_module",
   "examples/add",
   "examples/asm.js",
   "examples/char",

--- a/examples/node_module/.gitignore
+++ b/examples/node_module/.gitignore
@@ -1,0 +1,4 @@
+package-lock.json
+node_module.js
+node_module_bg.js
+node_module_bg.wasm

--- a/examples/node_module/Cargo.toml
+++ b/examples/node_module/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "node_module"
+version = "0.1.0"
+authors = ["Corbin Uselton <c@decimal.io>"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = { path = "../.." }

--- a/examples/node_module/README.md
+++ b/examples/node_module/README.md
@@ -1,0 +1,14 @@
+# Importing nodejs internal module
+
+This directory is an example of using the `#[wasm_bindgen]` macro to import a native nodejs module.
+
+You can build the example with:
+
+```
+$ ./build.sh
+```
+
+For more information about this example be sure to check out
+[`hello_world`][hello] which also has more comments about caveats and such.
+
+[hello]: https://github.com/alexcrichton/wasm-bindgen/tree/master/examples/hello_world

--- a/examples/node_module/build.sh
+++ b/examples/node_module/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# For more coments about what's going on here, see the `hello_world` example
+
+set -ex
+
+cargo +nightly build --target wasm32-unknown-unknown
+cargo +nightly run --manifest-path ../../crates/cli/Cargo.toml \
+  --bin wasm-bindgen -- \
+  ../../target/wasm32-unknown-unknown/debug/node_module.wasm --nodejs --out-dir .
+node index.js

--- a/examples/node_module/index.js
+++ b/examples/node_module/index.js
@@ -1,0 +1,34 @@
+//@ts-check
+// For more comments about what's going on here, check out the `hello_world`
+// example
+const events = require("events");
+
+const rust = require("./node_module");
+
+class MyEmitter extends events.EventEmitter {};
+
+const jsEmitter = new MyEmitter();
+
+console.log("created emitter");
+
+jsEmitter.on('jsevent', function(a, b) {
+    console.log(["jsevent", a, b]);
+});
+
+//rust.create_event(jsEmitter);
+
+//jsEmitter.emit("rsevent");
+
+rust.emit_event(jsEmitter);
+
+const rsEmitter = rust.get_emitter();
+
+rsEmitter.on('jsevent', function(a, b) {
+    console.log(["jsevent", a, b]);
+});
+
+//rust.create_event(rsEmitter);
+
+rust.emit_event(rsEmitter);
+
+rsEmitter.emit("rsEmitter");

--- a/examples/node_module/src/lib.rs
+++ b/examples/node_module/src/lib.rs
@@ -1,0 +1,49 @@
+#![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(module = "events", version = "^6.9.0")]
+extern {
+    pub type EventEmitter;
+
+    #[wasm_bindgen(constructor)]
+    fn new() -> EventEmitter;
+    #[wasm_bindgen(method)]
+    fn emit(this: &EventEmitter, event: &str, a: &str, b: &str) -> String;
+    #[wasm_bindgen(method)]
+    fn on(this: &EventEmitter, event: &str, cb: &Closure<FnMut() -> ()>) -> String;
+}
+
+// Import `console.log` so we can log something to the console
+#[wasm_bindgen]
+extern {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+#[wasm_bindgen]
+pub fn get_emitter() -> EventEmitter {
+    let emitter = EventEmitter::new();
+
+    log("created emitter");
+
+    return emitter;
+}
+
+#[wasm_bindgen]
+pub fn create_event(emiter: EventEmitter) {
+    let cb = Closure::new(move || {
+        log("rsevent");
+    });
+
+    emiter.on("rsevent", &cb);
+}
+
+#[wasm_bindgen]
+pub fn emit_event(emiter: EventEmitter) {
+    emiter.emit("jsevent", "a", "b");
+
+    log("emitted event");
+}


### PR DESCRIPTION
Adds an example of using a native node module. In this case the EventEmitter as I am using it currently. I haven't gotten the Closure's working yet for adding on from the Rust side. I am happy to take some input there.