### PR TITLE
Add bindings for static method String.from_char_code

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2940,6 +2940,34 @@ extern "C" {
     #[wasm_bindgen(method, js_class = "String", js_name = endsWith)]
     pub fn ends_with(this: &JsString, search_string: &str, length: i32) -> bool;
 
+    /// The static String.fromCharCode() method returns a string created from
+    /// the specified sequence of UTF-16 code units.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
+    ///
+    /// # Notes
+    ///
+    /// There are a few bindings to `from_char_code` in `js-sys`: `from_char_code1`, `from_char_code2`, etc...
+    /// with different arities.
+    #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
+    pub fn from_char_code1(a: f64) -> JsString;
+
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
+    #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
+    pub fn from_char_code2(a: f64, b: f64) -> JsString;
+
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
+    #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
+    pub fn from_char_code3(a: f64, b: f64, c: f64) -> JsString;
+
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
+    #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
+    pub fn from_char_code4(a: f64, b: f64, c: f64, d: f64) -> JsString;
+
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
+    #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
+    pub fn from_char_code5(a: f64, b: f64, c: f64, d: f64, e: f64) -> JsString;
+
     /// The `includes()` method determines whether one string may be found
     /// within another string, returning true or false as appropriate.
     ///

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2950,23 +2950,23 @@ extern "C" {
     /// There are a few bindings to `from_char_code` in `js-sys`: `from_char_code1`, `from_char_code2`, etc...
     /// with different arities.
     #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
-    pub fn from_char_code1(a: f64) -> JsString;
+    pub fn from_char_code1(a: u32) -> JsString;
 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
     #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
-    pub fn from_char_code2(a: f64, b: f64) -> JsString;
+    pub fn from_char_code2(a: u32, b: u32) -> JsString;
 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
     #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
-    pub fn from_char_code3(a: f64, b: f64, c: f64) -> JsString;
+    pub fn from_char_code3(a: u32, b: u32, c: u32) -> JsString;
 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
     #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
-    pub fn from_char_code4(a: f64, b: f64, c: f64, d: f64) -> JsString;
+    pub fn from_char_code4(a: u32, b: u32, c: u32, d: u32) -> JsString;
 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
     #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
-    pub fn from_char_code5(a: f64, b: f64, c: f64, d: f64, e: f64) -> JsString;
+    pub fn from_char_code5(a: u32, b: u32, c: u32, d: u32, e: u32) -> JsString;
 
     /// The `includes()` method determines whether one string may be found
     /// within another string, returning true or false as appropriate.

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -59,6 +59,19 @@ fn ends_with() {
 }
 
 #[wasm_bindgen_test]
+fn from_char_code() {
+    let s = "½+¾=";
+    let codes : Vec<f64> = s.chars()
+        .map(|char| char as u32 as f64)
+        .collect();
+
+    assert_eq!(JsString::from_char_code1(codes[0]), "½");
+    assert_eq!(JsString::from_char_code2(codes[0], codes[1]), "½+");
+    assert_eq!(JsString::from_char_code3(codes[0], codes[1], codes[2]), "½+¾");
+    assert_eq!(JsString::from_char_code4(codes[0], codes[1], codes[2], codes[3]), "½+¾=");
+}
+
+#[wasm_bindgen_test]
 fn includes() {
     let str = JsString::from("Blue Whale");
 

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -61,8 +61,8 @@ fn ends_with() {
 #[wasm_bindgen_test]
 fn from_char_code() {
     let s = "½+¾=";
-    let codes : Vec<f64> = s.chars()
-        .map(|char| char as u32 as f64)
+    let codes : Vec<u32> = s.chars()
+        .map(|char| char as u32)
         .collect();
 
     assert_eq!(JsString::from_char_code1(codes[0]), "½");

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -473,7 +473,10 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a Option<String>)> for syn::ForeignItemFn
                 kind,
             }
         } else if let Some(cls) = opts.static_method_of() {
-            let class = cls.to_string();
+            let class = opts
+                .js_class()
+                .map(Into::into)
+                .unwrap_or_else(|| cls.to_string());
             let ty = ident_ty(cls.clone());
 
             let kind = ast::MethodKind::Operation(ast::Operation {


### PR DESCRIPTION
Seems like this is the first static binding with a different `js_class` name?

Not sure if these are most appropriate decisions:
- Added multiple bindings with different arities
- Used `f64` as the argument type since `char_code_at` returns `f64`

(Note: I'm getting failures for `String.prototype.trimStart does not exist` and `.trimEnd`)

@fitzgen 