### PR TITLE
Forward attributes on `type` declaration to definition

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -84,6 +84,7 @@ pub struct ImportStatic {
 pub struct ImportType {
     pub vis: syn::Visibility,
     pub name: Ident,
+    pub attrs: Vec<syn::Attribute>,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -469,6 +470,7 @@ impl Program {
         ImportKind::Type(ImportType {
             vis: f.vis,
             name: f.ident,
+            attrs: f.attrs,
         })
     }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -505,8 +505,10 @@ impl ToTokens for ast::ImportType {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let vis = &self.vis;
         let name = &self.name;
+        let attrs = &self.attrs;
         (quote! {
             #[allow(bad_style)]
+            #(#attrs)*
             #vis struct #name {
                 obj: ::wasm_bindgen::JsValue,
             }

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -171,6 +171,7 @@ impl WebidlParse<()> for webidl::ast::NonPartialInterface {
                     pub_token: Default::default(),
                 }),
                 name: rust_ident(&self.name),
+                attrs: Vec::new(),
             }),
         });
 
@@ -379,7 +380,7 @@ impl<'a> WebidlParse<&'a str> for webidl::ast::StaticOperation {
         if util::is_chrome_only(&self.extended_attributes) {
             return Ok(())
         }
-        
+
         create_basic_method(
             &self.arguments,
             self.name.as_ref(),

--- a/tests/all/import_class.rs
+++ b/tests/all/import_class.rs
@@ -112,6 +112,7 @@ fn construct() {
 
                 #[wasm_bindgen(module = "./another")]
                 extern {
+                    #[derive(Clone)]
                     type Foo;
                     #[wasm_bindgen(js_namespace = Foo)]
                     fn create() -> Foo;
@@ -127,6 +128,7 @@ fn construct() {
                 pub fn run() {
                     let f = Foo::create();
                     assert_eq!(f.get_internal_string(), "this");
+                    assert_eq!(f.clone().get_internal_string(), "this");
                     f.append_to_internal_string(" foo");
                     f.assert_internal_string("this foo");
                 }


### PR DESCRIPTION
This'll allow things like `#[derive(Clone)]` or `#[derive(Debug)]` to control
traits for these types.