### PR TITLE
Don't generate JS bindings for unused imports

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1778,6 +1778,10 @@ impl<'a, 'b> SubContext<'a, 'b> {
         info: &shared::Import,
         import: &shared::ImportFunction,
     ) -> Result<(), Error> {
+        if !self.cx.wasm_import_needed(&import.shim) {
+            return Ok(())
+        }
+
         let descriptor = match self.cx.describe(&import.shim) {
             None => return Ok(()),
             Some(d) => d,

--- a/tests/all/imports.rs
+++ b/tests/all/imports.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::io::Read;
+
 use super::project;
 
 #[test]
@@ -667,4 +670,39 @@ fn custom_type() {
             }
         "#)
         .test();
+}
+
+#[test]
+fn unused_imports_not_generated() {
+    let mut project = project();
+    project
+        .debug(false)
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            extern {
+                pub fn foo();
+            }
+
+            #[wasm_bindgen]
+            pub fn run() {
+            }
+        "#)
+        .file("test.ts", r#"
+            import { run } from "./out";
+
+            export function test() {
+                run();
+            }
+        "#)
+        .test();
+
+    let contents = project.read_js();
+    assert!(contents.contains("run"), "didn't find `run` in {}", contents);
+    assert!(!contents.contains("foo"), "found `foo` in {}", contents);
 }


### PR DESCRIPTION
If a JS import's shim isn't actually imported that means that somewhere along
the way it was optimized out or it was never used in the first place! In that
case we can skip generation of the JS bindings for it as it's not needed.