### PR TITLE
Add unit test for HtmlHrElement web_sys binding

### DIFF
--- a/crates/web-sys/README.md
+++ b/crates/web-sys/README.md
@@ -205,7 +205,7 @@ bindings are fully working and have full test coverage.
  - [ ] HTMLFrameSetElement.webidl
  - [ ] HTMLHeadElement.webidl
  - [ ] HTMLHeadingElement.webidl
- - [ ] HTMLHRElement.webidl
+ - [x] HTMLHRElement.webidl
  - [ ] HTMLHtmlElement.webidl
  - [ ] HTMLHyperlinkElementUtils.webidl
  - [ ] HTMLIFrameElement.webidl
@@ -647,7 +647,7 @@ bindings are fully working and have full test coverage.
  - [ ] XPathEvaluator.webidl
  - [ ] XPathExpression.webidl
  - [ ] XPathNSResolver.webidl
- - [ ] XPathResult.webidl
+ - [x] XPathResult.webidl
  - [ ] XSLTProcessor.webidl
  - [ ] README.md
  - [ ] WaveShaperNode.webidl

--- a/crates/web-sys/tests/wasm/element.js
+++ b/crates/web-sys/tests/wasm/element.js
@@ -26,6 +26,10 @@ export function new_head() {
   return document.createElement("head");
 }
 
+export function new_hr() {
+    return document.createElement("hr");
+}
+
 export function new_html() {
   return document.createElement("html");
 }

--- a/crates/web-sys/tests/wasm/hr_element.rs
+++ b/crates/web-sys/tests/wasm/hr_element.rs
@@ -1,0 +1,24 @@
+use wasm_bindgen_test::*;
+use wasm_bindgen::prelude::*;
+use web_sys::HtmlHrElement;
+
+#[wasm_bindgen(module = "./tests/wasm/element.js")]
+extern {
+    fn new_hr() -> HtmlHrElement;
+}
+
+#[wasm_bindgen_test]
+fn test_hr_element() {
+    let hr = new_hr();
+    hr.set_color("blue");
+    assert_eq!(hr.color(), "blue");
+
+    hr.set_width("128");
+    assert_eq!(hr.width(), "128");
+
+    hr.set_width("256");
+    assert_eq!(hr.width(), "256");
+
+    hr.set_no_shade(true);
+    assert_eq!(hr.no_shade(), true);
+}

--- a/crates/web-sys/tests/wasm/main.rs
+++ b/crates/web-sys/tests/wasm/main.rs
@@ -17,6 +17,7 @@ pub mod element;
 pub mod head_element;
 pub mod headers;
 pub mod history;
+pub mod hr_element;
 pub mod html_element;
 pub mod html_html_element;
 pub mod response;


### PR DESCRIPTION
Hello again!  Fairly certain this test will pass, but unfortunately I can't seem to get cargo to find any tests at all.

```
~/projects/wasm-bindgen/crates/web-sys 
$ cargo test --target wasm32-unknown-unknown 
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s                                                                                                                                                                                                              
     Running /Users/twilcock/projects/wasm-bindgen/target/wasm32-unknown-unknown/debug/deps/all-a5c63a8c7fc00a5f.wasm
    Finished release [optimized] target(s) in 0.18s                                                                                                                                                                                                                        
     Running `/Users/twilcock/projects/wasm-bindgen/target/release/wasm-bindgen-test-runner /Users/twilcock/projects/wasm-bindgen/target/wasm32-unknown-unknown/debug/deps/all-a5c63a8c7fc00a5f.wasm`
no tests to run!
     Running /Users/twilcock/projects/wasm-bindgen/target/wasm32-unknown-unknown/debug/deps/wasm-d82521c4d7864ee1.wasm
    Finished release [optimized] target(s) in 0.16s                                                                                                                                                                                                                        
     Running `/Users/twilcock/projects/wasm-bindgen/target/release/wasm-bindgen-test-runner /Users/twilcock/projects/wasm-bindgen/target/wasm32-unknown-unknown/debug/deps/wasm-d82521c4d7864ee1.wasm`
Running server on http://127.0.0.1:8000  
```         

Is there some flag or part of the command that I am missing?
