### PR TITLE
Array.prototype.filter

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -91,6 +91,13 @@ extern {
     #[wasm_bindgen(method)]
     pub fn fill(this: &Array, value: JsValue, start: u32, end: u32) -> Array;
 
+    /// The `filter()` method creates a new array with all elements that pass the
+    /// test implemented by the provided function.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
+    #[wasm_bindgen(method)]
+    pub fn filter(this: &Array, predicate: &mut FnMut(JsValue, u32, Array) -> bool) -> Array;
+
     /// The length property of an object which is an instance of type Array
     /// sets or returns the number of elements in that array. The value is an
     /// unsigned, 32-bit integer that is always numerically greater than the

--- a/src/js.rs
+++ b/src/js.rs
@@ -77,7 +77,7 @@ extern {
     #[wasm_bindgen(method, js_name = copyWithin)]
     pub fn copy_within(this: &Array, target: i32, start: i32, end: i32) -> Array;
 
-    ///The concat() method is used to merge two or more arrays. This method
+    /// The concat() method is used to merge two or more arrays. This method
     /// does not change the existing arrays, but instead returns a new array.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -3,6 +3,39 @@
 use project;
 
 #[test]
+fn filter() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn keep_numbers(array: &js::Array) -> js::Array {
+                array.filter(&mut |x, _, _| x.as_f64().is_some())
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = ["a", "c", "x", "n"];
+                let numbers = [1, 2, 3, 4];
+                let mixed = ["a", 1, "b", 2];
+
+                assert.deepStrictEqual(wasm.keep_numbers(characters), []);
+                assert.deepStrictEqual(wasm.keep_numbers(numbers), numbers);
+                assert.deepStrictEqual(wasm.keep_numbers(mixed), [1, 2]);
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn index_of() {
     project()
         .file("src/lib.rs", r#"


### PR DESCRIPTION
The key to making the higher order functions like `Array.prototype.filter` work, is to *not* take values by reference in the closure. That is a little too tricky for the macros in `src/{convert,describe}.rs` and is also unnecessary since these things are all indices into a table under the hood anyways -- not something that is too big to efficiently pass directly.