### PR TITLE
add bindings for String.to_locale_XXX_case

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2156,6 +2156,20 @@ extern "C" {
     #[wasm_bindgen(method, js_class = "String")]
     pub fn substr(this: &JsString, start: i32, length: i32) -> JsString;
 
+    /// The toLocaleLowerCase() method returns the calling string value converted to lower case,
+    /// according to any locale-specific case mappings.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
+    #[wasm_bindgen(method, js_class = "String", js_name = toLocaleLowerCase)]
+    pub fn to_locale_lower_case(this: &JsString, local: Option<String>) -> JsString;
+
+    /// The toLocaleUpperCase() method returns the calling string value converted to upper case,
+    /// according to any locale-specific case mappings.
+    ///
+    /// https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
+    #[wasm_bindgen(method, js_class = "String", js_name = toLocaleUpperCase)]
+    pub fn to_locale_upper_case(this: &JsString, local: Option<String>) -> JsString;
+
     /// The `toLowerCase()` method returns the calling string value
     /// converted to lower case.
     ///

--- a/crates/js-sys/tests/all/JsString.rs
+++ b/crates/js-sys/tests/all/JsString.rs
@@ -618,6 +618,74 @@ fn substr() {
 }
 
 #[test]
+fn to_locale_lower_case() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(use_extern_macros)]
+
+            extern crate wasm_bindgen;
+            extern crate js_sys;
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn string_to_locale_lower_case(this: &js_sys::JsString, local: Option<String>) -> js_sys::JsString {
+                this.to_locale_lower_case(local)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.string_to_locale_lower_case("Mozilla"), "mozilla");
+                assert.equal(wasm.string_to_locale_lower_case("\u0130", "tr"), "i");
+                assert.notStrictEqual(wasm.string_to_locale_lower_case("\u0130", "en-US"), "i");
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
+fn to_locale_upper_case() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+            #![feature(use_extern_macros)]
+
+            extern crate wasm_bindgen;
+            extern crate js_sys;
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub fn string_to_locale_upper_case(this: &js_sys::JsString, local: Option<String>) -> js_sys::JsString {
+                this.to_locale_upper_case(local)
+            }
+        "#,
+        )
+        .file(
+            "test.js",
+            r#"
+            import * as assert from "assert";
+            import * as wasm from "./out";
+
+            export function test() {
+                assert.equal(wasm.string_to_locale_upper_case("mozilla"), "MOZILLA");
+                assert.equal(wasm.string_to_locale_upper_case("i\u0307", "lt"), "I");
+                assert.notStrictEqual(wasm.string_to_locale_upper_case("i\u0307", "en-US"), "I");
+            }
+        "#,
+        )
+        .test()
+}
+
+#[test]
 fn to_lower_case() {
     project()
         .file("src/lib.rs", r#"


### PR DESCRIPTION
I ignored tricky behavior of locale parameter passing as Array implicitly.

Ref. #275 