### PR TITLE
test(js) Fix expectations regarding given locales

### DIFF
--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -160,7 +160,7 @@ fn to_locale_date_string() {
                 let date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
                 let options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
 
-                assert.equal(wasm.to_locale_date_string(date, 'de-DE', options), 'Thursday, December 20, 2012');
+                assert.equal(wasm.to_locale_date_string(date, 'de-DE', options), 'Donnerstag, 20. Dezember 2012');
             }
         "#)
         .test()
@@ -188,7 +188,7 @@ fn to_locale_string() {
 
             export function test() {
                 let date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
-                assert.equal(wasm.to_locale_string(date, 'en-GB', { timeZone: 'UTC' }), "12/20/2012, 3:00:00 AM");
+                assert.equal(wasm.to_locale_string(date, 'en-GB', { timeZone: 'UTC' }), "20/12/2012, 03:00:00");
             }
         "#)
         .test()


### PR DESCRIPTION
I've no idea why these tests can be green on Travis.

Hope my patch will not make them red… while they _should_ be green :-).