### PR TITLE
Fix consuming a struct and returning a slice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,19 @@ matrix:
       env: JOB=test-bindgen
       install:
         - *INSTALL_NODE_VIA_NVM
+        - *INSTALL_GECKODRIVER
+        - export GECKODRIVER=`pwd`/geckodriver
       script:
+        # Run a test or two that makes sure `#[wasm_bindgen]` works "reasonably"
+        # on non-wasm platforms
         - cargo test
+        # Run the main body of the test suite
         - cargo test --target wasm32-unknown-unknown
+        # Rerun the test suite but disable `--debug` in generated JS
         - WASM_BINDGEN_NO_DEBUG=1 cargo test --target wasm32-unknown-unknown
+        # Make sure our serde tests work
         - cargo test --target wasm32-unknown-unknown --features serde-serialize
+        # Make sure the `std` feature works if disabled
         - cargo test --target wasm32-unknown-unknown -p no-std
       addons:
         firefox: latest

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -417,16 +417,16 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 "\
                  RET;\n\
                  const mem = getUint32Memory();\n\
-                 const ptr = mem[retptr / 4];\n\
-                 const len = mem[retptr / 4 + 1];\n\
+                 const rustptr = mem[retptr / 4];\n\
+                 const rustlen = mem[retptr / 4 + 1];\n\
                  {guard}
-                 const realRet = {}(ptr, len).slice();\n\
-                 wasm.__wbindgen_free(ptr, len * {});\n\
+                 const realRet = {}(rustptr, rustlen).slice();\n\
+                 wasm.__wbindgen_free(rustptr, rustlen * {});\n\
                  return realRet;\n\
                  ",
                 f,
                 ty.size(),
-                guard = if optional { "if (ptr === 0) return;" } else { "" },
+                guard = if optional { "if (rustptr === 0) return;" } else { "" },
             );
             return Ok(self);
         }

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -1,0 +1,27 @@
+#![cfg(target_arch = "wasm32")]
+#![feature(use_extern_macros)]
+
+extern crate wasm_bindgen_test;
+extern crate wasm_bindgen;
+
+use wasm_bindgen_test::*;
+use wasm_bindgen::prelude::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen]
+pub struct ConsumeRetString;
+
+#[wasm_bindgen]
+impl ConsumeRetString {
+    // https://github.com/rustwasm/wasm-bindgen/issues/329#issuecomment-411082013
+    //
+    // This used to cause two `const ptr = ...` declarations, which is invalid
+    // JS.
+    pub fn consume(self) -> String { String::new() }
+}
+
+#[wasm_bindgen_test]
+fn works() {
+    ConsumeRetString.consume();
+}


### PR DESCRIPTION
This came up in a [recent comment][1] and it turns out we're accidentally
generating two `const ptr = ...` declarations, invalid JS! While Node doesn't
catch this it looks like firefox does.

[1]: https://github.com/rustwasm/wasm-bindgen/issues/329#issuecomment-411082013