### PR TITLE
Test in release mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
         # to run `npm install` twice or by using `npm ci` (which is currently broken)
         - npm install
       script:
-        - cargo test
+        - cargo test --release
         # Check JS output from all tests against eslint
         - npm run run-lint-generated-tests
         # Check Examples against eslint
-        - npm run run-lint-examples        
+        - npm run run-lint-examples
       addons:
         firefox: latest
 


### PR DESCRIPTION
Contrary to #393 it looks like it's a big win now with the number of tests
we have. Tested in #429 it was confirmed that multiple threads are indeed
benefitting us here. A [debug build][1] took 22m while a [release build][2] took
15m.

[1]: https://travis-ci.org/rustwasm/wasm-bindgen/jobs/401819002
[2]: https://travis-ci.org/rustwasm/wasm-bindgen/jobs/401819004