### PR TITLE
Prepare to have targeted error diagnostics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,12 @@ matrix:
         - cargo test -p webidl-tests --target wasm32-unknown-unknown
       if: branch = master
 
+    # UI tests for the macro work just fine
+    - rust: nightly
+      env: JOB=macro-ui
+      script: cargo test -p ui-tests
+      if: branch = master
+
     # Dist linux binary
     - rust: nightly
       env: JOB=dist-linux TARGET=x86_64-unknown-linux-musl

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
   "crates/js-sys",
   "crates/test",
   "crates/typescript",
+  "crates/macro/ui-tests",
   "crates/web-sys",
   "crates/webidl",
   "crates/webidl-tests",

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -1,0 +1,83 @@
+use proc_macro2::*;
+use quote::ToTokens;
+
+pub struct Diagnostic {
+    inner: Repr,
+}
+enum Repr {
+    Single {
+        text: String,
+        span: Option<(Span, Span)>,
+    },
+    Multi {
+        diagnostics: Vec<Diagnostic>,
+    }
+}
+
+impl Diagnostic {
+    pub fn error<T: Into<String>>(text: T) -> Diagnostic {
+        Diagnostic {
+            inner: Repr::Single {
+                text: text.into(),
+                span: None,
+            }
+        }
+    }
+
+    pub fn span_error<T: Into<String>>(node: &ToTokens, text: T) -> Diagnostic {
+        Diagnostic {
+            inner: Repr::Single {
+                text: text.into(),
+                span: extract_spans(node),
+            }
+        }
+    }
+
+    pub fn from_vec(diagnostics: Vec<Diagnostic>) -> Result<(), Diagnostic> {
+        if diagnostics.len() == 0 {
+            Ok(())
+        } else {
+            Err(Diagnostic { inner: Repr::Multi { diagnostics }  })
+        }
+    }
+
+    #[allow(unconditional_recursion)]
+    pub fn panic(&self) -> ! {
+        match &self.inner {
+            Repr::Single { text, .. } => panic!("{}", text),
+            Repr::Multi { diagnostics } => diagnostics[0].panic(),
+        }
+    }
+}
+
+fn extract_spans(node: &ToTokens) -> Option<(Span, Span)> {
+    let mut t = TokenStream::new();
+    node.to_tokens(&mut t);
+    let mut tokens = t.into_iter();
+    let start = tokens.next().map(|t| t.span());
+    let end = tokens.last().map(|t| t.span());
+    start.map(|start| (start, end.unwrap_or(start)))
+}
+
+impl ToTokens for Diagnostic {
+    fn to_tokens(&self, dst: &mut TokenStream) {
+        match &self.inner {
+            Repr::Single { text, span } => {
+                let cs2 = (Span::call_site(), Span::call_site());
+                let (start, end) = span.unwrap_or(cs2);
+                dst.extend(Some(Ident::new("compile_error", start).into()));
+                dst.extend(Some(Punct::new('!', Spacing::Alone).into()));
+                let mut message = TokenStream::new();
+                message.extend(Some(Literal::string(text).into()));
+                let mut group = Group::new(Delimiter::Brace, message);
+                group.set_span(end);
+                dst.extend(Some(group.into()));
+            }
+            Repr::Multi { diagnostics } => {
+                for diagnostic in diagnostics {
+                    diagnostic.to_tokens(dst);
+                }
+            }
+        }
+    }
+}

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -14,7 +14,11 @@ extern crate syn;
 
 extern crate wasm_bindgen_shared as shared;
 
+pub use codegen::TryToTokens;
+pub use error::Diagnostic;
+
 pub mod ast;
 mod codegen;
 pub mod defined;
+mod error;
 pub mod util;

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -14,10 +14,9 @@ Definition of the `#[wasm_bindgen]` attribute, an internal dependency
 proc-macro = true
 
 [features]
-spans = ["proc-macro2/nightly", "wasm-bindgen-macro-support/spans"]
+spans = ["wasm-bindgen-macro-support/spans"]
 xxx_debug_only_print_generated_code = []
 
 [dependencies]
-syn = { version = '0.14', features = ['full'] }
-proc-macro2 = "0.4.9"
 wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.15" }
+quote = "0.6"

--- a/crates/macro/README.md
+++ b/crates/macro/README.md
@@ -1,0 +1,28 @@
+# `wasm-bindgen-macro`
+
+Implementation of the `#[wasm_bindgen]` attribute. See the `wasm-bindgen`
+documentation for more information about what this macro does.
+
+## Testing
+
+Testing of this macro is done through "ui tests" in the `ui-tests` subdirectory
+of this crate. Each Rust file in this folder is compiled with the `wasm_bindgen`
+crate, and the `*.stderr` file sitting next to it is the asserted output of the
+compiler. If the output matches, the test passes, and if the output doesn't
+match the test fails. Note that it is also considered a failure if a test
+actually compiles successfully.
+
+To add a test:
+
+* Create `ui-tests/my-awesome-test.rs`
+* Write an invalid `#[wasm_bindgen]` invocation, testing the error you're
+  generating
+* Execute `cargo test -p ui-tests`, the test will fail
+* From within the `ui-tests` folder, execute `./update-all-references.sh`. This
+  should create a `my-awesome-test.stderr` file.
+* Inspect `my-awesome-test.stderr` to make sure it looks ok
+* Rerun `cargo test -p ui-tests` and your tests should pass!
+
+Testing here is a work in progress, see
+[#601](https://github.com/rustwasm/wasm-bindgen/issues/601) for more
+information.

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,23 +1,21 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro/0.2")]
 
 extern crate proc_macro;
-extern crate proc_macro2;
-extern crate syn;
+#[macro_use]
+extern crate quote;
 extern crate wasm_bindgen_macro_support as macro_support;
 
-use macro_support::BindgenAttrs;
 use proc_macro::TokenStream;
 
 #[proc_macro_attribute]
 pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
-    let item = syn::parse::<syn::Item>(input.clone()).expect("expected a valid Rust item");
-    let opts = syn::parse::<BindgenAttrs>(attr).expect("invalid arguments to #[wasm_bindgen]");
-
-    let tokens = macro_support::expand(item, opts);
-
-    if cfg!(feature = "xxx_debug_only_print_generated_code") {
-        println!("{}", tokens);
+    match macro_support::expand(attr.into(), input.into()) {
+        Ok(tokens) => {
+            if cfg!(feature = "xxx_debug_only_print_generated_code") {
+                println!("{}", tokens);
+            }
+            tokens.into()
+        }
+        Err(diagnostic) => (quote! { #diagnostic }).into(),
     }
-
-    tokens.into()
 }

--- a/crates/macro/ui-tests/Cargo.toml
+++ b/crates/macro/ui-tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ui-tests"
+version = "0.1.0"
+authors = ["The wasm-bindgen Authors"]
+
+[lib]
+path = "test.rs"
+doctest = false
+harness = false
+
+[dependencies]
+wasm-bindgen = { path = "../../.." }
+
+[dev-dependencies]
+compiletest_rs = "0.3"

--- a/crates/macro/ui-tests/attribute-fails-to-parse.rs
+++ b/crates/macro/ui-tests/attribute-fails-to-parse.rs
@@ -1,0 +1,8 @@
+#![feature(use_extern_macros)]
+
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(nonsense)]
+pub fn foo() {}

--- a/crates/macro/ui-tests/attribute-fails-to-parse.stderr
+++ b/crates/macro/ui-tests/attribute-fails-to-parse.stderr
@@ -1,0 +1,8 @@
+error: error parsing #[wasm_bindgen] attribute options: failed to parse anything
+ --> $DIR/attribute-fails-to-parse.rs:7:16
+  |
+7 | #[wasm_bindgen(nonsense)]
+  |                ^^^^^^^^
+
+error: aborting due to previous error
+

--- a/crates/macro/ui-tests/non-public-function.rs
+++ b/crates/macro/ui-tests/non-public-function.rs
@@ -1,0 +1,8 @@
+#![feature(use_extern_macros)]
+
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+fn foo() {}

--- a/crates/macro/ui-tests/non-public-function.stderr
+++ b/crates/macro/ui-tests/non-public-function.stderr
@@ -1,0 +1,10 @@
+error: custom attribute panicked
+ --> $DIR/non-public-function.rs:7:1
+  |
+7 | #[wasm_bindgen]
+  | ^^^^^^^^^^^^^^^
+  |
+  = help: message: can only bindgen public functions
+
+error: aborting due to previous error
+

--- a/crates/macro/ui-tests/test.rs
+++ b/crates/macro/ui-tests/test.rs
@@ -1,0 +1,25 @@
+// ignore-test - not a test
+
+#![cfg(test)]
+
+extern crate compiletest_rs as compiletest;
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn main() {
+    let mut config = compiletest::Config::default();
+    config.mode = "ui".parse().expect("invalid mode");
+    let mut me = env::current_exe().unwrap();
+    me.pop();
+    config.target_rustcflags = Some(format!("-L {}", me.display()));
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    config.src_base = src;
+
+    me.pop();
+    me.pop();
+    config.build_base = me.join("tests/ui");
+    drop(fs::remove_dir_all(&config.build_base));
+    compiletest::run_tests(&config);
+}

--- a/crates/macro/ui-tests/update-all-references.sh
+++ b/crates/macro/ui-tests/update-all-references.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# A script to update the references for all tests. The idea is that
+# you do a run, which will generate files in the build directory
+# containing the (normalized) actual output of the compiler. You then
+# run this script, which will copy those files over. If you find
+# yourself manually editing a foo.stderr file, you're doing it wrong.
+#
+# See all `update-references.sh`, if you just want to update a single test.
+
+MY_DIR=$(dirname $0)
+cd $MY_DIR
+find . -name '*.rs' | xargs ./update-references.sh

--- a/crates/macro/ui-tests/update-references.sh
+++ b/crates/macro/ui-tests/update-references.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+# file at the top-level directory of this distribution and at
+# http://rust-lang.org/COPYRIGHT.
+#
+# Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+# http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+# <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+# option. This file may not be copied, modified, or distributed
+# except according to those terms.
+
+# A script to update the references for particular tests. The idea is
+# that you do a run, which will generate files in the build directory
+# containing the (normalized) actual output of the compiler. This
+# script will then copy that output and replace the "expected output"
+# files. You can then commit the changes.
+#
+# If you find yourself manually editing a foo.stderr file, you're
+# doing it wrong.
+
+MYDIR=$(dirname $0)
+
+BUILD_DIR="../../../target/tests/ui"
+
+while [[ "$1" != "" ]]; do
+    STDERR_NAME="${1/%.rs/.stderr}"
+    STDOUT_NAME="${1/%.rs/.stdout}"
+    shift
+    if [ -f $BUILD_DIR/$STDOUT_NAME ] && \
+           ! (diff $BUILD_DIR/$STDOUT_NAME $MYDIR/$STDOUT_NAME >& /dev/null); then
+        echo updating $MYDIR/$STDOUT_NAME
+        cp $BUILD_DIR/$STDOUT_NAME $MYDIR/$STDOUT_NAME
+    fi
+    if [ -f $BUILD_DIR/$STDERR_NAME ] && \
+           ! (diff $BUILD_DIR/$STDERR_NAME $MYDIR/$STDERR_NAME >& /dev/null); then
+        echo updating $MYDIR/$STDERR_NAME
+        cp $BUILD_DIR/$STDERR_NAME $MYDIR/$STDERR_NAME
+    fi
+done
+
+

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -33,11 +33,11 @@ use std::io::{self, Read};
 use std::iter::FromIterator;
 use std::path::Path;
 
+use backend::TryToTokens;
 use backend::defined::{ImportedTypeDefinitions, RemoveUndefinedImports};
 use backend::util::{ident_ty, rust_ident, wrap_import_function};
 use failure::{ResultExt, Fail};
 use heck::{ShoutySnakeCase};
-use quote::ToTokens;
 
 use first_pass::{FirstPass, FirstPassRecord};
 use util::{public, webidl_const_ty_to_syn_ty, webidl_const_v_to_backend_const_v, TypePosition, camel_case_ident, mdn_doc};
@@ -111,7 +111,9 @@ fn compile_ast(mut ast: backend::ast::Program) -> String {
     ast.remove_undefined_imports(&|id| defined.contains(id));
 
     let mut tokens = proc_macro2::TokenStream::new();
-    ast.to_tokens(&mut tokens);
+    if let Err(e) = ast.try_to_tokens(&mut tokens) {
+        e.panic();
+    }
     tokens.to_string()
 }
 


### PR DESCRIPTION
This commit starts to add infrastructure for targeted diagnostics in the
`#[wasm_bindgen]` attribute, intended eventually at providing much better errors
as they'll be pointing to exactly the code in question rather than always to a
`#[wasm_bindgen]` attribute.

The general changes are are:

* A new `Diagnostic` error type is added to the backend. A `Diagnostic` is
  created with a textual error or with a span, and it can also be created from a
  list of diagnostics. A `Diagnostic` implements `ToTokens` which emits a bunch
  of invocations of `compile_error!` that will cause rustc to later generate
  errors.

* Fallible implementations of `ToTokens` have switched to using a new trait,
  `TryToTokens`, which returns a `Result` to use `?` with.

* The `MacroParse` trait has changed to returning a `Result` to propagate errors
  upwards.

* A new `ui-tests` crate was added which uses `compiletest_rs` to add UI tests.
  These UI tests will verify that our output improves over time and does not
  regress. This test suite is added to CI as a new builder as well.

* No `Diagnostic` instances are created just yet, everything continues to panic
  and return `Ok`, with the one exception of the top-level invocations of
  `syn::parse` which now create a `Diagnostic` and pass it along.

This commit does not immediately improve diagnostics but the intention is that
it is laying the groundwork for improving diagnostics over time. It should
ideally be much easier to contribute improved diagnostics after this commit!

cc #601