### PR TITLE
Adds support for the Uint8Array constructor and its fill method.

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -65,6 +65,25 @@ extern {
     pub fn eval(js_source_text: &str) -> Result<JsValue, JsValue>;
 }
 
+// UInt8Array
+#[wasm_bindgen]
+extern {
+    pub type Uint8Array;
+
+    /// The `Uint8Array()` constructor creates an array of unsigned 8-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Uint8Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Uint8Array, value: JsValue, start: u32, end: u32) -> Uint8Array;
+}
+
 // Array
 #[wasm_bindgen]
 extern {

--- a/tests/all/js_globals/TypedArray.rs
+++ b/tests/all/js_globals/TypedArray.rs
@@ -1,0 +1,85 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn new_undefined() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn new_array() -> js::Uint8Array {
+                js::Uint8Array::new(JsValue::undefined())
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.new_array().length, 0);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn new_length() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn new_array() -> js::Uint8Array {
+                js::Uint8Array::new(JsValue::from_f64(4.0))
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.new_array().length, 4);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn fill() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn fill_with(this: &js::Uint8Array, value: JsValue, start: u32, end: u32) -> js::Uint8Array {
+                this.fill(value, start, end)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let characters = new Uint8Array([0, 0, 0, 0, 0, 0]);
+                let subset = wasm.fill_with(characters, 1, 0, 3);
+
+                assert.equal(subset[0], 1);
+                assert.equal(subset[4], 0);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -9,6 +9,7 @@ mod JsFunction;
 mod JsString;
 mod Number;
 mod Math;
+mod TypedArray;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
I added support for the Uint8Array constructor. It has a lot of overlap with the Array prototype, and all TypedArrays share the same methods, so these methods should be easy to populate alongside the corresponding Array methods. (It feels like a lot of prototypes will have to get duplicated this way.)