### PR TITLE
feat(js) Add `ArrayBuffer::new`, `::is_view` & `::slice` bindings.

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -254,6 +254,39 @@ extern "C" {
     pub fn unshift(this: &Array, value: JsValue) -> u32;
 }
 
+// ArrayBuffer
+#[wasm_bindgen]
+extern "C" {
+    pub type ArrayBuffer;
+
+    /// The `ArrayBuffer` object is used to represent a generic,
+    /// fixed-length raw binary data buffer. You cannot directly
+    /// manipulate the contents of an `ArrayBuffer`; instead, you
+    /// create one of the typed array objects or a `DataView` object
+    /// which represents the buffer in a specific format, and use that
+    /// to read and write the contents of the buffer.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
+    #[wasm_bindgen(constructor)]
+    pub fn new(length: f64) -> ArrayBuffer;
+
+    /// The `slice()` method returns a new `ArrayBuffer` whose contents
+    /// are a copy of this `ArrayBuffer`'s bytes from begin, inclusive,
+    /// up to end, exclusive.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
+    #[wasm_bindgen(static_method_of = ArrayBuffer, js_name = isView)]
+    pub fn is_view(value: JsValue) -> bool;
+
+    /// The `slice()` method returns a new `ArrayBuffer` whose contents
+    /// are a copy of this `ArrayBuffer`'s bytes from begin, inclusive,
+    /// up to end, exclusive.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
+    #[wasm_bindgen(method)]
+    pub fn slice(this: &ArrayBuffer, begin: f64) -> ArrayBuffer;
+}
+
 // Array Iterator
 #[wasm_bindgen]
 extern "C" {

--- a/src/js.rs
+++ b/src/js.rs
@@ -268,13 +268,13 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer
     #[wasm_bindgen(constructor)]
-    pub fn new(length: f64) -> ArrayBuffer;
+    pub fn new(length: u32) -> ArrayBuffer;
 
     /// The `slice()` method returns a new `ArrayBuffer` whose contents
     /// are a copy of this `ArrayBuffer`'s bytes from begin, inclusive,
     /// up to end, exclusive.
     ///
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView
     #[wasm_bindgen(static_method_of = ArrayBuffer, js_name = isView)]
     pub fn is_view(value: JsValue) -> bool;
 
@@ -284,7 +284,13 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
     #[wasm_bindgen(method)]
-    pub fn slice(this: &ArrayBuffer, begin: f64) -> ArrayBuffer;
+    pub fn slice(this: &ArrayBuffer, begin: u32) -> ArrayBuffer;
+
+    /// Like `slice()` but with the `end` argument.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice
+    #[wasm_bindgen(method, js_name = slice)]
+    pub fn slice_with_end(this: &ArrayBuffer, begin: u32, end: u32) -> ArrayBuffer;
 }
 
 // Array Iterator

--- a/tests/all/js_globals/ArrayBuffer.rs
+++ b/tests/all/js_globals/ArrayBuffer.rs
@@ -1,0 +1,83 @@
+#![allow(non_snake_case)]
+
+use super::project;
+
+#[test]
+fn new() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::ArrayBuffer;
+
+            #[wasm_bindgen]
+            pub fn new_arraybuffer() -> ArrayBuffer {
+                ArrayBuffer::new(42f64)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(typeof wasm.new_arraybuffer(), "object");
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn is_view() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use JsValue;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::ArrayBuffer;
+
+            #[wasm_bindgen]
+            pub fn is_uint8array(value: JsValue) -> bool {
+                ArrayBuffer::is_view(value)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.is_uint8array(new Uint8Array(42)), true);
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn slice() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::ArrayBuffer;
+
+            #[wasm_bindgen]
+            pub fn slice_at_2(arraybuffer: ArrayBuffer) -> ArrayBuffer {
+                ArrayBuffer::slice(&arraybuffer, 2f64)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const arraybuffer = new ArrayBuffer(4);
+                assert.equal(typeof wasm.slice_at_2(arraybuffer), "object");
+            }
+        "#)
+        .test()
+}

--- a/tests/all/js_globals/ArrayBuffer.rs
+++ b/tests/all/js_globals/ArrayBuffer.rs
@@ -14,7 +14,7 @@ fn new() {
 
             #[wasm_bindgen]
             pub fn new_arraybuffer() -> ArrayBuffer {
-                ArrayBuffer::new(42f64)
+                ArrayBuffer::new(42)
             }
         "#)
         .file("test.ts", r#"
@@ -66,8 +66,8 @@ fn slice() {
             use wasm_bindgen::js::ArrayBuffer;
 
             #[wasm_bindgen]
-            pub fn slice_at_2(arraybuffer: ArrayBuffer) -> ArrayBuffer {
-                ArrayBuffer::slice(&arraybuffer, 2f64)
+            pub fn slice(arraybuffer: &ArrayBuffer, begin: u32) -> ArrayBuffer {
+                arraybuffer.slice(begin)
             }
         "#)
         .file("test.ts", r#"
@@ -76,7 +76,34 @@ fn slice() {
 
             export function test() {
                 const arraybuffer = new ArrayBuffer(4);
-                assert.equal(typeof wasm.slice_at_2(arraybuffer), "object");
+                assert.equal(typeof wasm.slice(arraybuffer, 2), "object");
+            }
+        "#)
+        .test()
+}
+
+#[test]
+fn slice_with_end() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::ArrayBuffer;
+
+            #[wasm_bindgen]
+            pub fn slice_with_end(arraybuffer: &ArrayBuffer, begin: u32, end: u32) -> ArrayBuffer {
+                arraybuffer.slice_with_end(begin, end)
+            }
+        "#)
+        .file("test.ts", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const arraybuffer = new ArrayBuffer(4);
+                assert.equal(typeof wasm.slice_with_end(arraybuffer, 1, 2), "object");
             }
         "#)
         .test()

--- a/tests/all/js_globals/ArrayBuffer.rs
+++ b/tests/all/js_globals/ArrayBuffer.rs
@@ -40,7 +40,7 @@ fn is_view() {
             use wasm_bindgen::js::ArrayBuffer;
 
             #[wasm_bindgen]
-            pub fn is_uint8array(value: JsValue) -> bool {
+            pub fn is_view(value: JsValue) -> bool {
                 ArrayBuffer::is_view(value)
             }
         "#)
@@ -49,7 +49,7 @@ fn is_view() {
             import * as wasm from "./out";
 
             export function test() {
-                assert.equal(wasm.is_uint8array(new Uint8Array(42)), true);
+                assert.equal(wasm.is_view(new Uint8Array(42)), true);
             }
         "#)
         .test()

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -3,6 +3,7 @@
 use super::project;
 
 mod Array;
+mod ArrayBuffer;
 mod ArrayIterator;
 mod Boolean;
 mod Date;


### PR DESCRIPTION
Cf. https://github.com/rustwasm/wasm-bindgen/issues/275

My wish was to include `get ArrayBuffer[@@species]` but I've no idea how to tackle this binding :-). Any recommendation?