### PR TITLE
Add file location information when failing to parse WebIDL files.

### DIFF
--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -8,6 +8,7 @@ readme = "./README.md"
 env_logger = "0.5.10"
 failure = "0.1"
 wasm-bindgen-webidl = { path = "../webidl", version = "=0.2.14" }
+sourcefile = "0.1"
 
 [dependencies]
 wasm-bindgen = { path = "../..", version = "=0.2.14" }

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -16,6 +16,7 @@ wasm-bindgen-test-project-builder = { path = "../test-project-builder", version 
 
 [dependencies]
 failure = "0.1"
+failure_derive = "0.1"
 heck = "0.3"
 log = "0.4.1"
 proc-macro2 = "0.4.8"

--- a/crates/webidl/src/error.rs
+++ b/crates/webidl/src/error.rs
@@ -1,0 +1,65 @@
+use failure::{Backtrace, Context, Fail};
+use std::fmt;
+
+/// Either `Ok(t)` or `Err(Error)`.
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// The different contexts an error can occur in in this crate.
+#[derive(Debug, Fail, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum ErrorKind {
+    /// Failed to open a WebIDL file.
+    #[fail(display="opening WebIDL file")]
+    OpeningWebIDLFile,
+    /// Failed to read a WebIDL file.
+    #[fail(display="reading WebIDL file")]
+    ReadingWebIDLFile,
+    /// Failed to parse a WebIDL file.
+    #[fail(display="parsing WebIDL source text at {}", _0)]
+    ParsingWebIDLSourcePos(usize),
+    /// Failed to parse a WebIDL file.
+    #[fail(display="parsing WebIDL source text")]
+    ParsingWebIDLSource,
+}
+
+/// The error type for this crate.
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.inner, f)
+    }
+}
+
+impl Error {
+    /// The context for this error.
+    pub fn kind(&self) -> ErrorKind {
+        *self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error { inner: Context::new(kind) }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner: inner }
+    }
+}
+
+


### PR DESCRIPTION
This PR adds information to errors from parsing WebIDL files, so that the file name, line, and col number can be printed, to aid debugging.

The error (with XMLSerializer.webidl) went away when I did a rebase, but I'm still posting the code in case it's desirable.

Example error message:
```text
--- stderr
Error: compiling WebIDL into wasm-bindgen bindings in file "webidls/enabled/XMLSerializer.webidl", line 9 column 23
  caused by parsing WebIDL source text at 74937
  caused by Unrecognized token `Semicolon` found at 74937:74938
Expected one of ":" or "{"
```