### PR TITLE
Optimize the execution time of wasm-bindgen tools

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -19,5 +19,5 @@ serde_derive = "1.0"
 serde_json = "1.0"
 tempfile = "3.0"
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.14' }
-wasm-gc-api = "0.1.8"
+wasm-gc-api = "0.1.9"
 wasmi = "0.3"

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -10,10 +10,12 @@ extern crate wasmi;
 #[macro_use]
 extern crate failure;
 
+use std::any::Any;
 use std::collections::BTreeSet;
 use std::fmt;
 use std::fs::File;
 use std::io::{Read, Write};
+use std::mem;
 use std::path::{Path, PathBuf};
 
 use failure::{Error, ResultExt};
@@ -24,7 +26,7 @@ mod js;
 pub mod wasm2es6js;
 
 pub struct Bindgen {
-    path: Option<PathBuf>,
+    input: Input,
     nodejs: bool,
     nodejs_experimental_modules: bool,
     browser: bool,
@@ -36,10 +38,17 @@ pub struct Bindgen {
     keep_debug: bool,
 }
 
+enum Input {
+    Path(PathBuf),
+    Bytes(Vec<u8>, String),
+    Module(Module, String),
+    None,
+}
+
 impl Bindgen {
     pub fn new() -> Bindgen {
         Bindgen {
-            path: None,
+            input: Input::None,
             nodejs: false,
             nodejs_experimental_modules: false,
             browser: false,
@@ -53,7 +62,37 @@ impl Bindgen {
     }
 
     pub fn input_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Bindgen {
-        self.path = Some(path.as_ref().to_path_buf());
+        self.input = Input::Path(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Explicitly specify the already parsed input module.
+    ///
+    /// Note that this API is a little wonky to avoid tying itself with a public
+    /// dependency on the `parity-wasm` crate, what we currently use to parse
+    /// wasm mdoules.
+    ///
+    /// If the `module` argument is a `parity_wasm::Module` then it will be used
+    /// directly. Otherwise it will be passed to `into_bytes` to serialize the
+    /// module to a vector of bytes, and this will deserialize the module later.
+    ///
+    /// Note that even if the argument passed in is a `parity_wasm::Module` it
+    /// doesn't mean that this won't invoke `into_bytes`, if the `parity_wasm`
+    /// crate versions are different we'll have to go through serialization.
+    pub fn input_module<T: Any>(
+        &mut self,
+        name: &str,
+        mut module: T,
+        into_bytes: impl FnOnce(T) -> Vec<u8>,
+    ) -> &mut Bindgen {
+        let name = name.to_string();
+        if let Some(module) = (&mut module as &mut Any).downcast_mut::<Module>() {
+            let blank = Module::new(Vec::new());
+            self.input = Input::Module(mem::replace(module, blank), name);
+            return self
+        }
+
+        self.input = Input::Bytes(into_bytes(module), name);
         self
     }
 
@@ -107,17 +146,28 @@ impl Bindgen {
     }
 
     fn _generate(&mut self, out_dir: &Path) -> Result<(), Error> {
-        let input = match self.path {
-            Some(ref path) => path,
-            None => bail!("must have a path input for now"),
+        let (mut module, stem) = match self.input {
+            Input::None => bail!("must have an input by now"),
+            Input::Module(ref mut m, ref name) => {
+                let blank_module = Module::new(Vec::new());
+                (mem::replace(m, blank_module), &name[..])
+            }
+            Input::Bytes(ref b, ref name) => {
+                let module = parity_wasm::deserialize_buffer::<Module>(&b)
+                    .context("failed to parse input file as wasm")?;
+                (module, &name[..])
+            }
+            Input::Path(ref path) => {
+                let mut contents = Vec::new();
+                File::open(&path)
+                    .and_then(|mut f| f.read_to_end(&mut contents))
+                    .with_context(|_| format!("failed to read `{}`", path.display()))?;
+                let module = parity_wasm::deserialize_buffer::<Module>(&contents)
+                    .context("failed to parse input file as wasm")?;
+                let stem = path.file_stem().unwrap().to_str().unwrap();
+                (module, stem)
+            }
         };
-        let stem = input.file_stem().unwrap().to_str().unwrap();
-        let mut contents = Vec::new();
-        File::open(&input)
-            .and_then(|mut f| f.read_to_end(&mut contents))
-            .with_context(|_| format!("failed to read `{}`", input.display()))?;
-        let mut module = parity_wasm::deserialize_buffer::<Module>(&contents)
-            .with_context(|_| "failed to parse input file as wasm")?;
         let programs = extract_programs(&mut module)
             .with_context(|_| "failed to extract wasm-bindgen custom sections")?;
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -134,7 +134,9 @@ impl Bindgen {
         // This means that whenever we encounter an import or export we'll
         // execute a shim function which informs us about its type so we can
         // then generate the appropriate bindings.
-        let instance = wasmi::Module::from_buffer(&contents)
+        //
+        // TODO: avoid a `clone` here of the module if we can
+        let instance = wasmi::Module::from_parity_wasm_module(module.clone())
             .with_context(|_| "failed to create wasmi module")?;
         let instance = wasmi::ModuleInstance::new(&instance, &MyResolver)
             .with_context(|_| "failed to instantiate wasm module")?;

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -2,8 +2,8 @@ extern crate base64;
 extern crate tempfile;
 
 use std::collections::{HashMap, HashSet};
-use std::fs::File;
-use std::io::{self, Read, Write};
+use std::fs;
+use std::io;
 use std::process::Command;
 
 use failure::{Error, ResultExt};
@@ -375,8 +375,7 @@ impl Output {
         let td = tempfile::tempdir()?;
         let wasm = serialize(self.module)?;
         let wasm_file = td.as_ref().join("foo.wasm");
-        File::create(&wasm_file)
-            .and_then(|mut f| f.write_all(&wasm))
+        fs::write(&wasm_file, wasm)
             .with_context(|_| format!("failed to write wasm to `{}`", wasm_file.display()))?;
 
         let wast_file = td.as_ref().join("foo.wast");
@@ -396,9 +395,7 @@ impl Output {
             "wasm2asm",
         )?;
 
-        let mut asm_func = String::new();
-        File::open(&js_file)
-            .and_then(|mut f| f.read_to_string(&mut asm_func))
+        let asm_func = fs::read_to_string(&js_file)
             .with_context(|_| format!("failed to read `{}`", js_file.display()))?;
 
         let mut make_imports = String::from(

--- a/crates/cli/src/bin/wasm-bindgen-test-runner.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner.rs
@@ -4,8 +4,7 @@ extern crate wasm_bindgen_cli_support;
 extern crate parity_wasm;
 
 use std::env;
-use std::fs::{self, File};
-use std::io::{Write, Read};
+use std::fs;
 use std::path::PathBuf;
 use std::process::{self, Command};
 
@@ -107,9 +106,7 @@ fn rmain() -> Result<(), Error> {
     // Note that we're collecting *JS objects* that represent the functions to
     // execute, and then those objects are passed into wasm for it to execute
     // when it sees fit.
-    let mut wasm = Vec::new();
-    File::open(&wasm_file_to_test)
-        .and_then(|mut f| f.read_to_end(&mut wasm))
+    let wasm = fs::read(&wasm_file_to_test)
         .context("failed to read wasm file")?;
     let wasm = Module::deserialize(&mut &wasm[..])
         .context("failed to deserialize wasm module")?;
@@ -136,8 +133,7 @@ fn rmain() -> Result<(), Error> {
         .context("executing `wasm-bindgen` over the wasm file")?;
 
     let js_path = tmpdir.join("run.js");
-    File::create(&js_path)
-        .and_then(|mut f| f.write_all(js_to_execute.as_bytes()))
+    fs::write(&js_path, js_to_execute)
         .context("failed to write JS file")?;
 
     // Last but not least, execute `node`! Add an entry to `NODE_PATH` for the

--- a/crates/cli/src/bin/wasm2es6js.rs
+++ b/crates/cli/src/bin/wasm2es6js.rs
@@ -4,8 +4,7 @@ extern crate docopt;
 extern crate failure;
 extern crate wasm_bindgen_cli_support;
 
-use std::fs::File;
-use std::io::{Read, Write};
+use std::fs;
 use std::path::PathBuf;
 use std::process;
 
@@ -58,9 +57,7 @@ fn main() {
 }
 
 fn rmain(args: &Args) -> Result<(), Error> {
-    let mut wasm = Vec::new();
-    File::open(&args.arg_input)
-        .and_then(|mut f| f.read_to_end(&mut wasm))
+    let wasm = fs::read(&args.arg_input)
         .with_context(|_| format!("failed to read `{}`", args.arg_input.display()))?;
 
     let object = wasm_bindgen_cli_support::wasm2es6js::Config::new()
@@ -73,8 +70,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         if let Some(ref p) = args.flag_output {
             let dst = p.with_extension("d.ts");
             let ts = object.typescript();
-            File::create(&dst)
-                .and_then(|mut f| f.write_all(ts.as_bytes()))
+            fs::write(&dst, ts)
                 .with_context(|_| format!("failed to write `{}`", dst.display()))?;
         }
     }
@@ -83,8 +79,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
 
     match args.flag_output {
         Some(ref p) => {
-            File::create(p)
-                .and_then(|mut f| f.write_all(js.as_bytes()))
+            fs::write(p, js)
                 .with_context(|_| format!("failed to write `{}`", p.display()))?;
         }
         None => {


### PR DESCRIPTION
This commit optimizes the execution time of the various tools, primarily focusing on avoiding deserializing/serializing `parity_wasm::Module` instances all over the place. Now each process should parse at most once and serialize at most once!