### PR TITLE
Adds `Array.prototype.splice()` to js-sys

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -314,6 +314,13 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn sort(this: &Array) -> Array;
 
+    /// The splice() method changes the contents of an array by removing existing elements and/or
+    /// adding new elements.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice
+    #[wasm_bindgen(method)]
+    pub fn splice(this: &Array, start: u32, delete_count: u32, item: &JsValue) -> Array;
+
     /// The toLocaleString() method returns a string representing the elements of the array.
     /// The elements are converted to Strings using their toLocaleString methods and these
     /// Strings are separated by a locale-specific String (such as a comma “,”).

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -97,6 +97,15 @@ fn slice() {
 }
 
 #[wasm_bindgen_test]
+fn splice() {
+    let characters = js_array!["a", "c", "x", "n", 1, "8"];
+    let removed = characters.splice(1, 3, &"b".into());
+
+    assert_eq!(to_rust(&removed), array!["c", "x", "n"]);
+    assert_eq!(to_rust(&characters), array!["a", "b", 1, "8"]);
+}
+
+#[wasm_bindgen_test]
 fn fill() {
     let characters = js_array!["a", "c", "x", "n", 1, "8"];
     let subset = characters.fill(&0.into(), 0, 3);


### PR DESCRIPTION
Looking at `concat`, `push`, `unshift`, etc. that take varargs, I found no pattern that allowed for it. If there is one, I'd be happy to improve this (and those) APIs.