### PR TITLE
Add support and tests for EvalError

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -627,6 +627,23 @@ extern "C" {
     pub fn to_string(this: &Error) -> JsString;
 }
 
+// EvalError
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = Object, extends = Error)]
+    #[derive(Clone, Debug)]
+    pub type EvalError;
+
+    /// The EvalError object indicates an error regarding the global eval() function. This
+    /// exception is not thrown by JavaScript anymore, however the EvalError object remains for
+    /// compatibility.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError
+    #[wasm_bindgen(constructor)]
+    pub fn new(message: &str) -> EvalError;
+}
+
+
 // Float32Array
 #[wasm_bindgen]
 extern "C" {

--- a/crates/js-sys/tests/wasm/EvalError.rs
+++ b/crates/js-sys/tests/wasm/EvalError.rs
@@ -1,0 +1,55 @@
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+use wasm_bindgen::JsCast;
+use js_sys::*;
+
+// Note: This error is not thrown any more, so there are no tests that will generate this error.
+// Instead we just have to manually construct it
+
+#[wasm_bindgen_test]
+fn new() {
+    let error = EvalError::new("some message");
+    let base_error: &Error = error.dyn_ref().unwrap();
+    assert_eq!(JsValue::from(base_error.message()), "some message");
+}
+
+#[wasm_bindgen_test]
+fn set_message() {
+    let error = EvalError::new("test");
+    let base_error: &Error = error.dyn_ref().unwrap();
+    base_error.set_message("another");
+    assert_eq!(JsValue::from(base_error.message()), "another");
+}
+
+#[wasm_bindgen_test]
+fn name() {
+    let error = EvalError::new("test");
+    let base_error: &Error = error.dyn_ref().unwrap();
+    assert_eq!(JsValue::from(base_error.name()), "EvalError");
+}
+
+#[wasm_bindgen_test]
+fn set_name() {
+    let error = EvalError::new("test");
+    let base_error: &Error = error.dyn_ref().unwrap();
+    base_error.set_name("different");
+    assert_eq!(JsValue::from(base_error.name()), "different");
+}
+
+#[wasm_bindgen_test]
+fn to_string() {
+    let error = EvalError::new("error message 1");
+    let base_error: &Error = error.dyn_ref().unwrap();
+    assert_eq!(JsValue::from(base_error.to_string()), "EvalError: error message 1");
+    base_error.set_name("error_name_1");
+    assert_eq!(JsValue::from(base_error.to_string()), "error_name_1: error message 1");
+}
+
+
+#[wasm_bindgen_test]
+fn evalerror_inheritance() {
+    let error = EvalError::new("some message");
+    assert!(error.is_instance_of::<EvalError>());
+    assert!(error.is_instance_of::<Error>());
+    assert!(error.is_instance_of::<Object>());
+}

--- a/crates/js-sys/tests/wasm/main.rs
+++ b/crates/js-sys/tests/wasm/main.rs
@@ -14,6 +14,7 @@ pub mod Boolean;
 pub mod DataView;
 pub mod Date;
 pub mod Error;
+pub mod EvalError;
 pub mod Function;
 pub mod Generator;
 pub mod Intl;


### PR DESCRIPTION
The `EvalError` type extends from the `Error` type, and provides no methods of its own (other than a constructor).  I'm not sure how to deal with this.  In this proposed PR, the type doesn't declare any of the base methods, which means that in order to use them, you have to first cast to the base class (which is what the tests do currently.

If you try to declare them, wasm-bindgen will throw an error ("duplicate definitions for 'to_string'").  But casting to the base class everytime seems like a ergonomics loss.

So opening this PR as a discussion topic.