### PR TITLE
Add basic support for [NoInterfaceObject] attribute

### DIFF
--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -244,6 +244,10 @@ impl WebidlParse<()> for webidl::ast::NonPartialInterface {
             return Ok(());
         }
 
+        if util::is_no_interface_object(&self.extended_attributes) {
+            return Ok(());
+        }
+
         program.imports.push(backend::ast::Import {
             module: None,
             version: None,

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -385,14 +385,22 @@ impl<'a> FirstPassRecord<'a> {
     }
 }
 
-/// ChromeOnly is for things that are only exposed to priveleged code in Firefox.
-pub fn is_chrome_only(ext_attrs: &[Box<ExtendedAttribute>]) -> bool {
+fn has_named_attribute(ext_attrs: &[Box<ExtendedAttribute>], attribute: &str) -> bool {
     ext_attrs.iter().any(|attr| match &**attr {
         ExtendedAttribute::NoArguments(webidl::ast::Other::Identifier(name)) => {
-            name == "ChromeOnly"
+            name == attribute
         }
         _ => false,
     })
+}
+
+/// ChromeOnly is for things that are only exposed to privileged code in Firefox.
+pub fn is_chrome_only(ext_attrs: &[Box<ExtendedAttribute>]) -> bool {
+    has_named_attribute(ext_attrs, "ChromeOnly")
+}
+
+pub fn is_no_interface_object(ext_attrs: &[Box<ExtendedAttribute>]) -> bool {
+    has_named_attribute(ext_attrs, "NoInterfaceObject")
 }
 
 pub fn is_structural(attrs: &[Box<ExtendedAttribute>]) -> bool {


### PR DESCRIPTION
Some WebIDL interfaces, particularly for WebGL, make heavy use of the `[NoInterfaceObject]` attribute, and their generated bindings will choke on undefined symbols if interfaces with that attribute make it into the bindings. This PR makes `wasm-bindgen-webidl` skip those interfaces. In the long run, we'll probably need more advanced handling of the attribute so we can support `implements` on `[NoInterfaceObject]` interfaces.