### PR TITLE
deal with yet another locale/platform issue

### DIFF
--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -962,7 +962,9 @@ fn to_locale_string() {
                 import * as wasm from "./out";
 
                 export function test() {
-                    assert.equal(wasm.array_to_locale_string([1, 'a', new Date('21 Dec 1997 14:12:00 UTC')], 'en', {timeZone: 'UTC'}), '1,a,12/21/1997, 2:12:00 PM');
+                    const output = wasm.array_to_locale_string([1, 'a', new Date('21 Dec 1997 14:12:00 UTC')], 'en', {timeZone: 'UTC'});
+                    assert.equal(typeof output, 'string');
+                    assert.ok(output.length > 0);
                 }
             "#,
         )


### PR DESCRIPTION
This test fails on my system. As previously decided, until we can
figure out a better solution for this issue, for now we just check
to make sure the output is a non-empty string.