### PR TITLE
Remove usage of syn's `visit-mut` feature

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -20,5 +20,5 @@ log = "0.4"
 proc-macro2 = "0.4.8"
 quote = '0.6'
 serde_json = "1.0"
-syn = { version = '0.14', features = ['full', 'visit-mut'] }
+syn = { version = '0.14', features = ['full', 'visit'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.15" }


### PR DESCRIPTION
Looks like we're the only one in the dependency graph enabling this, so let's
try to cut down on compile times by not requiring it.