### PR TITLE
Bump to 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,33 +2,38 @@
 
 --------------------------------------------------------------------------------
 
-## Unreleased
+## 0.2.12
 
-Released YYYY/MM/DD.
+Released 2018/07/19.
+
+This release is mostly internal refactorings and minor improvements to the
+existing crates and functionality, but the bigs news is an upcoming `js-sys` and
+`web-sys` set of crates. The `js-sys` crate will expose [all global JS
+bindings][js-all] and the `web-sys` crate will be generated from WebIDL to
+expose all APIs browsers have. More info on this soon!
+
+[js-all]: https://github.com/rustwasm/wasm-bindgen/issues/275
 
 ### Added
 
-* TODO (or remove section if none)
+* Support for `Option<T>` was added where `T` can be a number of slices or
+  imported types.
+* Comments in Rust are now preserved in generated JS bindings, as well as
+  comments being generated to indicate the types of arguments/return values.
+* The online documentation has been reorganized [into a book][book].
+* The generated JS is now formatted better by default for readability.
+* A `--keep-debug` flag has been added to the CLI to retain debug sections by
+  default. This happens by default when `--debug` is passed.
 
-### Changed
-
-* TODO (or remove section if none)
-
-### Deprecated
-
-* TODO (or remove section if none)
-
-### Removed
-
-* TODO (or remove section if none)
+[book]: https://rustwasm.github.io/wasm-bindgen/
 
 ### Fixed
 
-* TODO (or remove section if none)
-
-### Security
-
-* TODO (or remove section if none)
+* Compilation with the latest nightly compiler has been fixed (nightlies on and
+  after 2018-07-19)
+* Declarations of an imported function in multiple crates have been fixed to not
+  conflict.
+* Compilation with `#![deny(missing_docs)]` has been fixed.
 
 --------------------------------------------------------------------------------
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "wasm-bindgen"
-version = "0.2.11"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 categories = ["wasm"]
-repository = "https://github.com/alexcrichton/wasm-bindgen"
-homepage = "https://github.com/alexcrichton/wasm-bindgen"
+repository = "https://github.com/rustwasm/wasm-bindgen"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
 documentation = "https://docs.rs/wasm-bindgen"
 description = """
 Easy support for interacting between JS and Rust.
@@ -27,12 +27,12 @@ serde-serialize = ["serde", "serde_json", "std"]
 xxx_debug_only_print_generated_code = ["wasm-bindgen-macro/xxx_debug_only_print_generated_code"]
 
 [dependencies]
-wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.11" }
+wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.12" }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test-project-builder = { path = "crates/test-project-builder", version = '=0.2.11' }
+wasm-bindgen-test-project-builder = { path = "crates/test-project-builder" }
 
 [workspace]
 members = [

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wasm-bindgen-backend"
-version = "0.2.11"
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/alexcrichton/wasm-bindgen"
-homepage = "https://github.com/alexcrichton/wasm-bindgen"
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
 documentation = "https://docs.rs/wasm-bindgen-backend"
 description = """
 Backend code generation of the wasm-bindgen tool
@@ -20,4 +20,4 @@ proc-macro2 = "0.4.8"
 quote = '0.6'
 serde_json = "1.0"
 syn = { version = '0.14', features = ['full', 'visit-mut'] }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.11" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.12" }

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![cfg_attr(feature = "extra-traits", deny(missing_debug_implementations))]
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-backend/0.2")]
 
 #[macro_use]
 extern crate log;

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wasm-bindgen-cli-support"
-version = "0.2.11"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/alexcrichton/wasm-bindgen"
-homepage = "https://github.com/alexcrichton/wasm-bindgen"
-documentation = "https://docs.rs/wasm-bindgen"
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli-support"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
+documentation = "https://docs.rs/wasm-bindgen-cli-support"
 description = """
 Shared support for the wasm-bindgen-cli package, an internal dependency
 """
@@ -18,6 +18,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 tempfile = "3.0"
-wasm-bindgen-shared = { path = "../shared", version = '=0.2.11' }
+wasm-bindgen-shared = { path = "../shared", version = '=0.2.12' }
 wasm-gc-api = "0.1.8"
 wasmi = "0.3"

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-cli-support/0.2")]
+
 extern crate parity_wasm;
 extern crate wasm_bindgen_shared as shared;
 #[macro_use]
@@ -339,7 +341,7 @@ or you can update the binary with
     cargo install -f wasm-bindgen-cli
 
 if this warning fails to go away though and you're not sure what to do feel free
-to open an issue at https://github.com/alexcrichton/wasm-bindgen/issues!
+to open an issue at https://github.com/rustwasm/wasm-bindgen/issues!
 ",
                     p.version,
                     version

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wasm-bindgen-cli"
-version = "0.2.11"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/alexcrichton/wasm-bindgen"
-homepage = "https://github.com/alexcrichton/wasm-bindgen"
-documentation = "https://docs.rs/wasm-bindgen"
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
+documentation = "https://rustwasm.github.io/wasm-bindgen/"
 categories = ["wasm"]
 description = """
 Command line interface of the `#[wasm_bindgen]` attribute and project. For more
@@ -17,13 +17,5 @@ docopt = "1.0"
 failure = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
-wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.11" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.11" }
-
-[[bin]]
-name = "wasm-bindgen"
-path = "src/bin/wasm-bindgen.rs"
-
-[[bin]]
-name = "wasm2es6js"
-path = "src/bin/wasm2es6js.rs"
+wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.12" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.12" }

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js-sys"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 readme = "./README.md"
 categories = ["wasm"]
@@ -17,7 +17,7 @@ test = false
 doctest = false
 
 [dependencies]
-wasm-bindgen = { path = "../..", version = "0.2.11" }
+wasm-bindgen = { path = "../..", version = "0.2.12" }
 
 [dev-dependencies]
 wasm-bindgen-test-project-builder = { path = "../test-project-builder" }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -16,6 +16,7 @@
 //! example, `decodeURI` in JavaScript is exposed as `decode_uri` in these
 //! bindings.
 
+#![doc(html_root_url = "https://docs.rs/js-sys/0.2")]
 #![feature(use_extern_macros, wasm_import_module)]
 
 extern crate wasm_bindgen;

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wasm-bindgen-macro"
-version = "0.2.11"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/alexcrichton/wasm-bindgen"
-homepage = "https://github.com/alexcrichton/wasm-bindgen"
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
 documentation = "https://docs.rs/wasm-bindgen"
 description = """
 Definition of the `#[wasm_bindgen]` attribute, an internal dependency
@@ -21,5 +21,5 @@ xxx_debug_only_print_generated_code = []
 syn = { version = '0.14', features = ['full'] }
 quote = '0.6'
 proc-macro2 = "0.4.8"
-wasm-bindgen-backend = { path = "../backend", version = "=0.2.11" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.11" }
+wasm-bindgen-backend = { path = "../backend", version = "=0.2.12" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.12" }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro/0.2")]
+
 extern crate proc_macro;
 extern crate proc_macro2;
 extern crate quote;

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wasm-bindgen-shared"
-version = "0.2.11"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
-repository = "https://github.com/alexcrichton/wasm-bindgen"
-homepage = "https://github.com/alexcrichton/wasm-bindgen"
-documentation = "https://docs.rs/wasm-bindgen"
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
+documentation = "https://docs.rs/wasm-bindgen-shared"
 description = """
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
 dependency.

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-shared/0.2")]
+
 #[macro_use]
 extern crate serde_derive;
 

--- a/crates/test-project-builder/Cargo.toml
+++ b/crates/test-project-builder/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "wasm-bindgen-test-project-builder"
-version = "0.2.11"
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/test-project-builder"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
+documentation = "https://docs.rs/wasm-bindgen-test-project-builder"
+description = """
+Internal test support for wasm-bindgen
+"""
 
 [dependencies]
 lazy_static = "1"
-wasm-bindgen-cli-support = { path = "../cli-support", version = '=0.2.11' }
+wasm-bindgen-cli-support = { path = "../cli-support", version = '=0.2.12' }

--- a/crates/test-project-builder/src/lib.rs
+++ b/crates/test-project-builder/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-test-project-builder/0.2")]
+
 #[macro_use]
 extern crate lazy_static;
 extern crate wasm_bindgen_cli_support as cli;

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -7,10 +7,10 @@ readme = "./README.md"
 [build-dependencies]
 env_logger = "0.5.10"
 failure = "0.1"
-wasm-bindgen-webidl = { path = "../webidl", version = "=0.2.11" }
+wasm-bindgen-webidl = { path = "../webidl", version = "=0.2.12" }
 
 [dependencies]
-wasm-bindgen = { path = "../..", version = "=0.2.11" }
+wasm-bindgen = { path = "../..", version = "=0.2.12" }
 
 [dev-dependencies]
-wasm-bindgen-test-project-builder = { path = "../test-project-builder", version = '=0.2.11' }
+wasm-bindgen-test-project-builder = { path = "../test-project-builder" }

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(wasm_import_module)]
+#![doc(html_root_url = "https://docs.rs/web-sys/0.2")]
 
 extern crate wasm_bindgen;
 

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -1,10 +1,18 @@
 [package]
 name = "wasm-bindgen-webidl"
-version = "0.2.11"
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+version = "0.2.12"
+authors = ["The wasm-bindgen Developers"]
+license = "MIT/Apache-2.0"
+categories = ["wasm"]
+repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/webidl"
+homepage = "https://rustwasm.github.io/wasm-bindgen/"
+documentation = "https://docs.rs/wasm-bindgen"
+description = """
+Support for parsing WebIDL specific to wasm-bindgen
+"""
 
 [dev-dependencies]
-wasm-bindgen-test-project-builder = { path = "../test-project-builder", version = '=0.2.11' }
+wasm-bindgen-test-project-builder = { path = "../test-project-builder" }
 
 [dependencies]
 failure = "0.1"
@@ -13,5 +21,5 @@ log = "0.4.1"
 proc-macro2 = "0.4.8"
 quote = '0.6'
 syn = { version = '0.14', features = ['full'] }
-wasm-bindgen-backend = { version = "=0.2.11", path = "../backend" }
+wasm-bindgen-backend = { version = "=0.2.12", path = "../backend" }
 webidl = "0.7.0"

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -7,6 +7,7 @@ emitted for the types and methods described in the WebIDL.
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen-webidl/0.2")]
 
 extern crate failure;
 extern crate heck;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![feature(use_extern_macros, wasm_import_module, unsize)]
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
 
 #[cfg(feature = "serde-serialize")]
 extern crate serde;


### PR DESCRIPTION
* Update all version numbers and deps
* Update all listed authors to `["The wasm-bindgen Developers"]`
* Update `repository` links to specific paths for each crate
* Update `homepage` links to the online book
* Update all links away from `alexcrichton/wasm-bindgen`
* Add `#[doc]` directives for HTML URLs