### PR TITLE
add more detailed error messages for invalid #[wasm_bindgen] invocations

### DIFF
--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![cfg_attr(feature = "extra-traits", deny(missing_debug_implementations))]
+#![feature(proc_macro)]
 
 extern crate proc_macro2;
 #[macro_use]

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -12,8 +12,8 @@ use quote::ToTokens;
 #[proc_macro_attribute]
 pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
     let item = syn::parse::<syn::Item>(input.clone()).expect("expected a valid Rust item");
-    let opts = syn::parse::<backend::ast::BindgenAttrs>(attr)
-        .expect("invalid arguments to #[wasm_bindgen]");
+    let context = backend::ast::BindgenAttrContext::from_item_toplevel(&item);
+    let opts = backend::ast::BindgenAttrs::parse(attr.into(), context);
 
     let mut ret = proc_macro2::TokenStream::new();
     let mut program = backend::ast::Program::default();

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -198,7 +198,10 @@ impl<'a> WebidlParse<&'a webidl::ast::NonPartialInterface> for webidl::ast::Exte
                     .map(|arg| (&*arg.name, &*arg.type_, arg.variadic)),
                 kind,
                 Some(self_ty),
-                vec![backend::ast::BindgenAttr::Constructor],
+                backend::ast::BindgenAttrs {
+                    constructor: Some(()),
+                    ..Default::default()
+                },
             ).map(|function| {
                 program.imports.push(backend::ast::Import {
                     module: None,

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -147,7 +147,7 @@ pub fn create_function<'a, I>(
     arguments: I,
     kind: backend::ast::ImportFunctionKind,
     ret: Option<syn::Type>,
-    mut attrs: Vec<backend::ast::BindgenAttr>,
+    mut opts: backend::ast::BindgenAttrs,
 ) -> Option<backend::ast::ImportFunction>
 where
     I: Iterator<Item = (&'a str, &'a webidl::ast::Type, bool)>,
@@ -160,10 +160,8 @@ where
     let js_ret = ret.clone();
 
     if let backend::ast::ImportFunctionKind::Method { .. } = kind {
-        attrs.push(backend::ast::BindgenAttr::Method);
+        opts.method = Some(());
     }
-
-    let opts = backend::ast::BindgenAttrs { attrs };
 
     let shim = {
         let ns = match kind {
@@ -232,7 +230,7 @@ pub fn create_basic_method(
             .map(|arg| (&*arg.name, &*arg.type_, arg.variadic)),
         kind,
         ret,
-        Vec::new(),
+        Default::default(),
     )
 }
 
@@ -261,7 +259,10 @@ pub fn create_getter(
         iter::empty(),
         kind,
         ret,
-        vec![backend::ast::BindgenAttr::Getter(Some(raw_ident(name)))],
+        backend::ast::BindgenAttrs {
+            getter: Some(Some(raw_ident(name))),
+            ..Default::default()
+        },
     )
 }
 
@@ -282,6 +283,9 @@ pub fn create_setter(
         iter::once((name, ty, false)),
         kind,
         None,
-        vec![backend::ast::BindgenAttr::Setter(Some(raw_ident(name)))],
+        backend::ast::BindgenAttrs {
+            setter: Some(Some(raw_ident(name))),
+            ..Default::default()
+        },
     )
 }


### PR DESCRIPTION
Allows this code:

```rust
#[wasm_bindgen(readonly)]
pub fn a() {}

#[wasm_bindgen(js_name)]
pub fn b() {}

#[wasm_bindgen(a = b)]
pub fn c() {}

#[wasm_bindgen(js_name = 1)]
pub fn d() {}

#[wasm_bindgen(version = "1", version = "2")]
extern {}
```

To produce this:

```
error: attribute is not available in this context
  --> src/lib.rs:15:16
   |
15 | #[wasm_bindgen(readonly)]
   |                ^^^^^^^^
   |
   = help: attribute "readonly" is not allowed before exported function

error: attribute "js_name" requires a value
  --> src/lib.rs:18:16
   |
18 | #[wasm_bindgen(js_name)]
   |                ^^^^^^^

error: unrecognized attribute "a"
  --> src/lib.rs:21:16
   |
21 | #[wasm_bindgen(a = b)]
   |                ^

error: failed to parse value for attribute "js_name"
  --> src/lib.rs:24:26
   |
24 | #[wasm_bindgen(js_name = 1)]
   |                          ^
   |
   = help: expected ident

error: duplicate attribute "version"
  --> src/lib.rs:27:31
   |
27 | #[wasm_bindgen(version = "1", version = "2")]
   |                               ^^^^^^^^^^^^^

error: aborting due to 5 previous errors
```