### PR TITLE
Allow renaming exported functions into JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 --------------------------------------------------------------------------------
 
+## 0.2.13
+
+Currently unreleased
+
+### Added
+
+* Support the `#[wasm_bindgen(js_name = foo)]` attribute on exported functions
+  and methods to allow renaming an export to JS. This allows JS to call it by
+  one name and Rust to call it by another, for example using `camelCase` in JS
+  and `snake_case` in Rust
+
+--------------------------------------------------------------------------------
+
 ## 0.2.12
 
 Released 2018-07-19.

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -20,6 +20,7 @@ pub struct Export {
     pub constructor: Option<String>,
     pub function: Function,
     pub comments: Vec<String>,
+    pub rust_name: Ident,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -297,7 +297,7 @@ impl ToTokens for ast::Export {
             0
         };
 
-        let name = &self.function.name;
+        let name = &self.rust_name;
         let receiver = match self.method_self {
             Some(ast::MethodSelf::ByValue) => {
                 let class = self.class.as_ref().unwrap();

--- a/guide/src/design/export-customization.md
+++ b/guide/src/design/export-customization.md
@@ -51,3 +51,35 @@ possibilities!
   const f = new Foo();
   console.log(f.get_contents());
   ```
+
+* `js_name` - this can be used to export a different name in JS than what
+  something is named in Rust, for example:
+
+  ```rust
+  #[wasm_bindgen]
+  pub struct Foo {
+      contents: u32,
+  }
+
+  #[wasm_bindgen(js_name = makeFoo)]
+  pub fn make_foo() -> Foo {
+      Foo { contents: 6 }
+  }
+
+  #[wasm_bindgen]
+  impl Foo {
+      #[wasm_bindgen(js_name = getContents)]
+      pub fn get_contents(&self) -> u32 {
+          self.contents
+      }
+  }
+  ```
+
+  Here this can be used in JS as:
+
+  ```js
+  import { makeFoo } from './my_module';
+
+  const foo = makeFoo();
+  console.log(foo.getContents());
+  ```

--- a/tests/all/classes.rs
+++ b/tests/all/classes.rs
@@ -709,3 +709,51 @@ fn double_consume() {
         "#)
         .test();
 }
+
+#[test]
+fn rename_function_for_js() {
+    project()
+        .file("src/lib.rs", r#"
+            #![feature(use_extern_macros, wasm_import_module)]
+
+            extern crate wasm_bindgen;
+
+            use wasm_bindgen::prelude::*;
+
+            #[wasm_bindgen]
+            pub struct Foo { }
+
+            #[wasm_bindgen]
+            impl Foo {
+                #[wasm_bindgen(constructor)]
+                pub fn new() -> Foo {
+                    let f = Foo {};
+                    f.foo();
+                    return f
+                }
+
+                #[wasm_bindgen(js_name = bar)]
+                pub fn foo(&self) {
+                }
+
+            }
+
+            #[wasm_bindgen(js_name = js_foo)]
+            pub fn foo() {}
+
+            #[wasm_bindgen]
+            pub fn bar() {
+                foo();
+            }
+        "#)
+        .file("test.js", r#"
+            import { Foo, js_foo, bar } from "./out";
+
+            export function test() {
+                Foo.new().bar();
+                js_foo();
+                bar();
+            }
+        "#)
+        .test();
+}


### PR DESCRIPTION
Support the `js_name` attribute on exports as well as imports to allow exporting
types as camelCase instead of snake_case, for example.

Closes #221