### PR TITLE
Add WebIDL support for the `ArrayBuffer` type

### DIFF
--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -16,6 +16,7 @@ sourcefile = "0.1"
 
 [dependencies]
 wasm-bindgen = { path = "../..", version = "0.2.15" }
+js-sys = { path = '../js-sys', version = '0.2.0' }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 futures = "0.1"

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/web-sys/0.2")]
 
 extern crate wasm_bindgen;
+extern crate js_sys;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/webidl-tests/Cargo.toml
+++ b/crates/webidl-tests/Cargo.toml
@@ -12,8 +12,9 @@ path = 'lib.rs'
 wasm-bindgen-webidl = { path = '../webidl' }
 
 [dev-dependencies]
-wasm-bindgen-test = { path = '../test' }
+js-sys = { path = '../js-sys' }
 wasm-bindgen = { path = '../..' }
+wasm-bindgen-test = { path = '../test' }
 
 [[test]]
 name = 'wasm'

--- a/crates/webidl-tests/array_buffer.js
+++ b/crates/webidl-tests/array_buffer.js
@@ -1,0 +1,8 @@
+global.ArrayBufferTest = class {
+  getBuffer() {
+    return new ArrayBuffer(3);
+  }
+  setBuffer(x) {
+    // ...
+  }
+};

--- a/crates/webidl-tests/array_buffer.rs
+++ b/crates/webidl-tests/array_buffer.rs
@@ -1,0 +1,11 @@
+use wasm_bindgen_test::*;
+
+include!(concat!(env!("OUT_DIR"), "/array_buffer.rs"));
+
+#[wasm_bindgen_test]
+fn take_and_return_a_bunch_of_slices() {
+    let f = ArrayBufferTest::new().unwrap();
+    let x = f.get_buffer();
+    f.set_buffer(None);
+    f.set_buffer(Some(x));
+}

--- a/crates/webidl-tests/array_buffer.webidl
+++ b/crates/webidl-tests/array_buffer.webidl
@@ -1,0 +1,5 @@
+[Constructor]
+interface ArrayBufferTest {
+  ArrayBuffer getBuffer();
+  void setBuffer(ArrayBuffer? b);
+};

--- a/crates/webidl-tests/build.rs
+++ b/crates/webidl-tests/build.rs
@@ -1,8 +1,9 @@
 extern crate wasm_bindgen_webidl;
 
-use std::fs;
 use std::env;
+use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     let idls = fs::read_dir(".")
@@ -41,6 +42,10 @@ fn main() {
             }}
         "#, js_file.display(), i));
 
-        fs::write(out_file, generated_rust).unwrap();
+        fs::write(&out_file, generated_rust).unwrap();
+
+        // Attempt to run rustfmt, but don't worry if it fails or if it isn't
+        // installed, this is just to help with debugging
+        drop(Command::new("rustfmt").arg(&out_file).status());
     }
 }

--- a/crates/webidl-tests/main.rs
+++ b/crates/webidl-tests/main.rs
@@ -1,10 +1,12 @@
 #![feature(use_extern_macros)]
 
-extern crate wasm_bindgen_test;
+extern crate js_sys;
 extern crate wasm_bindgen;
+extern crate wasm_bindgen_test;
 
+pub mod array;
+pub mod array_buffer;
 pub mod consts;
 pub mod enums;
 pub mod simple;
 pub mod throws;
-pub mod array;

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -102,6 +102,7 @@ fn compile_ast(mut ast: backend::ast::Program) -> String {
         vec![
             "str", "char", "bool", "JsValue", "u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64",
             "usize", "isize", "f32", "f64", "Result", "String", "Vec", "Option",
+            "ArrayBuffer",
         ].into_iter()
             .map(|id| proc_macro2::Ident::new(id, proc_macro2::Span::call_site())),
     );

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -422,9 +422,16 @@ impl<'a> FirstPassRecord<'a> {
                 }
             }
 
+            // This seems like a "naively correct" mapping, but the online docs
+            // are a bit scary in this regard...
+            //
+            // https://heycam.github.io/webidl/#es-buffer-source-types
+            webidl::ast::TypeKind::ArrayBuffer => {
+                simple_path_ty(vec![rust_ident("js_sys"), rust_ident("ArrayBuffer")])
+            }
+
             // Support for these types is not yet implemented, so skip
             // generating any bindings for this function.
-            webidl::ast::TypeKind::ArrayBuffer
             | webidl::ast::TypeKind::DataView
             | webidl::ast::TypeKind::Error
             | webidl::ast::TypeKind::FrozenArray(_)


### PR DESCRIPTION
Should help enable a slew of new bindings as well.