### PR TITLE
`String.prototype.substr()` support

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -359,7 +359,6 @@ extern {
     /// the start index and a number of characters after it.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
-    /// TODO: Add `NaN` and `undefined` support
     #[wasm_bindgen(method, js_class = "String")]
     pub fn substr(this: &JsString, start: i32, length: i32) -> JsString;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -340,6 +340,14 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
     #[wasm_bindgen(method, js_class = "String")]
     pub fn slice(this: &JsString, start: u32, end: u32) -> JsString;
+
+    /// The substr() method returns the part of a string between
+    /// the start index and a number of characters after it.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
+    /// TODO: Add `NaN` and `undefined` support
+    #[wasm_bindgen(method, js_class = "String")]
+    pub fn substr(this: &JsString, start: i32, length: i32) -> JsString;
 }
 
 impl<'a> From<&'a str> for JsString {

--- a/tests/all/js_globals/JsString.rs
+++ b/tests/all/js_globals/JsString.rs
@@ -30,3 +30,39 @@ fn slice() {
         "#)
         .test()
 }
+
+#[test]
+fn substr() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn create_substr(this: &js::JsString, start: i32, length: i32) -> js::JsString {
+                this.substr(start, length)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let aString = "Mozilla";
+
+                assert.equal(wasm.create_substr(aString, 0, 1), "M");
+                assert.equal(wasm.create_substr(aString, 1, 0), "");
+                assert.equal(wasm.create_substr(aString, -1, 1), "a");
+                assert.equal(wasm.create_substr(aString, 1, -1), "");
+                // TODO: Uncomment and test these assertions, once we have support for optional parameters
+                // assert.equal(wasm.create_substr(aString, -3), "lla");
+                // assert.equal(wasm.create_substr(aString, 1), "ozilla");
+                assert.equal(wasm.create_substr(aString, -20, 2), "Mo");
+                assert.equal(wasm.create_substr(aString, 20, 2), "");
+            }
+        "#)
+        .test()
+}


### PR DESCRIPTION
I wanted to open this PR as well as ask some questions. Not sure how the whole binding works, but I do know some stuff currently are not supported as the optional parameters( as well as `NaN` support). But I also wanted to raise the question: `What about all the special cases for specific handling?`, for example I can give `substr`:
```
If length is undefined, substr() extracts characters to the end of the string.
If length is a negative number, it is treated as 0.

For both start and length, NaN is treated as 0.
```

How can these cases be handled as a whole and what should we do about them until we can actually handle them?