### PR TITLE
Remove debug sections by default

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -19,5 +19,5 @@ serde_derive = "1.0"
 serde_json = "1.0"
 tempfile = "3.0"
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.11' }
-wasm-gc-api = "0.1"
+wasm-gc-api = "0.1.8"
 wasmi = "0.3"

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1580,6 +1580,7 @@ impl<'a> Context<'a> {
         let wasm_bytes = parity_wasm::serialize(module)?;
         let bytes = wasm_gc::Config::new()
             .demangle(self.config.demangle)
+            .keep_debug(self.config.keep_debug || self.config.debug)
             .gc(&wasm_bytes)?;
         *self.module = deserialize_buffer(&bytes)?;
         Ok(())

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -31,6 +31,7 @@ pub struct Bindgen {
     debug: bool,
     typescript: bool,
     demangle: bool,
+    keep_debug: bool,
 }
 
 impl Bindgen {
@@ -45,6 +46,7 @@ impl Bindgen {
             debug: false,
             typescript: false,
             demangle: true,
+            keep_debug: false,
         }
     }
 
@@ -90,6 +92,11 @@ impl Bindgen {
 
     pub fn demangle(&mut self, demangle: bool) -> &mut Bindgen {
         self.demangle = demangle;
+        self
+    }
+
+    pub fn keep_debug(&mut self, keep_debug: bool) -> &mut Bindgen {
+        self.keep_debug = keep_debug;
         self
     }
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -32,6 +32,7 @@ Options:
     --no-typescript          Don't emit a *.d.ts file
     --debug                  Include otherwise-extraneous debug checks in output
     --no-demangle            Don't demangle Rust symbol names
+    --keep-debug             Keep debug sections in wasm files
     -V --version             Print the version number of wasm-bindgen
 ";
 
@@ -47,6 +48,7 @@ struct Args {
     flag_version: bool,
     flag_no_demangle: bool,
     flag_no_modules_global: Option<String>,
+    flag_keep_debug: bool,
     arg_input: Option<PathBuf>,
 }
 
@@ -85,6 +87,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .no_modules(args.flag_no_modules)
         .debug(args.flag_debug)
         .demangle(!args.flag_no_demangle)
+        .keep_debug(args.flag_keep_debug)
         .typescript(typescript);
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name);


### PR DESCRIPTION
The changes on master Rust insert debug sections now (yay!) but this means that
wasm binaries by default pick up debug sections from the standard library, so
let's remove them by default in wasm-bindgen unless `--debug` is passed