### PR TITLE
`Map.prototype.forEach` binding.

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -764,6 +764,13 @@ extern {
     #[wasm_bindgen(method)]
     pub fn delete(this: &Map, key: &str) -> bool;
 
+    /// The forEach() method executes a provided function once per each
+    /// key/value pair in the Map object, in insertion order.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach
+    #[wasm_bindgen(method, js_name = forEach)]
+    pub fn for_each(this: &Map, callback: &mut FnMut(JsValue, JsValue));
+
     /// The get() method returns a specified element from a Map object.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -67,6 +67,51 @@ fn delete() {
 }
 
 #[test]
+fn for_each() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(use_extern_macros, wasm_custom_section)]
+
+            extern crate wasm_bindgen;
+            use wasm_bindgen::prelude::*;
+            use wasm_bindgen::js;
+
+            #[wasm_bindgen]
+            pub fn get_bool_vals(this: &js::Map) -> js::Map {
+                let res = js::Map::new();
+                this.for_each(&mut |value, key| {
+                    if value.as_bool().is_some() {
+                        res.set(&key, &value);
+                    }
+                });
+                res
+            }
+        "#)
+        .file("test.js", r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                const map = new Map();
+                map.set(1, true);
+                map.set(2, false);
+                map.set(3, "awoo");
+                map.set(4, 100);
+                map.set(5, []);
+                map.set(6, {});
+
+                const res = wasm.get_bool_vals(map);
+
+                assert.equal(map.size, 6);
+                assert.equal(res.size, 2);
+                assert.equal(res.get(1), true);
+                assert.equal(res.get(2), false);
+            }
+        "#)
+        .test()
+}
+
+#[test]
 fn get() {
     project()
         .file("src/lib.rs", r#"


### PR DESCRIPTION
This commit adds a `Map.prototype.forEach()` binding :)