### PR TITLE
WebIDL: Handle Invalid Enum Returns

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -112,6 +112,8 @@ pub struct ImportEnum {
     pub variants: Vec<Ident>,
     /// The JS string values of the variants
     pub variant_values: Vec<String>,
+    /// Attributes to apply to the Rust enum
+    pub rust_attrs: Vec<syn::Attribute>,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -616,7 +616,7 @@ impl ToTokens for ast::ImportEnum {
             }
 
             impl #name {
-                #vis fn from_js_value(obj: ::wasm_bindgen::JsValue) -> Option<#name> {
+                #vis fn from_js_value(obj: &::wasm_bindgen::JsValue) -> Option<#name> {
                     obj.as_string().and_then(|obj_str| match obj_str.as_str() {
                         #(#variant_strings => Some(#variant_paths_ref),)*
                         _ => None,
@@ -647,7 +647,7 @@ impl ToTokens for ast::ImportEnum {
                     js: Self::Abi,
                     extra: &mut ::wasm_bindgen::convert::Stack,
                 ) -> Self {
-                    #name::from_js_value(::wasm_bindgen::JsValue::from_abi(js, extra)).expect(#expect_string)
+                    #name::from_js_value(&::wasm_bindgen::JsValue::from_abi(js, extra)).expect(#expect_string)
                 }
             }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -583,6 +583,7 @@ impl ToTokens for ast::ImportEnum {
         let expect_string = format!("attempted to convert invalid JSValue into {}", name);
         let variants = &self.variants;
         let variant_strings = &self.variant_values;
+        let attrs = &self.rust_attrs;
 
         let mut current_idx: usize = 0;
         let variant_indexes: Vec<Literal> = variants
@@ -609,7 +610,7 @@ impl ToTokens for ast::ImportEnum {
 
         (quote! {
             #[allow(bad_style)]
-            #[derive(Copy, Clone, Debug)]
+            #(#attrs)*
             #vis enum #name {
                 #(#variants = #variant_indexes_ref,)*
             }

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -14,7 +14,9 @@ extern crate heck;
 #[macro_use]
 extern crate log;
 extern crate proc_macro2;
+#[macro_use]
 extern crate quote;
+#[macro_use]
 extern crate syn;
 extern crate wasm_bindgen_backend as backend;
 extern crate webidl;
@@ -640,6 +642,7 @@ impl<'a> WebidlParse<()> for webidl::ast::Enum {
                     .map(|v| rust_ident(v.to_camel_case().as_str()))
                     .collect(),
                 variant_values: self.variants.clone(),
+                rust_attrs: vec![parse_quote!(#[derive(Copy, Clone, PartialEq, Debug)])],
             }),
         });
 

--- a/crates/webidl/tests/all/enums.rs
+++ b/crates/webidl/tests/all/enums.rs
@@ -1,23 +1,25 @@
 use super::project;
 
+static SHAPE_IDL: &'static str = r#"
+    enum ShapeType { "circle", "square" };
+    
+    [Constructor(ShapeType kind)]
+    interface Shape {
+        [Pure]
+        boolean isSquare();
+
+        [Pure]
+        boolean isCircle();
+
+        [Pure]
+        ShapeType getShape();
+    };
+"#;
+
 #[test]
 fn top_level_enum() {
     project()
-        .file(
-            "shape.webidl",
-            r#"
-            enum ShapeType { "circle", "square" };
-            
-            [Constructor(ShapeType kind)]
-            interface Shape {
-                [Pure]
-                boolean isSquare();
-
-                [Pure]
-                boolean isCircle();
-            };
-        "#,
-        )
+        .file("shape.webidl", SHAPE_IDL)
         .file(
             "shape.mjs",
             r#"
@@ -32,6 +34,10 @@ fn top_level_enum() {
 
                 isCircle() {
                     return this.kind === 'circle';
+                }
+
+                getShape() {
+                    return this.kind;
                 }
             }
             "#,
@@ -57,6 +63,115 @@ fn top_level_enum() {
                 assert!(!circle.is_square());
                 assert!(square.is_square());
                 assert!(!square.is_circle());
+            }
+        "#,
+        )
+        .test();
+}
+
+#[test]
+fn valid_enum_return() {
+    project()
+        .file("shape.webidl", SHAPE_IDL)
+        .file(
+            "shape.mjs",
+            r#"
+            export class Shape {
+                constructor(kind) {
+                    this.kind = kind;
+                }
+
+                isSquare() {
+                    return this.kind === 'square';
+                }
+
+                isCircle() {
+                    return this.kind === 'circle';
+                }
+
+                getShape() {
+                    return this.kind;
+                }
+            }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(use_extern_macros)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            pub mod shape;
+
+            use shape::{Shape, ShapeType};
+
+            #[wasm_bindgen]
+            pub fn test() {
+                let circle = Shape::new(ShapeType::Circle).unwrap();
+                let square = Shape::new(ShapeType::Square).unwrap();
+                assert!(circle.is_circle());
+                assert!(!circle.is_square());
+                assert_eq!(circle.get_shape(), ShapeType::Circle);
+                assert!(square.is_square());
+                assert!(!square.is_circle());
+                assert_eq!(square.get_shape(), ShapeType::Square);
+            }
+        "#,
+        )
+        .test();
+}
+
+#[test]
+fn invalid_enum_return() {
+    project()
+        .file("shape.webidl", SHAPE_IDL)
+        .file(
+            "shape.mjs",
+            r#"
+            export class Shape {
+                constructor(kind) {
+                    this.kind = 'triangle'; // <-- invalid ShapeType
+                }
+
+                isSquare() {
+                    return this.kind === 'square';
+                }
+
+                isCircle() {
+                    return this.kind === 'circle';
+                }
+
+                getShape() {
+                    return this.kind;
+                }
+            }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(use_extern_macros)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            pub mod shape;
+
+            use shape::{Shape, ShapeType};
+
+            #[wasm_bindgen]
+            pub fn test() {
+                let actually_a_triangle = Shape::new(ShapeType::Circle).unwrap();
+                assert!(!actually_a_triangle.is_circle());
+                assert!(!actually_a_triangle.is_square());
+                match actually_a_triangle.get_shape() {
+                    ShapeType::Circle | ShapeType::Square => assert!(false),
+                    _ => {} // Success
+                };
             }
         "#,
         )


### PR DESCRIPTION
As discussed in #260 and #433 there are two main ways to handle invalid enum returns from JS in the WebIDL codegen:

### Method 1 ###
Convert enum returns in WebIDL to `Result<ENUM, String>`s

#### Advantages ####
* Fairly ergonomic and idiomatic
* You can add special handling logic for browser specific returns by examining the `String` in `Err`

#### Disadvantages ####
* Additive changes will break any `match`s that don't have a wildcard arm(unlike in Method 2, which forces a wildcard match), so the user might have to change their code when they update their `web-sys` version

### Method 2 ###
Non-exhaustive enums.

#### Advantages ####
* Any additive changes to the WebIDL enums(and as such the `web-sys` crate's Rust enum variants) don't break code because non-exhaustive enums force wildcard matches

#### Disadvantages ####
* Not very ergonomic on the end user since their code could end up with a lot of wildcard matches even in cases where the enum is coming from their own Rust code 
* Wildcard matches wouldn't give you specific information on the value returned(unless we want to make the enums un-copyable), just that it wasn't one of the known variants, so you couldn't add special handling for browser specific return values

I opted for Method 1 because it seems like it gives the cleanest code when using enums, and I like the idea of being able to handle browser specific returns that aren't document in WebIDL. Do you folks agree, or should we go with Method 2/something else?

Closes #260