### PR TITLE
Use rustfmt for standarized formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ matrix:
       install: true
       script: cargo build --manifest-path crates/cli/Cargo.toml
 
+    # check formatting
+    - rust: nightly
+      before_install: rustup component add rustfmt-preview --toolchain nightly
+      script: cargo fmt -- --check
+
     # Tests pass on nightly
     - rust: nightly
       before_install:
@@ -41,6 +46,7 @@ matrix:
         # Check JS output from all tests against eslint
         - ./node_modules/.bin/eslint ./target/generated-tests/*/out*.js
       env: RUST_BACKTRACE=1
+
     # WebIDL tests pass on nightly
     - rust: nightly
       before_install: rustup component add rustfmt-preview --toolchain nightly

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -405,7 +405,10 @@ impl Program {
             };
             let class_name = extract_path_ident(class_name)
                 .expect("first argument of method must be a bare type");
-            let class_name = wasm.opts.js_class().map(Into::into)
+            let class_name = wasm
+                .opts
+                .js_class()
+                .map(Into::into)
                 .unwrap_or_else(|| class_name.to_string());
 
             ImportFunctionKind::Method {

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -138,15 +138,15 @@ impl Descriptor {
 
     pub fn is_number(&self) -> bool {
         match *self {
-            Descriptor::I8 |
-            Descriptor::U8 |
-            Descriptor::I16 |
-            Descriptor::U16 |
-            Descriptor::I32 |
-            Descriptor::U32 |
-            Descriptor::F32 |
-            Descriptor::F64 |
-            Descriptor::Enum => true,
+            Descriptor::I8
+            | Descriptor::U8
+            | Descriptor::I16
+            | Descriptor::U16
+            | Descriptor::I32
+            | Descriptor::U32
+            | Descriptor::F32
+            | Descriptor::F64
+            | Descriptor::Enum => true,
             _ => return false,
         }
     }
@@ -191,19 +191,15 @@ impl Descriptor {
         let inner = match *self {
             Descriptor::String => return Some(VectorKind::String),
             Descriptor::Vector(ref d) => &**d,
-            Descriptor::Ref(ref d) => {
-                match **d {
-                    Descriptor::Slice(ref d) => &**d,
-                    Descriptor::String => return Some(VectorKind::String),
-                    _ => return None,
-                }
-            }
-            Descriptor::RefMut(ref d) => {
-                match **d {
-                    Descriptor::Slice(ref d) => &**d,
-                    _ => return None,
-                }
-            }
+            Descriptor::Ref(ref d) => match **d {
+                Descriptor::Slice(ref d) => &**d,
+                Descriptor::String => return Some(VectorKind::String),
+                _ => return None,
+            },
+            Descriptor::RefMut(ref d) => match **d {
+                Descriptor::Slice(ref d) => &**d,
+                _ => return None,
+            },
             _ => return None,
         };
         match *inner {
@@ -218,7 +214,7 @@ impl Descriptor {
             Descriptor::F32 => Some(VectorKind::F32),
             Descriptor::F64 => Some(VectorKind::F64),
             Descriptor::Anyref => Some(VectorKind::Anyref),
-            _ => None
+            _ => None,
         }
     }
 
@@ -248,8 +244,7 @@ impl Descriptor {
 
     pub fn is_by_ref(&self) -> bool {
         match *self {
-            Descriptor::Ref(_) |
-            Descriptor::RefMut(_) => true,
+            Descriptor::Ref(_) | Descriptor::RefMut(_) => true,
             _ => false,
         }
     }

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -68,9 +68,11 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
     /// passed should be `this.ptr`.
     pub fn method(&mut self, method: bool) -> &mut Self {
         if method {
-            self.prelude("if (this.ptr === 0) {
+            self.prelude(
+                "if (this.ptr === 0) {
                 throw new Error('Attempt to use a moved value');
-            }");
+            }",
+            );
             self.rust_arguments.insert(0, "this.ptr".to_string());
         }
         self
@@ -111,30 +113,46 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
         let name = self.abi_arg();
 
         if let Some(kind) = arg.vector_kind() {
-            self.js_arguments.push((name.clone(), kind.js_ty().to_string()));
+            self.js_arguments
+                .push((name.clone(), kind.js_ty().to_string()));
 
             let func = self.cx.pass_to_wasm_function(kind)?;
-            self.prelude(&format!("\
-                const [ptr{i}, len{i}] = {func}({arg});\n\
-            ", i = i, func = func, arg = name));
+            self.prelude(&format!(
+                "\
+                 const [ptr{i}, len{i}] = {func}({arg});\n\
+                 ",
+                i = i,
+                func = func,
+                arg = name
+            ));
             if arg.is_by_ref() {
                 if arg.is_mut_ref() {
                     let get = self.cx.memview_function(kind);
-                    self.finally(&format!("\
-                        {arg}.set({get}().subarray(\
-                            ptr{i} / {size}, \
-                            ptr{i} / {size} + len{i}\
-                        ));\n\
-                    ", i = i, arg = name, get = get, size = kind.size()));
+                    self.finally(&format!(
+                        "\
+                         {arg}.set({get}().subarray(\
+                         ptr{i} / {size}, \
+                         ptr{i} / {size} + len{i}\
+                         ));\n\
+                         ",
+                        i = i,
+                        arg = name,
+                        get = get,
+                        size = kind.size()
+                    ));
                 }
-                self.finally(&format!("\
-                    wasm.__wbindgen_free(ptr{i}, len{i} * {size});\n\
-                ", i = i, size = kind.size()));
+                self.finally(&format!(
+                    "\
+                     wasm.__wbindgen_free(ptr{i}, len{i} * {size});\n\
+                     ",
+                    i = i,
+                    size = kind.size()
+                ));
                 self.cx.require_internal_export("__wbindgen_free")?;
             }
             self.rust_arguments.push(format!("ptr{}", i));
             self.rust_arguments.push(format!("len{}", i));
-            return Ok(self)
+            return Ok(self);
         }
 
         if let Some(s) = arg.rust_struct() {
@@ -142,24 +160,32 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
 
             if self.cx.config.debug {
                 self.cx.expose_assert_class();
-                self.prelude(&format!("\
-                    _assertClass({arg}, {struct_});\n\
-                ", arg = name, struct_ = s));
+                self.prelude(&format!(
+                    "\
+                     _assertClass({arg}, {struct_});\n\
+                     ",
+                    arg = name,
+                    struct_ = s
+                ));
             }
 
             if arg.is_by_ref() {
                 self.rust_arguments.push(format!("{}.ptr", name));
             } else {
-                self.prelude(&format!("\
+                self.prelude(&format!(
+                    "\
                     const ptr{i} = {arg}.ptr;\n\
                     if (ptr{i} === 0) {{
                         throw new Error('Attempt to use a moved value');
                     }}
                     {arg}.ptr = 0;\n\
-                ", i = i, arg = name));
+                ",
+                    i = i,
+                    arg = name
+                ));
                 self.rust_arguments.push(format!("ptr{}", i));
             }
-            return Ok(self)
+            return Ok(self);
         }
 
         if arg.is_number() {
@@ -171,7 +197,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             }
 
             self.rust_arguments.push(name);
-            return Ok(self)
+            return Ok(self);
         }
 
         if let Some(signed) = arg.get_64bit() {
@@ -183,51 +209,55 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             self.cx.expose_uint32_memory();
             self.cx.expose_global_argument_ptr()?;
             self.js_arguments.push((name.clone(), "BigInt".to_string()));
-            self.prelude(&format!("\
-                {f}[0] = {name};\n\
-                const lo{i} = u32CvtShim[0];\n\
-                const hi{i} = u32CvtShim[1];\n\
-            ",
+            self.prelude(&format!(
+                "\
+                 {f}[0] = {name};\n\
+                 const lo{i} = u32CvtShim[0];\n\
+                 const hi{i} = u32CvtShim[1];\n\
+                 ",
                 i = i,
                 f = f,
                 name = name,
             ));
             self.rust_arguments.push(format!("lo{}", i));
             self.rust_arguments.push(format!("hi{}", i));
-            return Ok(self)
+            return Ok(self);
         }
 
         if arg.is_ref_anyref() {
             self.js_arguments.push((name.clone(), "any".to_string()));
             self.cx.expose_borrowed_objects();
             self.finally("stack.pop();");
-            self.rust_arguments.push(format!("addBorrowedObject({})", name));
-            return Ok(self)
+            self.rust_arguments
+                .push(format!("addBorrowedObject({})", name));
+            return Ok(self);
         }
 
         match *arg {
             Descriptor::Boolean => {
-                self.js_arguments.push((name.clone(), "boolean".to_string()));
+                self.js_arguments
+                    .push((name.clone(), "boolean".to_string()));
                 if self.cx.config.debug {
                     self.cx.expose_assert_bool();
-                    self.prelude(&format!("\
-                        _assertBoolean({name});\n\
-                    ", name = name));
+                    self.prelude(&format!(
+                        "\
+                         _assertBoolean({name});\n\
+                         ",
+                        name = name
+                    ));
                 }
                 self.rust_arguments.push(format!("{} ? 1 : 0", name));
             }
             Descriptor::Char => {
                 self.js_arguments.push((name.clone(), "string".to_string()));
                 self.rust_arguments.push(format!("{}.codePointAt(0)", name))
-            },
+            }
             Descriptor::Anyref => {
                 self.js_arguments.push((name.clone(), "any".to_string()));
                 self.cx.expose_add_heap_object();
                 self.rust_arguments.push(format!("addHeapObject({})", name));
             }
-            _ => {
-                bail!("unsupported argument to rust function {:?}", arg)
-            }
+            _ => bail!("unsupported argument to rust function {:?}", arg),
         }
         Ok(self)
     }
@@ -238,7 +268,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             None => {
                 self.ret_ty = "void".to_string();
                 self.ret_expr = format!("return RET;");
-                return Ok(self)
+                return Ok(self);
             }
         };
 
@@ -246,7 +276,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             self.ret_ty = "any".to_string();
             self.cx.expose_get_object();
             self.ret_expr = format!("return getObject(RET);");
-            return Ok(self)
+            return Ok(self);
         }
 
         if ty.is_by_ref() {
@@ -261,28 +291,32 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             self.cx.require_internal_export("__wbindgen_free")?;
             self.prelude("const retptr = globalArgumentPtr();");
             self.rust_arguments.insert(0, "retptr".to_string());
-            self.ret_expr = format!("\
-                RET;\n\
-                const mem = getUint32Memory();\n\
-                const ptr = mem[retptr / 4];\n\
-                const len = mem[retptr / 4 + 1];\n\
-                const realRet = {}(ptr, len).slice();\n\
-                wasm.__wbindgen_free(ptr, len * {});\n\
-                return realRet;\n\
-            ", f, ty.size());
-            return Ok(self)
+            self.ret_expr = format!(
+                "\
+                 RET;\n\
+                 const mem = getUint32Memory();\n\
+                 const ptr = mem[retptr / 4];\n\
+                 const len = mem[retptr / 4 + 1];\n\
+                 const realRet = {}(ptr, len).slice();\n\
+                 wasm.__wbindgen_free(ptr, len * {});\n\
+                 return realRet;\n\
+                 ",
+                f,
+                ty.size()
+            );
+            return Ok(self);
         }
 
         if let Some(name) = ty.rust_struct() {
             self.ret_ty = name.to_string();
             self.ret_expr = format!("return {name}.__construct(RET);", name = name);
-            return Ok(self)
+            return Ok(self);
         }
 
         if ty.is_number() {
             self.ret_ty = "number".to_string();
             self.ret_expr = format!("return RET;");
-            return Ok(self)
+            return Ok(self);
         }
 
         if let Some(signed) = ty.get_64bit() {
@@ -297,11 +331,14 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             };
             self.prelude("const retptr = globalArgumentPtr();");
             self.rust_arguments.insert(0, "retptr".to_string());
-            self.ret_expr = format!("\
-                RET;\n\
-                return {}()[retptr / 8];\n\
-            ", f);
-            return Ok(self)
+            self.ret_expr = format!(
+                "\
+                 RET;\n\
+                 return {}()[retptr / 8];\n\
+                 ",
+                f
+            );
+            return Ok(self);
         }
 
         match *ty {
@@ -333,7 +370,8 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
     /// generated function shim and the second is a TypeScript signature of the
     /// JS expression.
     pub fn finish(&self, prefix: &str, invoc: &str) -> (String, String) {
-        let js_args = self.js_arguments
+        let js_args = self
+            .js_arguments
             .iter()
             .map(|s| &s.0[..])
             .collect::<Vec<_>>()
@@ -342,29 +380,35 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
         js.push_str(&self.prelude);
         let rust_args = self.rust_arguments.join(", ");
 
-        let invoc = self.ret_expr.replace("RET", &format!("{}({})", invoc, rust_args));
+        let invoc = self
+            .ret_expr
+            .replace("RET", &format!("{}({})", invoc, rust_args));
         let invoc = if self.finally.len() == 0 {
             invoc
         } else {
-            format!("\
+            format!(
+                "\
                 try {{\n\
                     {}
                 \n}} finally {{\n\
                     {}
                 }}\n\
             ",
-                &invoc,
-                &self.finally,
+                &invoc, &self.finally,
             )
         };
         js.push_str(&invoc);
         js.push_str("\n}");
-        let ts_args = self.js_arguments
+        let ts_args = self
+            .js_arguments
             .iter()
             .map(|s| format!("{}: {}", s.0, s.1))
             .collect::<Vec<_>>()
             .join(", ");
-        let ts = format!("{} {}({}): {};\n", prefix, self.js_name, ts_args, self.ret_ty);
+        let ts = format!(
+            "{} {}({}): {};\n",
+            prefix, self.js_name, ts_args, self.ret_ty
+        );
         (js, ts)
     }
 }

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -393,7 +393,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 \n}} finally {{\n\
                     {}
                 }}\n\
-            ",
+                ",
                 &invoc, &self.finally,
             )
         };

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1,10 +1,10 @@
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
 use std::mem;
 
 use failure::{Error, ResultExt};
-use parity_wasm::elements::*;
 use parity_wasm;
+use parity_wasm::elements::*;
 use serde_json;
 use shared;
 use wasm_gc;
@@ -84,22 +84,22 @@ impl<'a> Context<'a> {
         self.global(&global);
     }
 
-    fn require_internal_export(&mut self, name: &'static str)
-        -> Result<(), Error>
-    {
+    fn require_internal_export(&mut self, name: &'static str) -> Result<(), Error> {
         if !self.required_internal_exports.insert(name) {
-            return Ok(())
+            return Ok(());
         }
         if let Some(s) = self.module.export_section() {
             if s.entries().iter().any(|e| e.field() == name) {
-                return Ok(())
+                return Ok(());
             }
         }
 
-        bail!("the exported function `{}` is required to generate bindings \
-               but it was not found in the wasm file, perhaps the `std` feature \
-               of the `wasm-bindgen` crate needs to be enabled?",
-              name);
+        bail!(
+            "the exported function `{}` is required to generate bindings \
+             but it was not found in the wasm file, perhaps the `std` feature \
+             of the `wasm-bindgen` crate needs to be enabled?",
+            name
+        );
     }
 
     pub fn finalize(&mut self, module_name: &str) -> Result<(String, String), Error> {
@@ -109,14 +109,17 @@ impl<'a> Context<'a> {
             me.expose_add_heap_object();
             me.expose_get_object();
             let bump_cnt = if me.config.debug {
-                String::from("
+                String::from(
+                    "
                     if (typeof(val) === 'number') throw new Error('corrupt slab');
                     val.cnt += 1;
-                ")
+                ",
+                )
             } else {
                 String::from("val.cnt += 1;")
             };
-            Ok(format!("
+            Ok(format!(
+                "
                 function(idx) {{
                     // If this object is on the stack promote it to the heap.
                     if ((idx & 1) === 1) return addHeapObject(getObject(idx));
@@ -127,92 +130,112 @@ impl<'a> Context<'a> {
                     {}
                     return idx;
                 }}
-            ", bump_cnt))
+            ",
+                bump_cnt
+            ))
         })?;
 
         self.bind("__wbindgen_object_drop_ref", &|me| {
             me.expose_drop_ref();
             Ok("function(i) {
                 dropRef(i);
-            }".to_string())
+            }"
+                .to_string())
         })?;
 
         self.bind("__wbindgen_string_new", &|me| {
             me.expose_add_heap_object();
             me.expose_get_string_from_wasm();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(p, l) {
                     return addHeapObject(getStringFromWasm(p, l));
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_number_new", &|me| {
             me.expose_add_heap_object();
-            Ok(String::from("function(i) {
+            Ok(String::from(
+                "function(i) {
                 return addHeapObject(i);
-            }"))
+            }",
+            ))
         })?;
 
         self.bind("__wbindgen_number_get", &|me| {
             me.expose_get_object();
             me.expose_uint8_memory();
-            Ok(format!("
+            Ok(format!(
+                "
                 function(n, invalid) {{
                     let obj = getObject(n);
                     if (typeof(obj) === 'number') return obj;
                     getUint8Memory()[invalid] = 1;
                     return 0;
                 }}
-            "))
+            "
+            ))
         })?;
 
         self.bind("__wbindgen_undefined_new", &|me| {
             me.expose_add_heap_object();
-            Ok(String::from("function() {
+            Ok(String::from(
+                "function() {
                 return addHeapObject(undefined);
-            }"))
+            }",
+            ))
         })?;
 
         self.bind("__wbindgen_null_new", &|me| {
             me.expose_add_heap_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function() {
                     return addHeapObject(null);
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_is_null", &|me| {
             me.expose_get_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(idx) {
                     return getObject(idx) === null ? 1 : 0;
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_is_undefined", &|me| {
             me.expose_get_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(idx) {
                     return getObject(idx) === undefined ? 1 : 0;
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_boolean_new", &|me| {
             me.expose_add_heap_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(v) {
                     return addHeapObject(v === 1);
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_boolean_get", &|me| {
             me.expose_get_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(i) {
                     let v = getObject(i);
                     if (typeof(v) === 'boolean') {
@@ -221,13 +244,15 @@ impl<'a> Context<'a> {
                         return 2;
                     }
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_symbol_new", &|me| {
             me.expose_get_string_from_wasm();
             me.expose_add_heap_object();
-            Ok(format!("
+            Ok(format!(
+                "
                 function(ptr, len) {{
                     let a;
                     if (ptr === 0) {{
@@ -237,23 +262,27 @@ impl<'a> Context<'a> {
                     }}
                     return addHeapObject(a);
                 }}
-            "))
+            "
+            ))
         })?;
 
         self.bind("__wbindgen_is_symbol", &|me| {
             me.expose_get_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(i) {
                     return typeof(getObject(i)) === 'symbol' ? 1 : 0;
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_string_get", &|me| {
             me.expose_pass_string_to_wasm()?;
             me.expose_get_object();
             me.expose_uint32_memory();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(i, len_ptr) {
                     let obj = getObject(i);
                     if (typeof(obj) !== 'string') return 0;
@@ -261,59 +290,70 @@ impl<'a> Context<'a> {
                     getUint32Memory()[len_ptr / 4] = len;
                     return ptr;
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_cb_drop", &|me| {
             me.expose_drop_ref();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(i) {
                     let obj = getObject(i).original;
                     obj.a = obj.b = 0;
                     dropRef(i);
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_cb_forget", &|me| {
             me.expose_drop_ref();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(i) {
                     dropRef(i);
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_json_parse", &|me| {
             me.expose_add_heap_object();
             me.expose_get_string_from_wasm();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(ptr, len) {
                     return addHeapObject(JSON.parse(getStringFromWasm(ptr, len)));
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_json_serialize", &|me| {
             me.expose_get_object();
             me.expose_pass_string_to_wasm()?;
             me.expose_uint32_memory();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(idx, ptrptr) {
                     const [ptr, len] = passStringToWasm(JSON.stringify(getObject(idx)));
                     getUint32Memory()[ptrptr / 4] = ptr;
                     return len;
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.bind("__wbindgen_jsval_eq", &|me| {
             me.expose_get_object();
-            Ok(String::from("
+            Ok(String::from(
+                "
                 function(a, b) {
                     return getObject(a) === getObject(b) ? 1 : 0;
                 }
-            "))
+            ",
+            ))
         })?;
 
         self.unexport_unused_internal_exports();
@@ -325,11 +365,13 @@ impl<'a> Context<'a> {
         // isn't gc'd).
         self.bind("__wbindgen_throw", &|me| {
             me.expose_get_string_from_wasm();
-            Ok(format!("
+            Ok(format!(
+                "
                 function(ptr, len) {{
                     throw new Error(getStringFromWasm(ptr, len));
                 }}
-            "))
+            "
+            ))
         })?;
 
         self.rewrite_imports(module_name);
@@ -361,24 +403,25 @@ impl<'a> Context<'a> {
             )
         } else {
             let import_wasm = if self.config.nodejs {
-                self.footer.push_str(&format!("wasm = require('./{}_bg');",
-                                              module_name));
+                self.footer
+                    .push_str(&format!("wasm = require('./{}_bg');", module_name));
                 format!("var wasm;")
             } else {
                 format!("import * as wasm from './{}_bg.wasm';", module_name)
             };
 
-            format!("\
+            format!(
+                "\
                 /* tslint:disable */\n\
                 {import_wasm}\n\
                 {imports}\n\
 
                 {globals}\n\
                 {footer}",
-                    import_wasm = import_wasm,
-                    globals = self.globals,
-                    imports = self.imports,
-                    footer = self.footer,
+                import_wasm = import_wasm,
+                globals = self.globals,
+                imports = self.imports,
+                footer = self.footer,
             )
         };
 
@@ -393,16 +436,16 @@ impl<'a> Context<'a> {
         Ok((js, self.typescript.clone()))
     }
 
-    fn bind(&mut self, name: &str, f: &Fn(&mut Self) -> Result<String, Error>)
-        -> Result<(), Error>
-    {
+    fn bind(
+        &mut self,
+        name: &str,
+        f: &Fn(&mut Self) -> Result<String, Error>,
+    ) -> Result<(), Error> {
         if !self.wasm_import_needed(name) {
             return Ok(());
         }
         let contents = f(self)
-            .with_context(|_| {
-                format!("failed to generate internal JS function `{}`", name)
-            })?;
+            .with_context(|_| format!("failed to generate internal JS function `{}`", name))?;
         self.export(name, &contents, None);
         Ok(())
     }
@@ -422,7 +465,8 @@ impl<'a> Context<'a> {
         if self.config.debug || class.constructor.is_some() {
             self.expose_constructor_token();
 
-            dst.push_str(&format!("
+            dst.push_str(&format!(
+                "
                 static __construct(ptr) {{
                     return new {}(new ConstructorToken(ptr));
                 }}
@@ -432,24 +476,33 @@ impl<'a> Context<'a> {
                         this.ptr = args[0].ptr;
                         return;
                     }}
-            ", name));
+            ",
+                name
+            ));
 
             if let Some(ref constructor) = class.constructor {
                 ts_dst.push_str(&format!("constructor(...args: any[]);\n"));
 
-                dst.push_str(&format!("
+                dst.push_str(&format!(
+                    "
                     // This invocation of new will call this constructor with a ConstructorToken
                     let instance = {class}.{constructor}(...args);
                     this.ptr = instance.ptr;
-                ", class = name, constructor = constructor));
+                ",
+                    class = name,
+                    constructor = constructor
+                ));
             } else {
-                dst.push_str("throw new Error('you cannot invoke `new` directly without having a \
-            method annotated a constructor');\n");
+                dst.push_str(
+                    "throw new Error('you cannot invoke `new` directly without having a \
+                     method annotated a constructor');\n",
+                );
             }
 
             dst.push_str("}");
         } else {
-            dst.push_str(&format!("
+            dst.push_str(&format!(
+                "
                 static __construct(ptr) {{
                     return new {}(ptr);
                 }}
@@ -457,18 +510,27 @@ impl<'a> Context<'a> {
                 constructor(ptr) {{
                     this.ptr = ptr;
                 }}
-            ", name));
+            ",
+                name
+            ));
         }
 
         let new_name = shared::new_function(&name);
         if self.wasm_import_needed(&new_name) {
             self.expose_add_heap_object();
 
-            self.export(&new_name, &format!("
+            self.export(
+                &new_name,
+                &format!(
+                    "
                 function(ptr) {{
                     return addHeapObject({}.__construct(ptr));
                 }}
-            ", name), None);
+            ",
+                    name
+                ),
+                None,
+            );
         }
 
         for field in class.fields.iter() {
@@ -481,13 +543,13 @@ impl<'a> Context<'a> {
 
             let set = {
                 let mut cx = Js2Rust::new(&field.name, self);
-                cx.method(true)
-                    .argument(&descriptor)?
-                    .ret(&None)?;
-                ts_dst.push_str(&format!("{}{}: {}\n",
-                                         if field.readonly { "readonly " } else { "" },
-                                         field.name,
-                                         &cx.js_arguments[0].1));
+                cx.method(true).argument(&descriptor)?.ret(&None)?;
+                ts_dst.push_str(&format!(
+                    "{}{}: {}\n",
+                    if field.readonly { "readonly " } else { "" },
+                    field.name,
+                    &cx.js_arguments[0].1
+                ));
                 cx.finish("", &format!("wasm.{}", wasm_setter)).0
             };
             let (get, _ts) = Js2Rust::new(&field.name, self)
@@ -509,13 +571,16 @@ impl<'a> Context<'a> {
             }
         }
 
-        dst.push_str(&format!("
+        dst.push_str(&format!(
+            "
             free() {{
                 const ptr = this.ptr;
                 this.ptr = 0;
                 wasm.{}(ptr);
             }}
-        ", shared::free_function(&name)));
+        ",
+            shared::free_function(&name)
+        ));
         ts_dst.push_str("free(): void;\n");
         dst.push_str(&class.contents);
         ts_dst.push_str(&class.typescript);
@@ -530,17 +595,16 @@ impl<'a> Context<'a> {
 
     fn export_table(&mut self) {
         if !self.function_table_needed {
-            return
+            return;
         }
         for section in self.module.sections_mut() {
             let exports = match *section {
                 Section::Export(ref mut s) => s,
                 _ => continue,
             };
-            let entry = ExportEntry::new("__wbg_function_table".to_string(),
-                                         Internal::Table(0));
+            let entry = ExportEntry::new("__wbg_function_table".to_string(), Internal::Table(0));
             exports.entries_mut().push(entry);
-            break
+            break;
         }
     }
 
@@ -550,17 +614,15 @@ impl<'a> Context<'a> {
         }
     }
 
-    fn _rewrite_imports(&mut self, module_name: &str)
-                        -> Vec<(String, String)>
-    {
+    fn _rewrite_imports(&mut self, module_name: &str) -> Vec<(String, String)> {
         let mut math_imports = Vec::new();
-        let imports = self.module.sections_mut()
+        let imports = self
+            .module
+            .sections_mut()
             .iter_mut()
-            .filter_map(|s| {
-                match *s {
-                    Section::Import(ref mut s) => Some(s),
-                    _ => None,
-                }
+            .filter_map(|s| match *s {
+                Section::Import(ref mut s) => Some(s),
+                _ => None,
             })
             .flat_map(|s| s.entries_mut());
 
@@ -578,10 +640,7 @@ impl<'a> Context<'a> {
 
             let renamed_import = format!("__wbindgen_{}", import.field());
             let mut bind_math = |expr: &str| {
-                math_imports.push((
-                    renamed_import.clone(),
-                    format!("function{}", expr),
-                ));
+                math_imports.push((renamed_import.clone(), format!("function{}", expr)));
             };
 
             // FIXME(#32): try to not use function shims
@@ -640,8 +699,7 @@ impl<'a> Context<'a> {
                 _ => continue,
             };
             exports.entries_mut().retain(|export| {
-                !export.field().starts_with("__wbindgen") ||
-                    required.contains(export.field())
+                !export.field().starts_with("__wbindgen") || required.contains(export.field())
             });
         }
     }
@@ -653,25 +711,32 @@ impl<'a> Context<'a> {
         self.expose_global_slab();
         self.expose_global_slab_next();
         let validate_owned = if self.config.debug {
-            String::from("
+            String::from(
+                "
                 if ((idx & 1) === 1) throw new Error('cannot drop ref of stack objects');
-            ")
+            ",
+            )
         } else {
             String::new()
         };
         let dec_ref = if self.config.debug {
-            String::from("
+            String::from(
+                "
                 if (typeof(obj) === 'number') throw new Error('corrupt slab');
                 obj.cnt -= 1;
                 if (obj.cnt > 0) return;
-            ")
+            ",
+            )
         } else {
-            String::from("
+            String::from(
+                "
                 obj.cnt -= 1;
                 if (obj.cnt > 0) return;
-            ")
+            ",
+            )
         };
-        self.global(&format!("
+        self.global(&format!(
+            "
             function dropRef(idx) {{
                 {}
                 let obj = slab[idx >> 1];
@@ -680,23 +745,31 @@ impl<'a> Context<'a> {
                 slab[idx >> 1] = slab_next;
                 slab_next = idx >> 1;
             }}
-        ", validate_owned, dec_ref));
+        ",
+            validate_owned, dec_ref
+        ));
     }
 
     fn expose_global_stack(&mut self) {
         if !self.exposed_globals.insert("stack") {
             return;
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             let stack = [];
-        "));
+        "
+        ));
         if self.config.debug {
-            self.export("assertStackEmpty", "
+            self.export(
+                "assertStackEmpty",
+                "
                 function() {
                     if (stack.length === 0) return;
                     throw new Error('stack is not currently empty');
                 }
-            ", None);
+            ",
+                None,
+            );
         }
     }
 
@@ -712,14 +785,21 @@ impl<'a> Context<'a> {
         ];
         self.global(&format!("let slab = [{}];", initial_values.join(", ")));
         if self.config.debug {
-            self.export("assertSlabEmpty", &format!("
+            self.export(
+                "assertSlabEmpty",
+                &format!(
+                    "
                 function() {{
                     for (let i = {}; i < slab.length; i++) {{
                         if (typeof(slab[i]) === 'number') continue;
                         throw new Error('slab is not currently empty');
                     }}
                 }}
-            ", initial_values.len()), None);
+            ",
+                    initial_values.len()
+                ),
+                None,
+            );
         }
     }
 
@@ -728,9 +808,11 @@ impl<'a> Context<'a> {
             return;
         }
         self.expose_global_slab();
-        self.global(&format!("
+        self.global(&format!(
+            "
             let slab_next = slab.length;
-        "));
+        "
+        ));
     }
 
     fn expose_get_object(&mut self) {
@@ -741,16 +823,21 @@ impl<'a> Context<'a> {
         self.expose_global_slab();
 
         let get_obj = if self.config.debug {
-            String::from("
+            String::from(
+                "
                 if (typeof(val) === 'number') throw new Error('corrupt slab');
                 return val.obj;
-            ")
+            ",
+            )
         } else {
-            String::from("
+            String::from(
+                "
                 return val.obj;
-            ")
+            ",
+            )
         };
-        self.global(&format!("
+        self.global(&format!(
+            "
             function getObject(idx) {{
                 if ((idx & 1) === 1) {{
                     return stack[idx >> 1];
@@ -759,31 +846,37 @@ impl<'a> Context<'a> {
                     {}
                 }}
             }}
-        ", get_obj));
+        ",
+            get_obj
+        ));
     }
 
     fn expose_assert_num(&mut self) {
         if !self.exposed_globals.insert("assert_num") {
             return;
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             function _assertNum(n) {{
                 if (typeof(n) !== 'number') throw new Error('expected a number argument');
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_assert_bool(&mut self) {
         if !self.exposed_globals.insert("assert_bool") {
             return;
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             function _assertBoolean(n) {{
                 if (typeof(n) !== 'boolean') {{
                     throw new Error('expected a boolean argument');
                 }}
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_pass_string_to_wasm(&mut self) -> Result<(), Error> {
@@ -800,7 +893,8 @@ impl<'a> Context<'a> {
         } else {
             ""
         };
-        self.global(&format!("
+        self.global(&format!(
+            "
             function passStringToWasm(arg) {{
                 {}
                 const buf = cachedEncoder.encode(arg);
@@ -808,7 +902,9 @@ impl<'a> Context<'a> {
                 getUint8Memory().set(buf, ptr);
                 return [ptr, buf.length];
             }}
-        ", debug));
+        ",
+            debug
+        ));
         Ok(())
     }
 
@@ -842,23 +938,29 @@ impl<'a> Context<'a> {
         self.pass_array_to_wasm("passArrayF64ToWasm", "getFloat64Memory", 8)
     }
 
-    fn pass_array_to_wasm(&mut self,
-                          name: &'static str,
-                          delegate: &str,
-                          size: usize) -> Result<(), Error>
-    {
+    fn pass_array_to_wasm(
+        &mut self,
+        name: &'static str,
+        delegate: &str,
+        size: usize,
+    ) -> Result<(), Error> {
         if !self.exposed_globals.insert(name) {
-            return Ok(())
+            return Ok(());
         }
         self.require_internal_export("__wbindgen_malloc")?;
         self.expose_uint64_memory();
-        self.global(&format!("
+        self.global(&format!(
+            "
             function {}(arg) {{
                 const ptr = wasm.__wbindgen_malloc(arg.length * {size});
                 {}().set(arg, ptr / {size});
                 return [ptr, arg.length];
             }}
-        ", name, delegate, size = size));
+        ",
+            name,
+            delegate,
+            size = size
+        ));
         Ok(())
     }
 
@@ -867,19 +969,25 @@ impl<'a> Context<'a> {
             return;
         }
         if self.config.nodejs {
-            self.global(&format!("
+            self.global(&format!(
+                "
                 const TextEncoder = require('util').TextEncoder;
-            "));
+            "
+            ));
         } else if !(self.config.browser || self.config.no_modules) {
-            self.global(&format!("
+            self.global(&format!(
+                "
                 const TextEncoder = typeof self === 'object' && self.TextEncoder
                     ? self.TextEncoder
                     : require('util').TextEncoder;
-            "));
+            "
+            ));
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             let cachedEncoder = new TextEncoder('utf-8');
-        "));
+        "
+        ));
     }
 
     fn expose_text_decoder(&mut self) {
@@ -887,19 +995,25 @@ impl<'a> Context<'a> {
             return;
         }
         if self.config.nodejs {
-            self.global(&format!("
+            self.global(&format!(
+                "
                 const TextDecoder = require('util').TextDecoder;
-            "));
+            "
+            ));
         } else if !(self.config.browser || self.config.no_modules) {
-            self.global(&format!("
+            self.global(&format!(
+                "
                 const TextDecoder = typeof self === 'object' && self.TextDecoder
                     ? self.TextDecoder
                     : require('util').TextDecoder;
-            "));
+            "
+            ));
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             let cachedDecoder = new TextDecoder('utf-8');
-        "));
+        "
+        ));
     }
 
     fn expose_constructor_token(&mut self) {
@@ -907,13 +1021,15 @@ impl<'a> Context<'a> {
             return;
         }
 
-        self.global("
+        self.global(
+            "
             class ConstructorToken {
                 constructor(ptr) {
                     this.ptr = ptr;
                 }
             }
-        ");
+        ",
+        );
     }
 
     fn expose_get_string_from_wasm(&mut self) {
@@ -922,11 +1038,13 @@ impl<'a> Context<'a> {
         }
         self.expose_text_decoder();
         self.expose_uint8_memory();
-        self.global(&format!("
+        self.global(&format!(
+            "
             function getStringFromWasm(ptr, len) {{
                 return cachedDecoder.decode(getUint8Memory().subarray(ptr, ptr + len));
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_get_array_js_value_from_wasm(&mut self) {
@@ -935,7 +1053,8 @@ impl<'a> Context<'a> {
         }
         self.expose_get_array_u32_from_wasm();
         self.expose_take_object();
-        self.global(&format!("
+        self.global(&format!(
+            "
             function getArrayJsValueFromWasm(ptr, len) {{
                 const mem = getUint32Memory();
                 const slice = mem.subarray(ptr / 4, ptr / 4 + len);
@@ -945,7 +1064,8 @@ impl<'a> Context<'a> {
                 }}
                 return result;
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_get_array_i8_from_wasm(&mut self) {
@@ -1002,7 +1122,8 @@ impl<'a> Context<'a> {
         if !self.exposed_globals.insert(name) {
             return;
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             function {name}(ptr, len) {{
                 return {mem}().subarray(ptr / {size}, ptr / {size} + len);
             }}
@@ -1106,12 +1227,12 @@ impl<'a> Context<'a> {
         }
     }
 
-
     fn memview(&mut self, name: &'static str, js: &str) {
         if !self.exposed_globals.insert(name) {
             return;
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             let cache{name} = null;
             function {name}() {{
                 if (cache{name} === null || cache{name}.buffer !== wasm.memory.buffer) {{
@@ -1129,14 +1250,16 @@ impl<'a> Context<'a> {
         if !self.exposed_globals.insert("assert_class") {
             return;
         }
-        self.global(&format!("
+        self.global(&format!(
+            "
             function _assertClass(instance, klass) {{
                 if (!(instance instanceof klass)) {{
                     throw new Error(`expected instance of ${{klass.name}}`);
                 }}
                 return instance.ptr;
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_borrowed_objects(&mut self) {
@@ -1144,12 +1267,14 @@ impl<'a> Context<'a> {
             return;
         }
         self.expose_global_stack();
-        self.global(&format!("
+        self.global(&format!(
+            "
             function addBorrowedObject(obj) {{
                 stack.push(obj);
                 return ((stack.length - 1) << 1) | 1;
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_take_object(&mut self) {
@@ -1158,13 +1283,15 @@ impl<'a> Context<'a> {
         }
         self.expose_get_object();
         self.expose_drop_ref();
-        self.global(&format!("
+        self.global(&format!(
+            "
             function takeObject(idx) {{
                 const ret = getObject(idx);
                 dropRef(idx);
                 return ret;
             }}
-        "));
+        "
+        ));
     }
 
     fn expose_add_heap_object(&mut self) {
@@ -1174,16 +1301,21 @@ impl<'a> Context<'a> {
         self.expose_global_slab();
         self.expose_global_slab_next();
         let set_slab_next = if self.config.debug {
-            String::from("
+            String::from(
+                "
                 if (typeof(next) !== 'number') throw new Error('corrupt slab');
                 slab_next = next;
-            ")
+            ",
+            )
         } else {
-            String::from("
+            String::from(
+                "
                 slab_next = next;
-            ")
+            ",
+            )
         };
-        self.global(&format!("
+        self.global(&format!(
+            "
             function addHeapObject(obj) {{
                 if (slab_next === slab.length) slab.push(slab.length + 1);
                 const idx = slab_next;
@@ -1192,7 +1324,9 @@ impl<'a> Context<'a> {
                 slab[idx] = {{ obj, cnt: 1 }};
                 return idx << 1;
             }}
-        ", set_slab_next));
+        ",
+            set_slab_next
+        ));
     }
 
     fn wasm_import_needed(&self, name: &str) -> bool {
@@ -1201,9 +1335,10 @@ impl<'a> Context<'a> {
             None => return false,
         };
 
-        imports.entries().iter().any(|i| {
-            i.module() == "__wbindgen_placeholder__" && i.field() == name
-        })
+        imports
+            .entries()
+            .iter()
+            .any(|i| i.module() == "__wbindgen_placeholder__" && i.field() == name)
     }
 
     fn pass_to_wasm_function(&mut self, t: VectorKind) -> Result<&'static str, Error> {
@@ -1212,23 +1347,19 @@ impl<'a> Context<'a> {
                 self.expose_pass_string_to_wasm()?;
                 "passStringToWasm"
             }
-            VectorKind::I8 |
-            VectorKind::U8 => {
+            VectorKind::I8 | VectorKind::U8 => {
                 self.expose_pass_array8_to_wasm()?;
                 "passArray8ToWasm"
             }
-            VectorKind::U16 |
-            VectorKind::I16 => {
+            VectorKind::U16 | VectorKind::I16 => {
                 self.expose_pass_array16_to_wasm()?;
                 "passArray16ToWasm"
             }
-            VectorKind::I32 |
-            VectorKind::U32 => {
+            VectorKind::I32 | VectorKind::U32 => {
                 self.expose_pass_array32_to_wasm()?;
                 "passArray32ToWasm"
             }
-            VectorKind::I64 |
-            VectorKind::U64 => {
+            VectorKind::I64 | VectorKind::U64 => {
                 self.expose_pass_array64_to_wasm()?;
                 "passArray64ToWasm"
             }
@@ -1240,9 +1371,7 @@ impl<'a> Context<'a> {
                 self.expose_pass_array_f64_to_wasm()?;
                 "passArrayF64ToWasm"
             }
-            VectorKind::Anyref => {
-                bail!("cannot pass list of JsValue to wasm yet")
-            }
+            VectorKind::Anyref => bail!("cannot pass list of JsValue to wasm yet"),
         };
         Ok(s)
     }
@@ -1306,12 +1435,14 @@ impl<'a> Context<'a> {
         }
         self.expose_uint32_memory();
         self.expose_global_argument_ptr()?;
-        self.global("
+        self.global(
+            "
             function getGlobalArgument(arg) {
                 const idx = globalArgumentPtr() / 4 + arg;
                 return getUint32Memory()[idx];
             }
-        ");
+        ",
+        );
         Ok(())
     }
 
@@ -1320,7 +1451,8 @@ impl<'a> Context<'a> {
             return Ok(());
         }
         self.require_internal_export("__wbindgen_global_argument_ptr")?;
-        self.global("
+        self.global(
+            "
             let cachedGlobalArgumentPtr = null;
             function globalArgumentPtr() {
                 if (cachedGlobalArgumentPtr === null) {{
@@ -1328,13 +1460,14 @@ impl<'a> Context<'a> {
                 }}
                 return cachedGlobalArgumentPtr;
             }
-        ");
+        ",
+        );
         Ok(())
     }
 
     fn expose_get_inherited_descriptor(&mut self) {
         if !self.exposed_globals.insert("get_inherited_descriptor") {
-            return
+            return;
         }
         // It looks like while rare some browsers will move descriptors up the
         // property chain which runs the risk of breaking wasm-bindgen-generated
@@ -1345,7 +1478,8 @@ impl<'a> Context<'a> {
         // As a result we have a small helper here which will walk the prototype
         // chain looking for a descriptor. For some more information on this see
         // #109
-        self.global("
+        self.global(
+            "
             function GetOwnOrInheritedPropertyDescriptor(obj, id) {
               while (obj) {
                 let desc = Object.getOwnPropertyDescriptor(obj, id);
@@ -1354,13 +1488,14 @@ impl<'a> Context<'a> {
               }
               throw new Error('descriptor not found');
             }
-        ");
+        ",
+        );
     }
 
     fn expose_u32_cvt_shim(&mut self) -> &'static str {
         let name = "u32CvtShim";
         if !self.exposed_globals.insert(name) {
-            return name
+            return name;
         }
         self.global(&format!("const {} = new Uint32Array(2);", name));
         name
@@ -1369,20 +1504,26 @@ impl<'a> Context<'a> {
     fn expose_int64_cvt_shim(&mut self) -> &'static str {
         let name = "int64CvtShim";
         if !self.exposed_globals.insert(name) {
-            return name
+            return name;
         }
         let n = self.expose_u32_cvt_shim();
-        self.global(&format!("const {} = new BigInt64Array({}.buffer);", name, n));
+        self.global(&format!(
+            "const {} = new BigInt64Array({}.buffer);",
+            name, n
+        ));
         name
     }
 
     fn expose_uint64_cvt_shim(&mut self) -> &'static str {
         let name = "uint64CvtShim";
         if !self.exposed_globals.insert(name) {
-            return name
+            return name;
         }
         let n = self.expose_u32_cvt_shim();
-        self.global(&format!("const {} = new BigUint64Array({}.buffer);", name, n));
+        self.global(&format!(
+            "const {} = new BigUint64Array({}.buffer);",
+            name, n
+        ));
         name
     }
 
@@ -1416,7 +1557,7 @@ impl<'a> Context<'a> {
 
     fn add_wasm_pack_section(&mut self) {
         if self.module_versions.len() == 0 {
-            return
+            return;
         }
 
         #[derive(Serialize)]
@@ -1440,11 +1581,12 @@ impl<'a> Context<'a> {
 impl<'a, 'b> SubContext<'a, 'b> {
     pub fn generate(&mut self) -> Result<(), Error> {
         for f in self.program.exports.iter() {
-            self.generate_export(f)
-                .with_context(|_| {
-                    format!("failed to generate bindings for Rust export `{}`",
-                            f.function.name)
-                })?;
+            self.generate_export(f).with_context(|_| {
+                format!(
+                    "failed to generate bindings for Rust export `{}`",
+                    f.function.name
+                )
+            })?;
         }
         for f in self.program.imports.iter() {
             self.generate_import(f)?;
@@ -1453,26 +1595,23 @@ impl<'a, 'b> SubContext<'a, 'b> {
             self.generate_enum(e);
         }
         for s in self.program.structs.iter() {
-            let mut class = self.cx.exported_classes
+            let mut class = self
+                .cx
+                .exported_classes
                 .entry(s.name.clone())
                 .or_insert_with(Default::default);
             class.comments = format_doc_comments(&s.comments);
-            class.fields
-                .extend(s.fields.iter().map(|f| {
-                    ClassField {
-                        name: f.name.clone(),
-                        readonly: f.readonly,
-                        comments: format_doc_comments(&f.comments),
-                    }
-                }));
+            class.fields.extend(s.fields.iter().map(|f| ClassField {
+                name: f.name.clone(),
+                readonly: f.readonly,
+                comments: format_doc_comments(&f.comments),
+            }));
         }
 
         Ok(())
     }
 
-    fn generate_export(&mut self, export: &shared::Export)
-        -> Result<(), Error>
-    {
+    fn generate_export(&mut self, export: &shared::Export) -> Result<(), Error> {
         if let Some(ref class) = export.class {
             return self.generate_export_for_class(class, export);
         }
@@ -1485,7 +1624,11 @@ impl<'a, 'b> SubContext<'a, 'b> {
         let (js, ts) = Js2Rust::new(&export.function.name, self.cx)
             .process(descriptor.unwrap_function())?
             .finish("function", &format!("wasm.{}", export.function.name));
-        self.cx.export(&export.function.name, &js, Some(format_doc_comments(&export.comments)));
+        self.cx.export(
+            &export.function.name,
+            &js,
+            Some(format_doc_comments(&export.comments)),
+        );
         self.cx.globals.push_str("\n");
         self.cx.typescript.push_str("export ");
         self.cx.typescript.push_str(&ts);
@@ -1509,15 +1652,22 @@ impl<'a, 'b> SubContext<'a, 'b> {
             .method(export.method)
             .process(descriptor.unwrap_function())?
             .finish("", &format!("wasm.{}", wasm_name));
-        let class = self.cx.exported_classes.entry(class_name.to_string())
+        let class = self
+            .cx
+            .exported_classes
+            .entry(class_name.to_string())
             .or_insert(ExportedClass::default());
-        class.contents.push_str(&format_doc_comments(&export.comments));
+        class
+            .contents
+            .push_str(&format_doc_comments(&export.comments));
         if !export.method {
             class.contents.push_str("static ");
             class.typescript.push_str("static ");
         }
 
-        let constructors: Vec<String> = self.program.exports
+        let constructors: Vec<String> = self
+            .program
+            .exports
             .iter()
             .filter(|x| x.class == Some(class_name.to_string()))
             .filter_map(|x| x.constructor.clone())
@@ -1540,27 +1690,24 @@ impl<'a, 'b> SubContext<'a, 'b> {
         self.validate_import_module(import)?;
         match import.kind {
             shared::ImportKind::Function(ref f) => {
-                self.generate_import_function(import, f)
-                    .with_context(|_| {
-                        format!("failed to generate bindings for JS import `{}`",
-                                f.function.name)
-                    })?;
+                self.generate_import_function(import, f).with_context(|_| {
+                    format!(
+                        "failed to generate bindings for JS import `{}`",
+                        f.function.name
+                    )
+                })?;
             }
             shared::ImportKind::Static(ref s) => {
-                self.generate_import_static(import, s)
-                    .with_context(|_| {
-                        format!("failed to generate bindings for JS import `{}`",
-                                s.name)
-                    })?;
+                self.generate_import_static(import, s).with_context(|_| {
+                    format!("failed to generate bindings for JS import `{}`", s.name)
+                })?;
             }
             shared::ImportKind::Type(_) => {}
         }
         Ok(())
     }
 
-    fn validate_import_module(&mut self, import: &shared::Import)
-        -> Result<(), Error>
-    {
+    fn validate_import_module(&mut self, import: &shared::Import) -> Result<(), Error> {
         let version = match import.version {
             Some(ref s) => s,
             None => return Ok(()),
@@ -1570,16 +1717,17 @@ impl<'a, 'b> SubContext<'a, 'b> {
             None => return Ok(()),
         };
         if module.starts_with("./") {
-            return Ok(())
+            return Ok(());
         }
         let pkg = if module.starts_with("@") {
             // Translate `@foo/bar/baz` to `@foo/bar` and `@foo/bar` to itself
             let first_slash = match module.find('/') {
                 Some(i) => i,
-                None => {
-                    bail!("packages starting with `@` must be of the form \
-                           `@foo/bar`, but found: `{}`", module)
-                }
+                None => bail!(
+                    "packages starting with `@` must be of the form \
+                     `@foo/bar`, but found: `{}`",
+                    module
+                ),
             };
             match module[first_slash + 1..].find('/') {
                 Some(i) => &module[..i],
@@ -1588,7 +1736,9 @@ impl<'a, 'b> SubContext<'a, 'b> {
         } else {
             module.split('/').next().unwrap()
         };
-        self.cx.module_versions.push((pkg.to_string(), version.clone()));
+        self.cx
+            .module_versions
+            .push((pkg.to_string(), version.clone()));
         Ok(())
     }
 
@@ -1596,32 +1746,42 @@ impl<'a, 'b> SubContext<'a, 'b> {
         &mut self,
         info: &shared::Import,
         import: &shared::ImportStatic,
-    )
-        -> Result<(), Error>
-    {
+    ) -> Result<(), Error> {
         // TODO: should support more types to import here
         let obj = self.import_name(info, &import.name)?;
         self.cx.expose_add_heap_object();
-        self.cx.export(&import.shim, &format!("
+        self.cx.export(
+            &import.shim,
+            &format!(
+                "
             function() {{
                 return addHeapObject({});
             }}
-        ", obj), None);
+        ",
+                obj
+            ),
+            None,
+        );
         Ok(())
     }
 
-    fn generate_import_function(&mut self,
-                                info: &shared::Import,
-                                import: &shared::ImportFunction)
-        -> Result<(), Error>
-    {
+    fn generate_import_function(
+        &mut self,
+        info: &shared::Import,
+        import: &shared::ImportFunction,
+    ) -> Result<(), Error> {
         let descriptor = match self.cx.describe(&import.shim) {
             None => return Ok(()),
             Some(d) => d,
         };
 
         let target = match &import.method {
-            Some(shared::MethodData { class, kind, getter, setter }) => {
+            Some(shared::MethodData {
+                class,
+                kind,
+                getter,
+                setter,
+            }) => {
                 let class = self.import_name(info, class)?;
                 if let shared::MethodKind::Constructor = kind {
                     format!("new {}", class)
@@ -1634,31 +1794,37 @@ impl<'a, 'b> SubContext<'a, 'b> {
 
                     let target = if let Some(g) = getter {
                         if import.structural {
-                            format!("function(y) {{
+                            format!(
+                                "function(y) {{
                                 return this.{};
-                            }}", g)
+                            }}",
+                                g
+                            )
                         } else {
                             self.cx.expose_get_inherited_descriptor();
                             format!(
                                 "GetOwnOrInheritedPropertyDescriptor\
-                                    ({}{}, '{}').get",
+                                 ({}{}, '{}').get",
                                 class,
-                                if is_static { "" } else { ".prototype "},
+                                if is_static { "" } else { ".prototype " },
                                 g,
                             )
                         }
                     } else if let Some(s) = setter {
                         if import.structural {
-                            format!("function(y) {{
+                            format!(
+                                "function(y) {{
                                 this.{} = y;
-                            }}", s)
+                            }}",
+                                s
+                            )
                         } else {
                             self.cx.expose_get_inherited_descriptor();
                             format!(
                                 "GetOwnOrInheritedPropertyDescriptor\
-                                    ({}{}, '{}').set",
+                                 ({}{}, '{}').set",
                                 class,
-                                if is_static { "" } else { ".prototype "},
+                                if is_static { "" } else { ".prototype " },
                                 s,
                             )
                         }
@@ -1684,21 +1850,36 @@ impl<'a, 'b> SubContext<'a, 'b> {
                             s.push_str(");\n}");
                             s
                         } else {
-                            format!("{}{}.{}", class, if is_static { "" } else { ".prototype" }, import.function.name)
+                            format!(
+                                "{}{}.{}",
+                                class,
+                                if is_static { "" } else { ".prototype" },
+                                import.function.name
+                            )
                         }
                     };
-                    self.cx.global(&format!("
+                    self.cx.global(&format!(
+                        "
                         const {}_target = {};
-                    ", import.shim, target));
-                    format!("{}_target{}", import.shim, if is_static { "" } else { ".call" })
+                    ",
+                        import.shim, target
+                    ));
+                    format!(
+                        "{}_target{}",
+                        import.shim,
+                        if is_static { "" } else { ".call" }
+                    )
                 }
             }
             None => {
                 let name = self.import_name(info, &import.function.name)?;
                 if name.contains(".") {
-                    self.cx.global(&format!("
+                    self.cx.global(&format!(
+                        "
                         const {}_target = {};
-                    ", import.shim, name));
+                    ",
+                        import.shim, name
+                    ));
                     format!("{}_target", import.shim)
                 } else {
                     name
@@ -1720,8 +1901,14 @@ impl<'a, 'b> SubContext<'a, 'b> {
         for variant in enum_.variants.iter() {
             variants.push_str(&format!("{}:{},", variant.name, variant.value));
         }
-        self.cx.export(&enum_.name, &format!("Object.freeze({{ {} }})", variants), Some(format_doc_comments(&enum_.comments)));
-        self.cx.typescript.push_str(&format!("export enum {} {{", enum_.name));
+        self.cx.export(
+            &enum_.name,
+            &format!("Object.freeze({{ {} }})", variants),
+            Some(format_doc_comments(&enum_.comments)),
+        );
+        self.cx
+            .typescript
+            .push_str(&format!("export enum {} {{", enum_.name));
 
         variants.clear();
         for variant in enum_.variants.iter() {
@@ -1731,26 +1918,33 @@ impl<'a, 'b> SubContext<'a, 'b> {
         self.cx.typescript.push_str("}\n");
     }
 
-    fn import_name(&mut self, import: &shared::Import, item: &str)
-        -> Result<String, Error>
-    {
+    fn import_name(&mut self, import: &shared::Import, item: &str) -> Result<String, Error> {
         if let Some(ref module) = import.module {
             if self.cx.config.no_modules {
-                bail!("import from `{}` module not allowed with `--no-modules`; \
-                      use `--nodejs` or `--browser` instead", module);
+                bail!(
+                    "import from `{}` module not allowed with `--no-modules`; \
+                     use `--nodejs` or `--browser` instead",
+                    module
+                );
             }
 
             let name = import.js_namespace.as_ref().map(|s| &**s).unwrap_or(item);
 
             if self.cx.imported_names.insert(name.to_string()) {
                 if self.cx.config.nodejs {
-                    self.cx.imports.push_str(&format!("\
-                        const {} = require('{}').{};\n\
-                    ", name, module, name));
+                    self.cx.imports.push_str(&format!(
+                        "\
+                         const {} = require('{}').{};\n\
+                         ",
+                        name, module, name
+                    ));
                 } else {
-                    self.cx.imports.push_str(&format!("\
-                        import {{ {} }} from '{}';\n\
-                    ", name, module));
+                    self.cx.imports.push_str(&format!(
+                        "\
+                         import {{ {} }} from '{}';\n\
+                         ",
+                        name, module
+                    ));
                 }
             }
         }
@@ -1762,6 +1956,9 @@ impl<'a, 'b> SubContext<'a, 'b> {
 }
 
 fn format_doc_comments(comments: &Vec<String>) -> String {
-    let body: String = comments.iter().map(|c| format!("*{}\n", c.trim_matches('"'))).collect();
+    let body: String = comments
+        .iter()
+        .map(|c| format!("*{}\n", c.trim_matches('"')))
+        .collect();
     format!("/**\n{}*/\n", body)
 }

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -271,7 +271,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 const mem = getUint32Memory();
                 mem[ret / 4] = retptr;
                 mem[ret / 4 + 1] = retlen;
-            ",
+                ",
                 f
             );
             return Ok(());
@@ -336,12 +336,12 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
 
             invoc = format!(
                 "\
-            try {{\n\
-            {}
-            }} catch (e) {{\n\
-            {}
-            }}\
-            ",
+                try {{\n\
+                {}
+                }} catch (e) {{\n\
+                {}
+                }}\
+                ",
                 &invoc, catch
             );
         };
@@ -349,12 +349,12 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         if self.finally.len() > 0 {
             invoc = format!(
                 "\
-            try {{\n\
-            {}
-            }} finally {{\n\
-            {}
-            }}\
-            ",
+                try {{\n\
+                {}
+                }} finally {{\n\
+                {}
+                }}\
+                ",
                 &invoc, &self.finally
             );
         }

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -1,7 +1,7 @@
 use failure::Error;
 
-use descriptor::{Descriptor, Function};
 use super::{Context, Js2Rust};
+use descriptor::{Descriptor, Function};
 
 /// Helper struct for manufacturing a shim in JS used to translate Rust types to
 /// JS, then invoking an imported JS function.
@@ -85,18 +85,27 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         if let Some(ty) = arg.vector_kind() {
             let abi2 = self.shim_argument();
             let f = self.cx.expose_get_vector_from_wasm(ty);
-            self.prelude(&format!("let v{0} = {func}({0}, {1});",
-                                  abi, abi2, func = f));
+            self.prelude(&format!(
+                "let v{0} = {func}({0}, {1});",
+                abi,
+                abi2,
+                func = f
+            ));
 
             if !arg.is_by_ref() {
-                self.prelude(&format!("\
-                    v{0} = v{0}.slice();\n\
-                    wasm.__wbindgen_free({0}, {1} * {size});\
-                ", abi, abi2, size = ty.size()));
+                self.prelude(&format!(
+                    "\
+                     v{0} = v{0}.slice();\n\
+                     wasm.__wbindgen_free({0}, {1} * {size});\
+                     ",
+                    abi,
+                    abi2,
+                    size = ty.size()
+                ));
                 self.cx.require_internal_export("__wbindgen_free")?;
             }
             self.js_arguments.push(format!("v{}", abi));
-            return Ok(())
+            return Ok(());
         }
 
         if let Some(signed) = arg.get_64bit() {
@@ -107,18 +116,19 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             };
             let hi = self.shim_argument();
             let name = format!("n{}", abi);
-            self.prelude(&format!("\
-                u32CvtShim[0] = {lo};\n\
-                u32CvtShim[1] = {hi};\n\
-                const {name} = {f}[0];\n\
-            ",
+            self.prelude(&format!(
+                "\
+                 u32CvtShim[0] = {lo};\n\
+                 u32CvtShim[1] = {hi};\n\
+                 const {name} = {f}[0];\n\
+                 ",
                 lo = abi,
                 hi = hi,
                 f = f,
                 name = name,
             ));
             self.js_arguments.push(name);
-            return Ok(())
+            return Ok(());
         }
 
         if let Some(class) = arg.rust_struct() {
@@ -128,14 +138,15 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             let assign = format!("let c{0} = {1}.__construct({0});", abi, class);
             self.prelude(&assign);
             self.js_arguments.push(format!("c{}", abi));
-            return Ok(())
+            return Ok(());
         }
 
         if let Some((f, mutable)) = arg.stack_closure() {
             let (js, _ts) = {
                 let mut builder = Js2Rust::new("", self.cx);
                 if mutable {
-                    builder.prelude("let a = this.a;\n")
+                    builder
+                        .prelude("let a = this.a;\n")
                         .prelude("this.a = 0;\n")
                         .rust_argument("a")
                         .finally("this.a = a;\n");
@@ -151,22 +162,28 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             self.cx.function_table_needed = true;
             let next_global = self.global_idx();
             self.global_idx();
-            self.prelude(&format!("\
-                let cb{0} = {js};\n\
-                cb{0}.f = wasm.__wbg_function_table.get({0});\n\
-                cb{0}.a = getGlobalArgument({next_global});\n\
-                cb{0}.b = getGlobalArgument({next_global} + 1);\n\
-            ", abi, js = js, next_global = next_global));
+            self.prelude(&format!(
+                "\
+                 let cb{0} = {js};\n\
+                 cb{0}.f = wasm.__wbg_function_table.get({0});\n\
+                 cb{0}.a = getGlobalArgument({next_global});\n\
+                 cb{0}.b = getGlobalArgument({next_global} + 1);\n\
+                 ",
+                abi,
+                js = js,
+                next_global = next_global
+            ));
             self.finally(&format!("cb{0}.a = cb{0}.b = 0;", abi));
             self.js_arguments.push(format!("cb{0}.bind(cb{0})", abi));
-            return Ok(())
+            return Ok(());
         }
 
         if let Some(closure) = arg.ref_closure() {
             let (js, _ts) = {
                 let mut builder = Js2Rust::new("", self.cx);
                 if closure.mutable {
-                    builder.prelude("let a = this.a;\n")
+                    builder
+                        .prelude("let a = this.a;\n")
                         .prelude("this.a = 0;\n")
                         .rust_argument("a")
                         .finally("this.a = a;\n");
@@ -182,38 +199,40 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             self.cx.expose_uint32_memory();
             self.cx.expose_add_heap_object();
             self.cx.function_table_needed = true;
-            let reset_idx  = format!("\
-                let cb{0} = {js};\n\
-                cb{0}.a = getGlobalArgument({a});\n\
-                cb{0}.b = getGlobalArgument({b});\n\
-                cb{0}.f = wasm.__wbg_function_table.get(getGlobalArgument({c}));\n\
-                let real = cb{0}.bind(cb{0});\n\
-                real.original = cb{0};\n\
-                idx{0} = getUint32Memory()[{0} / 4] = addHeapObject(real);\n\
-            ",
+            let reset_idx = format!(
+                "\
+                 let cb{0} = {js};\n\
+                 cb{0}.a = getGlobalArgument({a});\n\
+                 cb{0}.b = getGlobalArgument({b});\n\
+                 cb{0}.f = wasm.__wbg_function_table.get(getGlobalArgument({c}));\n\
+                 let real = cb{0}.bind(cb{0});\n\
+                 real.original = cb{0};\n\
+                 idx{0} = getUint32Memory()[{0} / 4] = addHeapObject(real);\n\
+                 ",
                 abi,
                 js = js,
                 a = self.global_idx(),
                 b = self.global_idx(),
                 c = self.global_idx(),
             );
-            self.prelude(&format!("\
-                let idx{0} = getUint32Memory()[{0} / 4];\n\
-                if (idx{0} === 0xffffffff) {{\n\
-                {1}\
-                }}\n\
-            ", abi, &reset_idx));
+            self.prelude(&format!(
+                "\
+                 let idx{0} = getUint32Memory()[{0} / 4];\n\
+                 if (idx{0} === 0xffffffff) {{\n\
+                 {1}\
+                 }}\n\
+                 ",
+                abi, &reset_idx
+            ));
             self.cx.expose_get_object();
             self.js_arguments.push(format!("getObject(idx{})", abi));
-            return Ok(())
+            return Ok(());
         }
 
         let invoc_arg = match *arg {
             ref d if d.is_number() => abi,
             Descriptor::Boolean => format!("{} !== 0", abi),
-            Descriptor::Char => {
-                format!("String.fromCodePoint({})", abi)
-            }
+            Descriptor::Char => format!("String.fromCodePoint({})", abi),
             Descriptor::Anyref => {
                 self.cx.expose_take_object();
                 format!("takeObject({})", abi)
@@ -222,7 +241,10 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 self.cx.expose_get_object();
                 format!("getObject({})", abi)
             }
-            _ => bail!("unimplemented argument type in imported function: {:?}", arg),
+            _ => bail!(
+                "unimplemented argument type in imported function: {:?}",
+                arg
+            ),
         };
         self.js_arguments.push(invoc_arg);
         Ok(())
@@ -233,7 +255,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             Some(ref t) => t,
             None => {
                 self.ret_expr = "JS;".to_string();
-                return Ok(())
+                return Ok(());
             }
         };
         if ty.is_by_ref() {
@@ -243,17 +265,20 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             let f = self.cx.pass_to_wasm_function(ty)?;
             self.cx.expose_uint32_memory();
             self.shim_arguments.insert(0, "ret".to_string());
-            self.ret_expr = format!("\
+            self.ret_expr = format!(
+                "\
                 const [retptr, retlen] = {}(JS);\n\
                 const mem = getUint32Memory();
                 mem[ret / 4] = retptr;
                 mem[ret / 4 + 1] = retlen;
-            ", f);
-            return Ok(())
+            ",
+                f
+            );
+            return Ok(());
         }
         if ty.is_number() {
             self.ret_expr = "return JS;".to_string();
-            return Ok(())
+            return Ok(());
         }
         if let Some(signed) = ty.get_64bit() {
             let f = if signed {
@@ -264,11 +289,14 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 "getUint64Memory"
             };
             self.shim_arguments.insert(0, "ret".to_string());
-            self.ret_expr = format!("\
-                const val = JS;\n\
-                {}()[ret / 8] = val;\n\
-            ", f);
-            return Ok(())
+            self.ret_expr = format!(
+                "\
+                 const val = JS;\n\
+                 {}()[ret / 8] = val;\n\
+                 ",
+                f
+            );
+            return Ok(());
         }
         self.ret_expr = match *ty {
             Descriptor::Boolean => "return JS ? 1 : 0;".to_string(),
@@ -301,33 +329,39 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         );
         if self.catch {
             let catch = "\
-                const view = getUint32Memory();\n\
-                view[exnptr / 4] = 1;\n\
-                view[exnptr / 4 + 1] = addHeapObject(e);\n\
-            ";
+                         const view = getUint32Memory();\n\
+                         view[exnptr / 4] = 1;\n\
+                         view[exnptr / 4 + 1] = addHeapObject(e);\n\
+                         ";
 
-            invoc = format!("\
+            invoc = format!(
+                "\
             try {{\n\
             {}
             }} catch (e) {{\n\
             {}
             }}\
-            ", &invoc, catch);
+            ",
+                &invoc, catch
+            );
         };
 
         if self.finally.len() > 0 {
-            invoc = format!("\
+            invoc = format!(
+                "\
             try {{\n\
             {}
             }} finally {{\n\
             {}
             }}\
-            ", &invoc, &self.finally);
+            ",
+                &invoc, &self.finally
+            );
         }
         ret.push_str(&invoc);
 
         ret.push_str("\n}\n");
-        return ret
+        return ret;
     }
 
     fn global_idx(&mut self) -> usize {

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -17,8 +17,8 @@ use std::path::{Path, PathBuf};
 use failure::{Error, ResultExt};
 use parity_wasm::elements::*;
 
-mod js;
 mod descriptor;
+mod js;
 pub mod wasm2es6js;
 
 pub struct Bindgen {
@@ -142,11 +142,9 @@ impl Bindgen {
                     let mut v = MyExternals(Vec::new());
                     match instance.invoke_export(name, &[], &mut v) {
                         Ok(None) => Some(v.0),
-                        Ok(Some(_)) => {
-                            unreachable!(
-                                "there is only one export, and we only return None from it"
-                            )
-                        },
+                        Ok(Some(_)) => unreachable!(
+                            "there is only one export, and we only return None from it"
+                        ),
                         // Allow missing exported describe functions. This can
                         // happen when a nested dependency crate exports things
                         // but the root crate doesn't use them.
@@ -207,13 +205,16 @@ impl Bindgen {
             shim.push_str(&format!("imports['{0}'] = require('{0}');\n", module));
         }
 
-        shim.push_str(&format!("
+        shim.push_str(&format!(
+            "
             const join = require('path').join;
             const bytes = require('fs').readFileSync(join(__dirname, '{}'));
             const wasmModule = new WebAssembly.Module(bytes);
             const wasmInstance = new WebAssembly.Instance(wasmModule, imports);
             module.exports = wasmInstance.exports;
-        ", path.file_name().unwrap().to_str().unwrap()));
+        ",
+            path.file_name().unwrap().to_str().unwrap()
+        ));
 
         reset_indentation(&shim)
     }
@@ -230,27 +231,25 @@ fn extract_programs(module: &mut Module) -> Result<Vec<shared::Program>, Error> 
             _ => continue,
         };
         if custom.name() != "__wasm_bindgen_unstable" {
-            continue
+            continue;
         }
         to_remove.push(i);
 
         let mut payload = custom.payload();
         while payload.len() > 0 {
-            let len =
-                ((payload[0] as usize) << 0) |
-                ((payload[1] as usize) << 8) |
-                ((payload[2] as usize) << 16) |
-                ((payload[3] as usize) << 24);
+            let len = ((payload[0] as usize) << 0)
+                | ((payload[1] as usize) << 8)
+                | ((payload[2] as usize) << 16)
+                | ((payload[3] as usize) << 24);
             let (a, b) = payload[4..].split_at(len as usize);
             payload = b;
             let p: shared::ProgramOnlySchema = match serde_json::from_slice(&a) {
                 Ok(f) => f,
-                Err(e) => {
-                    bail!("failed to decode what looked like wasm-bindgen data: {}", e)
-                }
+                Err(e) => bail!("failed to decode what looked like wasm-bindgen data: {}", e),
             };
             if p.schema_version != shared::SCHEMA_VERSION {
-                bail!("
+                bail!(
+                    "
 
 it looks like the Rust project used to create this wasm file was linked against
 a different version of wasm-bindgen than this binary:
@@ -272,13 +271,13 @@ or you can update the binary with
 if this warning fails to go away though and you're not sure what to do feel free
 to open an issue at https://github.com/alexcrichton/wasm-bindgen/issues!
 ",
-    p.version, version);
+                    p.version,
+                    version
+                );
             }
             let p: shared::Program = match serde_json::from_slice(&a) {
                 Ok(f) => f,
-                Err(e) => {
-                    bail!("failed to decode what looked like wasm-bindgen data: {}", e)
-                }
+                Err(e) => bail!("failed to decode what looked like wasm-bindgen data: {}", e),
             };
             ret.push(p);
         }
@@ -297,13 +296,13 @@ impl wasmi::ImportResolver for MyResolver {
         &self,
         module_name: &str,
         field_name: &str,
-        signature: &wasmi::Signature
+        signature: &wasmi::Signature,
     ) -> Result<wasmi::FuncRef, wasmi::Error> {
         // Route our special "describe" export to 1 and everything else to 0.
         // That way whenever the function 1 is invoked we know what to do and
         // when 0 is invoked (by accident) we'll trap and produce an error.
-        let idx = (module_name == "__wbindgen_placeholder__" &&
-            field_name == "__wbindgen_describe") as usize;
+        let idx = (module_name == "__wbindgen_placeholder__" && field_name == "__wbindgen_describe")
+            as usize;
         Ok(wasmi::FuncInstance::alloc_host(signature.clone(), idx))
     }
 
@@ -311,7 +310,7 @@ impl wasmi::ImportResolver for MyResolver {
         &self,
         _module_name: &str,
         _field_name: &str,
-        descriptor: &wasmi::GlobalDescriptor
+        descriptor: &wasmi::GlobalDescriptor,
     ) -> Result<wasmi::GlobalRef, wasmi::Error> {
         // dummy implementation to ensure instantiation succeeds
         let val = match descriptor.value_type() {
@@ -340,7 +339,7 @@ impl wasmi::ImportResolver for MyResolver {
         &self,
         _module_name: &str,
         _field_name: &str,
-        descriptor: &wasmi::TableDescriptor
+        descriptor: &wasmi::TableDescriptor,
     ) -> Result<wasmi::TableRef, wasmi::Error> {
         // dummy implementation to ensure instantiation succeeds
         let initial = descriptor.initial();
@@ -358,7 +357,7 @@ impl wasmi::Externals for MyExternals {
     fn invoke_index(
         &mut self,
         index: usize,
-        args: wasmi::RuntimeArgs
+        args: wasmi::RuntimeArgs,
     ) -> Result<Option<wasmi::RuntimeValue>, wasmi::Trap> {
         macro_rules! bail {
             ($($t:tt)*) => ({
@@ -413,7 +412,12 @@ fn indent_recurse(mut lines: ::std::str::Lines, current_indent: usize) -> String
         if trimmed.starts_with('?') || trimmed.starts_with(':') {
             current_indent += 1;
         }
-        format!("\n{}{}{}", "    ".repeat(current_indent), &trimmed, &indent_recurse(lines, next_indent))
+        format!(
+            "\n{}{}{}",
+            "    ".repeat(current_indent),
+            &trimmed,
+            &indent_recurse(lines, next_indent)
+        )
     } else {
         String::new()
     }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -212,7 +212,7 @@ impl Bindgen {
             const wasmModule = new WebAssembly.Module(bytes);
             const wasmInstance = new WebAssembly.Instance(wasmModule, imports);
             module.exports = wasmInstance.exports;
-        ",
+            ",
             path.file_name().unwrap().to_str().unwrap()
         ));
 

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -1,13 +1,13 @@
 extern crate base64;
 extern crate tempfile;
 
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{self, Write, Read};
+use std::io::{self, Read, Write};
 use std::process::Command;
 
-use parity_wasm::elements::*;
 use failure::{Error, ResultExt};
+use parity_wasm::elements::*;
 
 pub struct Config {
     base64: bool,
@@ -65,31 +65,36 @@ impl Output {
         let mut exports = format!("/* tslint:disable */\n");
 
         if let Some(i) = self.module.export_section() {
-            let imported_functions = self.module.import_section()
+            let imported_functions = self
+                .module
+                .import_section()
                 .map(|m| m.functions() as u32)
                 .unwrap_or(0);
             for entry in i.entries() {
                 let idx = match *entry.internal() {
                     Internal::Function(i) => i - imported_functions,
                     Internal::Memory(_) => {
-                        exports.push_str(&format!("
+                        exports.push_str(&format!(
+                            "
                             export const {}: WebAssembly.Memory;
-                        ", entry.field()));
-                        continue
+                        ",
+                            entry.field()
+                        ));
+                        continue;
                     }
-                    Internal::Table(_) => {
-                        continue
-                    }
-                    Internal::Global(_) => {
-                        continue
-                    }
+                    Internal::Table(_) => continue,
+                    Internal::Global(_) => continue,
                 };
 
-                let functions = self.module.function_section()
+                let functions = self
+                    .module
+                    .function_section()
                     .expect("failed to find function section");
                 let idx = functions.entries()[idx as usize].type_ref();
 
-                let types = self.module.type_section()
+                let types = self
+                    .module
+                    .type_section()
                     .expect("failed to find type section");
                 let ty = match types.types()[idx as usize] {
                     Type::Function(ref f) => f,
@@ -103,12 +108,17 @@ impl Output {
                     args.push_str(": number");
                 }
 
-                exports.push_str(&format!("
+                exports.push_str(&format!(
+                    "
                     export function {name}({args}): {ret};
                 ",
                     name = entry.field(),
                     args = args,
-                    ret = if ty.return_type().is_some() { "number" } else { "void" },
+                    ret = if ty.return_type().is_some() {
+                        "number"
+                    } else {
+                        "void"
+                    },
                 ));
             }
         }
@@ -117,7 +127,7 @@ impl Output {
             exports.push_str("export const booted: Promise<boolean>;");
         }
 
-        return exports
+        return exports;
     }
 
     pub fn js(self) -> Result<String, Error> {
@@ -146,19 +156,23 @@ impl Output {
                 }
 
                 if !set.insert(entry.module()) {
-                    continue
+                    continue;
                 }
 
                 let name = (b'a' + (set.len() as u8)) as char;
-                js_imports.push_str(&format!("import * as import_{} from '{}';",
-                                             name,
-                                             entry.module()));
+                js_imports.push_str(&format!(
+                    "import * as import_{} from '{}';",
+                    name,
+                    entry.module()
+                ));
                 imports.push_str(&format!("'{}': import_{}, ", entry.module(), name));
             }
         }
 
         if let Some(i) = self.module.export_section() {
-            let imported_functions = self.module.import_section()
+            let imported_functions = self
+                .module
+                .import_section()
                 .map(|m| m.functions() as u32)
                 .unwrap_or(0);
             for entry in i.entries() {
@@ -166,21 +180,21 @@ impl Output {
                     Internal::Function(i) => i - imported_functions,
                     Internal::Memory(_) => {
                         export_mem = true;
-                        continue
+                        continue;
                     }
-                    Internal::Table(_) => {
-                        continue
-                    }
-                    Internal::Global(_) => {
-                        continue
-                    }
+                    Internal::Table(_) => continue,
+                    Internal::Global(_) => continue,
                 };
 
-                let functions = self.module.function_section()
+                let functions = self
+                    .module
+                    .function_section()
                     .expect("failed to find function section");
                 let idx = functions.entries()[idx as usize].type_ref();
 
-                let types = self.module.type_section()
+                let types = self
+                    .module
+                    .type_section()
                     .expect("failed to find type section");
                 let ty = match types.types()[idx as usize] {
                     Type::Function(ref f) => f,
@@ -193,50 +207,67 @@ impl Output {
                     args.push((b'a' + (i as u8)) as char);
                 }
 
-                exports.push_str(&format!("
+                exports.push_str(&format!(
+                    "
                     export function {name}({args}) {{
                         {ret} wasm.exports.{name}({args});
                     }}
                 ",
                     name = entry.field(),
                     args = args,
-                    ret = if ty.return_type().is_some() { "return" } else { "" },
+                    ret = if ty.return_type().is_some() {
+                        "return"
+                    } else {
+                        ""
+                    },
                 ));
             }
         }
-        let inst = format!("WebAssembly.instantiate(bytes,{{ {imports} }})
+        let inst = format!(
+            "WebAssembly.instantiate(bytes,{{ {imports} }})
                 .then(obj => {{
                     wasm = obj.instance;
                     {memory}
                 }})",
-                imports = imports,
-                memory = if export_mem { "memory = wasm.exports.memory;" } else { "" },
-            );
+            imports = imports,
+            memory = if export_mem {
+                "memory = wasm.exports.memory;"
+            } else {
+                ""
+            },
+        );
         let (bytes, booted) = if self.base64 {
-            let wasm = serialize(self.module)
-                .expect("failed to serialize");
+            let wasm = serialize(self.module).expect("failed to serialize");
             (
-                format!("
+                format!(
+                    "
                     let bytes;
                     const base64 = \"{base64}\";
                     if (typeof Buffer === 'undefined') {{
                         bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
                     }} else {{
                         bytes = Buffer.from(base64, 'base64');
-                    }}", base64 = base64::encode(&wasm)),
-                inst
+                    }}",
+                    base64 = base64::encode(&wasm)
+                ),
+                inst,
             )
         } else if let Some(ref path) = self.fetch_path {
             (
                 String::new(),
-                format!("fetch('{path}')
+                format!(
+                    "fetch('{path}')
                 .then(res => res.arrayBuffer())
-                .then(bytes => {inst})", path = path, inst = inst)
+                .then(bytes => {inst})",
+                    path = path,
+                    inst = inst
+                ),
             )
         } else {
             bail!("the option --base64 or --fetch is required");
         };
-        Ok(format!("
+        Ok(format!(
+            "
             {js_imports}
             let wasm;
             {bytes}
@@ -273,16 +304,20 @@ impl Output {
 
                 let m = name_map.entry(entry.field()).or_insert(entry.module());
                 if *m != entry.module() {
-                    bail!("the name `{}` is imported from two differnet \
-                           modules which currently isn't supported in `wasm2asm` \
-                           mode");
+                    bail!(
+                        "the name `{}` is imported from two differnet \
+                         modules which currently isn't supported in `wasm2asm` \
+                         mode"
+                    );
                 }
 
                 let name = format!("import{}", i);
-                js_imports.push_str(&format!("import {{ {} as {} }} from '{}';\n",
-                                             entry.field(),
-                                             name,
-                                             entry.module()));
+                js_imports.push_str(&format!(
+                    "import {{ {} as {} }} from '{}';\n",
+                    entry.field(),
+                    name,
+                    entry.module()
+                ));
                 imported_items.push((entry.field().to_string(), name));
             }
         }
@@ -298,18 +333,17 @@ impl Output {
                     Internal::Global(_) => continue,
                 };
 
-                js_exports.push_str(&format!("export const {0} = ret.{0};\n",
-                                             entry.field()));
+                js_exports.push_str(&format!("export const {0} = ret.{0};\n", entry.field()));
             }
             if !export_mem {
-                bail!("the `wasm2asm` mode is currently only compatible with \
-                       modules that export memory")
+                bail!(
+                    "the `wasm2asm` mode is currently only compatible with \
+                     modules that export memory"
+                )
             }
         }
 
-        let memory_size = self.module.memory_section()
-            .unwrap()
-            .entries()[0]
+        let memory_size = self.module.memory_section().unwrap().entries()[0]
             .limits()
             .initial();
 
@@ -329,9 +363,7 @@ impl Output {
                 };
 
                 let base64 = base64::encode(entry.value());
-                js_init_mem.push_str(&format!("_assign({}, \"{}\");\n",
-                                              offset,
-                                              base64));
+                js_init_mem.push_str(&format!("_assign({}, \"{}\");\n", offset, base64));
             }
         }
 
@@ -340,9 +372,7 @@ impl Output {
         let wasm_file = td.as_ref().join("foo.wasm");
         File::create(&wasm_file)
             .and_then(|mut f| f.write_all(&wasm))
-            .with_context(|_| {
-                format!("failed to write wasm to `{}`", wasm_file.display())
-            })?;
+            .with_context(|_| format!("failed to write wasm to `{}`", wasm_file.display()))?;
 
         let wast_file = td.as_ref().join("foo.wast");
         run(
@@ -364,19 +394,19 @@ impl Output {
         let mut asm_func = String::new();
         File::open(&js_file)
             .and_then(|mut f| f.read_to_string(&mut asm_func))
-            .with_context(|_| {
-                format!("failed to read `{}`", js_file.display())
-            })?;
+            .with_context(|_| format!("failed to read `{}`", js_file.display()))?;
 
-
-        let mut make_imports = String::from("
+        let mut make_imports = String::from(
+            "
             var imports = {};
-        ");
+        ",
+        );
         for (name, import) in imported_items {
             make_imports.push_str(&format!("imports['{}'] = {};\n", name, import));
         }
 
-        Ok(format!("\
+        Ok(format!(
+            "\
             {js_imports}
 
             {asm_func}
@@ -424,28 +454,31 @@ impl Output {
 fn run(cmd: &mut Command, program: &str) -> Result<(), Error> {
     let output = cmd.output().with_context(|e| {
         if e.kind() == io::ErrorKind::NotFound {
-            format!("failed to execute `{}`, is the tool installed \
-                     from the binaryen project?\ncommand line: {:?}",
-                    program,
-                    cmd)
+            format!(
+                "failed to execute `{}`, is the tool installed \
+                 from the binaryen project?\ncommand line: {:?}",
+                program, cmd
+            )
         } else {
             format!("failed to execute: {:?}", cmd)
         }
     })?;
     if output.status.success() {
-        return Ok(())
+        return Ok(());
     }
 
-    let mut s = format!("failed to execute: {:?}\nstatus: {}\n",
-                        cmd,
-                        output.status);
+    let mut s = format!("failed to execute: {:?}\nstatus: {}\n", cmd, output.status);
     if !output.stdout.is_empty() {
-        s.push_str(&format!("----- stdout ------\n{}\n",
-                            String::from_utf8_lossy(&output.stdout)));
+        s.push_str(&format!(
+            "----- stdout ------\n{}\n",
+            String::from_utf8_lossy(&output.stdout)
+        ));
     }
     if !output.stderr.is_empty() {
-        s.push_str(&format!("----- stderr ------\n{}\n",
-                            String::from_utf8_lossy(&output.stderr)));
+        s.push_str(&format!(
+            "----- stderr ------\n{}\n",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     bail!("{}", s)
 }

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -77,7 +77,7 @@ impl Output {
                         exports.push_str(&format!(
                             "
                             export const {}: WebAssembly.Memory;
-                        ",
+                            ",
                             entry.field()
                         ));
                         continue;
@@ -111,7 +111,7 @@ impl Output {
                 exports.push_str(&format!(
                     "
                     export function {name}({args}): {ret};
-                ",
+                    ",
                     name = entry.field(),
                     args = args,
                     ret = if ty.return_type().is_some() {
@@ -212,7 +212,7 @@ impl Output {
                     export function {name}({args}) {{
                         {ret} wasm.exports.{name}({args});
                     }}
-                ",
+                    ",
                     name = entry.field(),
                     args = args,
                     ret = if ty.return_type().is_some() {
@@ -224,11 +224,13 @@ impl Output {
             }
         }
         let inst = format!(
-            "WebAssembly.instantiate(bytes,{{ {imports} }})
+            "
+            WebAssembly.instantiate(bytes,{{ {imports} }})
                 .then(obj => {{
                     wasm = obj.instance;
                     {memory}
-                }})",
+                }})
+            ",
             imports = imports,
             memory = if export_mem {
                 "memory = wasm.exports.memory;"
@@ -247,7 +249,8 @@ impl Output {
                         bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
                     }} else {{
                         bytes = Buffer.from(base64, 'base64');
-                    }}",
+                    }}
+                    ",
                     base64 = base64::encode(&wasm)
                 ),
                 inst,
@@ -256,9 +259,11 @@ impl Output {
             (
                 String::new(),
                 format!(
-                    "fetch('{path}')
-                .then(res => res.arrayBuffer())
-                .then(bytes => {inst})",
+                    "
+                    fetch('{path}')
+                        .then(res => res.arrayBuffer())
+                        .then(bytes => {inst})
+                    ",
                     path = path,
                     inst = inst
                 ),
@@ -274,7 +279,7 @@ impl Output {
             {mem_export}
             export const booted = {booted};
             {exports}
-        ",
+            ",
             bytes = bytes,
             booted = booted,
             js_imports = js_imports,
@@ -440,7 +445,7 @@ impl Output {
                 Infinity,
             }}, imports, mem);
             {js_exports}
-        ",
+            ",
             js_imports = js_imports,
             js_init_mem = js_init_mem,
             asm_func = asm_func,

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use std::process;
 
 use docopt::Docopt;
-use wasm_bindgen_cli_support::Bindgen;
 use failure::Error;
+use wasm_bindgen_cli_support::Bindgen;
 
 const USAGE: &'static str = "
 Generating JS bindings for a wasm file

--- a/crates/cli/src/bin/wasm2es6js.rs
+++ b/crates/cli/src/bin/wasm2es6js.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate serde_derive;
 extern crate docopt;
+extern crate failure;
 extern crate parity_wasm;
 extern crate wasm_bindgen_cli_support;
-extern crate failure;
 
 use std::fs::File;
-use std::io::{Write, Read};
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process;
 
@@ -76,9 +76,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
             let ts = object.typescript();
             File::create(&dst)
                 .and_then(|mut f| f.write_all(ts.as_bytes()))
-                .with_context(|_| {
-                    format!("failed to write `{}`", dst.display())
-                })?;
+                .with_context(|_| format!("failed to write `{}`", dst.display()))?;
         }
     }
 

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,9 +1,9 @@
 #![feature(proc_macro)]
 
-extern crate syn;
-extern crate quote;
 extern crate proc_macro;
 extern crate proc_macro2;
+extern crate quote;
+extern crate syn;
 extern crate wasm_bindgen_backend as backend;
 
 use proc_macro::TokenStream;

--- a/crates/typescript/src/definitions.rs
+++ b/crates/typescript/src/definitions.rs
@@ -26,7 +26,6 @@ pub(crate) enum TsExport {
         #[serde(rename = "returnValue")]
         return_value: TsReturnValue,
     },
-
     //TODO: implement ...
     //{ "$ref": "#/definitions/interfaceApiItem" },
     //{ "$ref": "#/definitions/namespaceApiItem" },

--- a/crates/typescript/src/lib.rs
+++ b/crates/typescript/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate proc_macro2;
 extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate syn;
 extern crate wasm_bindgen_backend as backend;

--- a/crates/typescript/src/parser.rs
+++ b/crates/typescript/src/parser.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 
-use backend::{self};
+use backend;
 use backend::ast::{BindgenAttrs, Export, Function};
-use proc_macro2::{self};
-use serde_json::{self};
-use syn::{self};
+use proc_macro2;
+use serde_json;
+use syn;
 
 use api_extractor;
 use definitions::*;
@@ -25,7 +25,11 @@ pub fn ts_to_program(file_name: &str) -> backend::ast::Program {
                     match member {
                         TsClassMembers::TsProperty { .. } => {}
                         TsClassMembers::TsConstructor { .. } => {}
-                        TsClassMembers::TsMethod  { parameters, return_value, .. } => {
+                        TsClassMembers::TsMethod {
+                            parameters,
+                            return_value,
+                            ..
+                        } => {
                             let function = build_function(member_name, parameters, return_value);
 
                             program.exports.push(Export {
@@ -33,14 +37,17 @@ pub fn ts_to_program(file_name: &str) -> backend::ast::Program {
                                 method: true,
                                 mutable: false,
                                 constructor: None,
-                                function, 
+                                function,
                             });
                         }
                     }
                 }
             }
 
-            TsExport::TsFunction { parameters, return_value } => {
+            TsExport::TsFunction {
+                parameters,
+                return_value,
+            } => {
                 let function = build_function(name, parameters, return_value);
 
                 program.exports.push(Export {
@@ -65,22 +72,29 @@ fn parse_json(file_name: &str) -> TsPackage {
     serde_json::from_str(&data).unwrap()
 }
 
-fn build_function(name: String, parameters: HashMap<String, TsMethodProperty>, return_value: TsReturnValue) -> Function {
-    let arguments = parameters.iter().map( |(_name, property)| {
-        let mut segments = syn::punctuated::Punctuated::new();
-        segments.push(syn::PathSegment {
-            ident: syn::Ident::new(&property.property_type, proc_macro2::Span::call_site()),
-            arguments: syn::PathArguments::None,
-        });
+fn build_function(
+    name: String,
+    parameters: HashMap<String, TsMethodProperty>,
+    return_value: TsReturnValue,
+) -> Function {
+    let arguments = parameters
+        .iter()
+        .map(|(_name, property)| {
+            let mut segments = syn::punctuated::Punctuated::new();
+            segments.push(syn::PathSegment {
+                ident: syn::Ident::new(&property.property_type, proc_macro2::Span::call_site()),
+                arguments: syn::PathArguments::None,
+            });
 
-        syn::Type::Path(syn::TypePath {
-            qself: None,
-            path: syn::Path {
-                leading_colon: None,
-                segments,
-            }
+            syn::Type::Path(syn::TypePath {
+                qself: None,
+                path: syn::Path {
+                    leading_colon: None,
+                    segments,
+                },
+            })
         })
-    }).collect::<Vec<_>>();
+        .collect::<Vec<_>>();
 
     let mut ret_segments = syn::punctuated::Punctuated::new();
     ret_segments.push(syn::PathSegment {
@@ -93,7 +107,7 @@ fn build_function(name: String, parameters: HashMap<String, TsMethodProperty>, r
         path: syn::Path {
             leading_colon: None,
             segments: ret_segments,
-        }
+        },
     });
 
     let rust_decl = Box::new(syn::FnDecl {

--- a/examples/asm.js/src/lib.rs
+++ b/examples/asm.js/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
 }

--- a/examples/char/src/lib.rs
+++ b/examples/char/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
 }
@@ -14,7 +14,7 @@ extern {
 #[wasm_bindgen]
 pub struct Counter {
     key: char,
-    count: i32
+    count: i32,
 }
 
 #[wasm_bindgen]
@@ -25,7 +25,10 @@ impl Counter {
     }
     pub fn new(key: char, count: i32) -> Counter {
         log(&format!("Counter::new({}, {})", key, count));
-        Counter { key: key, count: count }
+        Counter {
+            key: key,
+            count: count,
+        }
     }
 
     pub fn key(&self) -> char {

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -2,12 +2,12 @@
 
 extern crate wasm_bindgen;
 
-use wasm_bindgen::prelude::*;
 use wasm_bindgen::js::Date;
 use wasm_bindgen::js::JsString;
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     // Binding for the `setInverval` method in JS. This function takes a "long
     // lived" closure as the first argument so we use `Closure` instead of
     // a bare `&Fn()` which only surives for that one stack frame.
@@ -51,12 +51,11 @@ pub fn run() {
     set_interval(&a, 1000);
     update_time();
     fn update_time() {
-        document.get_element_by_id("current-time")
-            .set_inner_html(
-                &String::from(
-                    Date::new()
-                    .to_locale_string(
-                        JsString::from("en-GB"), JsValue::undefined())));
+        document
+            .get_element_by_id("current-time")
+            .set_inner_html(&String::from(
+                Date::new().to_locale_string(JsString::from("en-GB"), JsValue::undefined()),
+            ));
     }
 
     // We also want to count the number of times that our green square has been
@@ -65,7 +64,8 @@ pub fn run() {
     let mut clicks = 0;
     let b = Closure::new(move || {
         clicks += 1;
-        document.get_element_by_id("num-clicks")
+        document
+            .get_element_by_id("num-clicks")
             .set_inner_html(&clicks.to_string());
     });
     square.set_onclick(&b);
@@ -84,10 +84,12 @@ pub fn run() {
 
     // And finally now that our demo is ready to go let's switch things up so
     // everything is displayed and our loading prompt is hidden.
-    document.get_html_element_by_id("loading")
+    document
+        .get_html_element_by_id("loading")
         .style()
         .set_display("none");
-    document.get_html_element_by_id("script")
+    document
+        .get_html_element_by_id("script")
         .style()
         .set_display("block");
 }

--- a/examples/comments/src/lib.rs
+++ b/examples/comments/src/lib.rs
@@ -15,7 +15,6 @@ pub struct Comment {
     color: Color,
 }
 
-
 #[wasm_bindgen]
 impl Comment {
     #[wasm_bindgen(method)]

--- a/examples/console_log/src/lib.rs
+++ b/examples/console_log/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
     #[wasm_bindgen(js_namespace = console, js_name = log)]

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -15,7 +15,7 @@ use wasm_bindgen::prelude::*;
 // In the meantime these are written out by hand and correspond to the names and
 // signatures documented on MDN, for example
 #[wasm_bindgen]
-extern {
+extern "C" {
     type HTMLDocument;
     static document: HTMLDocument;
     #[wasm_bindgen(method)]

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn alert(s: &str);
 }
 

--- a/examples/import_js/src/lib.rs
+++ b/examples/import_js/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(module = "./defined-in-js")]
-extern {
+extern "C" {
     fn name() -> String;
 
     type MyClass;
@@ -23,7 +23,7 @@ extern {
 
 // Import `console.log` so we can log something to the console
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
 }

--- a/examples/math/src/lib.rs
+++ b/examples/math/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = Math)]
     fn log2(a: f64) -> f64;
     #[wasm_bindgen(js_namespace = Math)]

--- a/examples/no_modules/src/lib.rs
+++ b/examples/no_modules/src/lib.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn alert(s: &str);
 }
 

--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
-extern crate wasm_bindgen;
 extern crate humantime;
+extern crate wasm_bindgen;
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::*;
 // Like with the `dom` example this block will eventually be auto-generated, but
 // for now we can write it by hand to get by!
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Performance;
     static performance: Performance;
     #[wasm_bindgen(method)]

--- a/examples/smorgasboard/src/lib.rs
+++ b/examples/smorgasboard/src/lib.rs
@@ -7,10 +7,10 @@ use wasm_bindgen::prelude::*;
 // Strings can both be passed in and received
 #[wasm_bindgen]
 #[no_mangle]
-pub extern fn concat(a: &str, b: &str) -> String {
+pub extern "C" fn concat(a: &str, b: &str) -> String {
     let mut a = a.to_string();
     a.push_str(b);
-    return a
+    return a;
 }
 
 // A struct will show up as a class on the JS side of things
@@ -29,7 +29,7 @@ impl Foo {
     // can pass to a normal free function also all work in methods.
     pub fn add(&mut self, amt: u32) -> u32 {
         self.contents += amt;
-        return self.contents
+        return self.contents;
     }
 
     // You can also take a limited set of references to other types as well.
@@ -50,7 +50,7 @@ pub struct Bar {
 }
 
 #[wasm_bindgen(module = "./awesome")] // what ES6 module to import from
-extern {
+extern "C" {
     fn bar_on_reset(to: &str, opaque: &JsValue);
 
     // We can import classes and annotate functionality on those classes as well
@@ -64,9 +64,7 @@ extern {
 #[wasm_bindgen]
 impl Bar {
     pub fn from_str(s: &str, opaque: JsValue) -> Bar {
-        let contents = s.parse().unwrap_or_else(|_| {
-            Awesome::new().get_internal()
-        });
+        let contents = s.parse().unwrap_or_else(|_| Awesome::new().get_internal());
         Bar { contents, opaque }
     }
 

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 // Like with the `dom` example this block will eventually be auto-generated, but
 // for now we can write it by hand to get by!
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Module;
     #[wasm_bindgen(constructor, js_namespace = WebAssembly)]
     fn new(data: &[u8]) -> Module;

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,14 +1,14 @@
 //! This is mostly an internal module, no stability guarantees are provided. Use
 //! at your own risk.
 
+use core::char;
 use core::mem::{self, ManuallyDrop};
 use core::ops::{Deref, DerefMut};
 use core::slice;
 use core::str;
-use core::char;
 
-use {JsValue, throw};
 use describe::*;
+use {throw, JsValue};
 
 #[cfg(feature = "std")]
 use std::prelude::v1::*;
@@ -59,7 +59,7 @@ pub trait RefFromWasmAbi: WasmDescribe {
     /// invocation of the function that has an `&Self` parameter. This is
     /// required to ensure that the lifetimes don't persist beyond one function
     /// call, and so that they remain anonymous.
-    type Anchor: Deref<Target=Self>;
+    type Anchor: Deref<Target = Self>;
 
     /// Recover a `Self::Anchor` from `Self::Abi`.
     ///
@@ -71,7 +71,7 @@ pub trait RefFromWasmAbi: WasmDescribe {
 
 pub trait RefMutFromWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
-    type Anchor: DerefMut<Target=Self>;
+    type Anchor: DerefMut<Target = Self>;
     unsafe fn ref_mut_from_abi(js: Self::Abi, extra: &mut Stack) -> Self::Anchor;
 }
 
@@ -159,18 +159,24 @@ as_u32!(i8 u8 i16 u16 isize usize);
 impl IntoWasmAbi for bool {
     type Abi = u32;
 
-    fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
+    fn into_abi(self, _extra: &mut Stack) -> u32 {
+        self as u32
+    }
 }
 
 impl FromWasmAbi for bool {
     type Abi = u32;
 
-    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> bool { js != 0 }
+    unsafe fn from_abi(js: u32, _extra: &mut Stack) -> bool {
+        js != 0
+    }
 }
 
 impl IntoWasmAbi for char {
     type Abi = u32;
-    fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
+    fn into_abi(self, _extra: &mut Stack) -> u32 {
+        self as u32
+    }
 }
 
 impl FromWasmAbi for char {
@@ -183,7 +189,9 @@ impl FromWasmAbi for char {
 impl<T> IntoWasmAbi for *const T {
     type Abi = u32;
 
-    fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
+    fn into_abi(self, _extra: &mut Stack) -> u32 {
+        self as u32
+    }
 }
 
 impl<T> FromWasmAbi for *const T {
@@ -197,7 +205,9 @@ impl<T> FromWasmAbi for *const T {
 impl<T> IntoWasmAbi for *mut T {
     type Abi = u32;
 
-    fn into_abi(self, _extra: &mut Stack) -> u32 { self as u32 }
+    fn into_abi(self, _extra: &mut Stack) -> u32 {
+        self as u32
+    }
 }
 
 impl<T> FromWasmAbi for *mut T {
@@ -343,7 +353,7 @@ impl IntoWasmAbi for JsValue {
     fn into_abi(self, _extra: &mut Stack) -> u32 {
         let ret = self.idx;
         mem::forget(self);
-        return ret
+        return ret;
     }
 }
 
@@ -397,7 +407,9 @@ if_std! {
     }
 }
 
-pub struct GlobalStack { next: usize }
+pub struct GlobalStack {
+    next: usize,
+}
 
 const GLOBAL_STACK_CAP: usize = 16;
 static mut GLOBAL_STACK: [u32; GLOBAL_STACK_CAP] = [0; GLOBAL_STACK_CAP];
@@ -429,7 +441,7 @@ impl Stack for GlobalStack {
 
 #[doc(hidden)]
 #[no_mangle]
-pub unsafe extern fn __wbindgen_global_argument_ptr() -> *mut u32 {
+pub unsafe extern "C" fn __wbindgen_global_argument_ptr() -> *mut u32 {
     GLOBAL_STACK.as_mut_ptr()
 }
 

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -41,9 +41,7 @@ tys! {
 }
 
 pub fn inform(a: u32) {
-    unsafe {
-        super::__wbindgen_describe(a)
-    }
+    unsafe { super::__wbindgen_describe(a) }
 }
 
 pub trait WasmDescribe {
@@ -78,11 +76,15 @@ simple! {
 }
 
 impl<T> WasmDescribe for *const T {
-    fn describe() { inform(I32) }
+    fn describe() {
+        inform(I32)
+    }
 }
 
 impl<T> WasmDescribe for *mut T {
-    fn describe() { inform(I32) }
+    fn describe() {
+        inform(I32)
+    }
 }
 
 impl<T: WasmDescribe> WasmDescribe for [T] {
@@ -127,7 +129,9 @@ if_std! {
     }
 }
 
-fn _cnt<T: WasmDescribe>() -> u32 { 1 }
+fn _cnt<T: WasmDescribe>() -> u32 {
+    1
+}
 
 macro_rules! doit {
     ($( ($($var:ident)*))*) => ($(

--- a/src/js.rs
+++ b/src/js.rs
@@ -41,7 +41,7 @@ if_std! {
 // for that case.
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     /// The `decodeURI()` function decodes a Uniform Resource Identifier (URI)
     /// previously created by `encodeURI` or by a similar routine.
     ///
@@ -68,7 +68,7 @@ extern {
 
 // UInt8Array
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Uint8Array;
 
     /// The `Uint8Array()` constructor creates an array of unsigned 8-bit integers.
@@ -87,7 +87,7 @@ extern {
 
 // Array
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Array;
 
     /// The copyWithin() method shallow copies part of an array to another
@@ -106,7 +106,7 @@ extern {
 
     /// The every() method tests whether all elements in the array pass the test
     /// implemented by the provided function.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every
     #[wasm_bindgen(method)]
     pub fn every(this: &Array, predicate: &mut FnMut(JsValue, u32, Array) -> bool) -> bool;
@@ -233,7 +233,7 @@ extern {
 
 // Array Iterator
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type ArrayIterator;
 
     /// The keys() method returns a new Array Iterator object that contains the
@@ -253,7 +253,7 @@ extern {
 
 // Boolean
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Boolean;
 
     /// The `Boolean()` constructor creates an object wrapper for a boolean value.
@@ -271,12 +271,12 @@ extern {
 
 // Function
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Function;
 
     /// The apply() method calls a function with a given this value, and arguments provided as an array
     /// (or an array-like object).
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
     #[wasm_bindgen(method)]
     pub fn apply(this: &Function, context: &JsValue, args: &Array) -> Function;
@@ -296,7 +296,7 @@ extern {
     pub fn name(this: &Function) -> JsString;
 
     /// The toString() method returns a string representing the source code of the function.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/toString
     #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(this: &Function) -> JsString;
@@ -304,7 +304,7 @@ extern {
 
 // Math
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Math;
     /// The Math.abs() function returns the absolute value of a number, that is
     /// Math.abs(x) = |x|
@@ -365,7 +365,6 @@ extern {
     #[wasm_bindgen(static_method_of = Math)]
     pub fn atanh(x: i32) -> Number;
 
-
     /// The Math.cbrt() function returns the cube root of a number, that is
     /// Math.cbrt(x) = x^3 = the unique y such that y^3 = x
     ///
@@ -397,7 +396,7 @@ extern {
 
 // Number.
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Number;
 
     /// The toLocaleString() method returns a string with a language sensitive
@@ -445,35 +444,35 @@ extern {
 
 // Date.
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Date;
 
-    /// Creates a JavaScript Date instance that represents 
-    /// a single moment in time. Date objects are based on a time value that is 
+    /// Creates a JavaScript Date instance that represents
+    /// a single moment in time. Date objects are based on a time value that is
     /// the number of milliseconds since 1 January 1970 UTC.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
     #[wasm_bindgen(constructor)]
     pub fn new() -> Date;
 
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString
     #[wasm_bindgen(method, js_name = toDateString)]
     pub fn to_date_string(this: &Date) -> JsString;
 
     /// The toISOString() method returns a string in simplified extended ISO format (ISO
     /// 8601), which is always 24 or 27 characters long (YYYY-MM-DDTHH:mm:ss.sssZ or
-    /// ±YYYYYY-MM-DDTHH:mm:ss.sssZ, respectively). The timezone is always zero UTC offset, 
+    /// ±YYYYYY-MM-DDTHH:mm:ss.sssZ, respectively). The timezone is always zero UTC offset,
     /// as denoted by the suffix "Z"
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
     #[wasm_bindgen(method, js_name = toISOString)]
     pub fn to_iso_string(this: &Date) -> JsString;
 
     /// The toJSON() method returns a string representation of the Date object.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON
     #[wasm_bindgen(method, js_name = toJSON)]
     pub fn to_json(this: &Date) -> JsString;
@@ -485,17 +484,17 @@ extern {
     /// In older implementations, which ignore the locales and options arguments,
     /// the locale used and the form of the string
     /// returned are entirely implementation dependent.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
     #[wasm_bindgen(method, js_name = toLocaleDateString)]
     pub fn to_locale_date_string(this: &Date, locale: JsString, options: JsValue) -> JsString;
 
-    /// The toLocaleString() method returns a string with a language sensitive 
-    /// representation of this date. The new locales and options arguments 
-    /// let applications specify the language whose formatting conventions 
-    /// should be used and customize the behavior of the function. 
-    /// In older implementations, which ignore the locales 
-    /// and options arguments, the locale used and the form of the string 
+    /// The toLocaleString() method returns a string with a language sensitive
+    /// representation of this date. The new locales and options arguments
+    /// let applications specify the language whose formatting conventions
+    /// should be used and customize the behavior of the function.
+    /// In older implementations, which ignore the locales
+    /// and options arguments, the locale used and the form of the string
     /// returned are entirely implementation dependent.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
@@ -544,7 +543,7 @@ extern {
 
 // Object.
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type Object;
 
     /// The `hasOwnProperty()` method returns a boolean indicating whether the
@@ -585,7 +584,7 @@ extern {
     /// The Object.seal() method seals an object, preventing new properties
     /// from being added to it and marking all existing properties as non-configurable.
     /// Values of present properties can still be changed as long as they are writable.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal
     #[wasm_bindgen(static_method_of = Object)]
     pub fn seal(value: &JsValue) -> JsValue;
@@ -614,7 +613,7 @@ extern {
 
 // WeakMap
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type WeakMap;
 
     /// The WeakMap object is a collection of key/value pairs in which the keys are weakly referenced.  
@@ -624,21 +623,21 @@ extern {
     #[wasm_bindgen(constructor)]
     pub fn new() -> WeakMap;
 
-    /// The set() method sets the value for the key in the WeakMap object. Returns 
+    /// The set() method sets the value for the key in the WeakMap object. Returns
     /// the WeakMap object.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set
-    #[wasm_bindgen(method, js_class="WeakMap")]
+    #[wasm_bindgen(method, js_class = "WeakMap")]
     pub fn set(this: &WeakMap, key: Object, value: JsValue) -> WeakMap;
 
-    /// The get() method returns a specified by key element 
+    /// The get() method returns a specified by key element
     /// from a WeakMap object.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/get
     #[wasm_bindgen(method)]
     pub fn get(this: &WeakMap, key: Object) -> JsValue;
 
-    /// The has() method returns a boolean indicating whether an element with 
+    /// The has() method returns a boolean indicating whether an element with
     /// the specified key exists in the WeakMap object or not.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has
@@ -654,29 +653,29 @@ extern {
 
 // WeakSet
 #[wasm_bindgen]
-extern {
+extern "C" {
     pub type WeakSet;
 
     /// The WeakSet object lets you store weakly held objects in a collection.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet
     #[wasm_bindgen(constructor)]
     pub fn new() -> WeakSet;
 
     /// The has() method returns a boolean indicating whether an object exists in a WeakSet or not.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has
     #[wasm_bindgen(method)]
     pub fn has(this: &WeakSet, value: Object) -> bool;
 
     /// The add() method appends a new object to the end of a WeakSet object.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add
     #[wasm_bindgen(method)]
     pub fn add(this: &WeakSet, value: Object) -> WeakSet;
 
     /// The delete() method removes the specified element from a WeakSet object.
-    /// 
+    ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete
     #[wasm_bindgen(method)]
     pub fn delete(this: &WeakSet, value: Object) -> bool;
@@ -684,7 +683,7 @@ extern {
 
 // JsString
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_name = JsString)]
     pub type JsString;
 
@@ -737,7 +736,7 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf
     #[wasm_bindgen(method, js_class = "String", js_name = indexOf)]
     pub fn index_of(this: &JsString, search_value: &JsString, from_index: i32) -> i32;
-  
+
     /// The slice() method extracts a section of a string and returns it as a
     /// new string, without modifying the original string.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,16 +76,18 @@ const JSIDX_RESERVED: u32 = 8;
 
 impl JsValue {
     /// The `null` JS value constant.
-    pub const NULL: JsValue = JsValue { idx:  JSIDX_NULL };
+    pub const NULL: JsValue = JsValue { idx: JSIDX_NULL };
 
     /// The `undefined` JS value constant.
-    pub const UNDEFINED: JsValue = JsValue { idx:  JSIDX_UNDEFINED };
+    pub const UNDEFINED: JsValue = JsValue {
+        idx: JSIDX_UNDEFINED,
+    };
 
     /// The `true` JS value constant.
-    pub const TRUE: JsValue = JsValue { idx:  JSIDX_TRUE };
+    pub const TRUE: JsValue = JsValue { idx: JSIDX_TRUE };
 
     /// The `false` JS value constant.
-    pub const FALSE: JsValue = JsValue { idx:  JSIDX_FALSE };
+    pub const FALSE: JsValue = JsValue { idx: JSIDX_FALSE };
 
     /// Creates a new JS value which is a string.
     ///
@@ -93,7 +95,9 @@ impl JsValue {
     /// be owned by the JS garbage collector.
     pub fn from_str(s: &str) -> JsValue {
         unsafe {
-            JsValue { idx: __wbindgen_string_new(s.as_ptr(), s.len()) }
+            JsValue {
+                idx: __wbindgen_string_new(s.as_ptr(), s.len()),
+            }
         }
     }
 
@@ -103,7 +107,9 @@ impl JsValue {
     /// allocated number) and returns a handle to the JS version of it.
     pub fn from_f64(n: f64) -> JsValue {
         unsafe {
-            JsValue { idx: __wbindgen_number_new(n) }
+            JsValue {
+                idx: __wbindgen_number_new(n),
+            }
         }
     }
 
@@ -112,12 +118,16 @@ impl JsValue {
     /// This function creates a JS object representing a boolean (a heap
     /// allocated boolean) and returns a handle to the JS version of it.
     pub fn from_bool(b: bool) -> JsValue {
-        JsValue { idx: if b { JSIDX_TRUE } else { JSIDX_FALSE } }
+        JsValue {
+            idx: if b { JSIDX_TRUE } else { JSIDX_FALSE },
+        }
     }
 
     /// Creates a new JS value representing `undefined`.
     pub fn undefined() -> JsValue {
-        JsValue { idx: JSIDX_UNDEFINED }
+        JsValue {
+            idx: JSIDX_UNDEFINED,
+        }
     }
 
     /// Creates a new JS value representing `null`.
@@ -133,7 +143,9 @@ impl JsValue {
         unsafe {
             let ptr = description.map(|s| s.as_ptr()).unwrap_or(ptr::null());
             let len = description.map(|s| s.len()).unwrap_or(0);
-            JsValue { idx: __wbindgen_symbol_new(ptr, len) }
+            JsValue {
+                idx: __wbindgen_symbol_new(ptr, len),
+            }
         }
     }
 
@@ -154,7 +166,8 @@ impl JsValue {
     /// Returns any error encountered when serializing `T` into JSON.
     #[cfg(feature = "serde-serialize")]
     pub fn from_serde<T>(t: &T) -> serde_json::Result<JsValue>
-        where T: serde::ser::Serialize + ?Sized,
+    where
+        T: serde::ser::Serialize + ?Sized,
     {
         let s = serde_json::to_string(t)?;
         unsafe {
@@ -179,7 +192,8 @@ impl JsValue {
     /// Returns any error encountered when parsing the JSON into a `T`.
     #[cfg(feature = "serde-serialize")]
     pub fn into_serde<T>(&self) -> serde_json::Result<T>
-        where T: for<'a> serde::de::Deserialize<'a>,
+    where
+        T: for<'a> serde::de::Deserialize<'a>,
     {
         unsafe {
             let mut ptr = ptr::null_mut();
@@ -243,31 +257,23 @@ impl JsValue {
 
     /// Tests whether this JS value is `null`
     pub fn is_null(&self) -> bool {
-        unsafe {
-            __wbindgen_is_null(self.idx) == 1
-        }
+        unsafe { __wbindgen_is_null(self.idx) == 1 }
     }
 
     /// Tests whether this JS value is `undefined`
     pub fn is_undefined(&self) -> bool {
-        unsafe {
-            __wbindgen_is_undefined(self.idx) == 1
-        }
+        unsafe { __wbindgen_is_undefined(self.idx) == 1 }
     }
 
     /// Tests whether the type of this JS value is `symbol`
     pub fn is_symbol(&self) -> bool {
-        unsafe {
-            __wbindgen_is_symbol(self.idx) == 1
-        }
+        unsafe { __wbindgen_is_symbol(self.idx) == 1 }
     }
 }
 
 impl PartialEq for JsValue {
     fn eq(&self, other: &JsValue) -> bool {
-        unsafe {
-            __wbindgen_jsval_eq(self.idx, other.idx) != 0
-        }
+        unsafe { __wbindgen_jsval_eq(self.idx, other.idx) != 0 }
     }
 }
 
@@ -421,7 +427,7 @@ impl<T: FromWasmAbi + 'static> Deref for JsStatic<T> {
             // `JsStatic` a bit as well.
             let ptr = self.__inner.get();
             if let Some(ref t) = *ptr {
-                return t
+                return t;
             }
             let init = Some((self.__init)());
             debug_assert!((*ptr).is_none());
@@ -455,7 +461,7 @@ pub mod __rt {
     #[macro_export]
     #[cfg(feature = "std")]
     macro_rules! __wbindgen_if_not_std {
-        ($($i:item)*) => ()
+        ($($i:item)*) => {};
     }
 
     #[macro_export]
@@ -500,7 +506,10 @@ pub mod __rt {
     }
 
     impl<T: ?Sized> WasmRefCell<T> {
-        pub fn new(value: T) -> WasmRefCell<T> where T: Sized {
+        pub fn new(value: T) -> WasmRefCell<T>
+        where
+            T: Sized,
+        {
             WasmRefCell {
                 value: UnsafeCell::new(value),
                 borrow: Cell::new(0),
@@ -508,9 +517,7 @@ pub mod __rt {
         }
 
         pub fn get_mut(&mut self) -> &mut T {
-            unsafe {
-                &mut *self.value.get()
-            }
+            unsafe { &mut *self.value.get() }
         }
 
         pub fn borrow(&self) -> Ref<T> {
@@ -539,7 +546,10 @@ pub mod __rt {
             }
         }
 
-        pub fn into_inner(self) -> T where T: Sized {
+        pub fn into_inner(self) -> T
+        where
+            T: Sized,
+        {
             self.value.into_inner()
         }
     }
@@ -592,8 +602,10 @@ pub mod __rt {
     }
 
     fn borrow_fail() -> ! {
-        super::throw("recursive use of an object detected which would lead to \
-                      unsafe aliasing in rust");
+        super::throw(
+            "recursive use of an object detected which would lead to \
+             unsafe aliasing in rust",
+        );
     }
 
     if_std! {

--- a/tests/all/api.rs
+++ b/tests/all/api.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -108,8 +110,11 @@ fn works() {
             pub fn acquire_string2(a: &JsValue) -> String {
                 a.as_string().unwrap_or("wrong".to_string())
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -138,14 +143,17 @@ fn works() {
                 assert.strictEqual(wasm.acquire_string2(''), '');
                 assert.strictEqual(wasm.acquire_string2('a'), 'a');
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn eq_works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -161,8 +169,11 @@ fn eq_works() {
             pub fn test1(a: &JsValue) -> bool {
                 a == a
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -176,7 +187,7 @@ fn eq_works() {
                 assert.strictEqual(wasm.test(x, x), true);
                 assert.strictEqual(wasm.test1(x), true);
             }
-        "#)
+        "#,
+        )
         .test();
 }
-

--- a/tests/all/char.rs
+++ b/tests/all/char.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -30,8 +32,11 @@ fn works() {
 
             #[wasm_bindgen]
             pub fn char_round(c: char)-> char { js_parrot(c) }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             import * as wasm from './out';
 
             function assertEq(a, b) {
@@ -55,6 +60,7 @@ fn works() {
             }
 
             export function js_parrot(a) { return a; }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/classes.rs
+++ b/tests/all/classes.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn simple() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -31,8 +33,11 @@ fn simple() {
                     self.contents
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import { Foo } from "./out";
 
@@ -53,14 +58,17 @@ fn simple() {
                 assert.strictEqual(r3.add(42), 42);
                 r3.free();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn strings() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -98,8 +106,11 @@ fn strings() {
                     self.contents.clone()
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import { Foo } from "./out";
 
@@ -111,14 +122,17 @@ fn strings() {
                 assert.strictEqual(bar.name(), "foo-baz-3");
                 bar.free();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn exceptions() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -152,8 +166,11 @@ fn exceptions() {
                     B {}
                 }
             }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             import * as assert from "assert";
             import { A, B } from "./out";
 
@@ -173,17 +190,23 @@ fn exceptions() {
                 d.free();
                 c.free();
             };
-        "#)
-        .file("test.d.ts", r#"
+        "#,
+        )
+        .file(
+            "test.d.ts",
+            r#"
             export function test(): void;
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn pass_one_to_another() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -215,8 +238,11 @@ fn pass_one_to_another() {
                     B {}
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { A, B } from "./out";
 
             export function test() {
@@ -226,14 +252,17 @@ fn pass_one_to_another() {
                 a.bar(b);
                 a.free();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn pass_into_js() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -259,8 +288,11 @@ fn pass_into_js() {
             pub fn run() {
                 take_foo(Foo(13));
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run, Foo } from "./out";
             import * as assert from "assert";
 
@@ -273,14 +305,17 @@ fn pass_into_js() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn issue_27() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -309,21 +344,27 @@ fn issue_27() {
             pub fn context() -> Context {
                 Context {}
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { context } from "./out";
 
             export function test() {
                 context();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn pass_into_js_as_js_class() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -349,8 +390,11 @@ fn pass_into_js_as_js_class() {
             pub fn run() {
                 take_foo(Foo(13).into());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run, Foo } from "./out";
             import * as assert from "assert";
 
@@ -363,14 +407,17 @@ fn pass_into_js_as_js_class() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn constructors() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -416,8 +463,11 @@ fn constructors() {
                     self.number + self.number2
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import { Foo, Bar, cross_item_construction } from "./out";
 
@@ -440,7 +490,8 @@ fn constructors() {
 
                 assert.strictEqual(cross_item_construction().get_sum(), 15);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -448,7 +499,9 @@ fn constructors() {
 fn empty_structs() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -463,14 +516,18 @@ fn empty_structs() {
 
             #[wasm_bindgen]
             impl Other { pub fn return_a_value() -> MissingClass { MissingClass {} } }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { Other } from "./out";
 
             export function test() {
                 Other.return_a_value();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -478,7 +535,9 @@ fn empty_structs() {
 fn public_fields() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -500,8 +559,11 @@ fn public_fields() {
                     Foo::default()
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { Foo } from "./out";
             import * as assert from "assert";
 
@@ -523,7 +585,8 @@ fn public_fields() {
                 a.d = 3.3;
                 assert.strictEqual(a.d, 3);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -531,7 +594,9 @@ fn public_fields() {
 fn using_self() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -548,14 +613,18 @@ fn using_self() {
                     Foo {}
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { Foo } from "./out";
 
             export function test() {
                 Foo.new().free();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -563,7 +632,9 @@ fn using_self() {
 fn readonly_fields() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -583,8 +654,11 @@ fn readonly_fields() {
                     Foo::default()
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { Foo } from "./out";
             import * as assert from "assert";
 
@@ -594,6 +668,7 @@ fn readonly_fields() {
                 assert.throws(() => (a as any).a = 3, /has only a getter/);
                 a.free();
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/closures.rs
+++ b/tests/all/closures.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -25,8 +27,11 @@ fn works() {
 
                 assert_eq!(thread(&|a| a + 1), 3);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function call(a: any) {
@@ -40,14 +45,17 @@ fn works() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn cannot_reuse() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -66,8 +74,11 @@ fn cannot_reuse() {
                 call(&|| {});
                 assert!(call_again().is_err());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             let CACHE: any = null;
@@ -83,14 +94,17 @@ fn cannot_reuse() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn long_lived() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -125,8 +139,11 @@ fn long_lived() {
                 }
                 assert!(hit.get());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function call1(a: any) {
@@ -140,14 +157,17 @@ fn long_lived() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn many_arity() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -219,8 +239,11 @@ fn many_arity() {
                     assert_eq!((a, b, c, d, e, f, g), (1, 2, 3, 4, 5, 6, 7))
                 }));
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function call1(a: any) { a() }
@@ -235,14 +258,17 @@ fn many_arity() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn long_lived_dropping() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -270,8 +296,11 @@ fn long_lived_dropping() {
                 drop(a);
                 assert!(call().is_err());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             let CACHE: any = null;
@@ -282,14 +311,17 @@ fn long_lived_dropping() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn long_fnmut_recursive() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -311,8 +343,11 @@ fn long_fnmut_recursive() {
                 cache(&a);
                 assert!(call().is_ok());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             let CACHE: any = null;
@@ -323,14 +358,17 @@ fn long_fnmut_recursive() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn fnmut() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -356,8 +394,11 @@ fn fnmut() {
                 }), 3);
                 assert!(x);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function call(a: any) {
@@ -371,14 +412,17 @@ fn fnmut() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn fnmut_bad() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -408,8 +452,11 @@ fn fnmut_bad() {
 
                 assert!(again(true).is_err());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             let F: any = null;
@@ -426,14 +473,17 @@ fn fnmut_bad() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn string_arguments() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -454,8 +504,11 @@ fn string_arguments() {
                 });
                 assert!(x);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function call(a: any) {
@@ -465,14 +518,17 @@ fn string_arguments() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn string_ret() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -495,8 +551,11 @@ fn string_ret() {
                 });
                 assert!(x);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
             import * as assert from "assert";
 
@@ -508,7 +567,7 @@ fn string_ret() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
-

--- a/tests/all/comments.rs
+++ b/tests/all/comments.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn works() {
     let mut p = project();
-    p.file("src/lib.rs", r#"
+    p.file(
+        "src/lib.rs",
+        r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -33,24 +35,27 @@ fn works() {
                     self.a.clone()
                 }
             }
-        "#);
+        "#,
+    );
 
-        let (root, target) = p.cargo_build();
-        p.gen_bindings(&root, &target);
-        let js = p.read_js();
-        let comments = extract_doc_comments(&js);
-        assert!(comments.iter().all(|c| c == "This comment should exist"));
+    let (root, target) = p.cargo_build();
+    p.gen_bindings(&root, &target);
+    let js = p.read_js();
+    let comments = extract_doc_comments(&js);
+    assert!(comments.iter().all(|c| c == "This comment should exist"));
 }
 /// Pull out all lines in a js string that start with
 /// '* ', all other lines will either be comment start, comment
-/// end or actual js lines. 
+/// end or actual js lines.
 fn extract_doc_comments(js: &str) -> Vec<String> {
-    js.lines().filter_map(|l| {
-        let trimmed = l.trim();
-        if trimmed.starts_with("* ") {
-            Some(trimmed[2..].to_owned())
-        } else {
-            None
-        }
-    }).collect()
+    js.lines()
+        .filter_map(|l| {
+            let trimmed = l.trim();
+            if trimmed.starts_with("* ") {
+                Some(trimmed[2..].to_owned())
+            } else {
+                None
+            }
+        })
+        .collect()
 }

--- a/tests/all/enums.rs
+++ b/tests/all/enums.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn c_style_enum() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -25,8 +27,11 @@ fn c_style_enum() {
                     Color::Red => Color::Green,
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -38,14 +43,17 @@ fn c_style_enum() {
 
                 assert.strictEqual(wasm.cycle(wasm.Color.Green), wasm.Color.Yellow);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn c_style_enum_with_custom_values() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -73,8 +81,11 @@ fn c_style_enum_with_custom_values() {
                     Color::Red => Color::Green,
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -86,6 +97,7 @@ fn c_style_enum_with_custom_values() {
 
                 assert.strictEqual(wasm.cycle(wasm.Color.Green), wasm.Color.Yellow);
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/import_class.rs
+++ b/tests/all/import_class.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn simple() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -27,8 +29,11 @@ fn simple() {
                 #[wasm_bindgen(js_namespace = Math)]
                 fn log(a: f64) -> f64;
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -36,14 +41,17 @@ fn simple() {
                 wasm.get_random();
                 assert.strictEqual(wasm.do_log(1.0), Math.log(1.0));
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn import_class() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -60,8 +68,11 @@ fn import_class() {
             pub fn baz() {
                 bar();
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { baz } from "./out";
             import { called } from "./another";
             import * as assert from "assert";
@@ -70,8 +81,11 @@ fn import_class() {
                 baz();
                 assert.strictEqual(called, true);
             }
-        "#)
-        .file("another.ts", r#"
+        "#,
+        )
+        .file(
+            "another.ts",
+            r#"
             export let called = false;
 
             export class Foo {
@@ -79,14 +93,17 @@ fn import_class() {
                     called = true;
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn construct() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -113,8 +130,11 @@ fn construct() {
                 f.append_to_internal_string(" foo");
                 f.assert_internal_string("this foo");
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
             import { called } from "./another";
             import * as assert from "assert";
@@ -123,8 +143,11 @@ fn construct() {
                 run();
                 assert.strictEqual(called, true);
             }
-        "#)
-        .file("another.ts", r#"
+        "#,
+        )
+        .file(
+            "another.ts",
+            r#"
             import * as assert from "assert";
 
             export let called = false;
@@ -151,14 +174,17 @@ fn construct() {
                     called = true;
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn new_constructors() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -179,15 +205,21 @@ fn new_constructors() {
                 let f = Foo::new(1);
                 assert_eq!(f.get(), 2);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function test() {
                 run();
             }
-        "#)
-        .file("another.ts", r#"
+        "#,
+        )
+        .file(
+            "another.ts",
+            r#"
             export class Foo {
                 constructor(private field: number) {
                 }
@@ -196,14 +228,17 @@ fn new_constructors() {
                     return this.field + 1;
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn switch_methods() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -233,8 +268,11 @@ fn switch_methods() {
             pub fn b() {
                 Foo::new().b();
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { a, b } from "./out";
             import { Foo, called } from "./another";
             import * as assert from "assert";
@@ -259,8 +297,11 @@ fn switch_methods() {
                 b();
                 assert.strictEqual(called.a, true);
             }
-        "#)
-        .file("another.ts", r#"
+        "#,
+        )
+        .file(
+            "another.ts",
+            r#"
             export let called = { a: false };
 
             export class Foo {
@@ -275,14 +316,17 @@ fn switch_methods() {
                     called.a = true;
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn properties() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -310,15 +354,21 @@ fn properties() {
                 a.set_a(2);
                 assert_eq!(a.a(), 2);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function test() {
                 run();
             }
-        "#)
-        .file("another.ts", r#"
+        "#,
+        )
+        .file(
+            "another.ts",
+            r#"
             export class Foo {
                 constructor(private num: number) {
                     this.num = 1;
@@ -332,14 +382,17 @@ fn properties() {
                     this.num = val;
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn rename_setter_getter() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -367,15 +420,21 @@ fn rename_setter_getter() {
                 a.another(2);
                 assert_eq!(a.test(), 2);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function test() {
                 run();
             }
-        "#)
-        .file("another.ts", r#"
+        "#,
+        )
+        .file(
+            "another.ts",
+            r#"
             export class Foo {
                 constructor(private num: number) {
                     this.num = 1;
@@ -389,6 +448,7 @@ fn rename_setter_getter() {
                     this.num = val;
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/imports.rs
+++ b/tests/all/imports.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn simple() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -37,8 +39,11 @@ fn simple() {
             pub fn get_the_object() -> JsValue {
                 return_object()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -78,14 +83,17 @@ fn simple() {
 
                 assert.strictEqual(wasm.get_the_object(), SYM);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn unused() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             #![allow(dead_code)]
 
@@ -100,8 +108,11 @@ fn unused() {
 
             #[wasm_bindgen]
             pub fn bar() {}
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
 
             export function debug_print() {}
@@ -109,14 +120,17 @@ fn unused() {
             export function test() {
                 wasm.bar();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn string_ret() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -132,8 +146,11 @@ fn string_ret() {
             pub fn run() {
                 assert_eq!(foo(), "bar");
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
 
             export function foo(): string {
@@ -143,14 +160,17 @@ fn string_ret() {
             export function test() {
                 wasm.run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn strings() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -171,8 +191,11 @@ fn strings() {
             pub fn bar2(a: String) -> String {
                 foo(a)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -184,14 +207,17 @@ fn strings() {
                 assert.strictEqual(wasm.bar('a'), 'ab');
                 assert.strictEqual(wasm.bar2('a'), 'ab');
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn exceptions() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -217,8 +243,11 @@ fn exceptions() {
                 assert!(baz().is_err());
                 bar();
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run, run2 } from "./out";
             import * as assert from "assert";
 
@@ -242,14 +271,17 @@ fn exceptions() {
                 run2();
                 assert.strictEqual(called, true);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn exn_caught() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -266,8 +298,11 @@ fn exn_caught() {
             pub fn run() -> JsValue {
                 foo().unwrap_err()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
             import * as assert from "assert";
 
@@ -280,14 +315,17 @@ fn exn_caught() {
                 assert.strictEqual(obj instanceof Error, true);
                 assert.strictEqual(obj.message, 'error!');
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn free_imports() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -303,14 +341,18 @@ fn free_imports() {
             pub fn run() {
                 assert_eq!(parseInt("3"), 3);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -318,7 +360,9 @@ fn free_imports() {
 fn import_a_field() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -334,8 +378,11 @@ fn import_a_field() {
             pub fn run() {
                 assert_eq!(IMPORT.as_f64(), Some(1.0));
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export const IMPORT = 1.0;
@@ -343,14 +390,17 @@ fn import_a_field() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn rename() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -367,8 +417,11 @@ fn rename() {
             pub fn run() {
                 foo();
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -382,14 +435,17 @@ fn rename() {
                 wasm.run();
                 assert.strictEqual(called, true);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn versions() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -405,8 +461,11 @@ fn versions() {
             pub fn run() {
                 foo();
             }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             const fs = require("fs");
             const assert = require("assert");
 
@@ -426,14 +485,17 @@ fn versions() {
                     ]
                 });
             };
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn rust_keyword() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -450,8 +512,11 @@ fn rust_keyword() {
             pub fn run() {
                 assert_eq!(foo(), 2);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export function self() {
@@ -461,7 +526,8 @@ fn rust_keyword() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -469,7 +535,9 @@ fn rust_keyword() {
 fn rust_keyword2() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -487,8 +555,11 @@ fn rust_keyword2() {
             pub fn run() {
                 assert_eq!(FOO.as_f64(), Some(3.0));
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run } from "./out";
 
             export const bar = {
@@ -498,6 +569,7 @@ fn rust_keyword2() {
             export function test() {
                 run();
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn filter() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -17,8 +19,11 @@ fn filter() {
                 array.filter(&mut |x, _, _| x.as_f64().is_some())
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -31,14 +36,17 @@ fn filter() {
                 assert.deepStrictEqual(wasm.keep_numbers(numbers), numbers);
                 assert.deepStrictEqual(wasm.keep_numbers(mixed), [1, 2]);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn index_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -50,8 +58,11 @@ fn index_of() {
                 this.index_of(value, from_index)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -69,14 +80,17 @@ fn index_of() {
                 assert.equal(withFromIndex, 2);
                 assert.equal(withFromIndexNotFound, -1);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn is_array() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -87,8 +101,11 @@ fn is_array() {
             pub fn is_array(value: &JsValue) -> bool {
                 js::Array::is_array(value)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -109,14 +126,17 @@ fn is_array() {
                 assert(!wasm.is_array(false));
                 assert(!wasm.is_array({ __proto__: Array.prototype }));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn sort() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -128,8 +148,11 @@ fn sort() {
                 this.sort()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -139,14 +162,17 @@ fn sort() {
 
                 assert.deepStrictEqual(sorted, [1, 2, 3, 6])
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn last_index_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -158,8 +184,11 @@ fn last_index_of() {
                 this.last_index_of(value, from_index)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -177,14 +206,17 @@ fn last_index_of() {
                 assert.equal(withFromIndex, 1);
                 assert.equal(withFromIndexNotFound, -1);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn join() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -196,8 +228,11 @@ fn join() {
                 this.join(delimiter)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -209,14 +244,17 @@ fn join() {
                 let withForwardSlash = wasm.join_array(characters, "/");
                 assert.equal("a/c/x/n", withForwardSlash);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn slice() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -227,8 +265,11 @@ fn slice() {
             pub fn create_slice(this: &js::Array, start: u32, end: u32) -> js::Array {
                 this.slice(start, end)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -239,14 +280,17 @@ fn slice() {
                 assert.equal(subset[0], "c");
                 assert.equal(subset[1], "x");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn fill() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -257,8 +301,11 @@ fn fill() {
             pub fn fill_with(this: &js::Array, value: JsValue, start: u32, end: u32) -> js::Array {
                 this.fill(value, start, end)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -269,7 +316,8 @@ fn fill() {
                 assert.equal(subset[0], 0);
                 assert.equal(subset[4], 1);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
@@ -310,7 +358,9 @@ fn copy_within() {
 #[test]
 fn pop() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -322,8 +372,11 @@ fn pop() {
                 this.pop()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -333,15 +386,17 @@ fn pop() {
                 assert.equal(item, 2);
                 assert.equal(characters.length, 5);
             }
-        "#)
+        "#,
+        )
         .test()
 }
-
 
 #[test]
 fn push() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -353,8 +408,11 @@ fn push() {
                 this.push(value)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -364,14 +422,17 @@ fn push() {
                 assert.equal(length, 7);
                 assert.equal(characters[6], "a");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn reverse() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -383,8 +444,11 @@ fn reverse() {
                 this.reverse()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -394,14 +458,17 @@ fn reverse() {
                 assert.equal(reversed[0], 2);
                 assert.equal(reversed[5], 8);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn shift() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -413,8 +480,11 @@ fn shift() {
                 this.shift()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -425,14 +495,17 @@ fn shift() {
                 assert.equal(shiftedItem, 8);
                 assert.equal(characters.length, 5);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn unshift() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -444,8 +517,11 @@ fn unshift() {
                 this.unshift(value)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -456,14 +532,17 @@ fn unshift() {
                 assert.equal(length, 7);
                 assert.equal(characters[0], "abba");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -475,8 +554,11 @@ fn to_string() {
                 this.to_string()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -486,15 +568,17 @@ fn to_string() {
 
                 assert.equal(arrayString, "8,5,4,3,1,2");
             }
-        "#)
+        "#,
+        )
         .test()
 }
-
 
 #[test]
 fn includes() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -506,8 +590,11 @@ fn includes() {
                 this.includes(value, from_index)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -522,14 +609,17 @@ fn includes() {
                 let isThreeIncluded = wasm.array_includes(characters, 3, 4);
                 assert.ok(!isThreeIncluded);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn concat() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -541,8 +631,11 @@ fn concat() {
                 this.concat(arr)
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -553,14 +646,17 @@ fn concat() {
                 let new_array = wasm.array_concat(arr1, arr2)
                 assert.deepStrictEqual(new_array, [1, 2, 3, 4, 5, 6]);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn length() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -572,8 +668,11 @@ fn length() {
                 this.length()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -586,14 +685,17 @@ fn length() {
                 let emptyLength = wasm.array_length(empty);
                 assert.equal(emptyLength, 0);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn every() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -604,8 +706,11 @@ fn every() {
             pub fn array_every_number_is_even(array: &js::Array) -> bool {
                 array.every(&mut |el, _, _| el.as_f64().unwrap() % 2f64 == 0f64)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -618,6 +723,7 @@ fn every() {
                 assert(!wasm.array_every_number_is_even(arrayOdd));
                 assert(!wasm.array_every_number_is_even(arrayMixed));
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/ArrayIterator.rs
+++ b/tests/all/js_globals/ArrayIterator.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn keys() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -17,8 +19,11 @@ fn keys() {
                 this.keys()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -30,14 +35,17 @@ fn keys() {
                 assert.equal(iterator.toString(), wasmIterator.toString());
                 assert.equal(Array.from(iterator)[0], Array.from(wasmIterator)[0]);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn entries() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -49,8 +57,11 @@ fn entries() {
                 this.entries()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -64,6 +75,7 @@ fn entries() {
                 assert.equal(iterator.toString(), wasmIterator.toString());
                 assert.equal(jsItem.value[1], wasmItem.value[1]);
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/Boolean.rs
+++ b/tests/all/js_globals/Boolean.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn new_undefined() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,22 +18,28 @@ fn new_undefined() {
             pub fn new_boolean() -> js::Boolean {
                 js::Boolean::new(JsValue::undefined())
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.new_boolean().valueOf(), false);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn new_truely() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -42,14 +50,18 @@ fn new_truely() {
             pub fn new_boolean() -> js::Boolean {
                 js::Boolean::new(JsValue::from("foo"))
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.new_boolean().valueOf(), true);
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -5,7 +5,9 @@ use super::project;
 #[test]
 fn new() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,22 +18,28 @@ fn new() {
             pub fn new_date() -> Date {
                 Date::new()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(typeof wasm.new_date(), "object");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_date_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -42,8 +50,11 @@ fn to_date_string() {
             pub fn to_date_string(this: &Date) -> JsString {
                 this.to_date_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -52,14 +63,17 @@ fn to_date_string() {
 
                 assert.equal(wasm.to_date_string(date), 'Wed Jul 28 1993');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_iso_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -70,8 +84,11 @@ fn to_iso_string() {
             pub fn to_iso_string(this: &Date) -> JsString {
                 this.to_iso_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -80,14 +97,17 @@ fn to_iso_string() {
 
                 assert.equal(wasm.to_iso_string(date), '2011-10-05T14:48:00.000Z');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_json() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -98,8 +118,11 @@ fn to_json() {
             pub fn to_json(this: &Date) -> JsString {
                 this.to_json()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -108,7 +131,8 @@ fn to_json() {
 
                 assert.equal(wasm.to_json(date), '1975-08-19T23:15:30.000Z');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
@@ -173,7 +197,9 @@ fn to_locale_string() {
 #[test]
 fn to_locale_time_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -184,8 +210,11 @@ fn to_locale_time_string() {
             pub fn to_locale_time_string(this: &Date, locale: JsString) -> JsString {
                 this.to_locale_time_string(locale)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -193,14 +222,17 @@ fn to_locale_time_string() {
                 let date = new Date('August 19, 1975 23:15:30');
                 assert.equal(wasm.to_locale_time_string(date, 'en-US'), "11:15:30 PM");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -211,8 +243,11 @@ fn to_string() {
             pub fn to_string(this: &Date) -> JsString {
                 this.to_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -220,14 +255,17 @@ fn to_string() {
                 let date = new Date('August 19, 1975 23:15:30');
                 assert.equal(wasm.to_string(date).substring(0, 15), "Tue Aug 19 1975");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_time_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -238,8 +276,11 @@ fn to_time_string() {
             pub fn to_time_string(this: &Date) -> JsString {
                 this.to_time_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -247,14 +288,17 @@ fn to_time_string() {
                 let date = new Date('August 19, 1975 23:15:30');
                 assert.equal(wasm.to_time_string(date).substring(0, 8), "23:15:30");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_utc_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -265,8 +309,11 @@ fn to_utc_string() {
             pub fn to_utc_string(this: &Date) -> JsString {
                 this.to_utc_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -274,14 +321,17 @@ fn to_utc_string() {
                 let date = new Date('14 Jun 2017 00:00:00 PDT');
                 assert.equal(wasm.to_utc_string(date), "Wed, 14 Jun 2017 07:00:00 GMT");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn value_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -292,8 +342,11 @@ fn value_of() {
             pub fn js_value_of(this: &Date) -> Date {
                 this.value_of()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -301,6 +354,7 @@ fn value_of() {
                 let date = new Date(Date.UTC(96, 1, 2, 3, 4, 5));
                 assert.equal(wasm.js_value_of(date), 823230245000);
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/Function.rs
+++ b/tests/all/js_globals/Function.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn apply() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,8 +18,11 @@ fn apply() {
             pub fn apply(this: &js::Function, context: &JsValue, args: &js::Array) -> js::Function {
                 this.apply(context, args)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -28,14 +33,17 @@ fn apply() {
                 wasm.apply(Array.prototype.push, arr, [3]);
                 assert.equal(arr[2], 3);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn length() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -46,8 +54,11 @@ fn length() {
             pub fn fn_length(this: &js::Function) -> u32 {
                 this.length()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -68,14 +79,17 @@ fn length() {
                 assert.equal(wasm.fn_length(fn1), 1);
                 assert.equal(wasm.fn_length(fn2), 2);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn name() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -86,8 +100,11 @@ fn name() {
             pub fn fn_name(this: &js::Function) -> js::JsString {
                 this.name()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -109,14 +126,17 @@ fn name() {
                 const closure = () => {};
                 assert.equal(wasm.fn_name(closure), 'closure');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -127,8 +147,11 @@ fn to_string() {
             pub fn get_source_code(this: &js::Function) -> js::JsString {
                 this.to_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -139,6 +162,7 @@ fn to_string() {
                 assert.equal(wasm.get_source_code(fn1), 'function fn1(a, b) { return a + b; }');
                 assert.equal(wasm.get_source_code(fn2), 'function (a) { return console.log(a); }');
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/JsString.rs
+++ b/tests/all/js_globals/JsString.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn length() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -17,8 +19,11 @@ fn length() {
                 this.length()
             }
 
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -29,14 +34,17 @@ fn length() {
                 let empty = '';
                 assert.equal(wasm.string_length(empty), 0);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn char_at() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -47,8 +55,11 @@ fn char_at() {
             pub fn string_char_at(this: &js::JsString, index: u32) -> js::JsString {
                 this.char_at(index)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -58,14 +69,17 @@ fn char_at() {
                 assert.equal(wasm.string_char_at(anyString, 0), "B");
                 assert.equal(wasm.string_char_at(anyString, 999), "");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn char_code_at() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -76,8 +90,11 @@ fn char_code_at() {
             pub fn string_char_code_at(this: &js::JsString, index: u32) -> js::Number {
                 this.char_code_at(index)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -87,14 +104,17 @@ fn char_code_at() {
                 assert.equal(wasm.string_char_code_at(anyString, 0), 66);
                 assert.ok(isNaN(wasm.string_char_code_at(anyString, 999)));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn code_point_at() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -105,8 +125,11 @@ fn code_point_at() {
             pub fn string_code_point_at(this: &js::JsString, pos: u32) -> JsValue {
                 this.code_point_at(pos)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -115,14 +138,17 @@ fn code_point_at() {
                 assert.equal(wasm.string_code_point_at('\uD800\uDC00', 0), 65536);
                 assert.equal(wasm.string_code_point_at('XYZ', 42), undefined);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn concat() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -133,8 +159,11 @@ fn concat() {
             pub fn string_concat(this: &js::JsString, string_2: &js::JsString) -> js::JsString {
                 this.concat(string_2)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -147,7 +176,8 @@ fn concat() {
                 assert.equal(wasm.string_concat('foo', true), 'footrue');
                 assert.equal(wasm.string_concat('foo', 1234), 'foo1234');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
@@ -228,7 +258,9 @@ fn index_of() {
 #[test]
 fn slice() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -239,8 +271,11 @@ fn slice() {
             pub fn create_slice(this: &js::JsString, start: u32, end: u32) -> js::JsString {
                 this.slice(start, end)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -250,7 +285,8 @@ fn slice() {
 
                 assert.equal(subset, "cx");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
@@ -363,7 +399,9 @@ fn substr() {
 #[test]
 fn to_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -374,8 +412,11 @@ fn to_string() {
             pub fn string_to_string(this: &js::JsString) -> js::JsString {
                 this.to_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -383,14 +424,17 @@ fn to_string() {
                 let greeting = 'Hello world!';
                 assert.equal(wasm.string_to_string(greeting), 'Hello world!');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn trim() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -401,8 +445,11 @@ fn trim() {
             pub fn string_trim(this: &js::JsString) -> js::JsString {
                 this.trim()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -411,14 +458,17 @@ fn trim() {
                 // Another example of .trim() removing whitespace from just one side.
                 assert.equal(wasm.string_trim('foo   '), 'foo');
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn trim_end_and_trim_right() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -434,8 +484,11 @@ fn trim_end_and_trim_right() {
             pub fn string_trim_right(this: &js::JsString) -> js::JsString {
                 this.trim_right()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -445,14 +498,17 @@ fn trim_end_and_trim_right() {
                 assert.equal(wasm.string_trim_end(greeting), trimmed);
                 assert.equal(wasm.string_trim_right(greeting), trimmed);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn trim_start_and_trim_left() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -468,8 +524,11 @@ fn trim_start_and_trim_left() {
             pub fn string_trim_left(this: &js::JsString) -> js::JsString {
                 this.trim_left()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -479,14 +538,17 @@ fn trim_start_and_trim_left() {
                 assert.equal(wasm.string_trim_start(greeting), trimmed);
                 assert.equal(wasm.string_trim_left(greeting), trimmed);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn value_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -497,8 +559,11 @@ fn value_of() {
             pub fn string_value_of(this: &js::JsString) -> js::JsString {
                 this.value_of()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -506,6 +571,7 @@ fn value_of() {
                 let greeting = new String('Hello world!');
                 assert.equal(wasm.string_value_of(greeting), 'Hello world!');
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/Math.rs
+++ b/tests/all/js_globals/Math.rs
@@ -2,11 +2,12 @@
 
 use super::project;
 
-
 #[test]
 fn abs() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -17,8 +18,11 @@ fn abs() {
             pub fn abs(number: i32) -> js::Number {
                 js::Math::abs(number)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -26,14 +30,17 @@ fn abs() {
                 assert.equal(wasm.abs(-32), Math.abs(-32));
                 assert.equal(wasm.abs(32), 32);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn acos() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -44,22 +51,28 @@ fn acos() {
             pub fn acos(adjacent: i32, hypotenuse: i32) -> js::Number {
                 js::Math::acos(adjacent, hypotenuse)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.acos(-1, 1), Math.PI);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn acosh() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -70,8 +83,11 @@ fn acosh() {
             pub fn acosh(number: i32) -> js::Number {
                 js::Math::acosh(number)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -79,14 +95,17 @@ fn acosh() {
                 assert.equal(wasm.acosh(1), 0);
                 assert.equal(wasm.acosh(2), Math.acosh(2));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn asin() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -97,22 +116,28 @@ fn asin() {
             pub fn asin(opposite: i32, hypotenuse: i32) -> js::Number {
                 js::Math::asin(opposite / hypotenuse)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.asin(1, 1), Math.asin(1));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn asinh() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -123,22 +148,28 @@ fn asinh() {
             pub fn asinh(number: i32) -> js::Number {
                 js::Math::asinh(number)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.asinh(1), Math.asinh(1));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn atan() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -149,22 +180,28 @@ fn atan() {
             pub fn atan(number: i32) -> js::Number {
                 js::Math::atan(number)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.atan(1), Math.atan(1));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn atan2() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -175,22 +212,28 @@ fn atan2() {
             pub fn atan2(x: i32, y: i32) -> js::Number {
                 js::Math::atan2(x, y)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.atan2(1, 2), Math.atan2(1, 2));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn atanh() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -201,22 +244,28 @@ fn atanh() {
             pub fn atanh(x: i32) -> js::Number {
                 js::Math::atanh(x)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.atanh(1), Math.atanh(1));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn cbrt() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -227,22 +276,28 @@ fn cbrt() {
             pub fn cbrt(x: i32) -> js::Number {
                 js::Math::cbrt(x)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.cbrt(27), 3);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn ceil() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -253,8 +308,11 @@ fn ceil() {
             pub fn ceil(x: f32) -> js::Number {
                 js::Math::ceil(x)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -262,14 +320,17 @@ fn ceil() {
                 assert.equal(wasm.ceil(1.1), 2);
                 assert.equal(wasm.ceil(-1.1), -1);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn clz32() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -280,8 +341,11 @@ fn clz32() {
             pub fn clz32(x: i32) -> js::Number {
                 js::Math::clz32(x)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -289,14 +353,17 @@ fn clz32() {
                 assert.equal(wasm.clz32(1), 31);
                 assert.equal(wasm.clz32(1000), 22);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn floor() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -307,8 +374,11 @@ fn floor() {
             pub fn floor(x: f32) -> js::Number {
                 js::Math::floor(x)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -316,6 +386,7 @@ fn floor() {
                 assert.equal(wasm.floor(5.95), 5);
                 assert.equal(wasm.floor(-5.05), -6);
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -2,7 +2,6 @@
 
 use super::project;
 
-
 #[test]
 fn to_locale_string() {
     project()
@@ -36,7 +35,9 @@ fn to_locale_string() {
 #[test]
 fn to_precision() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -52,8 +53,11 @@ fn to_precision() {
                 };
                 result
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -61,14 +65,17 @@ fn to_precision() {
                 assert.equal(wasm.to_precision(0.1, 3), "0.100");
                 assert.equal(wasm.to_precision(10, 101), "RangeError");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -84,8 +91,11 @@ fn to_string() {
                 };
                 result
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -95,14 +105,17 @@ fn to_string() {
                 assert.equal(wasm.to_string(233, 16), "e9");
                 assert.equal(wasm.to_string(number, 100), "RangeError");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn value_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -113,8 +126,11 @@ fn value_of() {
             pub fn js_value_of(this: &js::Number) -> js::Number {
                 this.value_of()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -123,14 +139,17 @@ fn value_of() {
                 assert.equal(wasm.js_value_of(number), 42);
                 assert.equal(typeof wasm.js_value_of(number), "number");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_fixed() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -146,8 +165,11 @@ fn to_fixed() {
                 };
                 result
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -155,14 +177,17 @@ fn to_fixed() {
                 assert.equal(wasm.to_fixed(123.456, 2), "123.46");
                 assert.equal(wasm.to_fixed(10, 101), "RangeError");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_exponential() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -178,8 +203,11 @@ fn to_exponential() {
                 };
                 result
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -187,6 +215,7 @@ fn to_exponential() {
                 assert.equal(wasm.to_exponential(123456, 2), "1.23e+5");
                 assert.equal(wasm.to_exponential(10, 101), "RangeError");
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn new() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,22 +18,28 @@ fn new() {
             pub fn new_object() -> js::Object {
                 js::Object::new()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(typeof wasm.new_object(), "object");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn has_own_property() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -42,8 +50,11 @@ fn has_own_property() {
             pub fn has_own_foo_property(obj: &js::Object, property: &JsValue) -> bool {
                 obj.has_own_property(&property)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -55,14 +66,17 @@ fn has_own_property() {
                 const s = Symbol();
                 assert(wasm.has_own_foo_property({ [s]: "foo" }, s));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn to_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -79,8 +93,11 @@ fn to_string() {
                 let object = js::Object::new();
                 assert_eq!(String::from(object.to_string()), "[object Object]");
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -88,14 +105,17 @@ fn to_string() {
                 assert.equal(wasm.to_string({ foo: 42 }), "[object Object]");
                 wasm.test();
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn is_prototype_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -106,8 +126,11 @@ fn is_prototype_of() {
             pub fn obj_is_prototype_of_value(obj: &js::Object, value: &JsValue) -> bool {
                 obj.is_prototype_of(&value)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -119,14 +142,17 @@ fn is_prototype_of() {
                 assert(wasm.obj_is_prototype_of_value(Foo.prototype, foo));
                 assert(!wasm.obj_is_prototype_of_value(Bar.prototype, foo));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn keys() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -137,8 +163,11 @@ fn keys() {
             pub fn keys(obj: &js::Object) -> js::Array {
                 js::Object::keys(obj)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -146,14 +175,17 @@ fn keys() {
                 const obj = { a: 1, b: 2, c: 3 };
                 assert.deepStrictEqual(wasm.keys(obj), ["a", "b", "c"]);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn property_is_enumerable() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -164,8 +196,11 @@ fn property_is_enumerable() {
             pub fn property_is_enumerable(obj: &js::Object, property: &JsValue) -> bool {
                 obj.property_is_enumerable(&property)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -181,7 +216,8 @@ fn property_is_enumerable() {
                 const s = Symbol();
                 assert.ok(wasm.property_is_enumerable({ [s]: true }, s));
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
@@ -239,7 +275,9 @@ fn seal() {
 #[test]
 fn to_locale_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -251,22 +289,28 @@ fn to_locale_string() {
                 let object = js::Object::new();
                 object.to_locale_string()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.to_locale_string(), "[object Object]");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn value_of() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -277,8 +321,11 @@ fn value_of() {
             pub fn value_of(obj: &js::Object) -> js::Object {
                 obj.value_of()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -287,6 +334,7 @@ fn value_of() {
                 assert.strictEqual(wasm.value_of(obj), obj);
                 assert.notStrictEqual(wasm.value_of(obj), { foo: 42 });
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/TypedArray.rs
+++ b/tests/all/js_globals/TypedArray.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn new_undefined() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,22 +18,28 @@ fn new_undefined() {
             pub fn new_array() -> js::Uint8Array {
                 js::Uint8Array::new(JsValue::undefined())
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.new_array().length, 0);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn new_length() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -42,15 +50,19 @@ fn new_length() {
             pub fn new_array() -> js::Uint8Array {
                 js::Uint8Array::new(JsValue::from_f64(4.0))
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(wasm.new_array().length, 4);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 

--- a/tests/all/js_globals/WeakMap.rs
+++ b/tests/all/js_globals/WeakMap.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn new() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,23 +18,28 @@ fn new() {
             pub fn new_weak_map() -> js::WeakMap {
                 js::WeakMap::new()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(typeof wasm.new_weak_map(), "object");
             }
-        "#)
+        "#,
+        )
         .test()
 }
-
 
 #[test]
 fn get() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -43,8 +50,11 @@ fn get() {
             pub fn get_value(this: &js::WeakMap, key: js::Object) -> JsValue {
                 this.get(key)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -57,14 +67,17 @@ fn get() {
                 let undef = "unexisting_key";
                 assert.equal(typeof wasm.get_value(map, undef), "undefined");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn set() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -75,8 +88,11 @@ fn set() {
             pub fn set_value(this: &js::WeakMap, key: js::Object, value: JsValue) -> js::WeakMap {
                 this.set(key, value)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -86,14 +102,17 @@ fn set() {
                 wasm.set_value(map, key, "value");
                 assert.equal(map.get(key), "value");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn has() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -104,8 +123,11 @@ fn has() {
             pub fn has_value(this: &js::WeakMap, key: js::Object) -> bool {
                 this.has(key)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -118,14 +140,17 @@ fn has() {
                 let undef = "unexisting_key";
                 assert.equal(wasm.has_value(map, undef), false);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn delete() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -136,8 +161,11 @@ fn delete() {
             pub fn delete_key(this: &js::WeakMap, key: js::Object) -> bool {
                 this.delete(key)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -149,6 +177,7 @@ fn delete() {
                 assert.equal(map.has(key), false);
                 assert.equal(wasm.delete_key(map, key), false);
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/WeakSet.rs
+++ b/tests/all/js_globals/WeakSet.rs
@@ -5,7 +5,9 @@ use project;
 #[test]
 fn new() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -16,22 +18,28 @@ fn new() {
             pub fn new_weak_set() -> js::WeakSet {
                 js::WeakSet::new()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 assert.equal(typeof wasm.new_weak_set(), "object");
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn has() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -42,8 +50,11 @@ fn has() {
             pub fn has_value(this: &js::WeakSet, value: js::Object) -> bool {
                 this.has(value)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -56,14 +67,17 @@ fn has() {
                 let nonex = {nonexistent: "value"};
                 assert.equal(wasm.has_value(set, nonex), false);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn add() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -74,8 +88,11 @@ fn add() {
             pub fn add_value(this: &js::WeakSet, value: js::Object) -> js::WeakSet {
                 this.add(value)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -91,14 +108,17 @@ fn add() {
                 assert.throws(() => { wasm.add_value(set, null) }, TypeError);
                 assert.throws(() => { wasm.add_value(set, undefined) }, TypeError);
             }
-        "#)
+        "#,
+        )
         .test()
 }
 
 #[test]
 fn delete() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -109,8 +129,11 @@ fn delete() {
             pub fn delete_value(this: &js::WeakSet, value: js::Object) -> bool {
                 this.delete(value)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -128,6 +151,7 @@ fn delete() {
                 assert.equal(wasm.delete_value(set, null), false);
                 assert.equal(wasm.delete_value(set, undefined), false);
             }
-        "#)
+        "#,
+        )
         .test()
 }

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -9,17 +9,19 @@ mod Date;
 mod Function;
 mod JsString;
 mod Math;
-mod WeakMap;
-mod WeakSet;
 mod Number;
 mod Object;
 mod TypedArray;
+mod WeakMap;
+mod WeakSet;
 
 #[test]
 #[cfg(feature = "std")]
 fn decode_uri() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -35,7 +37,8 @@ fn decode_uri() {
 
                 assert!(js::decode_uri("%E0%A4%A").is_err());
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -43,7 +46,9 @@ fn decode_uri() {
 #[cfg(feature = "std")]
 fn encode_uri() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -55,14 +60,17 @@ fn encode_uri() {
                 let x = js::encode_uri("ABC abc 123");
                 assert_eq!(String::from(x), "ABC%20abc%20123");
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn eval() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -79,6 +87,7 @@ fn eval() {
                     .expect("eval should throw");
                 assert_eq!(err.as_f64().unwrap(), 42.0);
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/jsobjects.rs
+++ b/tests/all/jsobjects.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn simple() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -19,8 +21,11 @@ fn simple() {
             pub fn bar(s: &JsValue) {
                 foo(s);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -37,14 +42,17 @@ fn simple() {
                 wasm.bar(sym);
                 assert.strictEqual(ARG, sym);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn owned() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -60,8 +68,11 @@ fn owned() {
             pub fn bar(s: JsValue) {
                 foo(s);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -78,14 +89,17 @@ fn owned() {
                 wasm.bar(sym);
                 assert.strictEqual(ARG, sym);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn clone() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -109,8 +123,11 @@ fn clone() {
                 foo4(&s);
                 foo5(s);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -125,14 +142,17 @@ fn clone() {
             export function test() {
                 wasm.bar(ARG);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn promote() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -154,8 +174,11 @@ fn promote() {
                 foo3(s);
                 foo4(s.clone());
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -169,14 +192,17 @@ fn promote() {
             export function test() {
                 wasm.bar(ARG);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn returning_vector() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -196,8 +222,11 @@ fn returning_vector() {
                 }
                 res
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
             import * as assert from "assert";
 
@@ -207,14 +236,17 @@ fn returning_vector() {
                 const result = wasm.bar();
                 assert.strictEqual(result.length, 10);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn another_vector_return() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -233,15 +265,19 @@ fn another_vector_return() {
                     JsValue::from(6),
                 ]
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { get_array } from "./out";
             import * as assert from "assert";
 
             export function test() {
                 assert.deepStrictEqual(get_array(), [1, 2, 3, 4, 5, 6]);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -251,7 +287,9 @@ fn serde() {
         .serde(true)
         .depend("serde = '1.0'")
         .depend("serde_derive = '1.0'")
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -303,8 +341,11 @@ fn serde() {
                 let s = j.into_serde::<String>().unwrap();
                 assert_eq!(s, "bar");
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { run, parse } from "./out";
             import * as assert from "assert";
 
@@ -328,6 +369,7 @@ fn serde() {
                 run();
                 parse('bar');
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -411,15 +411,19 @@ impl Project {
 
         self.gen_bindings(&root, &target_dir);
         let mut wasm = Vec::new();
-        File::open(root.join("out_bg.wasm")).unwrap()
-            .read_to_end(&mut wasm).unwrap();
+        File::open(root.join("out_bg.wasm"))
+            .unwrap()
+            .read_to_end(&mut wasm)
+            .unwrap();
         let obj = cli::wasm2es6js::Config::new()
             .base64(true)
             .generate(&wasm)
             .expect("failed to convert wasm to js");
-        
-        File::create(root.join("out_bg.d.ts")).unwrap()
-            .write_all(obj.typescript().as_bytes()).unwrap();
+
+        File::create(root.join("out_bg.d.ts"))
+            .unwrap()
+            .write_all(obj.typescript().as_bytes())
+            .unwrap();
 
         // move files from the root into each test, it looks like this may be
         // needed for webpack to work well when invoked concurrently.
@@ -473,7 +477,6 @@ impl Project {
             }
             panic!("failed");
         }
-        
     }
     fn read_js(&self) -> String {
         let path = root().join("out.js");
@@ -522,12 +525,14 @@ mod api;
 mod char;
 mod classes;
 mod closures;
+mod comments;
 mod dependencies;
 mod enums;
 mod import_class;
 mod imports;
+#[cfg(feature = "js_globals")]
+mod js_globals;
 mod jsobjects;
-#[cfg(feature = "js_globals")] mod js_globals;
 mod math;
 mod node;
 mod non_debug;
@@ -536,6 +541,5 @@ mod simple;
 mod slice;
 mod structural;
 mod u64;
-mod webidl;
-mod comments;
 mod validate_prt;
+mod webidl;

--- a/tests/all/math.rs
+++ b/tests/all/math.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn auto_bind_math() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -64,14 +66,17 @@ fn auto_bind_math() {
                     (a % (b as f32))) as f64) +
                     (b + 2.0f64.powf(a as f64))
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import { math } from "./out";
 
             export function test() {
                 math(1.0, 2.0);
             }
-        "#)
+        "#,
+        )
         .test();
 }
-

--- a/tests/all/node.rs
+++ b/tests/all/node.rs
@@ -4,7 +4,9 @@ use super::project;
 fn works() {
     project()
         .node(true)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -111,8 +113,11 @@ fn works() {
                     (a % (b as f32))) as f64) +
                     (b + 2.0f64.powf(a as f64))
             }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             const assert = require('assert');
 
             var called = false;
@@ -149,6 +154,7 @@ fn works() {
                 math(1.0, 2.0);
             };
 
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/non_debug.rs
+++ b/tests/all/non_debug.rs
@@ -4,7 +4,9 @@ use super::project;
 fn works() {
     project()
         .debug(false)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -26,8 +28,11 @@ fn works() {
                 drop(a.clone());
                 a.clone()
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -37,6 +42,7 @@ fn works() {
                 let a = wasm.A.new();
                 a.free();
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/non_wasm.rs
+++ b/tests/all/non_wasm.rs
@@ -1,13 +1,14 @@
+use super::{project, run};
 use std::process::Command;
-use super::{run, project};
 
 #[test]
 fn works() {
     let mut p = project();
     let name = p.crate_name();
-    p
-        .rlib(true)
-        .file("src/lib.rs", r#"
+    p.rlib(true)
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -54,8 +55,12 @@ fn works() {
             #[wasm_bindgen]
             pub fn baz(_: JsValue) {
             }
-        "#)
-        .file("tests/foo.rs", &format!("
+        "#,
+        )
+        .file(
+            "tests/foo.rs",
+            &format!(
+                "
             extern crate {} as mytest;
 
             #[test]
@@ -63,8 +68,14 @@ fn works() {
                 mytest::foo(false);
                 mytest::A::new().foo();
             }}
-        ", name))
-        .file("benches/foo.rs", &format!("
+        ",
+                name
+            ),
+        )
+        .file(
+            "benches/foo.rs",
+            &format!(
+                "
             #![feature(test)]
             extern crate test;
             extern crate {} as mytest;
@@ -73,14 +84,18 @@ fn works() {
             fn foo(b: &mut test::Bencher) {{
                 b.iter(|| mytest::foo(false));
             }}
-        ", name));
+        ",
+                name
+            ),
+        );
     let (root, target_dir) = p.build();
     let mut cmd = Command::new("cargo");
     cmd.arg("test")
-        .arg("--test").arg("foo")
-        .arg("--bench").arg("foo")
+        .arg("--test")
+        .arg("foo")
+        .arg("--bench")
+        .arg("foo")
         .current_dir(&root)
         .env("CARGO_TARGET_DIR", &target_dir);
     run(&mut cmd, "cargo");
 }
-

--- a/tests/all/simple.rs
+++ b/tests/all/simple.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn add() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -37,8 +39,11 @@ fn add() {
                     return a
                 }
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -49,14 +54,17 @@ fn add() {
                 assert.strictEqual(wasm.get2(true), 2);
                 assert.strictEqual(wasm.return_and_take_bool(true, false), false);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn string_arguments() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -73,22 +81,28 @@ fn string_arguments() {
             pub fn assert_foo(a: &str) {
                 assert_eq!(a, "foo");
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out";
 
             export function test() {
                 wasm.assert_foo("foo");
                 wasm.assert_foo_and_bar("foo2", "bar");
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn return_a_string() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -104,8 +118,11 @@ fn return_a_string() {
             pub fn concat(a: &str, b: &str, c: i8) -> String {
                 format!("{} {} {}", a, b, c)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -115,14 +132,17 @@ fn return_a_string() {
                 assert.strictEqual(wasm.concat("a", "b", 3), "a b 3");
                 assert.strictEqual(wasm.concat("c", "d", -2), "c d -2");
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn exceptions() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -134,8 +154,11 @@ fn exceptions() {
 
             #[wasm_bindgen]
             pub fn bar(_a: &str) {}
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -143,10 +166,14 @@ fn exceptions() {
                 assert.throws(() => wasm.foo('a'), /expected a number argument/);
                 assert.throws(() => wasm.bar(3), /expected a string argument/);
             }
-        "#)
-        .file("test.d.ts", r#"
+        "#,
+        )
+        .file(
+            "test.d.ts",
+            r#"
             export function test(): void;
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -187,18 +214,24 @@ fn exceptions() {
 #[test]
 fn other_exports() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #[no_mangle]
             pub extern fn foo(_a: u32) {
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out_bg";
 
             export function test() {
                 wasm.foo(2);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
@@ -206,7 +239,9 @@ fn other_exports() {
 fn no_std() {
     project()
         .no_std(true)
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             #![no_std]
             #![allow(dead_code)]
@@ -229,28 +264,37 @@ fn no_std() {
 
             #[wasm_bindgen]
             pub fn foo(_a: u32) {}
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out_bg";
 
             export function test() {
                 // mostly just testing the project compiles here
                 wasm.foo(1);
             }
-        "#)
-        .file("foo.js", r#"
+        "#,
+        )
+        .file(
+            "foo.js",
+            r#"
             export class Js {
                 init() {
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn no_std_class() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             #![no_std]
             #![allow(dead_code)]
@@ -282,14 +326,18 @@ fn no_std_class() {
                 pub fn foo(&self) {}
                 pub fn bar(&mut self) {}
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as wasm from "./out_bg";
 
             export function test() {
                 // mostly just testing the project compiles here
                 wasm.foo(1);
             }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/slice.rs
+++ b/tests/all/slice.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn export() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -24,8 +26,11 @@ fn export() {
 
 
             doit! { i8 u8 i16 u16 i32 u32 f32 f64 }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -76,14 +81,17 @@ fn export() {
                 f64[1] = 2;
                 assert_arrays_equal(wasm.f64(f64), f64);
           }
-      "#)
+      "#,
+        )
         .test();
 }
 
 #[test]
 fn import() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -118,8 +126,11 @@ fn import() {
                 (rust_f32, js_f32, f32)
                 (rust_f64, js_f64, f64)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -225,14 +236,17 @@ fn import() {
                 f64[1] = 2;
                 assert_arrays_equal(wasm.rust_f64(f64), f64);
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn pass_array_works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -261,8 +275,11 @@ fn pass_array_works() {
                 (rust_f32, f32)
                 (rust_f64, f64)
             }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             const wasm = require("./out");
 
             module.exports.test = function() {
@@ -275,14 +292,17 @@ fn pass_array_works() {
                 wasm.rust_f32([1, 2]);
                 wasm.rust_f64([1, 2]);
             };
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn import_mut() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -328,8 +348,11 @@ fn import_mut() {
                 (rust_f32, js_f32, f32)
                 (rust_f64, js_f64, f64)
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -353,14 +376,17 @@ fn import_mut() {
             export function test() {
                 wasm.run();
             }
-        "#)
+        "#,
+        )
         .test();
 }
 
 #[test]
 fn export_mut() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section)]
 
             extern crate wasm_bindgen;
@@ -383,8 +409,11 @@ fn export_mut() {
 
 
             doit! { i8 u8 i16 u16 i32 u32 f32 f64 }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -412,14 +441,17 @@ fn export_mut() {
                 run(new Float32Array(3), wasm.f32);
                 run(new Float64Array(3), wasm.f64);
           }
-      "#)
+      "#,
+        )
         .test();
 }
 
 #[test]
 fn return_vec_ok() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             extern crate wasm_bindgen;
 
@@ -461,8 +493,11 @@ fn return_vec_ok() {
 
             pub fn main() {
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
@@ -485,7 +520,7 @@ fn return_vec_ok() {
                     assert.strictEqual(bad[8], 9);
                 }
             }
-      "#)
+      "#,
+        )
         .test();
 }
-

--- a/tests/all/structural.rs
+++ b/tests/all/structural.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             extern crate wasm_bindgen;
 
@@ -28,8 +30,11 @@ fn works() {
                 a.set_baz(2);
                 assert_eq!(a.baz(), 2);
             }
-        "#)
-        .file("test.ts", r#"
+        "#,
+        )
+        .file(
+            "test.ts",
+            r#"
             import * as assert from "assert";
             import { run } from "./out";
 
@@ -41,8 +46,7 @@ fn works() {
                 });
                 assert.strictEqual(called, true);
             }
-        "#)
+        "#,
+        )
         .test();
 }
-
-

--- a/tests/all/u64.rs
+++ b/tests/all/u64.rs
@@ -4,7 +4,9 @@ use super::project;
 fn works() {
     project()
         .requires_bigint()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
 
             extern crate wasm_bindgen;
@@ -42,8 +44,11 @@ fn works() {
 
             #[wasm_bindgen]
             pub fn u64_slice(a: &[u64]) -> Vec<u64> { a.to_vec() }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             import * as wasm from './out';
 
             function assertEq(a, b) {
@@ -95,6 +100,7 @@ fn works() {
 
             export function js_i64_round(a) { return a; }
             export function js_u64_round(a) { return a; }
-        "#)
+        "#,
+        )
         .test();
 }

--- a/tests/all/validate_prt.rs
+++ b/tests/all/validate_prt.rs
@@ -3,7 +3,9 @@ use super::project;
 #[test]
 fn works() {
     project()
-        .file("src/lib.rs", r#"
+        .file(
+            "src/lib.rs",
+            r#"
             #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -26,8 +28,11 @@ fn works() {
             }
             #[wasm_bindgen]
             pub fn eat(_fruit: Fruit) { }
-        "#)
-        .file("test.js", r#"
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
             import * as wasm from './out';
             const targetMessage = 'Attempt to use a moved value';
             function assertEq(a, b) {
@@ -64,6 +69,7 @@ fn works() {
                     assertEq(e.message, targetMessage);
                 }
             }
-        "#)
+        "#,
+        )
         .test();
 }


### PR DESCRIPTION
We have lots of multi-line strings as part of function calls, these seem to be a bit funky under rustfmt. I fixed up a number of them, but there are likely still a good number of them.