### PR TITLE
Remove target_args from Array.find_index()

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -177,7 +177,7 @@ extern "C" {
     /// 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
     #[wasm_bindgen(method, js_name = findIndex)]
-    pub fn find_index(this: &Array, predicate: &mut FnMut(JsValue, u32, Array) -> bool, this_arg: &JsValue) -> u32;
+    pub fn find_index(this: &Array, predicate: &mut FnMut(JsValue, u32, Array) -> bool) -> u32;
 
     /// The includes() method determines whether an array includes a certain
     /// element, returning true or false as appropriate.

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -908,11 +908,10 @@ fn find_index() {
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
                 use wasm_bindgen::js;
-                use JsValue;
 
                 #[wasm_bindgen]
                 pub fn array_find_first_even_number_index(array: &js::Array) -> u32 {
-                    array.find_index(&mut |el, _, _| el.as_f64().unwrap() % 2. == 0., &JsValue::undefined())
+                    array.find_index(&mut |el, _, _| el.as_f64().unwrap() % 2. == 0.)
                 }
             "#,
         )


### PR DESCRIPTION
Because closure can't access this_arg.
Referencing issue #475 .