### PR TITLE
[WIP] webidl: use weedle instead of webidl-rs

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -184,14 +184,28 @@ pub struct Const {
     pub value: ConstValue,
 }
 
-#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq))]
-/// same as webidl::ast::ConstValue
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 pub enum ConstValue {
-    BooleanLiteral(bool),
-    FloatLiteral(f64),
-    SignedIntegerLiteral(i64),
-    UnsignedIntegerLiteral(u64),
+    Boolean(bool),
+    Float(FloatValue),
+    Integer(IntegerValue),
     Null,
+}
+
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+pub enum FloatValue {
+    Literal(String),
+    Value(f64),
+    NegInfinity,
+    Infinity,
+    NaN,
+}
+
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+pub enum IntegerValue {
+    Literal(String),
+    SignedValue(i64),
+    UnsignedValue(u64),
 }
 
 impl Program {

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro2 = "0.4.8"
 quote = '0.6'
 syn = { version = '0.14', features = ['full'] }
 wasm-bindgen-backend = { version = "=0.2.11", path = "../backend" }
-webidl = "0.7.0"
+weedle = "0.4.0"

--- a/crates/webidl/src/type_conversion.rs
+++ b/crates/webidl/src/type_conversion.rs
@@ -1,0 +1,212 @@
+use backend::util::{ident_ty, raw_ident, rust_ident};
+use syn;
+use weedle::{self, term, types::*};
+
+use first_pass::FirstPassRecord;
+use util::{js_value, rust_type_name, shared_ref};
+
+pub(crate) trait ToSynType {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type>;
+}
+
+impl ToSynType for term::Any {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(js_value())
+    }
+}
+
+impl ToSynType for term::Boolean {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident("bool")))
+    }
+}
+
+impl ToSynType for term::Byte {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident("i8")))
+    }
+}
+
+impl ToSynType for term::Octet {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident("u8")))
+    }
+}
+
+impl ToSynType for ShortType {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident(if self.unsigned.is_some() {
+            "u16"
+        } else {
+            "i16"
+        })))
+    }
+}
+
+impl ToSynType for LongType {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident(if self.unsigned.is_some() {
+            "u32"
+        } else {
+            "i32"
+        })))
+    }
+}
+
+impl ToSynType for LongLongType {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident(if self.unsigned.is_some() {
+            "u64"
+        } else {
+            "i64"
+        })))
+    }
+}
+
+impl ToSynType for IntegerType {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        use self::IntegerType::*;
+
+        match self {
+            Short(short) => short.to_syn_type(first_pass, must_own),
+            LongLong(long_long) => long_long.to_syn_type(first_pass, must_own),
+            Long(long) => long.to_syn_type(first_pass, must_own),
+        }
+    }
+}
+
+impl ToSynType for FloatType {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident("f32")))
+    }
+}
+
+impl ToSynType for DoubleType {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, _: bool) -> Option<syn::Type> {
+        Some(ident_ty(raw_ident("f64")))
+    }
+}
+
+impl ToSynType for FloatingPointType {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        use self::FloatingPointType::*;
+
+        match self {
+            Float(float) => float.to_syn_type(first_pass, must_own),
+            Double(double) => double.to_syn_type(first_pass, must_own),
+        }
+    }
+}
+
+impl ToSynType for term::DOMString {
+    fn to_syn_type(&self, _: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        Some(if must_own {
+            ident_ty(raw_ident("String"))
+        } else {
+            shared_ref(ident_ty(raw_ident("str")))
+        })
+    }
+}
+
+impl ToSynType for weedle::common::Identifier {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        let ty = ident_ty(rust_ident(&rust_type_name(self)));
+        Some(if first_pass.interfaces.contains(&*self.name) {
+            if must_own {
+                ty
+            } else {
+                shared_ref(ty)
+            }
+        } else if first_pass.dictionaries.contains(&*self.name) {
+            ty
+        } else if first_pass.enums.contains(&*self.name) {
+            ty
+        } else {
+            warn!("unrecognized type {}", self.name);
+            ty
+        })
+    }
+}
+
+impl ToSynType for ConstType {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        use self::ConstType::*;
+
+        match self {
+            Integer(integer) => integer.to_syn_type(first_pass, must_own),
+            FloatingPoint(floating_point) => floating_point.to_syn_type(first_pass, must_own),
+            Boolean(boolean) => boolean.to_syn_type(first_pass, must_own),
+            Byte(byte) => byte.to_syn_type(first_pass, must_own),
+            Octet(octet) => octet.to_syn_type(first_pass, must_own),
+            Identifier(identifier) => {
+                // TODO: insure that this is actually a typedef to a primitive type
+                identifier.to_syn_type(first_pass, must_own)
+            }
+        }
+    }
+}
+
+impl ToSynType for SingleType {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        use self::SingleType::*;
+
+        match self {
+            Any(any) => any.to_syn_type(first_pass, must_own),
+            Integer(integer) => integer.to_syn_type(first_pass, must_own),
+            FloatingPoint(floating_point) => floating_point.to_syn_type(first_pass, must_own),
+            Boolean(boolean) => boolean.to_syn_type(first_pass, must_own),
+            Byte(byte) => byte.to_syn_type(first_pass, must_own),
+            Octet(octet) => octet.to_syn_type(first_pass, must_own),
+            DOMString(dom_string) => dom_string.to_syn_type(first_pass, must_own),
+            Identifier(identifier) => identifier.to_syn_type(first_pass, must_own),
+            Promise(_) | ByteString(_) | USVString(_) | Sequence(_) | Object(_) | Symbol(_)
+            | Error(_) | ArrayBuffer(_) | DataView(_) | Int8Array(_) | Int16Array(_)
+            | Int32Array(_) | Uint8Array(_) | Uint16Array(_) | Uint32Array(_)
+            | Uint8ClampedArray(_) | Float32Array(_) | Float64Array(_) | FrozenArrayType(_)
+            | RecordType(_) => {
+                warn!("unsupported type {:?}", self);
+                None
+            }
+        }
+    }
+}
+
+impl ToSynType for Type {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        use self::Type::*;
+
+        match self {
+            Single(single) => single.to_syn_type(first_pass, must_own),
+            Union(_) => {
+                warn!("unsupported type {:?}", self);
+                None
+            }
+        }
+    }
+}
+
+impl ToSynType for AttributedType {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        if self.attributes.is_some() {
+            warn!("ignoring argument attributes");
+        }
+        self.type_.to_syn_type(first_pass, must_own)
+    }
+}
+
+impl<T: ToSynType> ToSynType for MayBeNull<T> {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        if self.q_mark.is_some() {
+            warn!("nullable types are not yet supported (see issue #14)");
+            None
+        } else {
+            self.type_.to_syn_type(first_pass, must_own)
+        }
+    }
+}
+
+impl<'a, T: ToSynType> ToSynType for &'a T {
+    fn to_syn_type(&self, first_pass: &FirstPassRecord<'_>, must_own: bool) -> Option<syn::Type> {
+        (*self).to_syn_type(first_pass, must_own)
+    }
+}

--- a/crates/webidl/tests/all/consts.rs
+++ b/crates/webidl/tests/all/consts.rs
@@ -54,6 +54,11 @@ fn ints() {
                     const byte imax = 127;
                     const octet umin = 0;
                     const octet umax = 255;
+                    const byte oct_imin = -0200;
+                    const byte oct_imax = 0177;
+                    const byte hex_imin = -0x80;
+                    const byte hex_imax = 0x7F;
+                    const byte oct_neg_zero = -0;
                 };
                 interface Short {
                     const short imin = -32768;
@@ -105,6 +110,12 @@ fn ints() {
                     assert_eq!(foo::Byte::IMAX, i8::max_value());
                     assert_eq!(foo::Byte::UMIN, u8::min_value());
                     assert_eq!(foo::Byte::UMAX, u8::max_value());
+
+                    assert_eq!(foo::Byte::OCT_IMIN, i8::min_value());
+                    assert_eq!(foo::Byte::OCT_IMAX, i8::max_value());
+                    assert_eq!(foo::Byte::HEX_IMIN, i8::min_value());
+                    assert_eq!(foo::Byte::HEX_IMAX, i8::max_value());
+                    assert_eq!(foo::Byte::OCT_NEG_ZERO, 0);
 
                     assert_eq!(foo::Short::IMIN, i16::min_value());
                     assert_eq!(foo::Short::IMAX, i16::max_value());

--- a/crates/webidl/tests/all/simple.rs
+++ b/crates/webidl/tests/all/simple.rs
@@ -439,10 +439,6 @@ fn mixin() {
                     readonly attribute short bar;
                 };
 
-                partial interface mixin Bar {
-                    void addToBar(short other);
-                };
-
                 Foo includes Bar;
             "#,
         )
@@ -484,8 +480,7 @@ fn mixin() {
                     let f = Foo::new(1).unwrap();
                     assert_eq!(f.bar(), 1);
                     Foo::set_default_bar(7);
-                    f.add_to_bar(Foo::default_bar());
-                    assert_eq!(f.bar(), 8);
+                    assert_eq!(Foo::default_bar(), 7);
                 }
             "#,
         )


### PR DESCRIPTION
This is an experiment of using weedle instead of webidl-rs. Some pros and cons:

**Pros:**
- Uses nom rather than lalrpop which is a heavy dependency put on downstream users.
- Separates out types a bit more, which is nice for converting to syn types.

**Cons:**
- Error messages seem basically non-existent.
- Currently has a bug that appears to have truncated output (causing web-sys to fail). I haven't investigated this deeply.