### PR TITLE
feat(js) Implement the `WebAssembly.validate` binding.

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -1138,6 +1138,20 @@ extern "C" {
     pub fn delete(this: &WeakSet, value: Object) -> bool;
 }
 
+// WebAssembly
+#[wasm_bindgen]
+extern "C" {
+    pub type WebAssembly;
+
+    /// The `WebAssembly.validate()` function validates a given typed
+    /// array of WebAssembly binary code, returning whether the bytes
+    /// form a valid wasm module (`true`) or not (`false`).
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
+    #[wasm_bindgen(static_method_of = WebAssembly)]
+    pub fn validate(bufferSource: JsValue) -> bool;
+}
+
 // JsString
 #[wasm_bindgen]
 extern "C" {

--- a/src/js.rs
+++ b/src/js.rs
@@ -1148,8 +1148,8 @@ extern "C" {
     /// form a valid wasm module (`true`) or not (`false`).
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate
-    #[wasm_bindgen(static_method_of = WebAssembly)]
-    pub fn validate(bufferSource: JsValue) -> bool;
+    #[wasm_bindgen(static_method_of = WebAssembly, catch)]
+    pub fn validate(bufferSource: JsValue) -> Result<bool, JsValue>;
 }
 
 // JsString

--- a/tests/all/js_globals/WebAssembly.rs
+++ b/tests/all/js_globals/WebAssembly.rs
@@ -31,3 +31,38 @@ fn validate() {
         "#)
         .test()
 }
+
+#[test]
+fn validate_with_invalid_input() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use JsValue;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::WebAssembly;
+
+            #[wasm_bindgen]
+            pub fn validate_wasm(wasm: JsValue) -> JsValue {
+                match WebAssembly::validate(wasm) {
+                    Ok(value) => value.into(),
+                    Err(err) => err
+                }
+            }
+        "#)
+        .file("test.js", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                try {
+                    wasm.validate_wasm(42);
+                    assert.ok(false);
+                } catch (e) {
+                    assert.ok(true);
+                }
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/WebAssembly.rs
+++ b/tests/all/js_globals/WebAssembly.rs
@@ -1,0 +1,30 @@
+#![allow(non_snake_case)]
+
+use super::project;
+
+#[test]
+fn validate() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use JsValue;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::WebAssembly;
+
+            #[wasm_bindgen]
+            pub fn validate_wasm(wasm: JsValue) -> bool {
+                WebAssembly::validate(wasm)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.validate_wasm(new ArrayBuffer(42)), false);
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/WebAssembly.rs
+++ b/tests/all/js_globals/WebAssembly.rs
@@ -14,11 +14,14 @@ fn validate() {
             use wasm_bindgen::js::WebAssembly;
 
             #[wasm_bindgen]
-            pub fn validate_wasm(wasm: JsValue) -> bool {
-                WebAssembly::validate(wasm).unwrap_or(false)
+            pub fn validate_wasm(wasm: JsValue) -> JsValue {
+                match WebAssembly::validate(wasm) {
+                    Ok(value) => value.into(),
+                    Err(err) => err
+                }
             }
         "#)
-        .file("test.ts", r#"
+        .file("test.js", r#"
             import * as assert from "assert";
             import * as wasm from "./out";
 

--- a/tests/all/js_globals/WebAssembly.rs
+++ b/tests/all/js_globals/WebAssembly.rs
@@ -15,7 +15,7 @@ fn validate() {
 
             #[wasm_bindgen]
             pub fn validate_wasm(wasm: JsValue) -> bool {
-                WebAssembly::validate(wasm)
+                WebAssembly::validate(wasm).unwrap_or(false)
             }
         "#)
         .file("test.ts", r#"

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -20,6 +20,7 @@ mod SetIterator;
 mod TypedArray;
 mod WeakMap;
 mod WeakSet;
+mod WebAssembly;
 
 #[test]
 #[cfg(feature = "std")]


### PR DESCRIPTION
Cf. https://github.com/rustwasm/wasm-bindgen/issues/275.

`validate` should accept only a typed array or an `ArrayBuffer`, but I feel like it is not possible to get a strict type here (there is no common type in JS to represent to type). So I typed with `JsValue`.

I don't know how to support exception. And I don't even know the code will behave if an exception will be thrown :-). Any clue?