### PR TITLE
doc: add reference document (#242)

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -10,6 +10,7 @@
 - [Closures](./closures.md)
 - [Feature Reference](./feature-reference.md)
 - [CLI Reference](./cli-reference.md)
+- [Type Reference](./reference.md)
 
 --------------------------------------------------------------------------------
 

--- a/guide/src/reference.md
+++ b/guide/src/reference.md
@@ -1,0 +1,65 @@
+# Reference
+
+The table below provides an overview of all the types that wasm-bindgen can send/receive across the wasm ABI boundary.
+
+| Type | `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value |
+|:---:|:---:|:---:|:---:|:---:|
+| `u8` | Yes | No | No | Yes |
+| `i8` | Yes | No | No | Yes |
+| `u16` | Yes | No | No | Yes |
+| `i16` | Yes | No | No | Yes |
+| `u32` | Yes | Yes | Yes | Yes |
+| `i32` | Yes | Yes | Yes | Yes |
+| `u64` | Yes | No | No | Yes |
+| `i64` | Yes | No | No | Yes |
+| `f32` | Yes | Yes | Yes | Yes |
+| `f64` | Yes | Yes | Yes | Yes |
+| `isize` | Yes | No | No | Yes |
+| `usize` | Yes |No  | No | Yes |
+| `str` | No | Yes | No | Yes |
+| `char` | Yes | No | No | Yes |
+| `bool` | Yes | No | No | Yes |
+| `JsValue` | Yes | Yes | Yes | Yes |
+| `Box<[JsValue]>` | Yes | No | No | Yes |
+| `*const T` | Yes | No | No | Yes |
+| `*mut T` | Yes | No | No | Yes |
+| `Box<[u8]>` | Yes | No | No | Yes |
+| `&[u8]` | No | No | No | Yes |
+| `&mut[u8]` | No | No | No | Yes |
+| `[u8]` | No | Yes | Yes | No |
+| `Box<[i8]>` | Yes | No | No | Yes |
+| `&[i8]` | No | No | No | Yes |
+| `&mut[i8]` | No | No | No | Yes |
+| `[i8]` | No | Yes | Yes | No |
+| `Box<[u16]>` | Yes | No | No | Yes |
+| `&[u16]` | No | No | No | Yes |
+| `&mut[u16]` | No | No | No | Yes |
+| `[u16]` | No | Yes | Yes | No |
+| `Box<[i16]>` | Yes | No | No | Yes |
+| `&[i16]` | No | No | No | Yes |
+| `&mut[i16]` | No | No | No | Yes |
+| `[i16]` | No | Yes | Yes | No |
+| `Box<[u32]>` | Yes | No | No | Yes |
+| `&[u32]` | No | No | No | Yes |
+| `&mut[u32]` | No | No | No | Yes |
+| `[u32]` | No | Yes | Yes | No |
+| `Box<[i32]>` | Yes | No | No | Yes |
+| `&[i32]` | No | No | No | Yes |
+| `&mut[i32]` | No | No | No | Yes |
+| `[i32]` | No | Yes | Yes | No |
+| `Box<[u64]>` | Yes | No | No | Yes |
+| `&[u64]` | No | No | No | Yes |
+| `&mut[u64]` | No | No | No | Yes |
+| `[u64]` | No | Yes | Yes | No |
+| `Box<[i64]>` | Yes | No | No | Yes |
+| `&[i64]` | No | No | No | Yes |
+| `&mut[i64]` | No | No | No | Yes |
+| `[i64]` | No | Yes | Yes | No |
+| `Box<[f32]>` | Yes | No | No | Yes |
+| `&[f32]` | No | No | No | Yes |
+| `&mut[f32]` | No | No | No | Yes |
+| `[f32]` | No | Yes | Yes | No |
+| `Box<[f64]>` | Yes | No | No | Yes |
+| `&[f64]` | No | No | No | Yes |
+| `&mut[f64]` | No | No | No | Yes |
+| `[f64]` | No | Yes | Yes | No |

--- a/guide/src/reference.md
+++ b/guide/src/reference.md
@@ -4,18 +4,6 @@ The table below provides an overview of all the types that wasm-bindgen can send
 
 | Type | `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value |
 |:---:|:---:|:---:|:---:|:---:|
-| `u8` | Yes | No | No | Yes |
-| `i8` | Yes | No | No | Yes |
-| `u16` | Yes | No | No | Yes |
-| `i16` | Yes | No | No | Yes |
-| `u32` | Yes | Yes | Yes | Yes |
-| `i32` | Yes | Yes | Yes | Yes |
-| `u64` | Yes | No | No | Yes |
-| `i64` | Yes | No | No | Yes |
-| `f32` | Yes | Yes | Yes | Yes |
-| `f64` | Yes | Yes | Yes | Yes |
-| `isize` | Yes | No | No | Yes |
-| `usize` | Yes |No  | No | Yes |
 | `str` | No | Yes | No | Yes |
 | `char` | Yes | No | No | Yes |
 | `bool` | Yes | No | No | Yes |
@@ -23,43 +11,11 @@ The table below provides an overview of all the types that wasm-bindgen can send
 | `Box<[JsValue]>` | Yes | No | No | Yes |
 | `*const T` | Yes | No | No | Yes |
 | `*mut T` | Yes | No | No | Yes |
-| `Box<[u8]>` | Yes | No | No | Yes |
-| `&[u8]` | No | No | No | Yes |
-| `&mut[u8]` | No | No | No | Yes |
-| `[u8]` | No | Yes | Yes | No |
-| `Box<[i8]>` | Yes | No | No | Yes |
-| `&[i8]` | No | No | No | Yes |
-| `&mut[i8]` | No | No | No | Yes |
-| `[i8]` | No | Yes | Yes | No |
-| `Box<[u16]>` | Yes | No | No | Yes |
-| `&[u16]` | No | No | No | Yes |
-| `&mut[u16]` | No | No | No | Yes |
-| `[u16]` | No | Yes | Yes | No |
-| `Box<[i16]>` | Yes | No | No | Yes |
-| `&[i16]` | No | No | No | Yes |
-| `&mut[i16]` | No | No | No | Yes |
-| `[i16]` | No | Yes | Yes | No |
-| `Box<[u32]>` | Yes | No | No | Yes |
-| `&[u32]` | No | No | No | Yes |
-| `&mut[u32]` | No | No | No | Yes |
-| `[u32]` | No | Yes | Yes | No |
-| `Box<[i32]>` | Yes | No | No | Yes |
-| `&[i32]` | No | No | No | Yes |
-| `&mut[i32]` | No | No | No | Yes |
-| `[i32]` | No | Yes | Yes | No |
-| `Box<[u64]>` | Yes | No | No | Yes |
-| `&[u64]` | No | No | No | Yes |
-| `&mut[u64]` | No | No | No | Yes |
-| `[u64]` | No | Yes | Yes | No |
-| `Box<[i64]>` | Yes | No | No | Yes |
-| `&[i64]` | No | No | No | Yes |
-| `&mut[i64]` | No | No | No | Yes |
-| `[i64]` | No | Yes | Yes | No |
-| `Box<[f32]>` | Yes | No | No | Yes |
-| `&[f32]` | No | No | No | Yes |
-| `&mut[f32]` | No | No | No | Yes |
-| `[f32]` | No | Yes | Yes | No |
-| `Box<[f64]>` | Yes | No | No | Yes |
-| `&[f64]` | No | No | No | Yes |
-| `&mut[f64]` | No | No | No | Yes |
-| `[f64]` | No | Yes | Yes | No |
+| `u8` `i8` `u16` `i16` `u64` `i64` `isize` `size` | Yes | No | No | Yes |
+| `u32` `i32` `f32` `f64` | Yes | Yes | Yes | Yes |
+| `Box<[u8]>`  `Box<[i8]>` `Box<[u16]>` `Box<[i16]>` `Box<[u32]>` `Box<[i32]>` `Box<[u64]>` `Box<[i64]>` | Yes | No | No | Yes |
+| `Box<[f32]>` `Box<[f64]>` | Yes | No | No | Yes |
+| `[u8]` `[i8]` `[u16]` `[i16]` `[u32]` `[i32]` `[u64]` `[i64]` | No | Yes | Yes | No |
+| `&[u8]` `&mut[u8]` `&[i8]`  `&mut[i8]` `&[u16]` `&mut[u16]` `&[i16]` `&mut[i16]` `&[u32]` `&mut[u32]` `&[i32]` `&mut[i32]` `&[u64]` `&mut[u64]` `&[i64]` `&mut[i64]` | No | No | No | Yes |
+| `[f32]` `[f64]` | No | Yes | Yes | No |
+|  `&[f32]` `&mut[f32]` `&[f64]` `&mut[f64]` | No | No | No | Yes |


### PR DESCRIPTION
This PR adds the requested `reference.md` (#242) document which documents which types can be sent/received across the wasm ABI-boundary by wasm-bindgen.

I tried to dig into `convert.rs`to figure out which traits are implemented for which types and I think I covered them all except or the stack_closures macro part at the end of the file. I wasn't sure what exactly is happening there.

Here is the table as it is now:

| Type | `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value |
|:---:|:---:|:---:|:---:|:---:|
| `u8` | Yes | No | No | Yes |
| `i8` | Yes | No | No | Yes |
| `u16` | Yes | No | No | Yes |
| `i16` | Yes | No | No | Yes |
| `u32` | Yes | Yes | Yes | Yes |
| `i32` | Yes | Yes | Yes | Yes |
| `u64` | Yes | No | No | Yes |
| `i64` | Yes | No | No | Yes |
| `f32` | Yes | Yes | Yes | Yes |
| `f64` | Yes | Yes | Yes | Yes |
| `isize` | Yes | No | No | Yes |
| `usize` | Yes |No  | No | Yes |
| `str` | No | Yes | No | Yes |
| `char` | Yes | No | No | Yes |
| `bool` | Yes | No | No | Yes |
| `JsValue` | Yes | Yes | Yes | Yes |
| `Box<[JsValue]>` | Yes | No | No | Yes |
| `*const T` | Yes | No | No | Yes |
| `*mut T` | Yes | No | No | Yes |
| `Box<[u8]>` | Yes | No | No | Yes |
| `&[u8]` | No | No | No | Yes |
| `&mut[u8]` | No | No | No | Yes |
| `[u8]` | No | Yes | Yes | No |
| `Box<[i8]>` | Yes | No | No | Yes |
| `&[i8]` | No | No | No | Yes |
| `&mut[i8]` | No | No | No | Yes |
| `[i8]` | No | Yes | Yes | No |
| `Box<[u16]>` | Yes | No | No | Yes |
| `&[u16]` | No | No | No | Yes |
| `&mut[u16]` | No | No | No | Yes |
| `[u16]` | No | Yes | Yes | No |
| `Box<[i16]>` | Yes | No | No | Yes |
| `&[i16]` | No | No | No | Yes |
| `&mut[i16]` | No | No | No | Yes |
| `[i16]` | No | Yes | Yes | No |
| `Box<[u32]>` | Yes | No | No | Yes |
| `&[u32]` | No | No | No | Yes |
| `&mut[u32]` | No | No | No | Yes |
| `[u32]` | No | Yes | Yes | No |
| `Box<[i32]>` | Yes | No | No | Yes |
| `&[i32]` | No | No | No | Yes |
| `&mut[i32]` | No | No | No | Yes |
| `[i32]` | No | Yes | Yes | No |
| `Box<[u64]>` | Yes | No | No | Yes |
| `&[u64]` | No | No | No | Yes |
| `&mut[u64]` | No | No | No | Yes |
| `[u64]` | No | Yes | Yes | No |
| `Box<[i64]>` | Yes | No | No | Yes |
| `&[i64]` | No | No | No | Yes |
| `&mut[i64]` | No | No | No | Yes |
| `[i64]` | No | Yes | Yes | No |
| `Box<[f32]>` | Yes | No | No | Yes |
| `&[f32]` | No | No | No | Yes |
| `&mut[f32]` | No | No | No | Yes |
| `[f32]` | No | Yes | Yes | No |
| `Box<[f64]>` | Yes | No | No | Yes |
| `&[f64]` | No | No | No | Yes |
| `&mut[f64]` | No | No | No | Yes |
| `[f64]` | No | Yes | Yes | No |

Please tell me if I have missed any types or have misunderstood something completely. I really want to learn 😁 

I sorted the types approximately in the same order as they appear in `convert.rs`.