### PR TITLE
Add WebIDL support for the `object` type

### DIFF
--- a/crates/web-sys/tests/wasm/dom_point.rs
+++ b/crates/web-sys/tests/wasm/dom_point.rs
@@ -1,0 +1,33 @@
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+use web_sys::{DomPoint, DomPointReadOnly};
+
+#[wasm_bindgen_test]
+fn dom_point() {
+    let x = DomPoint::new(1.0, 2.0, 3.0, 4.0).unwrap();
+    assert_eq!(x.x(), 1.0);
+    x.set_x(1.5);
+    assert_eq!(x.x(), 1.5);
+
+    assert_eq!(x.y(), 2.0);
+    x.set_y(2.5);
+    assert_eq!(x.y(), 2.5);
+
+    assert_eq!(x.z(), 3.0);
+    x.set_z(3.5);
+    assert_eq!(x.z(), 3.5);
+
+    assert_eq!(x.w(), 4.0);
+    x.set_w(4.5);
+    assert_eq!(x.w(), 4.5);
+}
+
+#[wasm_bindgen_test]
+fn dom_point_readonly() {
+    let x = DomPoint::new(1.0, 2.0, 3.0, 4.0).unwrap();
+    let x = DomPointReadOnly::from(JsValue::from(x));
+    assert_eq!(x.x(), 1.0);
+    assert_eq!(x.y(), 2.0);
+    assert_eq!(x.z(), 3.0);
+    assert_eq!(x.w(), 4.0);
+}

--- a/crates/web-sys/tests/wasm/main.rs
+++ b/crates/web-sys/tests/wasm/main.rs
@@ -50,3 +50,5 @@ pub mod style_element;
 pub mod table_element;
 pub mod title_element;
 pub mod xpath_result;
+pub mod dom_point;
+pub mod performance;

--- a/crates/web-sys/tests/wasm/option_element.rs
+++ b/crates/web-sys/tests/wasm/option_element.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen_test::*;
-use wasm_bindgen::prelude::*;
 use web_sys::HtmlOptionElement;
 
 #[wasm_bindgen_test]

--- a/crates/web-sys/tests/wasm/performance.rs
+++ b/crates/web-sys/tests/wasm/performance.rs
@@ -1,0 +1,15 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+use web_sys::Performance;
+
+#[wasm_bindgen]
+extern {
+    #[wasm_bindgen(js_name = performance)]
+    static PERFORMANCE: Performance;
+}
+
+#[wasm_bindgen_test]
+fn to_json() {
+    let perf = JsValue::from(PERFORMANCE.to_json());
+    assert!(perf.is_object());
+}

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -102,7 +102,7 @@ fn compile_ast(mut ast: backend::ast::Program) -> String {
         vec![
             "str", "char", "bool", "JsValue", "u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64",
             "usize", "isize", "f32", "f64", "Result", "String", "Vec", "Option",
-            "ArrayBuffer",
+            "ArrayBuffer", "Object",
         ].into_iter()
             .map(|id| proc_macro2::Ident::new(id, proc_macro2::Span::call_site())),
     );

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -430,12 +430,18 @@ impl<'a> FirstPassRecord<'a> {
                 leading_colon_path_ty(vec![rust_ident("js_sys"), rust_ident("ArrayBuffer")])
             }
 
+            // The WebIDL `object` maps to the ECMAScript `Object`
+            //
+            // https://heycam.github.io/webidl/#es-object
+            webidl::ast::TypeKind::Object => {
+                leading_colon_path_ty(vec![rust_ident("js_sys"), rust_ident("Object")])
+            }
+
             // Support for these types is not yet implemented, so skip
             // generating any bindings for this function.
             | webidl::ast::TypeKind::DataView
             | webidl::ast::TypeKind::Error
             | webidl::ast::TypeKind::FrozenArray(_)
-            | webidl::ast::TypeKind::Object
             | webidl::ast::TypeKind::Promise(_)
             | webidl::ast::TypeKind::Record(..)
             | webidl::ast::TypeKind::Sequence(_)


### PR DESCRIPTION
This maps to the `Object` type in the `js_sys` crate.