### PR TITLE
Fix incorrect url

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1209,7 +1209,7 @@ extern "C" {
 
     /// The Math.hypot() function returns the square root of the sum of squares of its arguments.
     ///
-    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
     #[wasm_bindgen(static_method_of = Math)]
     pub fn hypot(x: f64, y: f64) -> f64;
 


### PR DESCRIPTION
Updating the incorrect documentation url to Math.hypot here. 

Ran a check on all functions in this file before submitting this request and everything else checks out.