### PR TITLE
Fix Language Statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.webidl linguist-vendored


### PR DESCRIPTION
Right now [linguist](https://github.com/github/linguist) is reporting mostly IDL:
![linguist-before](https://user-images.githubusercontent.com/5911086/42603589-7084989e-853c-11e8-8d01-8783d8581db2.png)
And that bothers me for some reason, so I added a `.gitattributes` to ignore the WebIDL.
![linguist-after](https://user-images.githubusercontent.com/5911086/42603645-a5374c3a-853c-11e8-8b21-21d1937d91d0.png)
