### PR TITLE
Implementing Element in web-sys

### DIFF
--- a/crates/web-sys/tests/all/element.rs
+++ b/crates/web-sys/tests/all/element.rs
@@ -1,0 +1,87 @@
+use super::websys_project;
+
+#[test]
+fn element() {
+    websys_project()
+        .file(
+            "src/lib.rs",
+            r#"
+                #![feature(use_extern_macros, wasm_custom_section)]
+                extern crate wasm_bindgen;
+                use wasm_bindgen::prelude::*;
+                extern crate web_sys;
+
+                #[wasm_bindgen]
+                pub fn test_element(element: &web_sys::Element) {
+                    assert_eq!(element.local_name(), "div", "Shouldn't have a div local name");
+                    assert_eq!(element.tag_name(), "div", "Should be a div tag");
+                    assert!(!element.has_attribute("id"), "Shouldn't have an id");
+                    element.set_id("beep");
+                    assert_eq!(element.id(), "beep", "Should have an id of 'beep'");
+
+                    // must_use is set on this result?
+                    assert_eq!(element.set_attribute("id", "beep").unwrap(), (), "Should set id");
+                    assert!(element.has_attribute("id"), "Should now have an id");
+                    assert_eq!(element.remove_attribute("id").unwrap(), (), "Should return nothing if removed");
+
+                    assert_eq!(element.class_name(), "", "Shouldn't have a class name");
+                    element.set_class_name("test thing");
+                    assert_eq!(element.class_name(), "test thing", "Should have a class name");
+                    assert_eq!(element.remove_attribute("class").unwrap(), (), "Should return nothing if removed");
+
+/*TODO should we enable toggle_attribute tests? (Firefox Nightly + Chrome canary only)
+                    // TODO toggle_attribute should permit a single argument when optional arguments are supported
+                    assert!(!element.has_attribute("disabled"), "Should not be disabled");
+                    assert!(element.toggle_attribute("disabled", true).unwrap(), "Should return true when attribute is set");
+                    assert!(element.has_attribute("disabled"), "Should be disabled");
+                    assert!(!element.toggle_attribute("disabled", false).unwrap(), "Should return false when attribute is not set");
+                    assert!(!element.has_attribute("disabled"), "Should not be disabled");
+*/
+
+                    assert!(!element.has_attribute("title"), "Should not have a title");
+                    assert_eq!(element.set_attribute("title", "boop").unwrap(), (), "Should return nothing if set correctly");
+                    assert!(element.has_attribute("title"), "Should have a title");
+                    // TODO check get_attribute here when supported
+                    assert_eq!(element.remove_attribute("title").unwrap(), (), "Should return nothing if removed");
+                    assert!(!element.has_attribute("title"), "Should not have a title");
+
+                    assert!(!element.has_attributes(), "Should not have any attributes");
+                    assert_eq!(element.set_attribute("title", "boop").unwrap(), (), "Should return nothing if set correctly");
+                    assert!(element.has_attributes(), "Should have attributes");
+                    assert_eq!(element.remove_attribute("title").unwrap(), (), "Should return nothing if removed");
+
+                    assert_eq!(element.matches(".this-is-a-thing").unwrap(), false, "Should not match selector");
+                    assert_eq!(element.webkit_matches_selector(".this-is-a-thing").unwrap(), false, "Should not match selector");
+                    element.set_class_name("this-is-a-thing");
+                    assert_eq!(element.matches(".this-is-a-thing").unwrap(), true, "Should match selector");
+                    assert_eq!(element.webkit_matches_selector(".this-is-a-thing").unwrap(), true, "Should match selector");
+                    assert_eq!(element.remove_attribute("class").unwrap(), (), "Should return nothing if removed");
+
+
+// TODO non standard moz_matches_selector should we even support?
+/* Tests needed for:
+  insert_adjacent_text
+  set_pointer_capture
+  release_pointer_capture
+  has_pointer_capture
+  set_capture
+  release_capture
+*/
+                }
+            "#,
+        )
+        .file(
+            "test.js",
+            r#"
+                import * as assert from "assert";
+                import * as wasm from "./out";
+
+                export function test() {
+                    let document = new Document();
+                    let el = document.createElement("div");
+                    wasm.test_element(el);
+                }
+            "#,
+        )
+        .test();
+}

--- a/crates/web-sys/tests/all/main.rs
+++ b/crates/web-sys/tests/all/main.rs
@@ -4,6 +4,7 @@ use project_builder::{project, Project};
 mod event;
 mod headers;
 mod response;
+mod element;
 
 fn websys_project() -> Project {
     project()

--- a/crates/web-sys/webidls/enabled/Element.webidl
+++ b/crates/web-sys/webidls/enabled/Element.webidl
@@ -65,12 +65,14 @@ interface Element : Node {
   [Throws, Pure, BinaryName="matches"]
   boolean webkitMatchesSelector(DOMString selector);
 
+/*TODO
   [Pure]
   HTMLCollection getElementsByTagName(DOMString localName);
   [Throws, Pure]
   HTMLCollection getElementsByTagNameNS(DOMString? namespace, DOMString localName);
   [Pure]
   HTMLCollection getElementsByClassName(DOMString classNames);
+*/
   [ChromeOnly, Pure]
   sequence<Element> getElementsWithGrid();
 
@@ -101,8 +103,10 @@ interface Element : Node {
    *
    * See <http://dev.w3.org/2006/webapi/selectors-api2/#matchesselector>
    */
+/* Non standard
   [Throws, Pure, BinaryName="matches"]
   boolean mozMatchesSelector(DOMString selector);
+*/
 
   // Pointer events methods.
   [Throws, Pref="dom.w3c_pointer_events.enabled"]
@@ -244,8 +248,10 @@ partial interface Element {
 partial interface Element {
   [Throws, Pure]
   Element?  querySelector(DOMString selectors);
+/*TODO
   [Throws, Pure]
   NodeList  querySelectorAll(DOMString selectors);
+*/
 };
 
 // https://dom.spec.whatwg.org/#dictdef-shadowrootinit
@@ -280,8 +286,10 @@ Element implements GeometryUtils;
 partial interface Element {
   [Throws, Func="nsDocument::IsUnprefixedFullscreenEnabled", NeedsCallerType]
   void requestFullscreen();
+/*Non standard
   [Throws, BinaryName="requestFullscreen", NeedsCallerType]
   void mozRequestFullScreen();
+*/
 };
 
 // https://w3c.github.io/pointerlock/#extensions-to-the-element-interface

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -176,8 +176,9 @@ impl<'a> FirstPassRecord<'a> {
             webidl::ast::TypeKind::DOMString if pos == TypePosition::Argument => {
                 shared_ref(ident_ty(raw_ident("str")))
             }
-            // `DOMString` is not supported yet in other positions.
-            webidl::ast::TypeKind::DOMString => return None,
+            webidl::ast::TypeKind::DOMString => {
+                ident_ty(raw_ident("String"))
+            },
 
             // `ByteString -> `&[u8]` for arguments
             webidl::ast::TypeKind::ByteString if pos == TypePosition::Argument => {


### PR DESCRIPTION
Open questions:
- [x] Should we support `toggle_attribute` it's only in Nightly's of Firefox, Canary Chrome, Webkit.
  - [x] Could `toggle_attribute` be controlled by a environment var or build flag?
- [x] Should we support `moz_matches_selector` it's non standard and Firefox only.

Part of https://github.com/rustwasm/wasm-bindgen/issues/446 as noted there, many key APIs aren't available still.