### PR TITLE
Fix some cases with `#[deny(missing_docs)]`

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -191,6 +191,7 @@ impl ToTokens for ast::Struct {
 
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             #[no_mangle]
+            #[doc(hidden)]
             pub unsafe extern fn #free_fn(ptr: u32) {
                 <#name as ::wasm_bindgen::convert::FromWasmAbi>::from_abi(
                     ptr,
@@ -246,6 +247,7 @@ impl ToTokens for ast::StructField {
         );
         (quote! {
             #[no_mangle]
+            #[doc(hidden)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             pub unsafe extern fn #getter(js: u32)
                 -> <#ty as ::wasm_bindgen::convert::IntoWasmAbi>::Abi
@@ -279,6 +281,7 @@ impl ToTokens for ast::StructField {
 
         (quote! {
             #[no_mangle]
+            #[doc(hidden)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             pub unsafe extern fn #setter(
                 js: u32,
@@ -441,8 +444,10 @@ impl ToTokens for ast::Export {
         let descriptor_name = Ident::new(&descriptor_name, Span::call_site());
         let nargs = self.function.arguments.len() as u32;
         let argtys = self.function.arguments.iter().map(|arg| &arg.ty);
+        let attrs = &self.function.rust_attrs;
 
         let tokens = quote! {
+            #(#attrs)*
             #[export_name = #export_name]
             #[allow(non_snake_case)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]

--- a/tests/all/import_class.rs
+++ b/tests/all/import_class.rs
@@ -456,3 +456,52 @@ fn rename_setter_getter() {
         )
         .test();
 }
+
+#[test]
+fn deny_missing_docs() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+                //! dox
+                #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+                #![deny(missing_docs)]
+                #![allow(dead_code)]
+
+                extern crate wasm_bindgen;
+
+                use wasm_bindgen::prelude::*;
+
+                /// dox
+                #[wasm_bindgen]
+                pub struct Bar {
+                    /// dox
+                    pub a: u32,
+                    b: i64,
+                }
+
+                #[wasm_bindgen]
+                extern {
+                    /// dox
+                    pub type Foo;
+
+                    /// dox
+                    #[wasm_bindgen(constructor)]
+                    pub fn new() -> Foo;
+
+                    /// dox
+                    #[wasm_bindgen(getter = a, method)]
+                    pub fn test(this: &Foo) -> i32;
+
+                    /// dox
+                    pub fn foo();
+                }
+
+                /// dox
+                #[wasm_bindgen]
+                pub fn test() {
+                }
+            "#,
+        )
+        .test();
+}


### PR DESCRIPTION
Generated functions by wasm-bindgen should either be `#[doc(hidden)]` or include
the docs on the original item!

Closes #425