### PR TITLE
Expose bindings/object is* methods

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -777,6 +777,12 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Object, js_name = isExtensible)]
     pub fn is_extensible(object: &Object) -> bool;
 
+    /// The Object.isFrozen() determines if an object is frozen.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen
+    #[wasm_bindgen(static_method_of = Object, js_name = isFrozen)]
+    pub fn is_frozen(object: &Object) -> bool;
+
     /// The isPrototypeOf() method checks if an object exists in another
     /// object's prototype chain.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -770,6 +770,13 @@ extern "C" {
     #[wasm_bindgen(method, js_name = hasOwnProperty)]
     pub fn has_own_property(this: &Object, property: &JsValue) -> bool;
 
+    /// The Object.isExtensible() method determines if an object is extensible
+    /// (whether it can have new properties added to it).
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible
+    #[wasm_bindgen(static_method_of = Object, js_name = isExtensible)]
+    pub fn is_extensible(object: &Object) -> bool;
+
     /// The isPrototypeOf() method checks if an object exists in another
     /// object's prototype chain.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -783,6 +783,12 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Object, js_name = isFrozen)]
     pub fn is_frozen(object: &Object) -> bool;
 
+    /// The Object.isSealed() method determines if an object is sealed.
+    /// 
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed
+    #[wasm_bindgen(static_method_of = Object, js_name = isSealed)]
+    pub fn is_sealed(object: &Object) -> bool;
+
     /// The isPrototypeOf() method checks if an object exists in another
     /// object's prototype chain.
     ///

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -111,6 +111,36 @@ fn to_string() {
 }
 
 #[test]
+fn is_extensible() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn is_extensible(obj: &js::Object) -> bool {
+                js::Object::is_extensible(&obj)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const object = {};
+                assert(wasm.is_extensible(object));
+
+                Object.preventExtensions(object);
+                assert(!wasm.is_extensible(object));
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn is_prototype_of() {
     project()
         .file(

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -171,6 +171,36 @@ fn is_frozen() {
 }
 
 #[test]
+fn is_sealed() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn is_sealed(obj: &js::Object) -> bool {
+                js::Object::is_sealed(&obj)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const object = {};
+                assert(!wasm.is_sealed(object));
+
+                Object.seal(object);
+                assert(wasm.is_sealed(object));
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn is_prototype_of() {
     project()
         .file(

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -141,6 +141,36 @@ fn is_extensible() {
 }
 
 #[test]
+fn is_frozen() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn is_frozen(obj: &js::Object) -> bool {
+                js::Object::is_frozen(&obj)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const object = {};
+                assert(!wasm.is_frozen(object));
+
+                Object.freeze(object);
+                assert(wasm.is_frozen(object));
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn is_prototype_of() {
     project()
         .file(


### PR DESCRIPTION
Implements bindings for `Object.isExtensible()`, `Object.isFrozen()` and `Object.isSealed()` static methods.