### PR TITLE
uses (JS) `const` for stack and slab declarations

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -766,7 +766,7 @@ impl<'a> Context<'a> {
         }
         self.global(&format!(
             "
-            let stack = [];
+            const stack = [];
         "
         ));
         if self.config.debug {
@@ -793,7 +793,7 @@ impl<'a> Context<'a> {
             "{ obj: true }",
             "{ obj: false }",
         ];
-        self.global(&format!("let slab = [{}];", initial_values.join(", ")));
+        self.global(&format!("const slab = [{}];", initial_values.join(", ")));
         if self.config.debug {
             self.export(
                 "assertSlabEmpty",

--- a/guide/src/design/js-objects-in-rust.md
+++ b/guide/src/design/js-objects-in-rust.md
@@ -47,7 +47,7 @@ and what we actually generate looks something like:
 // foo.js
 import * as wasm from './foo_bg';
 
-let stack = [];
+const stack = [];
 
 function addBorrowedObject(obj) {
   stack.push(obj);
@@ -135,7 +135,7 @@ different. Let's see the generated JS's slab in action:
 ```js
 import * as wasm from './foo_bg'; // imports from wasm file
 
-let slab = [];
+const slab = [];
 let slab_next = 0;
 
 function addHeapObject(obj) {


### PR DESCRIPTION
While this is rather a minor thing, while [reading through the guide](https://rustwasm.github.io/wasm-bindgen/design/js-objects-in-rust.html) I noticed that for JS `stack` and `slab` the `let` keyword is used, where in fact it should be a `const`.