### PR TITLE
Fix `web-sys` history unit test

### DIFF
--- a/crates/web-sys/tests/wasm/history.rs
+++ b/crates/web-sys/tests/wasm/history.rs
@@ -11,18 +11,6 @@ extern {
 
 #[wasm_bindgen_test]
 fn history() {
-    HISTORY.push_state(
-        Object::new().into(),
-        "I am a title",
-        Some("part/of/some/url"),
-    ).unwrap();
-    assert_eq!(HISTORY.length().unwrap(), 2);
-
-    assert!(HISTORY.go(1).is_ok());
-    assert!(HISTORY.back().is_ok());
-    assert!(HISTORY.forward().is_ok());
-    assert!(HISTORY.go(-1).is_ok());
-
     HISTORY.set_scroll_restoration(ScrollRestoration::Manual).expect("failure to set scroll restoration");
     assert_eq!(HISTORY.scroll_restoration().unwrap(), ScrollRestoration::Manual);
 


### PR DESCRIPTION
In an actual browser, the changing of the browser history using the binding worked a little too well, and caused the test to fail if you refreshed the page or manually used the back and forward buttons.  The stateful stuff has been removed - the remaining two assertions should adequately test that the binding works, which is the point of these tests anyway.