### PR TITLE
Generate const mixin bindings

### DIFF
--- a/crates/webidl-tests/consts.rs
+++ b/crates/webidl-tests/consts.rs
@@ -48,4 +48,5 @@ fn floats() {
     assert!(ConstDoubles::INF.is_infinite());
     assert!(ConstDoubles::INF.is_sign_positive());
     assert!(ConstDoubles::NAN.is_nan());
+    assert_eq!(ConstDoubles::ONE, 1.0);
 }

--- a/crates/webidl-tests/consts.webidl
+++ b/crates/webidl-tests/consts.webidl
@@ -44,3 +44,9 @@ interface ConstDoubles {
   const unrestricted double inf = Infinity;
   const unrestricted double nan = NaN;
 };
+
+interface mixin ConstDoublesMixin {
+  const double one = 1.0;
+};
+
+ConstDoubles includes ConstDoublesMixin;

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -477,9 +477,11 @@ impl<'a, 'src> WebidlParse<'src, &'a str> for weedle::mixin::MixinMember<'src> {
             weedle::mixin::MixinMember::Operation(op) => {
                 op.webidl_parse(program, first_pass, self_name)
             }
+            weedle::mixin::MixinMember::Const(const_) => {
+                const_.webidl_parse(program, first_pass, self_name)
+            }
             // TODO
-            weedle::mixin::MixinMember::Stringifier(_) |
-            weedle::mixin::MixinMember::Const(_) => {
+            weedle::mixin::MixinMember::Stringifier(_) => {
                 warn!("Unsupported WebIDL mixin member: {:?}", self);
                 Ok(())
             }


### PR DESCRIPTION
Whenever an interface includes a mixin which includes consts, inline the consts
onto the interface.