### PR TITLE
WebIDL Enum Support

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -41,6 +41,7 @@ pub enum ImportKind {
     Function(ImportFunction),
     Static(ImportStatic),
     Type(ImportType),
+    Enum(ImportEnum),
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -97,6 +98,18 @@ pub struct ImportType {
     pub vis: syn::Visibility,
     pub name: Ident,
     pub attrs: Vec<syn::Attribute>,
+}
+
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+pub struct ImportEnum {
+    /// The Rust enum's visibility
+    pub vis: syn::Visibility,
+    /// The Rust enum's identifiers
+    pub name: Ident,
+    /// The Rust identifiers for the variants
+    pub variants: Vec<Ident>,
+    /// The JS string values of the variants
+    pub variant_values: Vec<String>,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -279,6 +292,7 @@ impl ImportKind {
             ImportKind::Function(_) => true,
             ImportKind::Static(_) => false,
             ImportKind::Type(_) => false,
+            ImportKind::Enum(_) => false,
         }
     }
 
@@ -287,6 +301,7 @@ impl ImportKind {
             ImportKind::Function(ref f) => shared::ImportKind::Function(f.shared()),
             ImportKind::Static(ref f) => shared::ImportKind::Static(f.shared()),
             ImportKind::Type(ref f) => shared::ImportKind::Type(f.shared()),
+            ImportKind::Enum(ref f) => shared::ImportKind::Enum(f.shared()),
         }
     }
 }
@@ -361,6 +376,12 @@ impl ImportStatic {
 impl ImportType {
     fn shared(&self) -> shared::ImportType {
         shared::ImportType {}
+    }
+}
+
+impl ImportEnum {
+    fn shared(&self) -> shared::ImportEnum {
+        shared::ImportEnum {}
     }
 }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -626,7 +626,7 @@ impl ToTokens for ast::ImportEnum {
             }
 
             impl #name {
-                fn from_js_value(obj: ::wasm_bindgen::JsValue) -> Option<#name> {
+                #vis fn from_js_value(obj: ::wasm_bindgen::JsValue) -> Option<#name> {
                     obj.as_string().and_then(|obj_str| match obj_str.as_str() {
                         #(#variant_strings => Some(#variant_paths_ref),)*
                         _ => None,

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 use ast;
-use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::ToTokens;
 use serde_json;
 use shared;
@@ -500,6 +500,7 @@ impl ToTokens for ast::ImportKind {
             ast::ImportKind::Function(ref f) => f.to_tokens(tokens),
             ast::ImportKind::Static(ref s) => s.to_tokens(tokens),
             ast::ImportKind::Type(ref t) => t.to_tokens(tokens),
+            ast::ImportKind::Enum(ref e) => e.to_tokens(tokens),
         }
     }
 }
@@ -580,6 +581,98 @@ impl ToTokens for ast::ImportType {
             impl From<#name> for ::wasm_bindgen::JsValue {
                 fn from(obj: #name) -> ::wasm_bindgen::JsValue {
                     obj.obj
+                }
+            }
+        }).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for ast::ImportEnum {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let vis = &self.vis;
+        let name = &self.name;
+        let name_string = &self.name.to_string();
+        let variants = &self.variants;
+        let variant_strings = &self.variant_values;
+
+        let mut current_idx: usize = 0;
+        let variant_indexes: Vec<Literal> = variants
+            .iter()
+            .map(|_| {
+                let this_index = current_idx;
+                current_idx += 1;
+                Literal::usize_unsuffixed(this_index)
+            })
+            .collect();
+
+        // Borrow variant_indexes because we need to use it multiple times inside the quote! macro
+        let variant_indexes_ref = &variant_indexes;
+
+        // A vector of EnumName::VariantName tokens for this enum
+        let variant_paths: Vec<TokenStream> = self
+            .variants
+            .iter()
+            .map(|v| quote!(#name::#v).into_token_stream())
+            .collect();
+
+        // Borrow variant_paths because we need to use it multiple times inside the quote! macro
+        let variant_paths_ref = &variant_paths;
+
+        (quote! {
+            #[allow(bad_style)]
+            #[derive(Copy, Clone, Debug)]
+            #vis enum #name {
+                #(#variants = #variant_indexes_ref,)*
+            }
+
+            impl ::wasm_bindgen::describe::WasmDescribe for #name {
+                fn describe() {
+                    ::wasm_bindgen::JsValue::describe()
+                }
+            }
+
+            impl ::wasm_bindgen::convert::IntoWasmAbi for #name {
+                type Abi = <::wasm_bindgen::JsValue as
+                    ::wasm_bindgen::convert::IntoWasmAbi>::Abi;
+
+                fn into_abi(self, extra: &mut ::wasm_bindgen::convert::Stack) -> Self::Abi {
+                    match self {
+                        #(#variant_paths_ref => ::wasm_bindgen::JsValue::from_str(#variant_strings).into_abi(extra),)*
+                    }
+                }
+            }
+
+            impl ::wasm_bindgen::convert::FromWasmAbi for #name {
+                type Abi = <::wasm_bindgen::JsValue as
+                    ::wasm_bindgen::convert::FromWasmAbi>::Abi;
+
+                unsafe fn from_abi(
+                    js: Self::Abi,
+                    extra: &mut ::wasm_bindgen::convert::Stack,
+                ) -> Self {
+                    #name::from(::wasm_bindgen::JsValue::from_abi(js, extra))
+                }
+            }
+
+            impl From<::wasm_bindgen::JsValue> for #name {
+                fn from(obj: ::wasm_bindgen::JsValue) -> #name {
+                    let obj_str = match obj.as_string() {
+                        Some(string_value) => string_value,
+                        None => panic!("Can't convert a non-string into {}", #name_string),
+                    };
+
+                    match obj_str.as_str() {
+                        #(#variant_strings => #variant_paths_ref,)*
+                        unknown_value => panic!("Can't convert \"{}\" into {}", unknown_value, #name_string),
+                    }
+                }
+            }
+
+            impl From<#name> for ::wasm_bindgen::JsValue {
+                fn from(obj: #name) -> ::wasm_bindgen::JsValue {
+                    match obj {
+                        #(#variant_paths_ref => ::wasm_bindgen::JsValue::from_str(#variant_strings)),*
+                    }
                 }
             }
         }).to_tokens(tokens);
@@ -755,6 +848,7 @@ impl<'a> ToTokens for DescribeImport<'a> {
             ast::ImportKind::Function(ref f) => f,
             ast::ImportKind::Static(_) => return,
             ast::ImportKind::Type(_) => return,
+            ast::ImportKind::Enum(_) => return,
         };
         let describe_name = format!("__wbindgen_describe_{}", f.shim);
         let describe_name = Ident::new(&describe_name, Span::call_site());

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -645,9 +645,7 @@ impl ToTokens for ast::ImportEnum {
                     ::wasm_bindgen::convert::IntoWasmAbi>::Abi;
 
                 fn into_abi(self, extra: &mut ::wasm_bindgen::convert::Stack) -> Self::Abi {
-                    match self {
-                        #(#variant_paths_ref => ::wasm_bindgen::JsValue::from_str(#variant_strings).into_abi(extra),)*
-                    }
+                    ::wasm_bindgen::JsValue::from(self).into_abi(extra)
                 }
             }
 

--- a/crates/backend/src/defined.rs
+++ b/crates/backend/src/defined.rs
@@ -105,6 +105,7 @@ impl ImportedTypes for ast::ImportKind {
             ast::ImportKind::Static(s) => s.imported_types(f),
             ast::ImportKind::Function(fun) => fun.imported_types(f),
             ast::ImportKind::Type(ty) => ty.imported_types(f),
+            ast::ImportKind::Enum(enm) => enm.imported_types(f),
         }
     }
 }
@@ -202,6 +203,15 @@ impl ImportedTypes for syn::ArgCaptured {
 }
 
 impl ImportedTypes for ast::ImportType {
+    fn imported_types<F>(&self, f: &mut F)
+    where
+        F: FnMut(&Ident, ImportedTypeKind),
+    {
+        f(&self.name, ImportedTypeKind::Definition);
+    }
+}
+
+impl ImportedTypes for ast::ImportEnum {
     fn imported_types<F>(&self, f: &mut F)
     where
         F: FnMut(&Ident, ImportedTypeKind),

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -71,13 +71,15 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             self.prelude(
                 "if (this.ptr === 0) {
                     throw new Error('Attempt to use a moved value');
-                }"
+                }",
             );
             if consumed {
-                self.prelude("\
-                    const ptr = this.ptr;\n\
-                    this.ptr = 0;\n\
-                ");
+                self.prelude(
+                    "\
+                     const ptr = this.ptr;\n\
+                     this.ptr = 0;\n\
+                     ",
+                );
                 self.rust_arguments.insert(0, "ptr".to_string());
             } else {
                 self.rust_arguments.insert(0, "this.ptr".to_string());

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1756,6 +1756,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                 })?;
             }
             shared::ImportKind::Type(_) => {}
+            shared::ImportKind::Enum(_) => {}
         }
         Ok(())
     }

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -306,7 +306,8 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             // Insert an assertion to the type of the returned value as
             // otherwise this will cause memory unsafety on the Rust side of
             // things.
-            self.ret_expr = format!("\
+            self.ret_expr = format!(
+                "\
                 const val = JS;
                 if (!(val instanceof {0})) {{
                     throw new Error('expected value of type {0}');
@@ -314,8 +315,10 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 const ret = val.ptr;
                 val.ptr = 0;
                 return ret;\
-            ", class);
-            return Ok(())
+            ",
+                class
+            );
+            return Ok(());
         }
 
         self.ret_expr = match *ty {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -33,6 +33,7 @@ pub enum ImportKind {
     Function(ImportFunction),
     Static(ImportStatic),
     Type(ImportType),
+    Enum(ImportEnum),
 }
 
 #[derive(Deserialize, Serialize)]
@@ -77,6 +78,9 @@ pub struct ImportStatic {
 
 #[derive(Deserialize, Serialize)]
 pub struct ImportType {}
+
+#[derive(Deserialize, Serialize)]
+pub struct ImportEnum {}
 
 #[derive(Deserialize, Serialize)]
 pub struct Export {

--- a/crates/webidl/tests/all/enums.rs
+++ b/crates/webidl/tests/all/enums.rs
@@ -1,0 +1,64 @@
+use super::project;
+
+#[test]
+fn top_level_enum() {
+    project()
+        .file(
+            "shape.webidl",
+            r#"
+            enum ShapeType { "circle", "square" };
+            
+            [Constructor(ShapeType kind)]
+            interface Shape {
+                [Pure]
+                boolean isSquare();
+
+                [Pure]
+                boolean isCircle();
+            };
+        "#,
+        )
+        .file(
+            "shape.mjs",
+            r#"
+            export class Shape {
+                constructor(kind) {
+                    this.kind = kind;
+                }
+
+                isSquare() {
+                    return this.kind === 'square';
+                }
+
+                isCircle() {
+                    return this.kind === 'circle';
+                }
+            }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            pub mod shape;
+
+            use shape::{Shape, ShapeType};
+
+            #[wasm_bindgen]
+            pub fn test() {
+                let circle = Shape::new(ShapeType::Circle);
+                let square = Shape::new(ShapeType::Square);
+                assert!(circle.is_circle());
+                assert!(!circle.is_square());
+                assert!(square.is_square());
+                assert!(!square.is_circle());
+            }
+        "#,
+        )
+        .test();
+}

--- a/crates/webidl/tests/all/enums.rs
+++ b/crates/webidl/tests/all/enums.rs
@@ -51,8 +51,8 @@ fn top_level_enum() {
 
             #[wasm_bindgen]
             pub fn test() {
-                let circle = Shape::new(ShapeType::Circle);
-                let square = Shape::new(ShapeType::Square);
+                let circle = Shape::new(ShapeType::Circle).unwrap();
+                let square = Shape::new(ShapeType::Square).unwrap();
                 assert!(circle.is_circle());
                 assert!(!circle.is_square());
                 assert!(square.is_square());

--- a/crates/webidl/tests/all/main.rs
+++ b/crates/webidl/tests/all/main.rs
@@ -2,3 +2,4 @@ extern crate wasm_bindgen_test_project_builder as project_builder;
 use project_builder::project;
 
 mod simple;
+mod enums;


### PR DESCRIPTION
Adds basic support for enums to the WebIDL interface generator.

Per the consensus on #260 the enums are represented as normal Rust enums. Right now I'm just having it panic when an invalid string is converted, I was thinking of adding something along the lines of [this nice hack](https://github.com/rust-lang/rfcs/blob/master/text/2008-non-exhaustive.md#how-we-do-this-today) instead, but I wanted some feedback first to see if there's a better approach.