### PR TITLE
Add bindings for Map.xx

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -312,6 +312,12 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
     #[wasm_bindgen(method)]
     pub fn clear(this: &Map);
+
+    /// The delete() method removes the specified element from a Map object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
+    #[wasm_bindgen(method)]
+    pub fn delete(this: &Map, key: &str) -> bool;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -374,6 +374,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
     #[wasm_bindgen(method)]
     pub fn keys(this: &Map) -> MapIterator;
+
+    /// The values() method returns a new Iterator object that contains the 
+    /// values for each element in the Map object in insertion order.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values
+    #[wasm_bindgen(method)]
+    pub fn values(this: &Map) -> MapIterator;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -302,6 +302,18 @@ extern {
     pub fn to_string(this: &Function) -> JsString;
 }
 
+// Map
+#[wasm_bindgen]
+extern {
+    pub type Map;
+
+    /// The clear() method removes all elements from a Map object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
+    #[wasm_bindgen(method)]
+    pub fn clear(this: &Map);
+}
+
 // Math
 #[wasm_bindgen]
 extern {

--- a/src/js.rs
+++ b/src/js.rs
@@ -355,6 +355,20 @@ extern {
     pub fn size(this: &Map) -> Number;
 }
 
+// Map Iterator
+#[wasm_bindgen]
+extern {
+    pub type MapIterator;
+
+    /// The entries() method returns a new Iterator object that contains 
+    /// the [key, value] pairs for each element in the Map object in 
+    /// insertion order.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
+    #[wasm_bindgen(method)]
+    pub fn entries(this: &Map) -> MapIterator;
+}
+
 // Math
 #[wasm_bindgen]
 extern {

--- a/src/js.rs
+++ b/src/js.rs
@@ -331,6 +331,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
     #[wasm_bindgen(method)]
     pub fn has(this: &Map, key: &JsValue) -> bool;
+
+    /// The Map object holds key-value pairs. Any value (both objects and 
+    /// primitive values) maybe used as either a key or a value.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Map;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -324,6 +324,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
     #[wasm_bindgen(method)]
     pub fn get(this: &Map, key: &JsValue) -> JsValue;
+
+    /// The has() method returns a boolean indicating whether an element with 
+    /// the specified key exists or not.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
+    #[wasm_bindgen(method)]
+    pub fn has(this: &Map, key: &JsValue) -> bool;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -318,6 +318,12 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
     #[wasm_bindgen(method)]
     pub fn delete(this: &Map, key: &str) -> bool;
+
+    /// The get() method returns a specified element from a Map object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
+    #[wasm_bindgen(method)]
+    pub fn get(this: &Map, key: &JsValue) -> JsValue;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -367,6 +367,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
     #[wasm_bindgen(method)]
     pub fn entries(this: &Map) -> MapIterator;
+
+    /// The keys() method returns a new Iterator object that contains the 
+    /// keys for each element in the Map object in insertion order.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
+    #[wasm_bindgen(method)]
+    pub fn keys(this: &Map) -> MapIterator;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -345,6 +345,14 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
     #[wasm_bindgen(method)]
     pub fn set(this: &Map, key: &JsValue, value: &JsValue) -> Map;
+
+    /// The value of size is an integer representing how many entries 
+    /// the Map object has. A set accessor function for size is undefined; 
+    /// you can not change this property.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size
+    #[wasm_bindgen(method, getter, structural)]
+    pub fn size(this: &Map) -> Number;
 }
 
 // Math

--- a/src/js.rs
+++ b/src/js.rs
@@ -338,6 +338,13 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
     #[wasm_bindgen(constructor)]
     pub fn new() -> Map;
+
+    /// The set() method adds or updates an element with a specified key 
+    /// and value to a Map object.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
+    #[wasm_bindgen(method)]
+    pub fn set(this: &Map, key: &JsValue, value: &JsValue) -> Map;
 }
 
 // Math

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -153,3 +153,32 @@ fn new() {
         "#)
         .test()
 }
+
+#[test]
+fn set() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn set(this: &js::Map, key: &JsValue, value: &JsValue) -> js::Map {
+                this.set(key, value)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                const newMap = wasm.set(map, 'foo', 'bar');
+                assert.equal(map.has('foo'), true);
+                assert.equal(newMap.has('foo'), true);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -65,3 +65,34 @@ fn delete() {
         "#)
         .test()
 }
+
+#[test]
+fn get() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn map_get(this: &js::Map, key: &JsValue) -> JsValue {
+                this.get(key)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                map.set('foo', 'bar');
+                map.set(1, 2)
+                assert.equal(wasm.map_get(map, 'foo'), 'bar');
+                assert.equal(wasm.map_get(map, 1), 2);
+                assert.equal(wasm.map_get(map, 2), undefined);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -1,0 +1,35 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn clear() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn map_clear(this: &js::Map) {
+                this.clear();
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                map.set('foo', 'bar');
+                map.set('bar', 'baz');
+                assert.equal(map.size, 2);
+                wasm.map_clear(map);
+                assert.equal(map.size, 0);
+
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -33,3 +33,35 @@ fn clear() {
         "#)
         .test()
 }
+
+#[test]
+fn delete() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn map_delete(this: &js::Map, key: &str) -> bool {
+                this.delete(key)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                map.set('foo', 'bar');
+                assert.equal(map.size, 1);
+                assert.equal(wasm.map_delete(map, 'foo'), true);
+                assert.equal(wasm.map_delete(map, 'bar'), false);
+                assert.equal(map.size, 0);
+
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -96,3 +96,32 @@ fn get() {
         "#)
         .test()
 }
+
+#[test]
+fn has() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn has(this: &js::Map, key: &JsValue) -> bool {
+                this.has(key)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                map.set('foo', 'bar');
+                assert.equal(wasm.has(map, 'foo'), true);
+                assert.equal(wasm.has(map, 'bar'), false);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -182,3 +182,32 @@ fn set() {
         "#)
         .test()
 }
+
+#[test]
+fn size() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn map_size(this: &js::Map) -> js::Number {
+                this.size()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                map.set('foo', 'bar');
+                map.set('bar', 'baz');
+                assert.equal(wasm.map_size(map), 2);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -125,3 +125,31 @@ fn has() {
         "#)
         .test()
 }
+
+#[test]
+fn new() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn new_map() -> js::Map {
+                js::Map::new()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = wasm.new_map();
+
+                assert.equal(map.size, 0);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/MapIterator.rs
+++ b/tests/all/js_globals/MapIterator.rs
@@ -34,3 +34,35 @@ fn entries() {
         "#)
         .test()
 }
+
+#[test]
+fn keys() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn get_keys(this: &js::Map) -> js::MapIterator {
+                this.keys()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                const iterator = map.keys();
+                const wasmIterator = wasm.get_keys(map);
+                map.set('foo', 'bar');
+                map.set('bar', 'baz');
+
+                assert.equal(iterator.toString(), wasmIterator.toString());
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/MapIterator.rs
+++ b/tests/all/js_globals/MapIterator.rs
@@ -1,0 +1,36 @@
+#![allow(non_snake_case)]
+
+use project;
+
+
+#[test]
+fn entries() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn get_entries(this: &js::Map) -> js::MapIterator {
+                this.entries()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                const iterator = map.entries();
+                const wasmIterator = wasm.get_entries(map);
+                map.set('foo', 'bar');
+                map.set('bar', 'baz');
+
+                assert.equal(iterator.toString(), wasmIterator.toString());
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/MapIterator.rs
+++ b/tests/all/js_globals/MapIterator.rs
@@ -66,3 +66,35 @@ fn keys() {
         "#)
         .test()
 }
+
+#[test]
+fn values() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn get_values(this: &js::Map) -> js::MapIterator {
+                this.values()
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                const iterator = map.keys();
+                const wasmIterator = wasm.get_values(map);
+                map.set('foo', 'bar');
+                map.set('bar', 'baz');
+
+                assert.equal(iterator.toString(), wasmIterator.toString());
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -9,6 +9,7 @@ mod Date;
 mod Function;
 mod JsString;
 mod Map;
+mod MapIterator;
 mod Math;
 mod WeakMap;
 mod WeakSet;

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -8,6 +8,7 @@ mod Boolean;
 mod Date;
 mod Function;
 mod JsString;
+mod Map;
 mod Math;
 mod WeakMap;
 mod WeakSet;


### PR DESCRIPTION
This branch adds bindings for the following methods and properties of Map:

- [x] Map.new
- [x] Map.clear
- [x] Map.set
- [x] Map.get
- [x] Map.has
- [x] Map.delete
- [x] Map.size
- [x] Map.entries
- [x] Map.values
- [x] Map.keys

I added one commit per method/property and adjusted the line width of descriptions.