### PR TITLE
Generate normal Rust functions for imported bindings

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -702,7 +702,7 @@ impl ToTokens for ast::ImportFunction {
             #(#attrs)*
             #[allow(bad_style)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            #vis extern fn #rust_name(#me #(#arguments),*) #ret {
+            #vis fn #rust_name(#me #(#arguments),*) #ret {
                 ::wasm_bindgen::__rt::link_this_library();
                 #[wasm_import_module = "__wbindgen_placeholder__"]
                 extern {

--- a/crates/webidl/tests/expected/Event.rs
+++ b/crates/webidl/tests/expected/Event.rs
@@ -68,7 +68,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_new_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn new(type_: &str, event_init_dict: EventInit) -> Event {
+    pub fn new(type_: &str, event_init_dict: EventInit) -> Event {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -99,7 +99,7 @@ impl Event {
     pub extern "C" fn new(type_: &str, event_init_dict: EventInit) -> Event {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -117,7 +117,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_event_phase_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn event_phase(&self) -> u16 {
+    pub fn event_phase(&self) -> u16 {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -143,7 +143,7 @@ impl Event {
     pub extern "C" fn event_phase(&self) -> u16 {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -160,7 +160,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_stop_propagation_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn stop_propagation(&self) {
+    pub fn stop_propagation(&self) {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -183,7 +183,7 @@ impl Event {
     pub extern "C" fn stop_propagation(&self) {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -200,7 +200,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_stop_immediate_propagation_Event(
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn stop_immediate_propagation(&self) {
+    pub fn stop_immediate_propagation(&self) {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -223,7 +223,7 @@ impl Event {
     pub extern "C" fn stop_immediate_propagation(&self) {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -241,7 +241,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_bubbles_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn bubbles(&self) -> bool {
+    pub fn bubbles(&self) -> bool {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -267,7 +267,7 @@ impl Event {
     pub extern "C" fn bubbles(&self) -> bool {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -285,7 +285,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_cancelable_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn cancelable(&self) -> bool {
+    pub fn cancelable(&self) -> bool {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -311,7 +311,7 @@ impl Event {
     pub extern "C" fn cancelable(&self) -> bool {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -328,7 +328,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_prevent_default_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn prevent_default(&self) {
+    pub fn prevent_default(&self) {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -351,7 +351,7 @@ impl Event {
     pub extern "C" fn prevent_default(&self) {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -369,7 +369,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_default_prevented_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn default_prevented(&self) -> bool {
+    pub fn default_prevented(&self) -> bool {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -395,7 +395,7 @@ impl Event {
     pub extern "C" fn default_prevented(&self) -> bool {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -413,7 +413,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_composed_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn composed(&self) -> bool {
+    pub fn composed(&self) -> bool {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -439,7 +439,7 @@ impl Event {
     pub extern "C" fn composed(&self) -> bool {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -457,7 +457,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_is_trusted_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn is_trusted(&self) -> bool {
+    pub fn is_trusted(&self) -> bool {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -483,7 +483,7 @@ impl Event {
     pub extern "C" fn is_trusted(&self) -> bool {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -501,7 +501,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_time_stamp_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn time_stamp(&self) -> DOMHighResTimeStamp {
+    pub fn time_stamp(&self) -> DOMHighResTimeStamp {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -527,7 +527,7 @@ impl Event {
     pub extern "C" fn time_stamp(&self) -> DOMHighResTimeStamp {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -547,7 +547,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_init_event_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn init_event(&self, type_: &str, bubbles: bool, cancelable: bool) {
+    pub fn init_event(&self, type_: &str, bubbles: bool, cancelable: bool) {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -581,7 +581,7 @@ impl Event {
     pub extern "C" fn init_event(&self, type_: &str, bubbles: bool, cancelable: bool) {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -599,7 +599,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_cancel_bubble_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn cancel_bubble(&self) -> bool {
+    pub fn cancel_bubble(&self) -> bool {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -625,7 +625,7 @@ impl Event {
     pub extern "C" fn cancel_bubble(&self) -> bool {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -643,7 +643,7 @@ pub extern "C" fn __wbindgen_describe___widl_f_set_cancel_bubble_Event() {
 impl Event {
     #[allow(bad_style)]
     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-    pub extern "C" fn set_cancel_bubble(&self, cancel_bubble: bool) {
+    pub fn set_cancel_bubble(&self, cancel_bubble: bool) {
         ::wasm_bindgen::__rt::link_this_library();
         #[wasm_import_module = "__wbindgen_placeholder__"]
         extern "C" {
@@ -671,7 +671,7 @@ impl Event {
     pub extern "C" fn set_cancel_bubble(&self, cancel_bubble: bool) {
         panic!(
             "cannot call wasm-bindgen imported functions on \
-            non-wasm targets"
+             non-wasm targets"
         );
     }
 }
@@ -681,4 +681,4 @@ pub type DOMHighResTimeStamp = f64;
 pub type EventInit = bool;
 #[allow(non_upper_case_globals)]
 #[wasm_custom_section = "__wasm_bindgen_unstable"]
-const __WASM_BINDGEN_GENERATED_wasm_bindgen_webidl_0_2_11_0 : [ u8 ; 4451usize ] = * b"_\x11\0\0{\"exports\":[],\"enums\":[],\"imports\":[{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"type\"}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_new_Event\",\"catch\":false,\"method\":false,\"js_new\":true,\"structural\":false,\"getter\":null,\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"new\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_event_phase_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"eventPhase\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"eventPhase\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_stop_propagation_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":null,\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"stopPropagation\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_stop_immediate_propagation_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":null,\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"stopImmediatePropagation\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_bubbles_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"bubbles\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"bubbles\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_cancelable_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"cancelable\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"cancelable\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_prevent_default_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":null,\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"preventDefault\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_default_prevented_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"defaultPrevented\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"defaultPrevented\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_default_prevented_by_chrome_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"defaultPreventedByChrome\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"defaultPreventedByChrome\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_default_prevented_by_content_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"defaultPreventedByContent\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"defaultPreventedByContent\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_composed_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"composed\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"composed\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_is_trusted_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"isTrusted\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"isTrusted\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_time_stamp_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"timeStamp\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"timeStamp\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_init_event_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":null,\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"initEvent\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_cancel_bubble_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":\"cancelBubble\",\"setter\":null,\"class\":\"Event\",\"function\":{\"name\":\"cancelBubble\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_set_cancel_bubble_Event\",\"catch\":false,\"method\":true,\"js_new\":false,\"structural\":false,\"getter\":null,\"setter\":\"cancelBubble\",\"class\":\"Event\",\"function\":{\"name\":\"set_CancelBubble\"}}}],\"structs\":[],\"version\":\"0.2.11 (161fce9d5)\",\"schema_version\":\"4\"}" ;
+const __WASM_BINDGEN_GENERATED_wasm_bindgen_webidl_0_2_11_0 : [ u8 ; 3815usize ] = * b"\xE3\x0E\0\0{\"exports\":[],\"enums\":[],\"imports\":[{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"type\"}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_new_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Constructor\",\"getter\":null,\"setter\":null},\"structural\":false,\"function\":{\"name\":\"new\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_event_phase_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"eventPhase\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"eventPhase\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_stop_propagation_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":null,\"setter\":null},\"structural\":false,\"function\":{\"name\":\"stopPropagation\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_stop_immediate_propagation_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":null,\"setter\":null},\"structural\":false,\"function\":{\"name\":\"stopImmediatePropagation\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_bubbles_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"bubbles\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"bubbles\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_cancelable_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"cancelable\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"cancelable\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_prevent_default_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":null,\"setter\":null},\"structural\":false,\"function\":{\"name\":\"preventDefault\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_default_prevented_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"defaultPrevented\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"defaultPrevented\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_composed_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"composed\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"composed\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_is_trusted_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"isTrusted\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"isTrusted\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_time_stamp_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"timeStamp\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"timeStamp\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_init_event_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":null,\"setter\":null},\"structural\":false,\"function\":{\"name\":\"initEvent\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_cancel_bubble_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":\"cancelBubble\",\"setter\":null},\"structural\":false,\"function\":{\"name\":\"cancelBubble\"}}},{\"module\":null,\"version\":null,\"js_namespace\":null,\"kind\":{\"kind\":\"function\",\"shim\":\"__widl_f_set_cancel_bubble_Event\",\"catch\":false,\"method\":{\"class\":\"Event\",\"kind\":\"Normal\",\"getter\":null,\"setter\":\"cancelBubble\"},\"structural\":false,\"function\":{\"name\":\"set_cancelBubble\"}}}],\"structs\":[],\"version\":\"0.2.11 (13c93c46f)\",\"schema_version\":\"5\"}" ;

--- a/tests/all/import_class.rs
+++ b/tests/all/import_class.rs
@@ -418,7 +418,8 @@ fn rename_setter_getter() {
 
                 #[wasm_bindgen]
                 pub fn run() {
-                    let a = Foo::new();
+                    let x: fn() -> Foo = Foo::new;
+                    let a = x();
                     assert_eq!(a.test(), 1);
                     a.another(2);
                     assert_eq!(a.test(), 2);


### PR DESCRIPTION
No need to use the C ABI, it just mixes up the documentation!