### PR TITLE
Support named "special" operations in WebIDL

### DIFF
--- a/crates/web-sys/build.rs
+++ b/crates/web-sys/build.rs
@@ -65,6 +65,7 @@ fn try_main() -> Result<(), failure::Error> {
         .context("writing bindings to output file")?;
 
     // run rustfmt on the generated file - really handy for debugging
+    println!("cargo:rerun-if-env-changed=WEBIDL_RUSTFMT_BINDINGS");
     if env::var("WEBIDL_RUSTFMT_BINDINGS").is_ok() {
         let status = Command::new("rustfmt")
             .arg(&out_file_path)

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -370,7 +370,7 @@ impl<'src> FirstPassRecord<'src> {
     /// Create a wasm-bindgen method, if possible.
     pub fn create_basic_method(
         &self,
-        arguments: &[weedle::argument::Argument],
+        arguments: &[Argument],
         operation_id: first_pass::OperationId,
         return_type: &weedle::types::ReturnType,
         self_name: &str,
@@ -392,11 +392,11 @@ impl<'src> FirstPassRecord<'src> {
                     warn!("Operations without a name are unsupported");
                     return Vec::new();
                 }
-                Some(name) => name.to_string(),
+                Some(name) => name,
             },
-            first_pass::OperationId::IndexingGetter => "get".to_string(),
-            first_pass::OperationId::IndexingSetter => "set".to_string(),
-            first_pass::OperationId::IndexingDeleter => "delete".to_string(),
+            first_pass::OperationId::IndexingGetter => "get",
+            first_pass::OperationId::IndexingSetter => "set",
+            first_pass::OperationId::IndexingDeleter => "delete",
         };
 
         let kind = backend::ast::ImportFunctionKind::Method {
@@ -455,7 +455,7 @@ impl<'src> FirstPassRecord<'src> {
     /// whether there overloads with same argument names for given argument types
     pub fn get_operation_overloading(
         &self,
-        arguments: &[weedle::argument::Argument],
+        arguments: &[Argument],
         operation_id: &first_pass::OperationId,
         self_name: &str,
         namespace: bool,


### PR DESCRIPTION
This commit adds support for two different features of the "special" operations
in WebIDL. First, it implements the desugaring [described by WebIDL][1] where
this:

    interface Dictionary {
      getter double getProperty(DOMString propertyName);
      setter void setProperty(DOMString propertyName, double propertyValue);
    };

becomes ...

    interface Dictionary {
      double getProperty(DOMString propertyName);
      void setProperty(DOMString propertyName, double propertyValue);

      getter double (DOMString propertyName);
      setter void (DOMString propertyName, double propertyValue);
    };

where specifically a named `getter` generates both a getter and a named
function.

Second it implements the distinction between two different types of getters in
WebIDL, described as:

> Getters and setters come in two varieties: ones that take a DOMString as a
> property name, known as named property getters and named property setters, and
> ones that take an unsigned long as a property index, known as indexed property
> getters and indexed property setters.

The name `get` is given to DOMString arguments, and the name `get_idx` is given
to index property getters.

[1]: https://heycam.github.io/webidl/#idl-special-operations