### PR TITLE
Test release builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
         # to run `npm install` twice or by using `npm ci` (which is currently broken)
         - npm install
       script:
-        - cargo test
+        - cargo test --release
         # Check JS output from all tests against eslint
         - ./node_modules/.bin/eslint ./target/generated-tests/*/out*js
       addons:


### PR DESCRIPTION
Profiling locally shows a 3x speed improvement by testing release builds,
presumably due to the amount of wasm processing happening! Let's see what
happens on Travis and if we get a similar speedup.