### PR TITLE
Only emit static descriptors on wasm

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -76,7 +76,8 @@ impl ToTokens for ast::Program {
 
         (quote! {
             #[allow(non_upper_case_globals)]
-            #[link_section = "__wasm_bindgen,unstable"]
+            #[cfg(target_arch = "wasm32")]
+            #[link_section = "__wasm_bindgen_unstable"]
             #[doc(hidden)]
             pub static #generated_static_name: [u8; #generated_static_length] =
                 *#generated_static_value;

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -287,7 +287,7 @@ fn extract_programs(module: &mut Module) -> Result<Vec<shared::Program>, Error> 
             Section::Custom(ref s) => s,
             _ => continue,
         };
-        if custom.name() != "__wasm_bindgen,unstable" {
+        if custom.name() != "__wasm_bindgen_unstable" {
             continue;
         }
         to_remove.push(i);


### PR DESCRIPTION
This is a bit of a refinement of the solution from #548 to make sure that these
statics are only present on the `wasm32-*` targets, as otherwise these
descriptors are completely inert on other platforms!