### PR TITLE
Js sys promise arguments by shared ref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,9 +62,9 @@ matrix:
         - cargo test --target wasm32-unknown-unknown --features serde-serialize
         # Make sure the `std` feature works if disabled
         - cargo test --target wasm32-unknown-unknown -p no-std
-        # Make sure the `wasm-bindgen-futures` tests pass. Right now, this just
-        # verifies that the example program in the crate level docs compiles.
+        # Make sure the `wasm-bindgen-futures` tests pass.
         - cargo test -p wasm-bindgen-futures
+        - cargo test -p wasm-bindgen-futures --target wasm32-unknown-unknown
       addons:
         firefox: latest
       if: branch = master

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1868,24 +1868,28 @@ impl<'a, 'b> SubContext<'a, 'b> {
                                 ),
                             }
                         } else {
-                            let location = if *is_static { "" } else { ".prototype" };
+                            let (location, binding) = if *is_static {
+                                ("", format!(".bind({})", class))
+                            } else {
+                                (".prototype", "".into())
+                            };
 
                             match kind {
                                 shared::OperationKind::Regular => {
-                                    format!("{}{}.{}", class, location, import.function.name)
+                                    format!("{}{}.{}{}", class, location, import.function.name, binding)
                                 }
                                 shared::OperationKind::Getter(g) => {
                                     self.cx.expose_get_inherited_descriptor();
                                     format!(
-                                        "GetOwnOrInheritedPropertyDescriptor({}{}, '{}').get",
-                                        class, location, g,
+                                        "GetOwnOrInheritedPropertyDescriptor({}{}, '{}').get{}",
+                                        class, location, g, binding,
                                     )
                                 }
                                 shared::OperationKind::Setter(s) => {
                                     self.cx.expose_get_inherited_descriptor();
                                     format!(
-                                        "GetOwnOrInheritedPropertyDescriptor({}{}, '{}').set",
-                                        class, location, s,
+                                        "GetOwnOrInheritedPropertyDescriptor({}{}, '{}').set{}",
+                                        class, location, s, binding,
                                     )
                                 }
                                 shared::OperationKind::IndexingGetter => panic!("indexing getter should be structural"),

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -7,3 +7,6 @@ authors = ["The wasm-bindgen Developers"]
 futures = "0.1.20"
 js-sys = { path = "../js-sys", version = '0.2.0' }
 wasm-bindgen = { path = "../..", version = '0.2.15' }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = { path = '../test', version = '0.2.15' }

--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -54,7 +54,7 @@
 //!     pub fn new() -> NextTick {
 //!         // Create a resolved promise that will run its callbacks on the next
 //!         // tick of the micro task queue.
-//!         let promise = js_sys::Promise::resolve(JsValue::NULL);
+//!         let promise = js_sys::Promise::resolve(&JsValue::NULL);
 //!         // Convert the promise into a `JsFuture`.
 //!         let inner = JsFuture::from(promise);
 //!         NextTick { inner }

--- a/crates/futures/tests/tests.rs
+++ b/crates/futures/tests/tests.rs
@@ -1,0 +1,51 @@
+#![feature(use_extern_macros)]
+#![cfg(target_arch = "wasm32")]
+
+extern crate futures;
+extern crate js_sys;
+extern crate wasm_bindgen;
+extern crate wasm_bindgen_futures;
+extern crate wasm_bindgen_test;
+
+use futures::Future;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::{future_to_promise, JsFuture};
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test(async)]
+fn promise_resolve_is_ok_future() -> impl Future<Item = (), Error = JsValue> {
+    let p = js_sys::Promise::resolve(&JsValue::from(42));
+    JsFuture::from(p)
+        .map(|x| {
+            assert_eq!(x, 42);
+        }).map_err(|_| unreachable!())
+}
+
+#[wasm_bindgen_test(async)]
+fn promise_reject_is_error_future() -> impl Future<Item = (), Error = JsValue> {
+    let p = js_sys::Promise::reject(&JsValue::from(42));
+    JsFuture::from(p).map(|_| unreachable!()).or_else(|e| {
+        assert_eq!(e, 42);
+        Ok(())
+    })
+}
+
+#[wasm_bindgen_test(async)]
+fn ok_future_is_resolved_promise() -> impl Future<Item = (), Error = JsValue> {
+    let f = futures::future::ok(JsValue::from(42));
+    let p = future_to_promise(f);
+    JsFuture::from(p)
+        .map(|x| {
+            assert_eq!(x, 42);
+        }).map_err(|_| unreachable!())
+}
+
+#[wasm_bindgen_test(async)]
+fn error_future_is_rejected_promise() -> impl Future<Item = (), Error = JsValue> {
+    let f = futures::future::err(JsValue::from(42));
+    let p = future_to_promise(f);
+    JsFuture::from(p).map(|_| unreachable!()).or_else(|e| {
+        assert_eq!(e, 42);
+        Ok(())
+    })
+}

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3109,7 +3109,7 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all
     #[wasm_bindgen(static_method_of = Promise)]
-    pub fn all(obj: JsValue) -> Promise;
+    pub fn all(obj: &JsValue) -> Promise;
 
     /// The `Promise.race(iterable)` method returns a promise that resolves or
     /// rejects as soon as one of the promises in the iterable resolves or
@@ -3117,14 +3117,14 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race
     #[wasm_bindgen(static_method_of = Promise)]
-    pub fn race(obj: JsValue) -> Promise;
+    pub fn race(obj: &JsValue) -> Promise;
 
     /// The `Promise.reject(reason)` method returns a `Promise` object that is
     /// rejected with the given reason.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject
     #[wasm_bindgen(static_method_of = Promise)]
-    pub fn reject(obj: JsValue) -> Promise;
+    pub fn reject(obj: &JsValue) -> Promise;
 
     /// The `Promise.resolve(value)` method returns a `Promise` object that is
     /// resolved with the given value. If the value is a promise, that promise
@@ -3134,7 +3134,7 @@ extern {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve
     #[wasm_bindgen(static_method_of = Promise)]
-    pub fn resolve(obj: JsValue) -> Promise;
+    pub fn resolve(obj: &JsValue) -> Promise;
 
     /// The `catch()` method returns a `Promise` and deals with rejected cases
     /// only.  It behaves the same as calling `Promise.prototype.then(undefined,

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -31,17 +31,20 @@ use wasm_bindgen::prelude::*;
 // * Keep imports in alphabetical order.
 //
 // * Rename imports with `js_name = ...` according to the note about `camelCase`
-// and `snake_case` in the module's documentation above.
+//   and `snake_case` in the module's documentation above.
 //
 // * Include the one sentence summary of the import from the MDN link in the
-// module's documentation above, and the MDN link itself.
+//   module's documentation above, and the MDN link itself.
 //
 // * If a function or method can throw an exception, make it catchable by adding
-// `#[wasm_bindgen(catch)]`.
+//   `#[wasm_bindgen(catch)]`.
 //
 // * Add a new `#[test]` into the appropriate file in the
 //   `crates/js-sys/tests/wasm/` directory. If the imported function or method
 //   can throw an exception, make sure to also add test coverage for that case.
+//
+// * Arguments that are `JsValue`s or imported JavaScript types should be taken
+//   by reference.
 
 #[wasm_bindgen]
 extern "C" {


### PR DESCRIPTION
Not a breaking change because we haven't published js-sys with `Promise` bindings yet, thankfully.