### PR TITLE
Remove usage of #[wasm_custom_section]

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Import JavaScript things into Rust and export Rust things to JavaScript.
 `src/lib.rs`:
 
 ```rust
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -76,8 +76,9 @@ impl ToTokens for ast::Program {
 
         (quote! {
             #[allow(non_upper_case_globals)]
-            #[wasm_custom_section = "__wasm_bindgen_unstable"]
-            const #generated_static_name: [u8; #generated_static_length] =
+            #[link_section = "__wasm_bindgen_unstable"]
+            #[doc(hidden)]
+            pub static #generated_static_name: [u8; #generated_static_length] =
                 *#generated_static_value;
         }).to_tokens(tokens);
     }

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(wasm_custom_section, wasm_import_module)]
+#![feature(wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/crates/web-sys/tests/all/event.rs
+++ b/crates/web-sys/tests/all/event.rs
@@ -6,7 +6,7 @@ fn event() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
                 extern crate web_sys;

--- a/crates/web-sys/tests/all/headers.rs
+++ b/crates/web-sys/tests/all/headers.rs
@@ -6,7 +6,7 @@ fn headers() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
                 extern crate web_sys;

--- a/crates/web-sys/tests/all/response.rs
+++ b/crates/web-sys/tests/all/response.rs
@@ -6,7 +6,7 @@ fn response() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
                 extern crate web_sys;

--- a/crates/webidl/tests/all/consts.rs
+++ b/crates/webidl/tests/all/consts.rs
@@ -24,7 +24,7 @@ fn bool() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -93,7 +93,7 @@ fn ints() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -160,7 +160,7 @@ fn floats() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 

--- a/crates/webidl/tests/all/enums.rs
+++ b/crates/webidl/tests/all/enums.rs
@@ -39,7 +39,7 @@ fn top_level_enum() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/crates/webidl/tests/all/simple.rs
+++ b/crates/webidl/tests/all/simple.rs
@@ -29,7 +29,7 @@ fn method() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -87,7 +87,7 @@ fn property() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -149,7 +149,7 @@ fn named_constructor() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -198,7 +198,7 @@ fn static_method() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -251,7 +251,7 @@ fn static_property() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -303,7 +303,7 @@ fn one_method_using_an_undefined_import_doesnt_break_all_other_methods() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -348,7 +348,7 @@ fn unforgeable_is_structural() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -405,7 +405,7 @@ fn partial_interface() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -471,7 +471,7 @@ fn mixin() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 

--- a/crates/webidl/tests/all/throws.rs
+++ b/crates/webidl/tests/all/throws.rs
@@ -64,7 +64,7 @@ fn throws() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 

--- a/examples/add/src/lib.rs
+++ b/examples/add/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/asm.js/src/lib.rs
+++ b/examples/asm.js/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/char/src/lib.rs
+++ b/examples/char/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/comments/src/lib.rs
+++ b/examples/comments/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/console_log/src/lib.rs
+++ b/examples/console_log/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/import_js/src/lib.rs
+++ b/examples/import_js/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/julia_set/src/lib.rs
+++ b/examples/julia_set/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module, js_globals)]
+#![feature(use_extern_macros, wasm_import_module, js_globals)]
 
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;

--- a/examples/math/src/lib.rs
+++ b/examples/math/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/no_modules/src/lib.rs
+++ b/examples/no_modules/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate humantime;
 extern crate wasm_bindgen;

--- a/examples/smorgasboard/src/lib.rs
+++ b/examples/smorgasboard/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/guide/src/basic-usage.md
+++ b/guide/src/basic-usage.md
@@ -39,7 +39,7 @@ wasm-bindgen = "0.2"
 Next up our actual code! We'll write this in `src/lib.rs`:
 
 ```rust,ignore
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;

--- a/guide/src/what-else-can-we-do.md
+++ b/guide/src/what-else-can-we-do.md
@@ -5,7 +5,7 @@ can also [explore this code online](https://webassembly.studio/?f=t61j18noqz):
 
 ```rust,ignore
 // src/lib.rs
-#![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+#![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! interface.
 
 #![feature(use_extern_macros, wasm_import_module, unsize)]
-#![cfg_attr(feature = "js_globals", feature(use_extern_macros, wasm_custom_section))]
+#![cfg_attr(feature = "js_globals", feature(use_extern_macros))]
 #![no_std]
 
 #[cfg(feature = "serde-serialize")]

--- a/tests/all/api.rs
+++ b/tests/all/api.rs
@@ -6,7 +6,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -157,7 +157,7 @@ fn eq_works() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/char.rs
+++ b/tests/all/char.rs
@@ -6,7 +6,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/classes.rs
+++ b/tests/all/classes.rs
@@ -6,7 +6,7 @@ fn simple() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -75,7 +75,7 @@ fn strings() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -139,7 +139,7 @@ fn exceptions() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -207,7 +207,7 @@ fn pass_one_to_another() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -263,7 +263,7 @@ fn pass_into_js() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -316,7 +316,7 @@ fn issue_27() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -365,7 +365,7 @@ fn pass_into_js_as_js_class() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -418,7 +418,7 @@ fn constructors() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -502,7 +502,7 @@ fn empty_structs() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -538,7 +538,7 @@ fn public_fields() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -597,7 +597,7 @@ fn using_self() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -635,7 +635,7 @@ fn readonly_fields() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -677,7 +677,7 @@ fn readonly_fields() {
 fn double_consume() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/closures.rs
+++ b/tests/all/closures.rs
@@ -6,7 +6,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -56,7 +56,7 @@ fn cannot_reuse() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -105,7 +105,7 @@ fn long_lived() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -168,7 +168,7 @@ fn many_arity() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -269,7 +269,7 @@ fn long_lived_dropping() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -322,7 +322,7 @@ fn long_fnmut_recursive() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -369,7 +369,7 @@ fn fnmut() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -423,7 +423,7 @@ fn fnmut_bad() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -484,7 +484,7 @@ fn string_arguments() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -529,7 +529,7 @@ fn string_ret() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 

--- a/tests/all/comments.rs
+++ b/tests/all/comments.rs
@@ -6,7 +6,7 @@ fn works() {
     p.file(
         "src/lib.rs",
         r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/dependencies.rs
+++ b/tests/all/dependencies.rs
@@ -6,7 +6,7 @@ fn dependencies_work() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 extern crate dependency;
                 use wasm_bindgen::prelude::*;
@@ -51,7 +51,7 @@ fn dependencies_work() {
         .file(
             "vendor/dependency/src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -97,7 +97,7 @@ fn same_api_two_crates() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 extern crate a;
                 extern crate b;
@@ -158,7 +158,7 @@ fn same_api_two_crates() {
         .file(
             "a/src/lib.rs",
             "
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
 
                 use wasm_bindgen::prelude::*;
@@ -190,7 +190,7 @@ fn same_api_two_crates() {
         .file(
             "b/src/lib.rs",
             "
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
 
                 use wasm_bindgen::prelude::*;

--- a/tests/all/enums.rs
+++ b/tests/all/enums.rs
@@ -6,7 +6,7 @@ fn c_style_enum() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -54,7 +54,7 @@ fn c_style_enum_with_custom_values() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 

--- a/tests/all/import_class.rs
+++ b/tests/all/import_class.rs
@@ -6,7 +6,7 @@ fn simple() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -52,7 +52,7 @@ fn import_class() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -104,7 +104,7 @@ fn construct() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -187,7 +187,7 @@ fn new_constructors() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -242,7 +242,7 @@ fn switch_methods() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -330,7 +330,7 @@ fn properties() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -396,7 +396,7 @@ fn rename_setter_getter() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -464,7 +464,7 @@ fn deny_missing_docs() {
             "src/lib.rs",
             r#"
                 //! dox
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 #![deny(missing_docs)]
                 #![allow(dead_code)]
 

--- a/tests/all/imports.rs
+++ b/tests/all/imports.rs
@@ -6,7 +6,7 @@ fn simple() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -94,7 +94,7 @@ fn unused() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 #![allow(dead_code)]
 
                 extern crate wasm_bindgen;
@@ -131,7 +131,7 @@ fn string_ret() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -171,7 +171,7 @@ fn strings() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -218,7 +218,7 @@ fn exceptions() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -282,7 +282,7 @@ fn exn_caught() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -326,7 +326,7 @@ fn free_imports() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -363,7 +363,7 @@ fn import_a_field() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -401,7 +401,7 @@ fn rename() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -447,7 +447,7 @@ fn versions() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -496,7 +496,7 @@ fn underscore_pattern() {
     project()
         .debug(false)
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -531,7 +531,7 @@ fn rust_keyword() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -573,7 +573,7 @@ fn rust_keyword2() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -614,7 +614,7 @@ fn custom_type() {
     project()
         .debug(false)
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 
@@ -677,7 +677,7 @@ fn unused_imports_not_generated() {
     project
         .debug(false)
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/js_globals/Array.rs
+++ b/tests/all/js_globals/Array.rs
@@ -8,7 +8,7 @@ fn filter() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -47,7 +47,7 @@ fn index_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -91,7 +91,7 @@ fn is_array() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -137,7 +137,7 @@ fn sort() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -171,7 +171,7 @@ fn sort() {
 fn some() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -204,7 +204,7 @@ fn last_index_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -248,7 +248,7 @@ fn join() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -286,7 +286,7 @@ fn slice() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -322,7 +322,7 @@ fn fill() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -356,7 +356,7 @@ fn fill() {
 fn copy_within() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -392,7 +392,7 @@ fn pop() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -428,7 +428,7 @@ fn push() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -464,7 +464,7 @@ fn reverse() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -500,7 +500,7 @@ fn shift() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -537,7 +537,7 @@ fn unshift() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -574,7 +574,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -610,7 +610,7 @@ fn includes() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -651,7 +651,7 @@ fn concat() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -688,7 +688,7 @@ fn length() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -727,7 +727,7 @@ fn every() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -765,7 +765,7 @@ fn find() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -803,7 +803,7 @@ fn map() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -837,7 +837,7 @@ fn reduce() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -870,7 +870,7 @@ fn reduce_right() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -903,7 +903,7 @@ fn find_index() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -941,7 +941,7 @@ fn to_locale_string() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -974,7 +974,7 @@ fn to_locale_string() {
 fn for_each() {
     project()
         .file("src/lib.rs", r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/ArrayBuffer.rs
+++ b/tests/all/js_globals/ArrayBuffer.rs
@@ -6,7 +6,7 @@ use super::project;
 fn new() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -32,7 +32,7 @@ fn new() {
 fn is_view() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use JsValue;
@@ -59,7 +59,7 @@ fn is_view() {
 fn slice() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -86,7 +86,7 @@ fn slice() {
 fn slice_with_end() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/ArrayIterator.rs
+++ b/tests/all/js_globals/ArrayIterator.rs
@@ -8,7 +8,7 @@ fn keys() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -46,7 +46,7 @@ fn entries() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -86,7 +86,7 @@ fn values() {
     project.file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Boolean.rs
+++ b/tests/all/js_globals/Boolean.rs
@@ -8,7 +8,7 @@ fn new_undefined() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -40,7 +40,7 @@ fn new_truely() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/DataView.rs
+++ b/tests/all/js_globals/DataView.rs
@@ -6,7 +6,7 @@ use super::project;
 fn test() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Date.rs
+++ b/tests/all/js_globals/Date.rs
@@ -8,7 +8,7 @@ fn get_date() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -42,7 +42,7 @@ fn get_day() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -76,7 +76,7 @@ fn get_full_year() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -112,7 +112,7 @@ fn get_hours() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -146,7 +146,7 @@ fn get_milliseconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -182,7 +182,7 @@ fn get_minutes() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -216,7 +216,7 @@ fn get_month() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -250,7 +250,7 @@ fn get_seconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -284,7 +284,7 @@ fn get_time() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -318,7 +318,7 @@ fn get_timezone_offset() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -354,7 +354,7 @@ fn get_utc_date() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -390,7 +390,7 @@ fn get_utc_day() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -426,7 +426,7 @@ fn get_utc_full_year() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -462,7 +462,7 @@ fn get_utc_hours() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -498,7 +498,7 @@ fn get_utc_milliseconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -532,7 +532,7 @@ fn get_utc_minutes() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -568,7 +568,7 @@ fn get_utc_month() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -604,7 +604,7 @@ fn get_utc_seconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -638,7 +638,7 @@ fn new() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -668,7 +668,7 @@ fn new() {
 fn now() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -696,7 +696,7 @@ fn parse() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -732,7 +732,7 @@ fn set_date() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -771,7 +771,7 @@ fn set_full_year() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -810,7 +810,7 @@ fn set_hours() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -849,7 +849,7 @@ fn set_milliseconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -886,7 +886,7 @@ fn set_minutes() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -925,7 +925,7 @@ fn set_month() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -964,7 +964,7 @@ fn set_seconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1003,7 +1003,7 @@ fn set_time() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1041,7 +1041,7 @@ fn set_utc_date() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1080,7 +1080,7 @@ fn set_utc_full_year() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1119,7 +1119,7 @@ fn set_utc_hours() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1158,7 +1158,7 @@ fn set_utc_milliseconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1197,7 +1197,7 @@ fn set_utc_minutes() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1236,7 +1236,7 @@ fn set_utc_month() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1275,7 +1275,7 @@ fn set_utc_seconds() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1314,7 +1314,7 @@ fn to_date_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1348,7 +1348,7 @@ fn to_iso_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1382,7 +1382,7 @@ fn to_json() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1414,7 +1414,7 @@ fn to_json() {
 fn to_locale_date_string() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use JsValue;
@@ -1446,7 +1446,7 @@ fn to_locale_date_string() {
 fn to_locale_string() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use JsValue;
@@ -1478,7 +1478,7 @@ fn to_locale_time_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1511,7 +1511,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1544,7 +1544,7 @@ fn to_time_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1577,7 +1577,7 @@ fn to_utc_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1608,7 +1608,7 @@ fn to_utc_string() {
 fn utc() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -1636,7 +1636,7 @@ fn value_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Error.rs
+++ b/tests/all/js_globals/Error.rs
@@ -6,7 +6,7 @@ use project;
 fn new() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -36,7 +36,7 @@ fn new() {
 fn message() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -66,7 +66,7 @@ fn message() {
 fn set_message() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -97,7 +97,7 @@ fn set_message() {
 fn name() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -128,7 +128,7 @@ fn name() {
 fn set_name() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -159,7 +159,7 @@ fn set_name() {
 fn to_string() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Function.rs
+++ b/tests/all/js_globals/Function.rs
@@ -8,7 +8,7 @@ fn apply() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -44,7 +44,7 @@ fn bind() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -84,7 +84,7 @@ fn length() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -130,7 +130,7 @@ fn name() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -177,7 +177,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Generator.rs
+++ b/tests/all/js_globals/Generator.rs
@@ -8,7 +8,7 @@ fn return_() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -52,7 +52,7 @@ fn next() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -110,7 +110,7 @@ fn throw() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Intl.rs
+++ b/tests/all/js_globals/Intl.rs
@@ -6,7 +6,7 @@ use project;
 fn get_canonical_locales() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/JsString.rs
+++ b/tests/all/js_globals/JsString.rs
@@ -8,7 +8,7 @@ fn length() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -45,7 +45,7 @@ fn char_at() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -80,7 +80,7 @@ fn char_code_at() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -121,7 +121,7 @@ fn code_point_at() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -155,7 +155,7 @@ fn concat() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -191,7 +191,7 @@ fn concat() {
 fn ends_with() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -223,7 +223,7 @@ fn ends_with() {
 fn includes() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -258,7 +258,7 @@ fn includes() {
 fn index_of() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -297,7 +297,7 @@ fn index_of() {
 fn last_index_of() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -336,7 +336,7 @@ fn last_index_of() {
 fn normalize() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -368,7 +368,7 @@ fn normalize() {
 fn pad_end() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -408,7 +408,7 @@ fn pad_end() {
 fn pad_start() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -449,7 +449,7 @@ fn repeat() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -482,7 +482,7 @@ fn slice() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -515,7 +515,7 @@ fn slice() {
 fn starts_with() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -546,7 +546,7 @@ fn starts_with() {
 fn substring() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -585,7 +585,7 @@ fn substring() {
 fn substr() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -621,7 +621,7 @@ fn substr() {
 fn to_lower_case() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -649,7 +649,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -680,7 +680,7 @@ fn to_string() {
 fn to_upper_case() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -708,7 +708,7 @@ fn trim() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -742,7 +742,7 @@ fn trim_end_and_trim_right() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -782,7 +782,7 @@ fn trim_start_and_trim_left() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -822,7 +822,7 @@ fn value_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Map.rs
+++ b/tests/all/js_globals/Map.rs
@@ -6,7 +6,7 @@ use project;
 fn clear() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -38,7 +38,7 @@ fn clear() {
 fn delete() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -70,7 +70,7 @@ fn delete() {
 fn for_each() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -115,7 +115,7 @@ fn for_each() {
 fn get() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -146,7 +146,7 @@ fn get() {
 fn has() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -175,7 +175,7 @@ fn has() {
 fn new() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -203,7 +203,7 @@ fn new() {
 fn set() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -232,7 +232,7 @@ fn set() {
 fn size() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/MapIterator.rs
+++ b/tests/all/js_globals/MapIterator.rs
@@ -7,7 +7,7 @@ use project;
 fn entries() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -39,7 +39,7 @@ fn entries() {
 fn keys() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -71,7 +71,7 @@ fn keys() {
 fn values() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Math.rs
+++ b/tests/all/js_globals/Math.rs
@@ -8,7 +8,7 @@ fn abs() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -42,7 +42,7 @@ fn acos() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -76,7 +76,7 @@ fn acosh() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -110,7 +110,7 @@ fn asin() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -144,7 +144,7 @@ fn asinh() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -177,7 +177,7 @@ fn atan() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -210,7 +210,7 @@ fn atan2() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -243,7 +243,7 @@ fn atanh() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -277,7 +277,7 @@ fn cbrt() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -310,7 +310,7 @@ fn ceil() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -343,7 +343,7 @@ fn clz32() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -374,7 +374,7 @@ fn clz32() {
 fn cos() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -401,7 +401,7 @@ fn cos() {
 fn cosh() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -428,7 +428,7 @@ fn cosh() {
 fn exp() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -456,7 +456,7 @@ fn exp() {
 fn expm1() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -487,7 +487,7 @@ fn floor() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -518,7 +518,7 @@ fn floor() {
 fn fround() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -547,7 +547,7 @@ fn fround() {
 fn imul() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -575,7 +575,7 @@ fn imul() {
 fn log() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -602,7 +602,7 @@ fn log() {
 fn log10() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -630,7 +630,7 @@ fn log10() {
 fn log1p() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -659,7 +659,7 @@ fn log1p() {
 fn log2() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -688,7 +688,7 @@ fn log2() {
 fn pow() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -716,7 +716,7 @@ fn pow() {
 fn random() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -743,7 +743,7 @@ fn random() {
 fn round() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -773,7 +773,7 @@ fn round() {
 fn sign() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -803,7 +803,7 @@ fn sign() {
 fn sin() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -831,7 +831,7 @@ fn sin() {
 fn sinh() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -859,7 +859,7 @@ fn sinh() {
 fn sqrt() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -889,7 +889,7 @@ fn sqrt() {
 fn tan() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -917,7 +917,7 @@ fn tan() {
 fn tanh() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -945,7 +945,7 @@ fn tanh() {
 fn trunc() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Number.rs
+++ b/tests/all/js_globals/Number.rs
@@ -6,7 +6,7 @@ use super::project;
 fn is_finite() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -36,7 +36,7 @@ fn is_finite() {
 fn is_integer() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -63,7 +63,7 @@ fn is_integer() {
 fn is_safe_integer() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -95,7 +95,7 @@ fn is_safe_integer() {
 fn new() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -123,7 +123,7 @@ fn parse_int_float() {
     project()
         .file(
             "src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -162,7 +162,7 @@ fn parse_int_float() {
 fn to_locale_string() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -194,7 +194,7 @@ fn to_precision() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -232,7 +232,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -272,7 +272,7 @@ fn value_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -306,7 +306,7 @@ fn to_fixed() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -344,7 +344,7 @@ fn to_exponential() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Object.rs
+++ b/tests/all/js_globals/Object.rs
@@ -8,7 +8,7 @@ fn new() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -40,7 +40,7 @@ fn has_own_property() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -77,7 +77,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -114,7 +114,7 @@ fn to_string() {
 fn is_extensible() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -144,7 +144,7 @@ fn is_extensible() {
 fn is_frozen() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -174,7 +174,7 @@ fn is_frozen() {
 fn is_sealed() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -206,7 +206,7 @@ fn is_prototype_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -243,7 +243,7 @@ fn keys() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -274,7 +274,7 @@ fn keys() {
 fn prevent_extensions() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -309,7 +309,7 @@ fn property_is_enumerable() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -348,7 +348,7 @@ fn property_is_enumerable() {
 fn seal() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -399,7 +399,7 @@ fn seal() {
 fn set_prototype_of() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -431,7 +431,7 @@ fn to_locale_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -464,7 +464,7 @@ fn value_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -496,7 +496,7 @@ fn value_of() {
 fn values() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Proxy.rs
+++ b/tests/all/js_globals/Proxy.rs
@@ -6,7 +6,7 @@ use project;
 fn new() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -40,7 +40,7 @@ fn new() {
 fn revocable() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Reflect.rs
+++ b/tests/all/js_globals/Reflect.rs
@@ -8,7 +8,7 @@ fn apply() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -40,7 +40,7 @@ fn construct() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -86,7 +86,7 @@ fn construct_with_new_target() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -144,7 +144,7 @@ fn define_property() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -178,7 +178,7 @@ fn delete_property() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -221,7 +221,7 @@ fn get() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -261,7 +261,7 @@ fn get_own_property_descriptor() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -298,7 +298,7 @@ fn get_prototype_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -336,7 +336,7 @@ fn has() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -376,7 +376,7 @@ fn is_extensible() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -420,7 +420,7 @@ fn own_keys() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -458,7 +458,7 @@ fn prevent_extensions() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -494,7 +494,7 @@ fn set() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -532,7 +532,7 @@ fn set_with_receiver() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -570,7 +570,7 @@ fn set_prototype_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Set.rs
+++ b/tests/all/js_globals/Set.rs
@@ -6,7 +6,7 @@ use project;
 fn add() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -39,7 +39,7 @@ fn add() {
 fn clear() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -70,7 +70,7 @@ fn clear() {
 fn delete() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -99,7 +99,7 @@ fn delete() {
 fn for_each() {
     project()
         .file("src/lib.rs", r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -145,7 +145,7 @@ fn for_each() {
 fn has() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -174,7 +174,7 @@ fn has() {
 fn new() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -202,7 +202,7 @@ fn new() {
 fn size() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/SetIterator.rs
+++ b/tests/all/js_globals/SetIterator.rs
@@ -6,7 +6,7 @@ use project;
 fn entries() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -38,7 +38,7 @@ fn entries() {
 fn keys() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -69,7 +69,7 @@ fn keys() {
 fn values() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/Symbol.rs
+++ b/tests/all/js_globals/Symbol.rs
@@ -8,7 +8,7 @@ fn has_instance() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -47,7 +47,7 @@ fn is_concat_spreadable() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -89,7 +89,7 @@ fn iterator() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -130,7 +130,7 @@ fn match_() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -170,7 +170,7 @@ fn replace() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -212,7 +212,7 @@ fn search() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -255,7 +255,7 @@ fn species() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -297,7 +297,7 @@ fn split() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -342,7 +342,7 @@ fn to_primitive() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -384,7 +384,7 @@ fn to_string_tag() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -423,7 +423,7 @@ fn for_() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -463,7 +463,7 @@ fn key_for() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -502,7 +502,7 @@ fn to_string() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -539,7 +539,7 @@ fn value_of() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/TypedArray.rs
+++ b/tests/all/js_globals/TypedArray.rs
@@ -5,7 +5,7 @@ use std::string::String;
 
 fn new_undefined_lib(array_type: &str) -> String {
     format!(r#"
-    #![feature(use_extern_macros, wasm_custom_section)]
+    #![feature(use_extern_macros)]
 
     extern crate wasm_bindgen;
     use wasm_bindgen::prelude::*;
@@ -103,7 +103,7 @@ fn new_Float64Array_undefined() {
 
 fn new_length_lib(array_type: &str) -> String {
     format!(r#"
-    #![feature(use_extern_macros, wasm_custom_section)]
+    #![feature(use_extern_macros)]
 
     extern crate wasm_bindgen;
     use wasm_bindgen::prelude::*;
@@ -201,7 +201,7 @@ fn new_Float64Array_length() {
 
 fn fill_lib(array_type: &str, el_type: &str) -> String {
     format!(r#"
-    #![feature(use_extern_macros, wasm_custom_section)]
+    #![feature(use_extern_macros)]
 
     extern crate wasm_bindgen;
     use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/WeakMap.rs
+++ b/tests/all/js_globals/WeakMap.rs
@@ -8,7 +8,7 @@ fn new() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -40,7 +40,7 @@ fn get() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -78,7 +78,7 @@ fn set() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -113,7 +113,7 @@ fn has() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -151,7 +151,7 @@ fn delete() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/WeakSet.rs
+++ b/tests/all/js_globals/WeakSet.rs
@@ -8,7 +8,7 @@ fn new() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -40,7 +40,7 @@ fn has() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -78,7 +78,7 @@ fn add() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -119,7 +119,7 @@ fn delete() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/js_globals/WebAssembly.rs
+++ b/tests/all/js_globals/WebAssembly.rs
@@ -6,7 +6,7 @@ use super::project;
 fn validate() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use JsValue;
@@ -36,7 +36,7 @@ fn validate() {
 fn validate_with_invalid_input() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use JsValue;

--- a/tests/all/js_globals/mod.rs
+++ b/tests/all/js_globals/mod.rs
@@ -35,7 +35,7 @@ fn decode_uri() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -61,7 +61,7 @@ fn decode_uri_component() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -88,7 +88,7 @@ fn encode_uri() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -110,7 +110,7 @@ fn encode_uri_component() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -132,7 +132,7 @@ fn eval() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -159,7 +159,7 @@ fn is_finite() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
@@ -193,7 +193,7 @@ fn is_finite() {
 fn parse_int_float() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
@@ -224,7 +224,7 @@ fn parse_int_float() {
 fn escape() {
     project()
         .file("src/lib.rs", r#"
-            #![feature(use_extern_macros, wasm_custom_section)]
+            #![feature(use_extern_macros)]
 
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;

--- a/tests/all/jsobjects.rs
+++ b/tests/all/jsobjects.rs
@@ -6,7 +6,7 @@ fn simple() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -53,7 +53,7 @@ fn owned() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -100,7 +100,7 @@ fn clone() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -153,7 +153,7 @@ fn promote() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -203,7 +203,7 @@ fn returning_vector() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -247,7 +247,7 @@ fn another_vector_return() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -290,7 +290,7 @@ fn serde() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
                 #[macro_use]

--- a/tests/all/math.rs
+++ b/tests/all/math.rs
@@ -6,7 +6,7 @@ fn auto_bind_math() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 

--- a/tests/all/node.rs
+++ b/tests/all/node.rs
@@ -8,7 +8,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 

--- a/tests/all/non_debug.rs
+++ b/tests/all/non_debug.rs
@@ -7,7 +7,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 

--- a/tests/all/non_wasm.rs
+++ b/tests/all/non_wasm.rs
@@ -9,7 +9,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/simple.rs
+++ b/tests/all/simple.rs
@@ -6,7 +6,7 @@ fn add() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -66,7 +66,7 @@ fn add_headless() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -98,7 +98,7 @@ fn string_arguments() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -136,7 +136,7 @@ fn return_a_string() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -176,7 +176,7 @@ fn exceptions() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -208,7 +208,7 @@ fn exceptions() {
 // fn other_imports() {
 //     project()
 //         .file("src/lib.rs", r#"
-//             #![feature(use_extern_macros, wasm_custom_section)]
+//             #![feature(use_extern_macros)]
 //
 //             extern crate wasm_bindgen;
 //
@@ -269,7 +269,7 @@ fn no_std() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 #![no_std]
                 #![allow(dead_code)]
 
@@ -322,7 +322,7 @@ fn no_std_class() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 #![no_std]
                 #![allow(dead_code)]
 
@@ -375,7 +375,7 @@ fn jsvalue_typeof() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
 
@@ -420,7 +420,7 @@ fn binding_to_unimplemented_apis_doesnt_break_everything() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
                 use wasm_bindgen::prelude::*;
                 use wasm_bindgen::js::*;

--- a/tests/all/slice.rs
+++ b/tests/all/slice.rs
@@ -6,7 +6,7 @@ fn export() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -92,7 +92,7 @@ fn import() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -247,7 +247,7 @@ fn pass_array_works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -303,7 +303,7 @@ fn import_mut() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 
@@ -387,7 +387,7 @@ fn export_mut() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section)]
+                #![feature(use_extern_macros)]
 
                 extern crate wasm_bindgen;
 
@@ -452,7 +452,7 @@ fn return_vec_ok() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
 
                 use wasm_bindgen::prelude::*;

--- a/tests/all/structural.rs
+++ b/tests/all/structural.rs
@@ -6,7 +6,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
                 extern crate wasm_bindgen;
 
                 use wasm_bindgen::prelude::*;

--- a/tests/all/typescript.rs
+++ b/tests/all/typescript.rs
@@ -7,7 +7,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+                #![feature(use_extern_macros, wasm_import_module)]
 
                 extern crate wasm_bindgen;
 

--- a/tests/all/u64.rs
+++ b/tests/all/u64.rs
@@ -7,7 +7,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
 
             extern crate wasm_bindgen;
 

--- a/tests/all/validate_prt.rs
+++ b/tests/all/validate_prt.rs
@@ -6,7 +6,7 @@ fn works() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(use_extern_macros, wasm_custom_section, wasm_import_module)]
+            #![feature(use_extern_macros, wasm_import_module)]
             extern crate wasm_bindgen;
             use wasm_bindgen::prelude::*;
             #[wasm_bindgen]


### PR DESCRIPTION
This has been stabilized on nightly as `#[link_section]`, so no need for an
unstable attribute any more. Yay!