### PR TITLE
Add initial support and tests for JSON

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2663,6 +2663,31 @@ extern "C" {
     pub fn validate(bufferSource: &JsValue) -> Result<bool, JsValue>;
 }
 
+// JSON
+#[wasm_bindgen]
+extern "C" {
+
+    #[derive(Clone, Debug)]
+    pub type JSON;
+
+    /// The `JSON.parse()` method parses a JSON string, constructing the
+    /// JavaScript value or object described by the string.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
+    #[wasm_bindgen(catch, static_method_of = JSON)]
+    pub fn parse(text: &str) -> Result<JsValue, JsValue>;
+
+    /// The JSON.stringify() method converts a JavaScript value to a JSON string,
+    /// optionally replacing values if a replacer function is specified or
+    /// optionally including only the specified properties if a replacer array is
+    /// specified.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+    #[wasm_bindgen(static_method_of = JSON)]
+    pub fn stringify(obj: &JsValue) -> JsString;
+
+}
+
 // JsString
 #[wasm_bindgen]
 extern "C" {

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2683,8 +2683,8 @@ extern "C" {
     /// specified.
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-    #[wasm_bindgen(static_method_of = JSON)]
-    pub fn stringify(obj: &JsValue) -> JsString;
+    #[wasm_bindgen(catch, static_method_of = JSON)]
+    pub fn stringify(obj: &JsValue) -> Result<JsString, JsValue>;
 
 }
 

--- a/crates/js-sys/tests/wasm/JSON.js
+++ b/crates/js-sys/tests/wasm/JSON.js
@@ -1,4 +1,0 @@
-exports.set_in_object = function(obj, name, value) {
-    obj[name] = value;
-};
-

--- a/crates/js-sys/tests/wasm/JSON.js
+++ b/crates/js-sys/tests/wasm/JSON.js
@@ -1,0 +1,4 @@
+exports.set_in_object = function(obj, name, value) {
+    obj[name] = value;
+};
+

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -1,0 +1,69 @@
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::*;
+use wasm_bindgen::JsCast;
+use js_sys::*;
+
+#[wasm_bindgen_test]
+fn parse_array() {
+
+    let js_array = JSON::parse("[1, 2, 3]").unwrap();;
+    assert!(Array::is_array(&js_array));
+
+    let array = Array::from(&js_array);
+    assert_eq!(array.length(), 3);
+    assert_eq!(array.pop(), 3);
+    assert_eq!(array.pop(), 2);
+    assert_eq!(array.pop(), 1);
+
+}
+
+#[wasm_bindgen_test]
+fn parse_object() {
+
+    let js_object = JSON::parse("{\"x\": 5, \"y\": true, \"z\": [\"foo\", \"bar\"]}").unwrap();
+    assert!(js_object.is_object());
+
+    let obj = Object::from(js_object);
+    let keys = Object::keys(&obj);
+    assert_eq!(keys.length(), 3);
+    assert_eq!(keys.pop().as_string().unwrap(), "z");
+    assert_eq!(keys.pop().as_string().unwrap(), "y");
+    assert_eq!(keys.pop().as_string().unwrap(), "x");
+
+    let values = Object::values(&obj);
+    assert_eq!(values.length(), 3);
+
+    let z = values.pop();
+    assert!(Array::is_array(&z));
+    let z_array = Array::from(&z);
+    assert_eq!(z_array.length(), 2);
+
+    let y = values.pop();
+    assert_eq!(y.as_bool(), Some(true));
+
+    let x = values.pop();
+    assert!(Number::is_integer(&x));
+    let x_num = Number::new(&x);
+    assert_eq!(x_num.value_of(), 5.0);
+
+}
+
+#[wasm_bindgen_test]
+fn parse_error() {
+    let js_object = JSON::parse("invalid json");
+    assert!(js_object.is_err());
+    let err = js_object.unwrap_err();
+    assert!(err.is_instance_of::<Error>());
+}
+
+#[wasm_bindgen_test]
+fn stringify() {
+    let arr = Array::new();
+    arr.push(&JsValue::from(1));
+    arr.push(&JsValue::from(true));
+    arr.push(&JsValue::from("hello"));
+
+    let str = JSON::stringify(&JsValue::from(arr));
+    let rust_str: String = From::from(str);
+    assert_eq!(rust_str, "[1,true,\"hello\"]");
+}

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -1,14 +1,7 @@
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
-use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use js_sys::*;
-
-
-#[wasm_bindgen(module = "tests/wasm/JSON.js")]
-extern {
-    fn set_in_object(obj: &Object, name: &str, value: &JsValue);
-}
 
 #[wasm_bindgen_test]
 fn parse_array() {
@@ -79,7 +72,7 @@ fn stringify() {
 fn stringify_error() {
     let func = Function::new_no_args("throw new Error(\"rust really rocks\")");
     let obj = Object::new();
-    set_in_object(&obj, "toJSON", &JsValue::from(func));
+    Reflect::set(obj.as_ref(), &JsValue::from("toJSON"), func.as_ref());
 
     let result = JSON::stringify(&JsValue::from(obj));
     assert!(result.is_err());

--- a/crates/js-sys/tests/wasm/main.rs
+++ b/crates/js-sys/tests/wasm/main.rs
@@ -18,6 +18,7 @@ pub mod Function;
 pub mod Generator;
 pub mod Intl;
 pub mod JsString;
+pub mod JSON;
 pub mod Map;
 pub mod MapIterator;
 pub mod Math;


### PR DESCRIPTION
Not yet added is the optional arguments to `JSON.parse()` and `JSON.stringify()`.