### PR TITLE
Use f64 for most Math.* bindings

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -459,7 +459,7 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn abs(number: i32) -> Number;
+    pub fn abs(x: f64) -> Number;
 
     /// The Math.acos() function returns the arccosine (in radians) of a
     /// number, that is ∀x∊[-1;1]
@@ -467,7 +467,7 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn acos(adjacent: i32, hypotenuse: i32) -> Number;
+    pub fn acos(x: f64) -> Number;
 
     /// The Math.acosh() function returns the hyperbolic arc-cosine of a
     /// number, that is ∀x ≥ 1
@@ -475,7 +475,7 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn acosh(number: i32) -> Number;
+    pub fn acosh(x: f64) -> Number;
 
     /// The Math.asin() function returns the arcsine (in radians) of a
     /// number, that is ∀x ∊ [-1;1]
@@ -483,27 +483,27 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn asin(number: i32) -> Number;
+    pub fn asin(x: f64) -> Number;
 
     /// The Math.asinh() function returns the hyperbolic arcsine of a
     /// number, that is Math.asinh(x) = arsinh(x) = the unique y such that sinh(y) = x
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn asinh(number: i32) -> Number;
+    pub fn asinh(x: f64) -> Number;
 
     /// The Math.atan() function returns the arctangent (in radians) of a
     /// number, that is Math.atan(x) = arctan(x) = the unique y ∊ [-π2;π2]such that
     /// tan(y) = x
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn atan(number: i32) -> Number;
+    pub fn atan(x: f64) -> Number;
 
     /// The Math.atan2() function returns the arctangent of the quotient of
     /// its arguments.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn atan2(y: i32, x: i32) -> Number;
+    pub fn atan2(y: f64, x: f64) -> Number;
 
     /// The Math.atanh() function returns the hyperbolic arctangent of a number,
     /// that is ∀x ∊ (-1,1), Math.atanh(x) = arctanh(x) = the unique y such that
@@ -511,21 +511,21 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn atanh(x: i32) -> Number;
+    pub fn atanh(x: f64) -> Number;
 
     /// The Math.cbrt() function returns the cube root of a number, that is
     /// Math.cbrt(x) = x^3 = the unique y such that y^3 = x
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn cbrt(x: i32) -> Number;
+    pub fn cbrt(x: f64) -> Number;
 
     /// The Math.ceil() function returns the smallest integer greater than
     /// or equal to a given number.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn ceil(x: f32) -> Number;
+    pub fn ceil(x: f64) -> Number;
 
     /// The Math.clz32() function returns the number of leading zero bits in
     /// the 32-bit binary representation of a number.
@@ -539,7 +539,7 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn cos(x: f32) -> Number;
+    pub fn cos(x: f64) -> Number;
 
 
     /// The Math.cosh() function returns the hyperbolic cosine of a number,
@@ -547,35 +547,35 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn cosh(x: f32) -> Number;
+    pub fn cosh(x: f64) -> Number;
 
     /// The Math.exp() function returns e^x, where x is the argument, and e is Euler's number
     /// (also known as Napier's constant), the base of the natural logarithms.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn exp(x: f32) -> Number;
+    pub fn exp(x: f64) -> Number;
 
     /// The Math.expm1() function returns e^x - 1, where x is the argument, and e the base of the
     /// natural logarithms.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn expm1(x: f32) -> Number;
+    pub fn expm1(x: f64) -> Number;
 
     /// The Math.floor() function returns the largest integer less than or
     /// equal to a given number.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn floor(x: f32) -> Number;
+    pub fn floor(x: f64) -> Number;
 
     /// The Math.fround() function returns the nearest 32-bit single precision float representation
     /// of a Number.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn fround(x: f32) -> Number;
+    pub fn fround(x: f64) -> Number;
 
     /// The Math.imul() function returns the result of the C-like 32-bit multiplication of the
     /// two parameters.
@@ -589,24 +589,24 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn log(x: f32) -> Number;
+    pub fn log(x: f64) -> Number;
 
     /// The Math.log10() function returns the base 10 logarithm of a number.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn log10(x: f32) -> Number;
+    pub fn log10(x: f64) -> Number;
 
     /// The Math.log1p() function returns the natural logarithm (base e) of 1 + a number.
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn log1p(x: f32) -> Number;
+    pub fn log1p(x: f64) -> Number;
 
     /// The Math.log2() function returns the base 2 logarithm of a number.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2
     #[wasm_bindgen(static_method_of = Math)]
-    pub fn log2(x: f32) -> Number;
+    pub fn log2(x: f64) -> Number;
 
 }
 

--- a/tests/all/js_globals/Math.rs
+++ b/tests/all/js_globals/Math.rs
@@ -15,8 +15,8 @@ fn abs() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn abs(number: i32) -> js::Number {
-                js::Math::abs(number)
+            pub fn abs(x: f64) -> js::Number {
+                js::Math::abs(x)
             }
         "#,
         )
@@ -29,6 +29,7 @@ fn abs() {
             export function test() {
                 assert.equal(wasm.abs(-32), Math.abs(-32));
                 assert.equal(wasm.abs(32), 32);
+                assert.equal(wasm.abs(-4.7), Math.abs(-4.7));
             }
         "#,
         )
@@ -48,8 +49,8 @@ fn acos() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn acos(adjacent: i32, hypotenuse: i32) -> js::Number {
-                js::Math::acos(adjacent, hypotenuse)
+            pub fn acos(x: f64) -> js::Number {
+                js::Math::acos(x)
             }
         "#,
         )
@@ -60,7 +61,9 @@ fn acos() {
             import * as wasm from "./out";
 
             export function test() {
-                assert.equal(wasm.acos(-1, 1), Math.PI);
+                assert.equal(wasm.acos(-1), Math.PI);
+                assert.equal(wasm.acos(0.5), 1.0471975511965979);
+                assert(Number.isNaN(wasm.acos(2)));
             }
         "#,
         )
@@ -80,8 +83,8 @@ fn acosh() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn acosh(number: i32) -> js::Number {
-                js::Math::acosh(number)
+            pub fn acosh(x: f64) -> js::Number {
+                js::Math::acosh(x)
             }
         "#,
         )
@@ -94,6 +97,7 @@ fn acosh() {
             export function test() {
                 assert.equal(wasm.acosh(1), 0);
                 assert.equal(wasm.acosh(2), Math.acosh(2));
+                assert(Number.isNaN(wasm.acosh(0.5)));
             }
         "#,
         )
@@ -113,8 +117,8 @@ fn asin() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn asin(opposite: i32, hypotenuse: i32) -> js::Number {
-                js::Math::asin(opposite / hypotenuse)
+            pub fn asin(x: f64) -> js::Number {
+                js::Math::asin(x)
             }
         "#,
         )
@@ -125,7 +129,9 @@ fn asin() {
             import * as wasm from "./out";
 
             export function test() {
-                assert.equal(wasm.asin(1, 1), Math.asin(1));
+                assert.equal(wasm.asin(1), Math.asin(1));
+                assert.equal(wasm.asin(0.5), Math.asin(0.5));
+                assert(Number.isNaN(wasm.asin(2)));
             }
         "#,
         )
@@ -145,8 +151,8 @@ fn asinh() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn asinh(number: i32) -> js::Number {
-                js::Math::asinh(number)
+            pub fn asinh(x: f64) -> js::Number {
+                js::Math::asinh(x)
             }
         "#,
         )
@@ -158,6 +164,7 @@ fn asinh() {
 
             export function test() {
                 assert.equal(wasm.asinh(1), Math.asinh(1));
+                assert.equal(wasm.asinh(0.5), Math.asinh(0.5));
             }
         "#,
         )
@@ -177,8 +184,8 @@ fn atan() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn atan(number: i32) -> js::Number {
-                js::Math::atan(number)
+            pub fn atan(x: f64) -> js::Number {
+                js::Math::atan(x)
             }
         "#,
         )
@@ -190,6 +197,7 @@ fn atan() {
 
             export function test() {
                 assert.equal(wasm.atan(1), Math.atan(1));
+                assert.equal(wasm.atan(0.5), Math.atan(0.5));
             }
         "#,
         )
@@ -209,8 +217,8 @@ fn atan2() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn atan2(x: i32, y: i32) -> js::Number {
-                js::Math::atan2(x, y)
+            pub fn atan2(y: f64, x: f64) -> js::Number {
+                js::Math::atan2(y, x)
             }
         "#,
         )
@@ -222,6 +230,7 @@ fn atan2() {
 
             export function test() {
                 assert.equal(wasm.atan2(1, 2), Math.atan2(1, 2));
+                assert.equal(wasm.atan2(0.7, 3.8), Math.atan2(0.7, 3.8));
             }
         "#,
         )
@@ -241,7 +250,7 @@ fn atanh() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn atanh(x: i32) -> js::Number {
+            pub fn atanh(x: f64) -> js::Number {
                 js::Math::atanh(x)
             }
         "#,
@@ -254,6 +263,8 @@ fn atanh() {
 
             export function test() {
                 assert.equal(wasm.atanh(1), Math.atanh(1));
+                assert.equal(wasm.atanh(0.5), Math.atanh(0.5));
+                assert(Number.isNaN(wasm.atanh(2)));
             }
         "#,
         )
@@ -273,7 +284,7 @@ fn cbrt() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn cbrt(x: i32) -> js::Number {
+            pub fn cbrt(x: f64) -> js::Number {
                 js::Math::cbrt(x)
             }
         "#,
@@ -286,6 +297,7 @@ fn cbrt() {
 
             export function test() {
                 assert.equal(wasm.cbrt(27), 3);
+                assert.equal(wasm.cbrt(12.3), Math.cbrt(12.3));
             }
         "#,
         )
@@ -305,7 +317,7 @@ fn ceil() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn ceil(x: f32) -> js::Number {
+            pub fn ceil(x: f64) -> js::Number {
                 js::Math::ceil(x)
             }
         "#,
@@ -369,7 +381,7 @@ fn cos() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn cos(x: f32) -> js::Number {
+            pub fn cos(x: f64) -> js::Number {
                 js::Math::cos(x)
             }
         "#)
@@ -396,7 +408,7 @@ fn cosh() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn cosh(x: f32) -> js::Number {
+            pub fn cosh(x: f64) -> js::Number {
                 js::Math::cosh(x)
             }
         "#)
@@ -423,7 +435,7 @@ fn exp() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn exp(x: f32) -> js::Number {
+            pub fn exp(x: f64) -> js::Number {
                 js::Math::exp(x)
             }
         "#)
@@ -451,7 +463,7 @@ fn expm1() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn expm1(x: f32) -> js::Number {
+            pub fn expm1(x: f64) -> js::Number {
                 js::Math::expm1(x)
             }
         "#)
@@ -482,7 +494,7 @@ fn floor() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn floor(x: f32) -> js::Number {
+            pub fn floor(x: f64) -> js::Number {
                 js::Math::floor(x)
             }
         "#,
@@ -513,7 +525,7 @@ fn fround() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn fround(x: f32) -> js::Number {
+            pub fn fround(x: f64) -> js::Number {
                 js::Math::fround(x)
             }
         "#)
@@ -570,7 +582,7 @@ fn log() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn log(x: f32) -> js::Number {
+            pub fn log(x: f64) -> js::Number {
                 js::Math::log(x)
             }
         "#)
@@ -597,7 +609,7 @@ fn log10() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn log10(x: f32) -> js::Number {
+            pub fn log10(x: f64) -> js::Number {
                 js::Math::log10(x)
             }
         "#)
@@ -625,7 +637,7 @@ fn log1p() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn log1p(x: f32) -> js::Number {
+            pub fn log1p(x: f64) -> js::Number {
                 js::Math::log1p(x)
             }
         "#)
@@ -654,7 +666,7 @@ fn log2() {
             use wasm_bindgen::js;
 
             #[wasm_bindgen]
-            pub fn log2(x: f32) -> js::Number {
+            pub fn log2(x: f64) -> js::Number {
                 js::Math::log2(x)
             }
         "#)


### PR DESCRIPTION
Change most Math.* bindings from i32 or f32 to f64, except the functions that specifically take integers.