### PR TITLE
feat(Set): add bindings and tests

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -617,10 +617,10 @@ extern {
 extern {
     pub type Set;
 
-    /// The add() method appends a new element with a specified value to the end of a Set object.
+    /// The add() method appends a new element with a specified value to the 
+    /// end of a Set object.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add
-    
     #[wasm_bindgen(method)]
     pub fn add(this: &Set, value: &JsValue) -> Set;
 
@@ -636,13 +636,15 @@ extern {
     #[wasm_bindgen(method)]
     pub fn delete(this: &Set, value: &JsValue) -> bool;
 
-    /// The has() method returns a boolean indicating whether an element with the specified value exists in a Set object or not.
+    /// The has() method returns a boolean indicating whether an element 
+    /// with the specified value exists in a Set object or not.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has
     #[wasm_bindgen(method)]
     pub fn has(this: &Set, value: &JsValue) -> bool;
 
-    /// The Set object lets you store unique values of any type, whether primitive values or object references.
+    /// The Set object lets you store unique values of any type, whether primitive 
+    /// values or object references.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
     #[wasm_bindgen(constructor)]
@@ -651,7 +653,6 @@ extern {
     /// The size accessor property returns the number of elements in a Set object.
     /// 
     /// https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Set/size
-    
     #[wasm_bindgen(method, getter, structural)]
     pub fn size(this: &Set) -> Number;
 }
@@ -661,18 +662,20 @@ extern {
 extern {
     pub type SetIterator;
 
-    /// The entries() method returns a new Iterator object that contains an array of [value, value] 
-    /// for each element in the Set object, in insertion order. For Set objects 
-    /// there is no key like in Map objects. However, to keep the API similar 
-    /// to the Map object, each entry has the same value for its key and value here, 
-    /// so that an array [value, value] is returned.
+    /// The entries() method returns a new Iterator object that contains 
+    /// an array of [value, value] for each element in the Set object, 
+    /// in insertion order. For Set objects there is no key like in 
+    /// Map objects. However, to keep the API similar to the Map object,
+    /// each entry has the same value for its key and value here, so that 
+    /// an array [value, value] is returned.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries
     #[wasm_bindgen(method)]
     pub fn entries(set: &Set) -> SetIterator;
     
-    /// The keys() method is an alias for this method (for similarity with Map objects); 
-    /// it behaves exactly the same and returns values of Set elements.
+    /// The keys() method is an alias for this method (for similarity with 
+    /// Map objects); it behaves exactly the same and returns values 
+    /// of Set elements.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
     
@@ -683,7 +686,6 @@ extern {
     /// element in the Set object in insertion order.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
-    
     #[wasm_bindgen(method)]
     pub fn values(set: &Set) -> SetIterator;
 }

--- a/src/js.rs
+++ b/src/js.rs
@@ -612,6 +612,82 @@ extern {
     pub fn value_of(this: &Object) -> Object;
 }
 
+// Set
+#[wasm_bindgen]
+extern {
+    pub type Set;
+
+    /// The size accessor property returns the number of elements in a Set object.
+    /// 
+    /// https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Set/size
+    
+    #[wasm_bindgen(method, getter, structural)]
+    pub fn size(this: &Set) -> Number;
+
+    /// The add() method appends a new element with a specified value to the end of a Set object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add
+    
+    #[wasm_bindgen(method)]
+    pub fn add(this: &Set, value: &JsValue) -> Set;
+
+    /// The clear() method removes all elements from a Set object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear
+    #[wasm_bindgen(method)]
+    pub fn clear(this: &Set);
+
+    /// The delete() method removes the specified element from a Set object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete
+    #[wasm_bindgen(method)]
+    pub fn delete(this: &Set, value: &JsValue) -> bool;
+
+    /// The has() method returns a boolean indicating whether an element with the specified value exists in a Set object or not.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has
+    #[wasm_bindgen(method)]
+    pub fn has(this: &Set, value: &JsValue) -> bool;
+
+    /// The Set object lets you store unique values of any type, whether primitive values or object references.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Set;
+}
+
+// SetIterator
+#[wasm_bindgen]
+extern {
+    pub type SetIterator;
+
+    /// The entries() method returns a new Iterator object that contains an array of [value, value] 
+    /// for each element in the Set object, in insertion order. For Set objects 
+    /// there is no key like in Map objects. However, to keep the API similar 
+    /// to the Map object, each entry has the same value for its key and value here, 
+    /// so that an array [value, value] is returned.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries
+    #[wasm_bindgen(method)]
+    pub fn entries(set: &Set) -> SetIterator;
+
+    /// The values() method returns a new Iterator object that contains the values for each 
+    /// element in the Set object in insertion order.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
+    
+    #[wasm_bindgen(method)]
+    pub fn values(set: &Set) -> SetIterator;
+    
+    /// The keys() method is an alias for this method (for similarity with Map objects); 
+    /// it behaves exactly the same and returns values of Set elements.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
+    
+    #[wasm_bindgen(method)]
+    pub fn keys(set: &Set) -> SetIterator;
+}
+
 // WeakMap
 #[wasm_bindgen]
 extern {

--- a/src/js.rs
+++ b/src/js.rs
@@ -617,13 +617,6 @@ extern {
 extern {
     pub type Set;
 
-    /// The size accessor property returns the number of elements in a Set object.
-    /// 
-    /// https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Set/size
-    
-    #[wasm_bindgen(method, getter, structural)]
-    pub fn size(this: &Set) -> Number;
-
     /// The add() method appends a new element with a specified value to the end of a Set object.
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add
@@ -654,6 +647,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
     #[wasm_bindgen(constructor)]
     pub fn new() -> Set;
+
+    /// The size accessor property returns the number of elements in a Set object.
+    /// 
+    /// https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Set/size
+    
+    #[wasm_bindgen(method, getter, structural)]
+    pub fn size(this: &Set) -> Number;
 }
 
 // SetIterator
@@ -670,14 +670,6 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries
     #[wasm_bindgen(method)]
     pub fn entries(set: &Set) -> SetIterator;
-
-    /// The values() method returns a new Iterator object that contains the values for each 
-    /// element in the Set object in insertion order.
-    /// 
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
-    
-    #[wasm_bindgen(method)]
-    pub fn values(set: &Set) -> SetIterator;
     
     /// The keys() method is an alias for this method (for similarity with Map objects); 
     /// it behaves exactly the same and returns values of Set elements.
@@ -686,6 +678,14 @@ extern {
     
     #[wasm_bindgen(method)]
     pub fn keys(set: &Set) -> SetIterator;
+    
+    /// The values() method returns a new Iterator object that contains the values for each 
+    /// element in the Set object in insertion order.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
+    
+    #[wasm_bindgen(method)]
+    pub fn values(set: &Set) -> SetIterator;
 }
 
 // WeakMap

--- a/tests/all/js_globals/Set.rs
+++ b/tests/all/js_globals/Set.rs
@@ -1,0 +1,182 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn size() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn size(this: &js::Set) -> js::Number {
+                this.size()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([8, 5, 4, 3, 1, 2]);
+
+                assert.equal(wasm.size(set), 6);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn add() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn add(this: &js::Set, value: &JsValue) -> js::Set {
+                this.add(value)
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([]);
+
+                wasm.add(set, 100);
+
+
+                assert.equal(set.size, 1);
+                assert.equal(Array.from(set)[0], 100);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn clear() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn clear(this: &js::Set) {
+                this.clear();
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([1, 2, 3]);
+
+                wasm.clear(set);
+
+                assert.equal(set.size, 0);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn delete() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn set_delete(this: &js::Set, value: &JsValue) -> bool {
+                this.delete(value)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([1, 2, 3]);
+
+                assert.equal(wasm.set_delete(set, 4), false);
+                assert.equal(wasm.set_delete(set, 2), true);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn has() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn has(this: &js::Set, value: &JsValue) -> bool {
+                this.has(value)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([1, 2, 3]);
+
+                assert.equal(wasm.has(set, 4), false);
+                assert.equal(wasm.has(set, 2), true);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn new() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn new_set() -> js::Set {
+                js::Set::new()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = wasm.new_set();
+
+                assert.equal(set.size, 0);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/SetIterator.rs
+++ b/tests/all/js_globals/SetIterator.rs
@@ -1,0 +1,97 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn entries() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn entries(this: &js::Set) -> js::SetIterator {
+                this.entries()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([8, 5, 4, 3, 1, 2]);
+                let wasmIterator = wasm.entries(set);
+                let nextValue = wasmIterator.next().value;
+
+                assert.equal(nextValue[0], 8);
+                assert.equal(nextValue[1], 8);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn values() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn values(this: &js::Set) -> js::SetIterator {
+                this.values()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([8, 5, 4, 3, 1, 2]);
+                let wasmIterator = wasm.values(set);
+                let nextValue = wasmIterator.next().value;
+
+                assert.equal(nextValue, 8);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn keys() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn keys(this: &js::Set) -> js::SetIterator {
+                this.keys()
+            }
+
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let set = new Set([8, 5, 4, 3, 1, 2]);
+                let wasmIterator = wasm.keys(set);
+                let nextValue = wasmIterator.next().value;
+
+                assert.equal(nextValue, 8);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -13,6 +13,8 @@ mod WeakMap;
 mod WeakSet;
 mod Number;
 mod Object;
+mod Set;
+mod SetIterator;
 mod TypedArray;
 
 #[test]


### PR DESCRIPTION
This PR implements the bindings and the corresponding tests for the following properties and methods of Set:

- [x] Set.size
- [x] Set.add
- [x] Set.clear
- [x] Set.delete
- [x] Set.has
- [x] new Set()
- [x] Set.entries
- [x] Set.keys
- [x] Set.values

Same as in #342 I was not able to implement `Set.forEach`, `Set[@@iterator]` and the other Symbol based properties/methods.