### PR TITLE
bindings for Date.setXXX

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -1066,6 +1066,13 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setSeconds)]
     pub fn set_seconds(this: &Date, seconds: u32) -> f64;
 
+    /// The setTime() method sets the Date object to the time represented by a number of milliseconds
+    /// since January 1, 1970, 00:00:00 UTC.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime
+    #[wasm_bindgen(method, js_name = setTime)]
+    pub fn set_time(this: &Date, time: f64) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1027,6 +1027,13 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setDate)]
     pub fn set_date(this: &Date, day: u32) -> f64;
 
+    /// The setFullYear() method sets the full year for a specified date according to local time.
+    /// Returns new timestamp.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear
+    #[wasm_bindgen(method, js_name = setFullYear)]
+    pub fn set_full_year(this: &Date, year: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1048,6 +1048,12 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setMilliseconds)]
     pub fn set_milliseconds(this: &Date, milliseconds: u32) -> f64;
 
+    /// The setMinutes() method sets the minutes for a specified date according to local time.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes
+    #[wasm_bindgen(method, js_name = setMinutes)]
+    pub fn set_minutes(this: &Date, minutes: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1034,6 +1034,14 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setFullYear)]
     pub fn set_full_year(this: &Date, year: u32) -> f64;
 
+    /// The setHours() method sets the hours for a specified date according to local time,
+    /// and returns the number of milliseconds since January 1, 1970 00:00:00 UTC until the time represented
+    /// by the updated Date instance.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours
+    #[wasm_bindgen(method, js_name = setHours)]
+    pub fn set_hours(this: &Date, hours: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1060,6 +1060,12 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setMonth)]
     pub fn set_month(this: &Date, month: u32) -> f64;
 
+    /// The setSeconds() method sets the seconds for a specified date according to local time.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds
+    #[wasm_bindgen(method, js_name = setSeconds)]
+    pub fn set_seconds(this: &Date, seconds: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1042,6 +1042,12 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setHours)]
     pub fn set_hours(this: &Date, hours: u32) -> f64;
 
+    /// The setMilliseconds() method sets the milliseconds for a specified date according to local time.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds
+    #[wasm_bindgen(method, js_name = setMilliseconds)]
+    pub fn set_milliseconds(this: &Date, milliseconds: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1021,6 +1021,12 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Date)]
     pub fn parse(date: JsString) -> f64;
 
+    /// The setDate() method sets the day of the Date object relative to the beginning of the currently set month.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate
+    #[wasm_bindgen(method, js_name = setDate)]
+    pub fn set_date(this: &Date, day: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/src/js.rs
+++ b/src/js.rs
@@ -1054,6 +1054,12 @@ extern "C" {
     #[wasm_bindgen(method, js_name = setMinutes)]
     pub fn set_minutes(this: &Date, minutes: u32) -> f64;
 
+    /// The setMonth() method sets the month for a specified date according to the currently set year.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth
+    #[wasm_bindgen(method, js_name = setMonth)]
+    pub fn set_month(this: &Date, month: u32) -> f64;
+
     /// The toDateString() method returns the date portion of a Date object
     /// in human readable form in American English.
     ///

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -959,6 +959,45 @@ fn set_month() {
 }
 
 #[test]
+fn set_seconds() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_seconds(this: &Date, seconds: u32) -> f64 {
+                this.set_seconds(seconds)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('August 19, 1975 23:15:30');
+                let event2 = new Date('August 19, 1975 23:15:42');
+
+                let eventMsFromUnixEpoch = wasm.set_seconds(event1, 42);
+
+                assert.equal(eventMsFromUnixEpoch, 177689742000);
+                assert.equal(event1.getTime(), event2.valueOf());
+                assert.equal(event1.getSeconds(), 42);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -998,6 +998,44 @@ fn set_seconds() {
 }
 
 #[test]
+fn set_time() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_time(this: &Date, time: f64) -> f64 {
+                this.set_time(time)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('July 1, 1999');
+                let event2 = new Date();
+
+                let eventMsFromUnixEpoch = wasm.set_time(event2, event1.getTime());
+
+                assert.equal(eventMsFromUnixEpoch, 930754800000);
+                assert.equal(event1.valueOf(), event2.getTime());
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -766,6 +766,45 @@ fn set_date() {
 }
 
 #[test]
+fn set_full_year() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_full_year(this: &Date, year: u32) -> f64 {
+                this.set_full_year(year)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('August 19, 1975 23:15:30');
+                let event2 = new Date('August 19, 1976 23:15:30');
+
+                let eventMsFromUnixEpoch = wasm.set_full_year(event1, 1976);
+
+                assert.equal(eventMsFromUnixEpoch, 209312130000);
+                assert.equal(event1.getTime(), event2.valueOf());
+                assert.equal(event1.getFullYear(), 1976);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -756,7 +756,7 @@ fn set_date() {
 
                 let eventMsFromUnixEpoch = wasm.set_date(event1, 24);
 
-                assert.equal(eventMsFromUnixEpoch, 178121730000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.getTime(), event2.valueOf());
                 assert.equal(event1.getDate(), 24);
             }
@@ -795,7 +795,7 @@ fn set_full_year() {
 
                 let eventMsFromUnixEpoch = wasm.set_full_year(event1, 1976);
 
-                assert.equal(eventMsFromUnixEpoch, 209312130000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.getTime(), event2.valueOf());
                 assert.equal(event1.getFullYear(), 1976);
             }
@@ -834,7 +834,7 @@ fn set_hours() {
 
                 let eventMsFromUnixEpoch = wasm.set_hours(event1, 20);
 
-                assert.equal(eventMsFromUnixEpoch, 177678930000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.getTime(), event2.valueOf());
                 assert.equal(event1.getHours(), 20);
             }
@@ -872,7 +872,7 @@ fn set_milliseconds() {
 
                 let eventMsFromUnixEpoch = wasm.set_milliseconds(event, 456);
 
-                assert.equal(eventMsFromUnixEpoch, 177689730456);
+                assert.equal(eventMsFromUnixEpoch, event.getTime());
                 assert.equal(event.getMilliseconds(), 456);
             }
         "#,
@@ -910,7 +910,7 @@ fn set_minutes() {
 
                 let eventMsFromUnixEpoch = wasm.set_minutes(event1, 45);
 
-                assert.equal(eventMsFromUnixEpoch, 177691530000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.getTime(), event2.valueOf());
                 assert.equal(event1.getMinutes(), 45);
             }
@@ -949,7 +949,7 @@ fn set_month() {
 
                 let eventMsFromUnixEpoch = wasm.set_month(event1, 3);
 
-                assert.equal(eventMsFromUnixEpoch, 167148930000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.getTime(), event2.valueOf());
                 assert.equal(event1.getMonth(), 3);
             }
@@ -988,7 +988,7 @@ fn set_seconds() {
 
                 let eventMsFromUnixEpoch = wasm.set_seconds(event1, 42);
 
-                assert.equal(eventMsFromUnixEpoch, 177689742000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.getTime(), event2.valueOf());
                 assert.equal(event1.getSeconds(), 42);
             }
@@ -1027,7 +1027,7 @@ fn set_time() {
 
                 let eventMsFromUnixEpoch = wasm.set_time(event2, event1.getTime());
 
-                assert.equal(eventMsFromUnixEpoch, 930754800000);
+                assert.equal(eventMsFromUnixEpoch, event2.getTime());
                 assert.equal(event1.valueOf(), event2.getTime());
             }
         "#,

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -727,6 +727,45 @@ fn parse() {
 }
 
 #[test]
+fn set_date() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_date(this: &Date, day: u32) -> f64 {
+                this.set_date(day)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('August 19, 1975 23:15:30');
+                let event2 = new Date('August 24, 1975 23:15:30');
+
+                let eventMsFromUnixEpoch = wasm.set_date(event1, 24);
+
+                assert.equal(eventMsFromUnixEpoch, 178121730000);
+                assert.equal(event1.getTime(), event2.valueOf());
+                assert.equal(event1.getDate(), 24);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -844,6 +844,43 @@ fn set_hours() {
 }
 
 #[test]
+fn set_milliseconds() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_milliseconds(this: &Date, milliseconds: u32) -> f64 {
+                this.set_milliseconds(milliseconds)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event = new Date('August 19, 1975 23:15:30');
+
+                let eventMsFromUnixEpoch = wasm.set_milliseconds(event, 456);
+
+                assert.equal(eventMsFromUnixEpoch, 177689730456);
+                assert.equal(event.getMilliseconds(), 456);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -920,6 +920,45 @@ fn set_minutes() {
 }
 
 #[test]
+fn set_month() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_month(this: &Date, month: u32) -> f64 {
+                this.set_month(month)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('August 19, 1975 23:15:30');
+                let event2 = new Date('April 19, 1975 23:15:30');
+
+                let eventMsFromUnixEpoch = wasm.set_month(event1, 3);
+
+                assert.equal(eventMsFromUnixEpoch, 167148930000);
+                assert.equal(event1.getTime(), event2.valueOf());
+                assert.equal(event1.getMonth(), 3);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -881,6 +881,45 @@ fn set_milliseconds() {
 }
 
 #[test]
+fn set_minutes() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_minutes(this: &Date, minutes: u32) -> f64 {
+                this.set_minutes(minutes)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('August 19, 1975 23:15:30');
+                let event2 = new Date('August 19, 1975 23:45:30');
+
+                let eventMsFromUnixEpoch = wasm.set_minutes(event1, 45);
+
+                assert.equal(eventMsFromUnixEpoch, 177691530000);
+                assert.equal(event1.getTime(), event2.valueOf());
+                assert.equal(event1.getMinutes(), 45);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -805,6 +805,45 @@ fn set_full_year() {
 }
 
 #[test]
+fn set_hours() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(proc_macro, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js::Date;
+
+            #[wasm_bindgen]
+            pub fn set_hours(this: &Date, hours: u32) -> f64 {
+                this.set_hours(hours)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                let event1 = new Date('August 19, 1975 23:15:30');
+                let event2 = new Date('August 19, 1975 20:15:30');
+
+                let eventMsFromUnixEpoch = wasm.set_hours(event1, 20);
+
+                assert.equal(eventMsFromUnixEpoch, 177678930000);
+                assert.equal(event1.getTime(), event2.valueOf());
+                assert.equal(event1.getHours(), 20);
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_date_string() {
     project()
         .file(


### PR DESCRIPTION
I'm not sure my decision is correct, but I ignored the bindings for optional arguments because it seems unintuitive for the methods to take those arguments at all times.

Referencing issue #275.
