### PR TITLE
Bindings for TypedArray subclasses

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -106,25 +106,6 @@ extern "C" {
     pub fn parse_float(text: &str) -> f64;
 }
 
-// UInt8Array
-#[wasm_bindgen]
-extern "C" {
-    pub type Uint8Array;
-
-    /// The `Uint8Array()` constructor creates an array of unsigned 8-bit integers.
-    ///
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
-    #[wasm_bindgen(constructor)]
-    pub fn new(constructor_arg: JsValue) -> Uint8Array;
-
-    /// The fill() method fills all the elements of an array from a start index
-    /// to an end index with a static value. The end index is not included.
-    ///
-    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
-    #[wasm_bindgen(method)]
-    pub fn fill(this: &Uint8Array, value: JsValue, start: u32, end: u32) -> Uint8Array;
-}
-
 // Array
 #[wasm_bindgen]
 extern "C" {
@@ -590,6 +571,44 @@ extern "C" {
     pub fn to_string(this: &Error) -> JsString;
 }
 
+// Float32Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Float32Array;
+
+    /// The `Float32Array()` constructor creates an array of 32-bit floats.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Float32Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Float32Array, value: JsValue, start: u32, end: u32) -> Float32Array;
+}
+
+// Float64Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Float64Array;
+
+    /// The `Float64Array()` constructor creates an array of 64-bit floats.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Float64Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Float64Array, value: JsValue, start: u32, end: u32) -> Float64Array;
+}
+
 // Function
 #[wasm_bindgen]
 extern "C" {
@@ -669,6 +688,63 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw
     #[wasm_bindgen(method, structural, catch)]
     pub fn throw(this: &Generator, error: &Error) -> Result<JsValue, JsValue>;
+}
+
+// Int8Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Int8Array;
+
+    /// The `Int8Array()` constructor creates an array of signed 8-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Int8Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Int8Array, value: JsValue, start: u32, end: u32) -> Int8Array;
+}
+
+// Int16Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Int16Array;
+
+    /// The `Int16Array()` constructor creates an array of signed 16-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Int16Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Int16Array, value: JsValue, start: u32, end: u32) -> Int16Array;
+}
+
+// Int32Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Int32Array;
+
+    /// The `Int32Array()` constructor creates an array of signed 32-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Int32Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Int32Array, value: JsValue, start: u32, end: u32) -> Int32Array;
 }
 
 // Map
@@ -1735,6 +1811,84 @@ extern {
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values
     #[wasm_bindgen(method)]
     pub fn values(set: &Set) -> SetIterator;
+}
+
+// Uint8Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Uint8Array;
+
+    /// The `Uint8Array()` constructor creates an array of unsigned 8-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Uint8Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Uint8Array, value: JsValue, start: u32, end: u32) -> Uint8Array;
+}
+
+// Uint8ClampedArray
+#[wasm_bindgen]
+extern "C" {
+    pub type Uint8ClampedArray;
+
+    /// The `Uint8ClampedArray()` constructor creates an array of unsigned 8-bit integers clamped
+    /// to 0-255; if you specified a value that is out of the range of [0,255], 0 or 255 will be
+    /// set instead.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Uint8ClampedArray;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Uint8ClampedArray, value: JsValue, start: u32, end: u32) -> Uint8ClampedArray;
+}
+
+// Uint16Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Uint16Array;
+
+    /// The `Uint16Array()` constructor creates an array of unsigned 16-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Uint16Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Uint16Array, value: JsValue, start: u32, end: u32) -> Uint16Array;
+}
+
+// Uint32Array
+#[wasm_bindgen]
+extern "C" {
+    pub type Uint32Array;
+
+    /// The `Uint32Array()` constructor creates an array of unsigned 32-bit integers.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array
+    #[wasm_bindgen(constructor)]
+    pub fn new(constructor_arg: JsValue) -> Uint32Array;
+
+    /// The fill() method fills all the elements of an array from a start index
+    /// to an end index with a static value. The end index is not included.
+    ///
+    /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
+    #[wasm_bindgen(method)]
+    pub fn fill(this: &Uint32Array, value: JsValue, start: u32, end: u32) -> Uint32Array;
 }
 
 // WeakMap

--- a/src/js.rs
+++ b/src/js.rs
@@ -587,7 +587,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Float32Array, value: JsValue, start: u32, end: u32) -> Float32Array;
+    pub fn fill(this: &Float32Array, value: f32, start: u32, end: u32) -> Float32Array;
 }
 
 // Float64Array
@@ -606,7 +606,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Float64Array, value: JsValue, start: u32, end: u32) -> Float64Array;
+    pub fn fill(this: &Float64Array, value: f64, start: u32, end: u32) -> Float64Array;
 }
 
 // Function
@@ -706,7 +706,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Int8Array, value: JsValue, start: u32, end: u32) -> Int8Array;
+    pub fn fill(this: &Int8Array, value: i8, start: u32, end: u32) -> Int8Array;
 }
 
 // Int16Array
@@ -725,7 +725,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Int16Array, value: JsValue, start: u32, end: u32) -> Int16Array;
+    pub fn fill(this: &Int16Array, value: i16, start: u32, end: u32) -> Int16Array;
 }
 
 // Int32Array
@@ -744,7 +744,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Int32Array, value: JsValue, start: u32, end: u32) -> Int32Array;
+    pub fn fill(this: &Int32Array, value: i32, start: u32, end: u32) -> Int32Array;
 }
 
 // Map
@@ -1829,7 +1829,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Uint8Array, value: JsValue, start: u32, end: u32) -> Uint8Array;
+    pub fn fill(this: &Uint8Array, value: u8, start: u32, end: u32) -> Uint8Array;
 }
 
 // Uint8ClampedArray
@@ -1850,7 +1850,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Uint8ClampedArray, value: JsValue, start: u32, end: u32) -> Uint8ClampedArray;
+    pub fn fill(this: &Uint8ClampedArray, value: u8, start: u32, end: u32) -> Uint8ClampedArray;
 }
 
 // Uint16Array
@@ -1869,7 +1869,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Uint16Array, value: JsValue, start: u32, end: u32) -> Uint16Array;
+    pub fn fill(this: &Uint16Array, value: u16, start: u32, end: u32) -> Uint16Array;
 }
 
 // Uint32Array
@@ -1888,7 +1888,7 @@ extern "C" {
     ///
     /// http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill
     #[wasm_bindgen(method)]
-    pub fn fill(this: &Uint32Array, value: JsValue, start: u32, end: u32) -> Uint32Array;
+    pub fn fill(this: &Uint32Array, value: u32, start: u32, end: u32) -> Uint32Array;
 }
 
 // WeakMap

--- a/tests/all/js_globals/TypedArray.rs
+++ b/tests/all/js_globals/TypedArray.rs
@@ -199,7 +199,7 @@ fn new_Float64Array_length() {
         .test()
 }
 
-fn fill_lib(array_type: &str) -> String {
+fn fill_lib(array_type: &str, el_type: &str) -> String {
     format!(r#"
     #![feature(use_extern_macros, wasm_custom_section)]
 
@@ -208,10 +208,10 @@ fn fill_lib(array_type: &str) -> String {
     use wasm_bindgen::js;
 
     #[wasm_bindgen]
-    pub fn fill_with(this: &js::{}, value: JsValue, start: u32, end: u32) -> js::{} {{
+    pub fn fill_with(this: &js::{}, value: {}, start: u32, end: u32) -> js::{} {{
         this.fill(value, start, end)
     }}
-    "#, array_type, array_type)
+    "#, array_type, el_type, array_type)
 }
 
 fn fill_test_js(array_type: &str) -> String {
@@ -232,7 +232,7 @@ fn fill_test_js(array_type: &str) -> String {
 #[test]
 fn fill_Uint8Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Uint8Array"),)
+        .file("src/lib.rs", &fill_lib("Uint8Array", "u8"),)
         .file("test.js", &fill_test_js("Uint8Array"))
         .test()
 }
@@ -240,7 +240,7 @@ fn fill_Uint8Array() {
 #[test]
 fn fill_Uint8ClampedArray() {
     project()
-        .file("src/lib.rs", &fill_lib("Uint8ClampedArray"),)
+        .file("src/lib.rs", &fill_lib("Uint8ClampedArray", "u8"),)
         .file("test.js", &fill_test_js("Uint8ClampedArray"))
         .test()
 }
@@ -248,7 +248,7 @@ fn fill_Uint8ClampedArray() {
 #[test]
 fn fill_Uint16Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Uint16Array"),)
+        .file("src/lib.rs", &fill_lib("Uint16Array", "u16"),)
         .file("test.js", &fill_test_js("Uint16Array"))
         .test()
 }
@@ -256,7 +256,7 @@ fn fill_Uint16Array() {
 #[test]
 fn fill_Uint32Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Uint32Array"),)
+        .file("src/lib.rs", &fill_lib("Uint32Array", "u32"),)
         .file("test.js", &fill_test_js("Uint32Array"))
         .test()
 }
@@ -264,7 +264,7 @@ fn fill_Uint32Array() {
 #[test]
 fn fill_Int8Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Int8Array"),)
+        .file("src/lib.rs", &fill_lib("Int8Array", "i8"),)
         .file("test.js", &fill_test_js("Int8Array"))
         .test()
 }
@@ -272,7 +272,7 @@ fn fill_Int8Array() {
 #[test]
 fn fill_Int16Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Int16Array"),)
+        .file("src/lib.rs", &fill_lib("Int16Array", "i16"),)
         .file("test.js", &fill_test_js("Int16Array"))
         .test()
 }
@@ -280,7 +280,7 @@ fn fill_Int16Array() {
 #[test]
 fn fill_Int32Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Int32Array"),)
+        .file("src/lib.rs", &fill_lib("Int32Array", "i32"),)
         .file("test.js", &fill_test_js("Int32Array"))
         .test()
 }
@@ -288,7 +288,7 @@ fn fill_Int32Array() {
 #[test]
 fn fill_Float32Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Float32Array"),)
+        .file("src/lib.rs", &fill_lib("Float32Array", "f32"),)
         .file("test.js", &fill_test_js("Float32Array"))
         .test()
 }
@@ -296,7 +296,7 @@ fn fill_Float32Array() {
 #[test]
 fn fill_Float64Array() {
     project()
-        .file("src/lib.rs", &fill_lib("Float64Array"),)
+        .file("src/lib.rs", &fill_lib("Float64Array", "f64"),)
         .file("test.js", &fill_test_js("Float64Array"))
         .test()
 }

--- a/tests/all/js_globals/TypedArray.rs
+++ b/tests/all/js_globals/TypedArray.rs
@@ -1,97 +1,302 @@
 #![allow(non_snake_case)]
 
 use project;
+use std::string::String;
+
+fn new_undefined_lib(array_type: &str) -> String {
+    format!(r#"
+    #![feature(use_extern_macros, wasm_custom_section)]
+
+    extern crate wasm_bindgen;
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::js;
+
+    #[wasm_bindgen]
+    pub fn new_array() -> js::{} {{
+        js::{}::new(JsValue::undefined())
+    }}
+    "#, array_type, array_type)
+}
+
+fn new_undefined_test_js() -> &'static str {
+    r#"
+    import * as assert from "assert";
+    import * as wasm from "./out";
+
+    export function test() {
+        assert.equal(wasm.new_array().length, 0);
+    }
+    "#
+}
 
 #[test]
-fn new_undefined() {
+fn new_Uint8Array_undefined() {
     project()
-        .file(
-            "src/lib.rs",
-            r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
-
-            extern crate wasm_bindgen;
-            use wasm_bindgen::prelude::*;
-            use wasm_bindgen::js;
-
-            #[wasm_bindgen]
-            pub fn new_array() -> js::Uint8Array {
-                js::Uint8Array::new(JsValue::undefined())
-            }
-        "#,
-        )
-        .file(
-            "test.js",
-            r#"
-            import * as assert from "assert";
-            import * as wasm from "./out";
-
-            export function test() {
-                assert.equal(wasm.new_array().length, 0);
-            }
-        "#,
-        )
+        .file("src/lib.rs", &new_undefined_lib("Uint8Array"),)
+        .file("test.js", new_undefined_test_js(),)
         .test()
 }
 
 #[test]
-fn new_length() {
+fn new_Uint8ClampedArray_undefined() {
     project()
-        .file(
-            "src/lib.rs",
-            r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
-
-            extern crate wasm_bindgen;
-            use wasm_bindgen::prelude::*;
-            use wasm_bindgen::js;
-
-            #[wasm_bindgen]
-            pub fn new_array() -> js::Uint8Array {
-                js::Uint8Array::new(JsValue::from_f64(4.0))
-            }
-        "#,
-        )
-        .file(
-            "test.js",
-            r#"
-            import * as assert from "assert";
-            import * as wasm from "./out";
-
-            export function test() {
-                assert.equal(wasm.new_array().length, 4);
-            }
-        "#,
-        )
+        .file("src/lib.rs", &new_undefined_lib("Uint8ClampedArray"),)
+        .file("test.js", new_undefined_test_js(),)
         .test()
 }
 
 #[test]
-fn fill() {
+fn new_Uint16Array_undefined() {
     project()
-        .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+        .file("src/lib.rs", &new_undefined_lib("Uint16Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
 
-            extern crate wasm_bindgen;
-            use wasm_bindgen::prelude::*;
-            use wasm_bindgen::js;
+#[test]
+fn new_Uint32Array_undefined() {
+    project()
+        .file("src/lib.rs", &new_undefined_lib("Uint32Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
 
-            #[wasm_bindgen]
-            pub fn fill_with(this: &js::Uint8Array, value: JsValue, start: u32, end: u32) -> js::Uint8Array {
-                this.fill(value, start, end)
-            }
-        "#)
-        .file("test.js", r#"
-            import * as assert from "assert";
-            import * as wasm from "./out";
+#[test]
+fn new_Int8Array_undefined() {
+    project()
+        .file("src/lib.rs", &new_undefined_lib("Int8Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
 
-            export function test() {
-                let characters = new Uint8Array([0, 0, 0, 0, 0, 0]);
-                let subset = wasm.fill_with(characters, 1, 0, 3);
+#[test]
+fn new_Int16Array_undefined() {
+    project()
+        .file("src/lib.rs", &new_undefined_lib("Int16Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
 
-                assert.equal(subset[0], 1);
-                assert.equal(subset[4], 0);
-            }
-        "#)
+#[test]
+fn new_Int32Array_undefined() {
+    project()
+        .file("src/lib.rs", &new_undefined_lib("Int32Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Float32Array_undefined() {
+    project()
+        .file("src/lib.rs", &new_undefined_lib("Float32Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Float64Array_undefined() {
+    project()
+        .file("src/lib.rs", &new_undefined_lib("Float64Array"),)
+        .file("test.js", new_undefined_test_js(),)
+        .test()
+}
+
+fn new_length_lib(array_type: &str) -> String {
+    format!(r#"
+    #![feature(use_extern_macros, wasm_custom_section)]
+
+    extern crate wasm_bindgen;
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::js;
+
+    #[wasm_bindgen]
+    pub fn new_array() -> js::{} {{
+        js::{}::new(JsValue::from_f64(4.0))
+    }}
+    "#, array_type, array_type)
+}
+
+fn new_length_test_js() -> &'static str {
+    r#"
+    import * as assert from "assert";
+    import * as wasm from "./out";
+
+    export function test() {
+        assert.equal(wasm.new_array().length, 4);
+    }
+    "#
+}
+
+#[test]
+fn new_Uint8Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Uint8Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Uint8ClampedArray_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Uint8ClampedArray"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Uint16Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Uint16Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Uint32Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Uint32Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Int8Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Int8Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Int16Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Int16Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Int32Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Int32Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Float32Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Float32Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+#[test]
+fn new_Float64Array_length() {
+    project()
+        .file("src/lib.rs", &new_length_lib("Float64Array"),)
+        .file("test.js", new_length_test_js(),)
+        .test()
+}
+
+fn fill_lib(array_type: &str) -> String {
+    format!(r#"
+    #![feature(use_extern_macros, wasm_custom_section)]
+
+    extern crate wasm_bindgen;
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::js;
+
+    #[wasm_bindgen]
+    pub fn fill_with(this: &js::{}, value: JsValue, start: u32, end: u32) -> js::{} {{
+        this.fill(value, start, end)
+    }}
+    "#, array_type, array_type)
+}
+
+fn fill_test_js(array_type: &str) -> String {
+    format!(r#"
+    import * as assert from "assert";
+    import * as wasm from "./out";
+
+    export function test() {{
+        let characters = new {}([0, 0, 0, 0, 0, 0]);
+        let subset = wasm.fill_with(characters, 1, 0, 3);
+
+        assert.equal(subset[0], 1);
+        assert.equal(subset[4], 0);
+    }}
+    "#, array_type)
+}
+
+#[test]
+fn fill_Uint8Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Uint8Array"),)
+        .file("test.js", &fill_test_js("Uint8Array"))
+        .test()
+}
+
+#[test]
+fn fill_Uint8ClampedArray() {
+    project()
+        .file("src/lib.rs", &fill_lib("Uint8ClampedArray"),)
+        .file("test.js", &fill_test_js("Uint8ClampedArray"))
+        .test()
+}
+
+#[test]
+fn fill_Uint16Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Uint16Array"),)
+        .file("test.js", &fill_test_js("Uint16Array"))
+        .test()
+}
+
+#[test]
+fn fill_Uint32Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Uint32Array"),)
+        .file("test.js", &fill_test_js("Uint32Array"))
+        .test()
+}
+
+#[test]
+fn fill_Int8Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Int8Array"),)
+        .file("test.js", &fill_test_js("Int8Array"))
+        .test()
+}
+
+#[test]
+fn fill_Int16Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Int16Array"),)
+        .file("test.js", &fill_test_js("Int16Array"))
+        .test()
+}
+
+#[test]
+fn fill_Int32Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Int32Array"),)
+        .file("test.js", &fill_test_js("Int32Array"))
+        .test()
+}
+
+#[test]
+fn fill_Float32Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Float32Array"),)
+        .file("test.js", &fill_test_js("Float32Array"))
+        .test()
+}
+
+#[test]
+fn fill_Float64Array() {
+    project()
+        .file("src/lib.rs", &fill_lib("Float64Array"),)
+        .file("test.js", &fill_test_js("Float64Array"))
         .test()
 }


### PR DESCRIPTION
More progress towards #275.  This exposes the bindings for constructors and `fill` methods for `Uint16Array`, `Uint32Array`, `Uint8ClampedArray`, `Int8Array`, `Int16Array`, `Int32Array`, `Float32Array`, and `Float64Array`, following very closely the already-existing support for `Uint8Array` supplied in #316.  Small tweaks to the existing `Uint8Array` code (moved to alphabetical position in `js.rs`, refactored tests) are included in this PR.

Feedback welcome - this is my first contribution to this project, and actually to any project written in the Rust language.