### PR TITLE
Add basic support for String.prototype.char_at()

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -326,6 +326,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
     #[wasm_bindgen(method, js_class = "String")]
     pub fn slice(this: &JsString, start: u32, end: u32) -> JsString;
+
+    /// The String object's charAt() method returns a new string consisting of the single
+    /// UTF-16 code unit located at the specified offset into the string.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt
+    #[wasm_bindgen(method, js_name = charAt)]
+    pub fn char_at(this: &JsString, index: u32) -> JsString;
 }
 
 impl<'a> From<&'a str> for JsString {

--- a/src/js.rs
+++ b/src/js.rs
@@ -331,7 +331,7 @@ extern {
     /// UTF-16 code unit located at the specified offset into the string.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt
-    #[wasm_bindgen(method, js_name = charAt)]
+    #[wasm_bindgen(method, js_class = "String", js_name = charAt)]
     pub fn char_at(this: &JsString, index: u32) -> JsString;
 }
 

--- a/tests/all/js_globals/JsString.rs
+++ b/tests/all/js_globals/JsString.rs
@@ -3,6 +3,35 @@
 use project;
 
 #[test]
+fn char_at() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn string_char_at(this: &js::JsString, index: u32) -> js::JsString {
+                this.char_at(index)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            var anyString = 'Brave new world';
+
+            export function test() {
+                assert.equal(wasm.string_char_at(anyString, 0), "B");
+                assert.equal(wasm.string_char_at(anyString, 999), "");
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn slice() {
     project()
         .file("src/lib.rs", r#"


### PR DESCRIPTION
Now that we have implementation for String, I can add basic support for `char_at`

PS: Still needs the optional parameter for `index`. Maybe somebody can link that issue and add it as task to it as well.