### PR TITLE
Add documentation for passing arbitrary data

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [What Else Can We Do?](./what-else-can-we-do.md)
 - [Closures](./closures.md)
 - [No ES Modules](./no-esm.md)
+- [Passing Arbitrary data](./passing-data.md)
 - [Feature Reference](./feature-reference.md)
 - [CLI Reference](./cli-reference.md)
 - [Type Reference](./reference.md)

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -1,12 +1,12 @@
 # Passing arbitrary data to JS
 
 It's possible to pass data from Rust to JS not explicitly supported
-in the [Feature Reference]: ./feature-reference by serializing vis [Serde]: https://github.com/serde-rs/serde
+in the [Feature Reference](./feature-reference.md) by serializing vis [Serde] (https://github.com/serde-rs/serde).
 
-Wasm_bindgen includes the JsValue type, which handles serializing and
-deserializing smoothly.
+Wasm_bindgen includes the JsValue type, which streamlines serializing and deserializing.
+This page describes how to use it.
 
-In order to make this work, you must include the serde and serde_derive
+In order accomplish this, we must include the serde and serde_derive
 crates in Cargo.toml, and configure wasm_bindgen to work with this feature:
 
 Cargo.toml
@@ -20,14 +20,14 @@ version = "^0.2"
 features = ["serde-serialize"]
 ```
 
-In our top-level Rust file (eg lib.rs or main.rs), we must enable the Serialize
+In our top-level Rust file (eg lib.rs or main.rs), weenable the Serialize
 macro: 
 ```rust
 #[macro_use]
 extern crate serde_derive;
 ```
 
-The data you pass must be supported by serde, or be a struct or enum that
+The data we pass at all nesting levels must be supported by serde, or be a struct or enum that
 derives the Serialize trait. For example, let's say we'd like to pass this
 struct to JS; doing so is not possible in bindgen directly due to the use
 of public fields, HashMaps, arrays, and nested Vecs. Note that we do not
@@ -58,7 +58,7 @@ pub fn pass_example() -> JsValue {
 }
 ```
 
-When calling this function from JS, its result will automatically be deserialized.
+When calling this function from JS, its output will automatically be deserialized.
 In this example, fied1 will be a JS object (Not a JS Map), field2 will be a 
 2d JS array, and field3 will be a 1d JS array. Example calling code:
 

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -1,7 +1,7 @@
 # Passing arbitrary data to JS
 
 It's possible to pass data from Rust to JS not explicitly supported
-in the [Feature Reference](./feature-reference.md) by serializing vis [Serde] (https://github.com/serde-rs/serde).
+in the [Feature Reference](./feature-reference.md) by serializing via [Serde](https://github.com/serde-rs/serde).
 
 Wasm_bindgen includes the JsValue type, which streamlines serializing and deserializing.
 This page describes how to use it.

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -4,7 +4,6 @@ It's possible to pass data from Rust to JS not explicitly supported
 in the [Feature Reference](./feature-reference.md) by serializing via [Serde](https://github.com/serde-rs/serde).
 
 `wasm-bindgen` includes the `JsValue` type, which streamlines serializing and deserializing.
-This page describes how to use it.
 
 In order accomplish this, we must include the serde and serde_derive
 crates in `Cargo.toml`, and configure `wasm-bindgen` to work with this feature:

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -3,11 +3,11 @@
 It's possible to pass data from Rust to JS not explicitly supported
 in the [Feature Reference](./feature-reference.md) by serializing via [Serde](https://github.com/serde-rs/serde).
 
-Wasm_bindgen includes the JsValue type, which streamlines serializing and deserializing.
+`wasm-bindgen` includes the `JsValue` type, which streamlines serializing and deserializing.
 This page describes how to use it.
 
 In order accomplish this, we must include the serde and serde_derive
-crates in Cargo.toml, and configure wasm_bindgen to work with this feature:
+crates in `Cargo.toml`, and configure `wasm-bindgen` to work with this feature:
 
 Cargo.toml
 ```toml
@@ -20,18 +20,18 @@ version = "^0.2"
 features = ["serde-serialize"]
 ```
 
-In our top-level Rust file (eg lib.rs or main.rs), weenable the Serialize
+In our top-level Rust file (eg `lib.rs` or `main.rs`), we enable the `Serialize`
 macro: 
 ```rust
 #[macro_use]
 extern crate serde_derive;
 ```
 
-The data we pass at all nesting levels must be supported by serde, or be a struct or enum that
+The data we pass at all nesting levels must be supported by serde, or be a `struct` or `enum` that
 derives the Serialize trait. For example, let's say we'd like to pass this
 struct to JS; doing so is not possible in bindgen directly due to the use
-of public fields, HashMaps, arrays, and nested Vecs. Note that we do not
-need to use the #[wasm_bindgen] macro.
+of public fields, `HashMap`s, arrays, and nested `Vec`s. Note that we do not
+need to use the `#[wasm_bindgen]` macro.
 
 ```rust
 #[derive(Serialize)]
@@ -42,7 +42,7 @@ pub struct Example {
 }
 ```
 
-Here's a function that will pass an instance of this struct to JS:
+Here's a function that will pass an instance of this `struct` to JS:
 ```rust
 #[wasm_bindgen]
 pub fn pass_example() -> JsValue {
@@ -59,8 +59,8 @@ pub fn pass_example() -> JsValue {
 ```
 
 When calling this function from JS, its output will automatically be deserialized.
-In this example, fied1 will be a JS object (Not a JS Map), field2 will be a 
-2d JS array, and field3 will be a 1d JS array. Example calling code:
+In this example, `fied1` will be a JS `object` (Not a JS `Map`), `field2` will be a 
+2d JS `array`, and `field3` will be a 1d JS `array`. Example calling code:
 
 ```typescript
 const rust = import("./from_rust");


### PR DESCRIPTION
Bindgen can indirectly pass data structs more varied and complex than those directly supported via serialization. This pull adds a page describing how to do so.