### PR TITLE
Add bindings for Proxy

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -1030,6 +1030,20 @@ extern "C" {
     pub fn values(object: &Object) -> Array;
 }
 
+// Proxy
+#[wasm_bindgen]
+extern {
+    pub type Proxy;
+
+    /// The Proxy object is used to define custom behavior for fundamental
+    /// operations (e.g. property lookup, assignment, enumeration, function
+    /// invocation, etc).
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
+    #[wasm_bindgen(constructor)]
+    pub fn new(target: &JsValue, handler: &Object) -> Proxy;
+}
+
 // Set
 #[wasm_bindgen]
 extern {

--- a/src/js.rs
+++ b/src/js.rs
@@ -1042,6 +1042,12 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
     #[wasm_bindgen(constructor)]
     pub fn new(target: &JsValue, handler: &Object) -> Proxy;
+
+    /// The Proxy.revocable() method is used to create a revocable Proxy object.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable
+    #[wasm_bindgen(static_method_of = Proxy)]
+    pub fn revocable(target: &JsValue, handler: &Object) -> Object;
 }
 
 // Set

--- a/tests/all/js_globals/Proxy.rs
+++ b/tests/all/js_globals/Proxy.rs
@@ -1,0 +1,37 @@
+#![allow(non_snake_case)]
+
+use project;
+
+#[test]
+fn new() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn new_proxy(target: JsValue, handler: js::Object) -> js::Proxy {
+                js::Proxy::new(&target, &handler)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const target = { a: 100 };
+                const handler = {
+                     get: function(obj: any, prop: any) {
+                         return prop in obj ? obj[prop] : 37;
+                     }
+                };
+                const proxy = wasm.new_proxy(target, handler);
+                assert.equal(proxy.a, 100);
+                assert.equal(proxy.b, 37);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/Proxy.rs
+++ b/tests/all/js_globals/Proxy.rs
@@ -17,14 +17,14 @@ fn new() {
                 js::Proxy::new(&target, &handler)
             }
         "#)
-        .file("test.ts", r#"
+        .file("test.js", r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 const target = { a: 100 };
                 const handler = {
-                     get: function(obj: any, prop: any) {
+                     get: function(obj, prop) {
                          return prop in obj ? obj[prop] : 37;
                      }
                 };
@@ -51,14 +51,14 @@ fn revocable() {
                 js::Proxy::revocable(&target, &handler)
             }
         "#)
-        .file("test.ts", r#"
+        .file("test.js", r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 
             export function test() {
                 const target = { a: 100 };
                 const handler = {
-                     get: function(obj: any, prop: any) {
+                     get: function(obj, prop) {
                          return prop in obj ? obj[prop] : 37;
                      }
                 };

--- a/tests/all/js_globals/Proxy.rs
+++ b/tests/all/js_globals/Proxy.rs
@@ -35,3 +35,42 @@ fn new() {
         "#)
         .test()
 }
+
+#[test]
+fn revocable() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn new_revocable_proxy(target: JsValue, handler: js::Object) -> js::Object {
+                js::Proxy::revocable(&target, &handler)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const target = { a: 100 };
+                const handler = {
+                     get: function(obj: any, prop: any) {
+                         return prop in obj ? obj[prop] : 37;
+                     }
+                };
+                const { proxy, revoke } =
+                   wasm.new_revocable_proxy(target, handler);
+                assert.equal(proxy.a, 100);
+                assert.equal(proxy.b, 37);
+                revoke();
+                assert.throws(() => { proxy.a }, TypeError);
+                assert.throws(() => { proxy.b }, TypeError);
+                assert.equal(typeof proxy, "object");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -16,6 +16,7 @@ mod MapIterator;
 mod Math;
 mod Number;
 mod Object;
+mod Proxy;
 mod Set;
 mod SetIterator;
 mod TypedArray;


### PR DESCRIPTION
This is for #275.

I'm not entire sure about the bindings added for `Proxy.revocable` -- I would want to be more explicit about the return type [here](https://github.com/rustwasm/wasm-bindgen/compare/master...srenatus:sr/js_globals/Proxy#diff-2e17c66ff42936abe2d7eae32713e8caR998), but I haven't found a way to express _"it's an `Object` with `proxy` of type `Proxy` and `revoke` a function"_.