### PR TITLE
Default to headless testing for the test runner

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -210,6 +210,11 @@ although more driver support may be added! You can download these at:
     * chromedriver - http://chromedriver.chromium.org/downloads
     * safaridriver - should be preinstalled on OSX
 
+If you would prefer to not use headless testing and would instead like to do
+interactive testing in a web browser then you can specify `NO_HEADLESS=1` as
+an environment variable. When rerun the tests will start a server that you can
+visit in a web browser, and headless testing should not be used.
+
 If you're still having difficulty resolving this error, please feel free to open
 an issue against rustwasm/wasm-bindgen!
     ")

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -122,7 +122,7 @@ fn rmain() -> Result<(), Error> {
         }
         node = !custom.payload().contains(&0x01);
     }
-    let headless = env::var("CI").is_ok();
+    let headless = env::var("NO_HEADLESS").is_err();
 
     // Make the generated bindings available for the tests to execute against.
     shell.status("Executing bindgen...");
@@ -159,7 +159,12 @@ fn rmain() -> Result<(), Error> {
     // TODO: eventually we should provide the ability to exit at some point
     // (gracefully) here, but for now this just runs forever.
     if !headless {
-        println!("Running server on http://{}", addr);
+        println!("Interactive browsers tests are now available at http://{}", addr);
+        println!("");
+        println!("Note that interactive mode is enabled because `NO_HEADLESS`");
+        println!("is specified in the environment of this process. Once you're");
+        println!("done with testing you'll need to kill this server with");
+        println!("Ctrl-C.");
         return Ok(srv.run())
     }
 


### PR DESCRIPTION
We've gotten a number of reports that the interactive tests are a bit surprising
and confusing (also because it barely prints anything!). Instead let's default
to headless testing which matches the Rust style of testing much better.

The error message for a missing WebDriver binary has been updated with a note of
how to *not* do headless testing and the message for interactive testing was
also updated to display more information as well.