### PR TITLE
Add Array.prototype.forEach bindings

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -148,6 +148,12 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn find(this: &Array, predicate: &mut FnMut(JsValue, u32, Array) -> bool) -> JsValue;
 
+    /// The forEach() method executes a provided function once for each array element.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+    #[wasm_bindgen(method, js_name = forEach)]
+    pub fn for_each(this: &Array, callback: &Function) -> JsValue;
+
     /// The includes() method determines whether an array includes a certain
     /// element, returning true or false as appropriate.
     ///

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -42,6 +42,57 @@ fn filter() {
 }
 
 #[test]
+fn for_each() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn for_each(this: &js::Array, callback: &js::Function) -> JsValue {
+                this.for_each(callback)
+            }
+
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            const testArray = [1, 2, 3, 4];
+
+            export function test() {
+                const callbackArgs = [];
+
+                let count = 0;
+
+                function callback(...args){
+                    count++;
+                    callbackArgs.push(args);
+                }
+
+                wasm.for_each(testArray, callback);
+
+                assert.equal(count, testArray.length);
+
+                callbackArgs.forEach(([value, index, arr], idx) => {
+                    assert.equal(value, testArray[idx]);
+                    assert.equal(index, idx);
+                    assert.equal(arr, testArray);
+                });
+            }
+        "#,
+        )
+        .test()
+}
+#[test]
 fn index_of() {
     project()
         .file(


### PR DESCRIPTION
This PR should add bindings to `forEach`.

This is also my first PR to `wasm-bindgen`, so let me know if I've goofed anything up. Possible places for improvement:

1. This implementation is returning a `JsValue`, when I suspect it really ought to return a `JsValue::undefined()`, but my Rust-fu wasn't strong enough to get that granular. Let me know if `JsValue` isn't restrictive enough.
2. The tests are really calling out for a spy _a la_ `sinon`, but I didn't want to add another dependency to the project for one test.

Referencing issue #275.