### PR TITLE
Make JS use a '.wasm' extension when importing the binary

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -132,8 +132,8 @@ impl<'a> Context<'a> {
 
         self.bind("__wbindgen_object_drop_ref", &|me| {
             me.expose_drop_ref();
-            Ok("function(i) { 
-                dropRef(i); 
+            Ok("function(i) {
+                dropRef(i);
             }".to_string())
         })?;
 
@@ -149,8 +149,8 @@ impl<'a> Context<'a> {
 
         self.bind("__wbindgen_number_new", &|me| {
             me.expose_add_heap_object();
-            Ok(String::from("function(i) { 
-                return addHeapObject(i); 
+            Ok(String::from("function(i) {
+                return addHeapObject(i);
             }"))
         })?;
 
@@ -169,8 +169,8 @@ impl<'a> Context<'a> {
 
         self.bind("__wbindgen_undefined_new", &|me| {
             me.expose_add_heap_object();
-            Ok(String::from("function() { 
-                return addHeapObject(undefined); 
+            Ok(String::from("function() {
+                return addHeapObject(undefined);
             }"))
         })?;
 
@@ -365,7 +365,7 @@ impl<'a> Context<'a> {
                                               module_name));
                 format!("var wasm;")
             } else {
-                format!("import * as wasm from './{}_bg';", module_name)
+                format!("import * as wasm from './{}_bg.wasm';", module_name)
             };
 
             format!("\

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -403,11 +403,11 @@ fn indent_recurse(mut lines: ::std::str::Lines, current_indent: usize) -> String
             next_indent += 1;
         }
         if trimmed.starts_with('}') || trimmed.ends_with('}') {
-            if current_indent > 0 { 
-                current_indent -= 1; 
+            if current_indent > 0 {
+                current_indent -= 1;
             }
-            if next_indent > 0 { 
-                next_indent -= 1; 
+            if next_indent > 0 {
+                next_indent -= 1;
             }
         }
         if trimmed.starts_with('?') || trimmed.starts_with(':') {


### PR DESCRIPTION
Relevant change is

```patch
-                format!("import * as wasm from './{}_bg';", module_name)
+                format!("import * as wasm from './{}_bg.wasm';", module_name)
```

So the JS output becomes:

```js
import * as wasm from './foo_bg.wasm';
```

This works the same on Webpack and lets you use [rollup](https://github.com/rollup/rollup) and [rollup-plugin-wasm](https://github.com/rollup/rollup-plugin-wasm). :tada:

There [is an argument](https://youtu.be/M3BM9TB-8yA?t=13m56s) to be explicit about the extensions in module resolution, but this was mostly about the Rollup for me, so the commonjs output and the tests have the same tendency to not use `.js` extensions.

Other changes are auto removal of trailing whitespace.