### PR TITLE
Allow js_name attribute to accept a string

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -116,7 +116,7 @@ pub struct ImportStatic {
     pub ty: syn::Type,
     pub shim: Ident,
     pub rust_name: Ident,
-    pub js_name: Ident,
+    pub js_name: String,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -143,7 +143,7 @@ pub struct ImportEnum {
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 pub struct Function {
-    pub name: Ident,
+    pub name: String,
     pub arguments: Vec<syn::ArgCaptured>,
     pub ret: Option<syn::Type>,
     pub rust_attrs: Vec<syn::Attribute>,

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -563,7 +563,7 @@ impl<'a> FirstPassRecord<'a> {
                 name.to_snake_case()
             }
         );
-        let name = raw_ident(name);
+        let name = name.to_string();
 
         let arguments = self.webidl_arguments_to_syn_arg_captured(arguments.into_iter(), &kind)?;
 

--- a/tests/all/imports.rs
+++ b/tests/all/imports.rs
@@ -37,6 +37,91 @@ fn unused_imports_not_generated() {
 }
 
 #[test]
+fn rename_with_string() {
+    project()
+        .file(
+            "src/lib.rs",
+            r#"
+                #![feature(use_extern_macros)]
+
+                extern crate wasm_bindgen;
+
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen(module = "./test")]
+                extern {
+                    #[wasm_bindgen(js_name = "baz$")]
+                    fn foo();
+                }
+
+                #[wasm_bindgen]
+                pub fn run() {
+                    foo();
+                }
+            "#,
+        )
+        .file(
+            "test.js",
+            r#"
+                import * as wasm from "./out";
+                import * as assert from "assert";
+
+                let called = false;
+
+                export function baz$() {
+                    called = true;
+                }
+
+                export function test() {
+                    wasm.run();
+                    assert.strictEqual(called, true);
+                }
+            "#,
+        )
+        .test();
+}
+
+#[test]
+fn rename_static_with_string() {
+    project()
+        .debug(false)
+        .file(
+            "src/lib.rs",
+            r#"
+                #![feature(use_extern_macros)]
+
+                extern crate wasm_bindgen;
+
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen(module = "./test")]
+                extern {
+                    #[wasm_bindgen(js_name = "$foo")]
+                    static FOO: JsValue;
+                }
+
+                #[wasm_bindgen]
+                pub fn run() {
+                    assert_eq!(FOO.as_f64(), Some(1.0));
+                }
+            "#,
+        )
+        .file(
+            "test.js",
+            r#"
+                import { run } from "./out";
+
+                export const $foo = 1.0;
+
+                export function test() {
+                    run();
+                }
+            "#,
+        )
+        .test();
+}
+
+#[test]
 fn versions() {
     project()
         .debug(false)


### PR DESCRIPTION
I think there's room for improvement in these changes. But I'm adding it here to show how far I got, and to see whether it's a viable approach.

Fixes #583 