### PR TITLE
Implement `Debug for JsValue`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate serde_json;
 extern crate wasm_bindgen_macro;
 
 use core::cell::UnsafeCell;
+use core::fmt;
 use core::ops::Deref;
 use core::ptr;
 
@@ -360,6 +361,33 @@ impl Clone for JsValue {
             let idx = __wbindgen_object_clone_ref(self.idx);
             JsValue { idx }
         }
+    }
+}
+
+impl fmt::Debug for JsValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(n) = self.as_f64() {
+            return n.fmt(f)
+        }
+        #[cfg(feature = "std")]
+        {
+            if let Some(n) = self.as_string() {
+                return n.fmt(f)
+            }
+        }
+        if let Some(n) = self.as_bool() {
+            return n.fmt(f)
+        }
+        if self.is_null() {
+            return fmt::Display::fmt("null", f)
+        }
+        if self.is_undefined() {
+            return fmt::Display::fmt("undefined", f)
+        }
+        if self.is_symbol() {
+            return fmt::Display::fmt("Symbol(..)", f)
+        }
+        fmt::Display::fmt("[object]", f)
     }
 }
 

--- a/tests/all/api.rs
+++ b/tests/all/api.rs
@@ -76,6 +76,7 @@ fn works() {
                     c: &JsValue,
                 ) {
                     assert_eq!(a.as_bool(), Some(true));
+                    assert_eq!(format!("{:?}", a), "true");
                     assert_eq!(b.as_bool(), Some(false));
                     assert_eq!(c.as_bool(), None);
                 }
@@ -84,6 +85,7 @@ fn works() {
                 pub fn mk_symbol() -> JsValue {
                     let a = JsValue::symbol(None);
                     assert!(a.is_symbol());
+                    assert_eq!(format!("{:?}", a), "Symbol(..)");
                     return a
                 }
 
@@ -103,6 +105,7 @@ fn works() {
                 #[wasm_bindgen]
                 pub fn acquire_string(a: &JsValue, b: &JsValue) {
                     assert_eq!(a.as_string().unwrap(), "foo");
+                    assert_eq!(format!("{:?}", a), "\"foo\"");
                     assert_eq!(b.as_string(), None);
                 }
 


### PR DESCRIPTION
This'll allow `#[derive(Debug)]` if something contains a `JsValue`