### PR TITLE
Explicitly ignore "Exposed" attributes

### DIFF
--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -353,6 +353,14 @@ impl<'a> WebidlParse<&'a webidl::ast::NonPartialInterface> for webidl::ast::Exte
             {
                 add_constructor(arguments, &interface.name)
             }
+            webidl::ast::ExtendedAttribute::IdentifierList(
+                webidl::ast::IdentifierListExtendedAttribute { lhs, .. },
+            )
+                if lhs == "Exposed" =>
+            {
+                // ignore these attributes for now, we just splat everything in
+                // the crate whether it's workable in a web worker or not.
+            }
             webidl::ast::ExtendedAttribute::NoArguments(webidl::ast::Other::Identifier(name))
                 if name == "Constructor" =>
             {


### PR DESCRIPTION
It looks like these are primarily targeted at informing whether functionality is
either on web workers, windows, or both. For now we'll generate the same
bindings regardless, and users will need to be proactive about what they're
using. In that case there shouldn't be any need for us to process these, so
avoid warning about them!