### PR TITLE
Add support webidl namespaces.

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use proc_macro2::{Ident, Span};
 use shared;
 use syn;
@@ -21,7 +21,7 @@ pub struct Program {
     /// rust consts
     pub consts: Vec<Const>,
     /// rust submodules
-    pub modules: HashMap<Ident, Module>,
+    pub modules: BTreeMap<Ident, Module>,
 }
 
 /// A rust to js interface. Allows interaction with rust objects/functions
@@ -227,8 +227,8 @@ pub enum ConstValue {
 ///
 /// This exists to give the ability to namespace js imports.
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
-#[derive(Default)]
 pub struct Module {
+    pub vis: syn::Visibility,
     /// js -> rust interfaces
     pub imports: Vec<Import>,
 }

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -227,6 +227,7 @@ pub enum ConstValue {
 ///
 /// This exists to give the ability to namespace js imports.
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+#[derive(Default)]
 pub struct Module {
     /// js -> rust interfaces
     pub imports: Vec<Import>,

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use proc_macro2::{Ident, Span};
 use shared;
 use syn;
@@ -20,18 +21,7 @@ pub struct Program {
     /// rust consts
     pub consts: Vec<Const>,
     /// rust submodules
-    pub modules: Vec<Module>,
-}
-
-/// A rust module
-///
-/// This exists to give the ability to namespace js imports.
-#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
-pub struct Module {
-    /// module name
-    pub name: String,
-    /// js -> rust interfaces
-    pub imports: Vec<Import>,
+    pub modules: HashMap<Ident, Module>,
 }
 
 /// A rust to js interface. Allows interaction with rust objects/functions
@@ -233,6 +223,15 @@ pub enum ConstValue {
     Null,
 }
 
+/// A rust module
+///
+/// This exists to give the ability to namespace js imports.
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+pub struct Module {
+    /// js -> rust interfaces
+    pub imports: Vec<Import>,
+}
+
 impl Program {
     pub(crate) fn shared(&self) -> Result<shared::Program, Diagnostic> {
         Ok(shared::Program {
@@ -241,7 +240,7 @@ impl Program {
             enums: self.enums.iter().map(|a| a.shared()).collect(),
             imports: self.imports.iter()
                 // add in imports from inside modules
-                .chain(self.modules.iter().flat_map(|m| m.imports.iter()))
+                .chain(self.modules.values().flat_map(|m| m.imports.iter()))
                 .map(|a| a.shared())
                 .collect::<Result<_, Diagnostic>>()?,
             version: shared::version(),

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -19,6 +19,19 @@ pub struct Program {
     pub structs: Vec<Struct>,
     /// rust consts
     pub consts: Vec<Const>,
+    /// rust submodules
+    pub modules: Vec<Module>,
+}
+
+/// A rust module
+///
+/// This exists to give the ability to namespace js imports.
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+pub struct Module {
+    /// module name
+    pub name: String,
+    /// js -> rust interfaces
+    pub imports: Vec<Import>,
 }
 
 /// A rust to js interface. Allows interaction with rust objects/functions
@@ -227,6 +240,8 @@ impl Program {
             structs: self.structs.iter().map(|a| a.shared()).collect(),
             enums: self.enums.iter().map(|a| a.shared()).collect(),
             imports: self.imports.iter()
+                // add in imports from inside modules
+                .chain(self.modules.iter().flat_map(|m| m.imports.iter()))
                 .map(|a| a.shared())
                 .collect::<Result<_, Diagnostic>>()?,
             version: shared::version(),

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1131,6 +1131,7 @@ impl<'a> TryToTokens for ModuleInIter<'a> {
         for i in imports.iter() {
             DescribeImport(&i.kind).to_tokens(tokens);
         }
+        let vis = &self.module.vis;
         let mut body = TokenStream::new();
         for i in imports.iter() {
             if let Err(e) = i.kind.try_to_tokens(&mut body) {
@@ -1139,7 +1140,7 @@ impl<'a> TryToTokens for ModuleInIter<'a> {
         }
         Diagnostic::from_vec(errors)?;
         (quote!{
-            pub mod #name {
+            #vis mod #name {
                 #body
             }
         }).to_tokens(tokens);

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -43,6 +43,8 @@ impl TryToTokens for ast::Program {
         for i in self.imports.iter() {
             DescribeImport(&i.kind).to_tokens(tokens);
 
+            // If there is a js namespace, check that name isn't a type. If it is,
+            // this import might be a method on that type.
             if let Some(ns) = &i.js_namespace {
                 if types.contains(ns) && i.kind.fits_on_impl() {
                     let kind = match i.kind.try_to_token_stream() {
@@ -58,6 +60,11 @@ impl TryToTokens for ast::Program {
             }
 
             if let Err(e) = i.kind.try_to_tokens(tokens) {
+                errors.push(e);
+            }
+        }
+        for m in self.modules.iter() {
+            if let Err(e) = m.try_to_tokens(tokens) {
                 errors.push(e);
             }
         }
@@ -87,6 +94,7 @@ impl TryToTokens for ast::Program {
         // Each JSON blob is prepended with the length of the JSON blob so when
         // all these sections are concatenated in the final wasm file we know
         // how to extract all the JSON pieces, so insert the byte length here.
+        // The value is little-endian.
         let generated_static_length = description.len() + 4;
         let mut bytes = vec![
             (description.len() >> 0) as u8,
@@ -1100,6 +1108,29 @@ impl ToTokens for ast::Const {
         } else {
             declaration.to_tokens(tokens);
         }
+    }
+}
+
+impl TryToTokens for ast::Module {
+    fn try_to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostic> {
+        let mut errors = Vec::new();
+        for i in self.imports.iter() {
+            DescribeImport(&i.kind).to_tokens(tokens);
+        }
+        let name = &self.name;
+        let mut body = TokenStream::new();
+        for i in self.imports.iter() {
+            if let Err(e) = i.kind.try_to_tokens(&mut body) {
+                errors.push(e);
+            }
+        }
+        Diagnostic::from_vec(errors)?;
+        (quote!{
+            pub mod #name {
+                #body
+            }
+        }).to_tokens(tokens);
+        Ok(())
     }
 }
 

--- a/crates/web-sys/build.rs
+++ b/crates/web-sys/build.rs
@@ -13,6 +13,8 @@ use std::path;
 use std::process::{self, Command};
 
 fn main() {
+    env_logger::init();
+
     if let Err(e) = try_main() {
         eprintln!("Error: {}", e);
         for c in e.iter_causes() {
@@ -24,11 +26,9 @@ fn main() {
 
 fn try_main() -> Result<(), failure::Error> {
     println!("cargo:rerun-if-changed=build.rs");
-    env_logger::init();
-
     println!("cargo:rerun-if-changed=webidls/enabled");
-    let entries = fs::read_dir("webidls/enabled").context("reading webidls/enabled directory")?;
 
+    let entries = fs::read_dir("webidls/enabled").context("reading webidls/enabled directory")?;
     let mut source = SourceFile::default();
     for entry in entries {
         let entry = entry.context("getting webidls/enabled/*.webidl entry")?;
@@ -38,8 +38,7 @@ fn try_main() -> Result<(), failure::Error> {
         }
         println!("cargo:rerun-if-changed={}", path.display());
         source = source.add_file(&path)
-            .with_context(|_| format!("reading contents of file \"{}\"",
-                                      path.display()))?;
+            .with_context(|_| format!("reading contents of file \"{}\"", path.display()))?;
     }
 
     let bindings = match wasm_bindgen_webidl::compile(&source.contents) {
@@ -70,9 +69,9 @@ fn try_main() -> Result<(), failure::Error> {
         let status = Command::new("rustfmt")
             .arg(&out_file_path)
             .status()
-           .context("running rustfmt")?;
+            .context("running rustfmt")?;
         if !status.success() {
-           bail!("rustfmt failed: {}", status)
+            bail!("rustfmt failed: {}", status)
         }
     }
 

--- a/crates/web-sys/tests/wasm/console.rs
+++ b/crates/web-sys/tests/wasm/console.rs
@@ -1,0 +1,9 @@
+use wasm_bindgen_test::*;
+use wasm_bindgen::prelude::*;
+use web_sys::console;
+
+#[wasm_bindgen_test]
+fn test_console() {
+    console::time("test label");
+    console::time_end("test label");
+}

--- a/crates/web-sys/tests/wasm/main.rs
+++ b/crates/web-sys/tests/wasm/main.rs
@@ -14,6 +14,7 @@ pub mod anchor_element;
 pub mod body_element;
 pub mod br_element;
 pub mod button_element;
+pub mod console;
 pub mod div_element;
 pub mod element;
 pub mod event;

--- a/crates/webidl-tests/main.rs
+++ b/crates/webidl-tests/main.rs
@@ -10,3 +10,4 @@ pub mod consts;
 pub mod enums;
 pub mod simple;
 pub mod throws;
+pub mod namespace;

--- a/crates/webidl-tests/namespace.js
+++ b/crates/webidl-tests/namespace.js
@@ -1,0 +1,11 @@
+const strictEqual = require('assert').strictEqual;
+
+global.math = class {
+    powf(base, exp) {
+        return Math.pow(base, exp);
+    }
+
+    add_one(val) {
+        return val + 1;
+    }
+};

--- a/crates/webidl-tests/namespace.js
+++ b/crates/webidl-tests/namespace.js
@@ -1,11 +1,11 @@
 const strictEqual = require('assert').strictEqual;
 
-global.math = class {
-    powf(base, exp) {
-        return Math.pow(base, exp);
-    }
+global.mathtest = {};
 
-    add_one(val) {
-        return val + 1;
-    }
-};
+global.mathtest.powf = function powf(base, exp) {
+    return Math.pow(base, exp);
+}
+
+global.mathtest.add_one = function add_one(val) {
+    return val + 1;
+}

--- a/crates/webidl-tests/namespace.rs
+++ b/crates/webidl-tests/namespace.rs
@@ -4,7 +4,7 @@ include!(concat!(env!("OUT_DIR"), "/namespace.rs"));
 
 #[wasm_bindgen_test]
 fn simple_namespace_test() {
-    assert_eq!(math::add_one(1), 2);
-    assert_eq!(math::powf(1.0, 100.0), 1.0);
-    assert_eq!(math::powf(10.0, 2.0), 100.0);
+    assert_eq!(mathtest::add_one(1), 2);
+    assert_eq!(mathtest::powf(1.0, 100.0), 1.0);
+    assert_eq!(mathtest::powf(10.0, 2.0), 100.0);
 }

--- a/crates/webidl-tests/namespace.rs
+++ b/crates/webidl-tests/namespace.rs
@@ -1,0 +1,10 @@
+use wasm_bindgen_test::*;
+
+include!(concat!(env!("OUT_DIR"), "/namespace.rs"));
+
+#[wasm_bindgen_test]
+fn simple_namespace_test() {
+    assert_eq!(math::add_one(1), 2);
+    assert_eq!(math::powf(1.0, 100.0), 1.0);
+    assert_eq!(math::powf(10.0, 2.0), 100.0);
+}

--- a/crates/webidl-tests/namespace.webidl
+++ b/crates/webidl-tests/namespace.webidl
@@ -1,4 +1,4 @@
-namespace math {
+namespace mathtest {
     long add_one(long val);
     double powf(double base, double exponent);
 };

--- a/crates/webidl-tests/namespace.webidl
+++ b/crates/webidl-tests/namespace.webidl
@@ -1,0 +1,4 @@
+namespace math {
+    long add_one(long val);
+    double powf(double base, double exponent);
+};

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -350,7 +350,7 @@ impl<'src> FirstPass<'src, ()> for weedle::NamespaceDefinition<'src> {
             .namespaces
             .entry(self.identifier.0)
             .and_modify(|entry| entry.partial = false)
-            .or_insert_with(Namespace::empty_non_partial);
+            .or_insert_with(NamespaceData::empty_non_partial);
 
         if util::is_chrome_only(&self.attributes) {
             return Ok(())

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -36,7 +36,7 @@ use std::path::Path;
 
 use backend::TryToTokens;
 use backend::defined::{ImportedTypeDefinitions, RemoveUndefinedImports};
-use backend::util::{ident_ty, rust_ident, wrap_import_function};
+use backend::util::{ident_ty, rust_ident, raw_ident, wrap_import_function};
 use failure::ResultExt;
 use heck::{ShoutySnakeCase, SnakeCase};
 use proc_macro2::{Ident, Span};
@@ -892,7 +892,7 @@ impl<'src> WebidlParse<'src, NamespaceNames<'src>> for weedle::namespace::Operat
 
         let import = backend::ast::Import {
             module: None,
-            js_namespace: Some(ns_names.js_name.clone()),
+            js_namespace: Some(raw_ident(ns_names.js_name)),
             kind: backend::ast::ImportKind::Function(imported_fn),
         };
 

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -1063,7 +1063,7 @@ impl<'src> FirstPassRecord<'src> {
         let doc_comment = format!("The `{}.{}()` function\n\n{}",
                                   namespace_name,
                                   name,
-                                  mdn_doc(namespace_name, Some(&name))); // TODO check link
+                                  mdn_doc(namespace_name, Some(&name))); // checked link
 
         self.create_function(
             &name,

--- a/guide/src/testing.md
+++ b/guide/src/testing.md
@@ -26,7 +26,7 @@ cargo test
 ## The Web IDL Frontend's Tests
 
 ```
-cargo test -p wasm-bindgen-webidl
+cargo test -p webidl-tests --target wasm32-unknown-unknown
 ```
 
 ## The Macro UI Tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -790,7 +790,7 @@ pub mod __rt {
     /// above. That means if this function is called and referenced we'll pull
     /// in the object file and link the intrinsics.
     ///
-    /// Note that this is an #[inline] function to remove the function call
+    /// Note that this is an `#[inline]` function to remove the function call
     /// overhead we inject in functions, but right now it's unclear how to do
     /// this in a zero-cost fashion. The lowest cost seems to be generating a
     /// store that can't be optimized away (to a global), which is listed below.


### PR DESCRIPTION
I'm opening this early to get feedback.

This PR aims to get namespaces supported, so you can do

```rust
console::log("string")
```

So far it can generate code from the AST, which I reconstructed from the following code snippet which I checked compiles correctly.

```rust
extern crate wasm_bindgen;

#[no_mangle]
#[allow(non_snake_case)]
#[doc(hidden)]
#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
pub extern "C" fn __wbindgen_describe___wbg_log_894f9ca062837e26() {
    use wasm_bindgen::describe::*;
    inform(FUNCTION);
    inform(1u32);
    <&str as WasmDescribe>::describe();
    inform(0);
}

mod console {
#[allow(bad_style)]
#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
#[doc = ""]
pub fn log(s: &str) {
    ::wasm_bindgen::__rt::link_mem_intrinsics();
    #[link(wasm_import_module = "__wbindgen_placeholder__")]
    extern "C" {
        fn __wbg_log_894f9ca062837e26(s: <&str as ::wasm_bindgen::convert::IntoWasmAbi>::Abi)
            -> ();
    }
    unsafe {
        let _ret = {
            let mut __stack = ::wasm_bindgen::convert::GlobalStack::new();
            let s = <&str as ::wasm_bindgen::convert::IntoWasmAbi>::into_abi(s, &mut __stack);
            __wbg_log_894f9ca062837e26(s)
        };
        ()
    }
}
#[allow(bad_style, unused_variables)]
#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
#[doc = ""]
pub fn log(s: &str) {
    panic!(
        "cannot call wasm-bindgen imported functions on \
         non-wasm targets"
    );
}
}

#[allow(non_upper_case_globals)]
#[cfg(target_arch = "wasm32")]
#[link_section = "__wasm_bindgen_unstable"]
#[doc(hidden)]
pub static __WASM_BINDGEN_GENERATED_50eb08d47552231d :
[ u8 ; 283usize ] = *
b"\x17\x01\x00\x00{\"exports\":[],\"enums\":[],\"imports\":[{\"module\":null,\"js_namespace\":\"console\",\"kind\":{\"kind\":\"function\",\"shim\":\"__wbg_log_894f9ca062837e26\",\"catch\":false,\"method\":null,\"structural\":false,\"function\":{\"name\":\"log\"}}}],\"structs\":[],\"version\":\"0.2.15 (5b935526f)\",\"schema_version\":\"8\"}";

pub fn greet(name: &str) {
    console::log(&format!("Hello, {}!", name));
}
#[export_name = "greet"]
#[allow(non_snake_case)]
#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
pub extern "C" fn __wasm_bindgen_generated_greet(
    arg0: <str as ::wasm_bindgen::convert::RefFromWasmAbi>::Abi,
) {
    ::wasm_bindgen::__rt::link_mem_intrinsics();
    let _ret = {
        let mut __stack = unsafe { ::wasm_bindgen::convert::GlobalStack::new() };
        let arg0 = unsafe {
            <str as ::wasm_bindgen::convert::RefFromWasmAbi>::ref_from_abi(arg0, &mut __stack)
        };
        let arg0 = &*arg0;
        greet(arg0)
    };
}
#[no_mangle]
#[allow(non_snake_case)]
#[doc(hidden)]
#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
pub extern "C" fn __wbindgen_describe_greet() {
    use wasm_bindgen::describe::*;
    inform(FUNCTION);
    inform(1u32);
    <&str as WasmDescribe>::describe();
    inform(0);
}
#[allow(non_upper_case_globals)]
#[cfg(target_arch = "wasm32")]
#[link_section = "__wasm_bindgen_unstable"]
#[doc(hidden)]
pub static
__WASM_BINDGEN_GENERATED_bbc0315d281cc3c3 : [ u8 ; 214usize ] = *
b"\xd2\x00\x00\x00{\"exports\":[{\"class\":null,\"method\":false,\"consumed\":false,\"constructor\":null,\"function\":{\"name\":\"greet\"},\"comments\":[]}],\"enums\":[],\"imports\":[],\"structs\":[],\"version\":\"0.2.15 (5b935526f)\",\"schema_version\":\"8\"}"
;
```