### PR TITLE
Translate `ByteString` in WebIDL to `[u8]`

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -15,8 +15,9 @@ spans = ["proc-macro2/nightly"]
 extra-traits = ["syn/extra-traits"]
 
 [dependencies]
-quote = '0.6'
+log = "0.4"
 proc-macro2 = "0.4.8"
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.11" }
-syn = { version = '0.14', features = ['full', 'visit-mut'] }
+quote = '0.6'
 serde_json = "1.0"
+syn = { version = '0.14', features = ['full', 'visit-mut'] }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.11" }

--- a/crates/backend/src/defined.rs
+++ b/crates/backend/src/defined.rs
@@ -269,7 +269,12 @@ where
         self.retain(|x| {
             let mut all_defined = true;
             x.imported_type_references(&mut |id| {
-                all_defined = all_defined && is_defined(id);
+                if all_defined {
+                    if !is_defined(id) {
+                        info!("removing due to {} not being defined", id);
+                        all_defined = false;
+                    }
+                }
             });
             all_defined
         });

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "256"]
 #![cfg_attr(feature = "extra-traits", deny(missing_debug_implementations))]
 
+#[macro_use]
+extern crate log;
 extern crate proc_macro2;
 #[macro_use]
 extern crate quote;

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -79,7 +79,7 @@ fn compile_ast(mut ast: backend::ast::Program) -> String {
     let mut defined = BTreeSet::from_iter(
         vec![
             "str", "char", "bool", "JsValue", "u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64",
-            "usize", "isize", "f32", "f64", "Result",
+            "usize", "isize", "f32", "f64", "Result", "String", "Vec",
         ].into_iter()
             .map(|id| proc_macro2::Ident::new(id, proc_macro2::Span::call_site())),
     );


### PR DESCRIPTION
In arguments take `&[u8]` and in return value return `Vec<u8>`. Should help fill
out a few more APIs on `Header` and `Response`!