### PR TITLE
Js docs

### DIFF
--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -368,6 +368,14 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
         Ok(self)
     }
 
+    pub fn js_doc_comments(&self) -> String {
+        let mut ret: String = self.js_arguments.iter().map(|a| {
+            format!("@param {{{}}} {}\n", a.1, a.0)
+        }).collect();
+        ret.push_str(&format!("@returns {{{}}}", self.ret_ty));
+        ret
+    }
+
     /// Generate the actual function.
     ///
     /// The `prefix` specified is typically the string "function" but may be
@@ -377,7 +385,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
     /// Returns two strings, the first of which is the JS expression for the
     /// generated function shim and the second is a TypeScript signature of the
     /// JS expression.
-    pub fn finish(&self, prefix: &str, invoc: &str) -> (String, String) {
+    pub fn finish(&self, prefix: &str, invoc: &str) -> (String, String, String) {
         let js_args = self
             .js_arguments
             .iter()
@@ -417,6 +425,6 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             "{} {}({}): {};\n",
             prefix, self.js_name, ts_args, self.ret_ty
         );
-        (js, ts)
+        (js, ts, self.js_doc_comments())
     }
 }

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -142,7 +142,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         }
 
         if let Some((f, mutable)) = arg.stack_closure() {
-            let (js, _ts) = {
+            let (js, _ts, _js_doc) = {
                 let mut builder = Js2Rust::new("", self.cx);
                 if mutable {
                     builder
@@ -179,7 +179,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         }
 
         if let Some(closure) = arg.ref_closure() {
-            let (js, _ts) = {
+            let (js, _ts, _js_doc) = {
                 let mut builder = Js2Rust::new("", self.cx);
                 if closure.mutable {
                     builder

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -443,7 +443,7 @@ fn reset_indentation(s: &str) -> String {
 
     for line in s.lines() {
         let line = line.trim();
-        if line.starts_with('}') || line.ends_with('}') {
+        if line.starts_with('}') || (line.ends_with('}') && !line.starts_with('*')) {
             indent = indent.saturating_sub(1);
         }
         let extra = if line.starts_with(':') || line.starts_with('?') { 1 } else { 0 };

--- a/tests/all/comments.rs
+++ b/tests/all/comments.rs
@@ -41,7 +41,8 @@ fn works() {
     p.gen_bindings();
     let js = p.read_js();
     let comments = extract_doc_comments(&js);
-    assert!(comments.iter().all(|c| c == "This comment should exist"));
+    assert!(comments.iter().all(|c| c == "This comment should exist" ||
+                                    c.starts_with("@")));
 }
 
 /// Pull out all lines in a js string that start with


### PR DESCRIPTION
This addresses two of the 3 remaining items in #57, all user exported functions will now be annotated with the JSDoc `@param` and `@returns` statements.

Upon further investigation into applying the `@constructor` statement I discovered that we are still using the `class` keyword when using `no-modules`, meaning that this would not be required.

This should effectively close #57 unless we are looking to provide an output that uses the function constructor + prototype syntax.