### PR TITLE
Misc fixes and enable tests on appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,11 @@ test_script:
   - npm ci
   - cargo test
   - cargo build --release -p wasm-bindgen-cli
+  - where chromedriver
+  - set CHROMEDRIVER=C:\Tools\WebDriver\chromedriver.exe
+  - cargo test -p js-sys --target wasm32-unknown-unknown
+  - cargo test -p web-sys --target wasm32-unknown-unknown
+  - cargo test -p webidl-tests --target wasm32-unknown-unknown
 
 branches:
   only:

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -543,7 +543,7 @@ impl ToTokens for ast::ImportType {
             const #const_name: () = {
                 use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi, Stack};
                 use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
-                use wasm_bindgen::convert::{RefFromWasmAbi, GlobalStack};
+                use wasm_bindgen::convert::RefFromWasmAbi;
                 use wasm_bindgen::describe::WasmDescribe;
                 use wasm_bindgen::{JsValue, JsCast};
                 use wasm_bindgen::__rt::core::mem::ManuallyDrop;
@@ -633,7 +633,7 @@ impl ToTokens for ast::ImportType {
                             fn #instanceof_shim(val: u32) -> u32;
                         }
                         unsafe {
-                            let idx = val.into_abi(&mut GlobalStack::new());
+                            let idx = val.into_abi(&mut ::wasm_bindgen::convert::GlobalStack::new());
                             #instanceof_shim(idx) != 0
                         }
                     }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2033,7 +2033,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                 if let Some(module) = &import.module {
                     if use_node_require {
                         imports.push_str(&format!(
-                            "const {} = require('{}').{};\n",
+                            "const {} = require(String.raw`{}`).{};\n",
                             name, module, name_to_import
                         ));
                     } else if name_to_import == name {

--- a/crates/webidl-tests/build.rs
+++ b/crates/webidl-tests/build.rs
@@ -28,7 +28,7 @@ fn main() {
                 use wasm_bindgen::prelude::*;
                 use wasm_bindgen_test::*;
 
-                #[wasm_bindgen(module = "{}")]
+                #[wasm_bindgen(module = r"{}")]
                 extern {{
                     fn not_actually_a_function{1}();
                 }}


### PR DESCRIPTION
The first commit removes an unused import, which reduces the amount of warning spam on build.

The second commit was needed to get the tests to build on my windows machine (which uses back-slashes in paths).  