### PR TITLE
Implement support for WebIDL dictionaries

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -21,6 +21,10 @@ pub struct Program {
     pub consts: Vec<Const>,
     /// rust submodules
     pub modules: Vec<Module>,
+    /// "dictionaries", generated for WebIDL, which are basically just "typed
+    /// objects" in the sense that they represent a JS object with a particular
+    /// shape in JIT parlance.
+    pub dictionaries: Vec<Dictionary>,
 }
 
 /// A rust to js interface. Allows interaction with rust objects/functions
@@ -251,6 +255,21 @@ pub struct Module {
     pub name: Ident,
     /// js -> rust interfaces
     pub imports: Vec<Import>,
+}
+
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+#[derive(Clone)]
+pub struct Dictionary {
+    pub name: Ident,
+    pub fields: Vec<DictionaryField>,
+}
+
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+#[derive(Clone)]
+pub struct DictionaryField {
+    pub name: Ident,
+    pub required: bool,
+    pub ty: syn::Type,
 }
 
 impl Program {

--- a/crates/webidl-tests/Cargo.toml
+++ b/crates/webidl-tests/Cargo.toml
@@ -10,6 +10,7 @@ path = 'lib.rs'
 
 [build-dependencies]
 wasm-bindgen-webidl = { path = '../webidl' }
+env_logger = "0.5"
 
 [dev-dependencies]
 js-sys = { path = '../js-sys' }
@@ -19,4 +20,3 @@ wasm-bindgen-test = { path = '../test' }
 [[test]]
 name = 'wasm'
 path = 'main.rs'
-

--- a/crates/webidl-tests/build.rs
+++ b/crates/webidl-tests/build.rs
@@ -1,4 +1,5 @@
 extern crate wasm_bindgen_webidl;
+extern crate env_logger;
 
 use std::env;
 use std::fs;
@@ -6,6 +7,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn main() {
+    env_logger::init();
     let idls = fs::read_dir(".")
         .unwrap()
         .map(|f| f.unwrap().path())

--- a/crates/webidl-tests/dictionary.js
+++ b/crates/webidl-tests/dictionary.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+global.assert_dict_c = function(c) {
+  assert.strictEqual(c.a, 1);
+  assert.strictEqual(c.b, 2);
+  assert.strictEqual(c.c, 3);
+  assert.strictEqual(c.d, 4);
+  assert.strictEqual(c.e, 5);
+  assert.strictEqual(c.f, 6);
+  assert.strictEqual(c.g, 7);
+  assert.strictEqual(c.h, 8);
+};
+
+global.mk_dict_a = function() {
+  return {};
+};
+
+global.assert_dict_required = function(c) {
+  assert.strictEqual(c.a, 3);
+  assert.strictEqual(c.b, "a");
+  assert.strictEqual(c.c, 4);
+};

--- a/crates/webidl-tests/dictionary.rs
+++ b/crates/webidl-tests/dictionary.rs
@@ -1,0 +1,54 @@
+use wasm_bindgen_test::*;
+use wasm_bindgen::prelude::*;
+
+include!(concat!(env!("OUT_DIR"), "/dictionary.rs"));
+
+#[wasm_bindgen]
+extern {
+    fn assert_dict_c(c: &C);
+    #[wasm_bindgen(js_name = assert_dict_c)]
+    fn assert_dict_c2(c: C);
+    #[wasm_bindgen(js_name = assert_dict_c)]
+    fn assert_dict_c3(c: Option<&C>);
+    #[wasm_bindgen(js_name = assert_dict_c)]
+    fn assert_dict_c4(c: Option<C>);
+    fn mk_dict_a() -> A;
+    #[wasm_bindgen(js_name = mk_dict_a)]
+    fn mk_dict_a2() -> Option<A>;
+    fn assert_dict_required(r: &Required);
+}
+
+#[wasm_bindgen_test]
+fn smoke() {
+    A::new().c(1).g(2).h(3).d(4);
+    B::new().c(1).g(2).h(3).d(4).a(5).b(6);
+
+    let mut c = C::new();
+    c.a(1).b(2).c(3).d(4).e(5).f(6).g(7).h(8);
+    assert_dict_c(&c);
+    assert_dict_c2(c.clone());
+    assert_dict_c3(Some(&c));
+    assert_dict_c4(Some(c));
+}
+
+#[wasm_bindgen_test]
+fn get_dict() {
+    mk_dict_a();
+    assert!(mk_dict_a2().is_some());
+}
+
+#[wasm_bindgen_test]
+fn casing() {
+    CamelCaseMe::new().snake_case_me(3);
+}
+
+#[wasm_bindgen_test]
+fn many_types() {
+    ManyTypes::new()
+        .a("a");
+}
+
+#[wasm_bindgen_test]
+fn required() {
+    assert_dict_required(Required::new(3, "a").c(4));
+}

--- a/crates/webidl-tests/dictionary.webidl
+++ b/crates/webidl-tests/dictionary.webidl
@@ -1,0 +1,47 @@
+// example from https://heycam.github.io/webidl/#idl-dictionaries
+dictionary B : A {
+  long b;
+  long a;
+};
+
+dictionary A {
+  long c;
+  long g;
+};
+
+dictionary C : B {
+  long e;
+  long f;
+};
+
+partial dictionary A {
+  long h;
+  long d;
+};
+
+// case needs changing
+dictionary camel_case_me {
+  long snakeCaseMe;
+};
+
+dictionary ManyTypes {
+  DOMString a;
+  octet n1;
+  byte n2;
+  unsigned short n3;
+  short n4;
+  unsigned long n5;
+  long n6;
+  // TODO: needs fixing
+  // OtherDict c;
+};
+
+dictionary OtherDict {
+  long a;
+};
+
+dictionary Required {
+  required DOMString b;
+  required long a;
+  long c;
+};

--- a/crates/webidl-tests/main.rs
+++ b/crates/webidl-tests/main.rs
@@ -11,3 +11,4 @@ pub mod enums;
 pub mod namespace;
 pub mod simple;
 pub mod throws;
+pub mod dictionary;

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -9,6 +9,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use weedle::{DictionaryDefinition, PartialDictionaryDefinition};
 use weedle::argument::Argument;
 use weedle::attribute::ExtendedAttribute;
 use weedle::interface::{StringifierOrStatic, Special};
@@ -24,13 +25,13 @@ use util::camel_case_ident;
 #[derive(Default)]
 pub(crate) struct FirstPassRecord<'src> {
     pub(crate) interfaces: BTreeMap<&'src str, InterfaceData<'src>>,
-    pub(crate) dictionaries: BTreeSet<&'src str>,
     pub(crate) enums: BTreeSet<&'src str>,
     /// The mixins, mapping their name to the webidl ast node for the mixin.
     pub(crate) mixins: BTreeMap<&'src str, MixinData<'src>>,
     pub(crate) typedefs: BTreeMap<&'src str, &'src weedle::types::Type<'src>>,
     pub(crate) namespaces: BTreeMap<&'src str, NamespaceData<'src>>,
     pub(crate) includes: BTreeMap<&'src str, BTreeSet<&'src str>>,
+    pub(crate) dictionaries: BTreeMap<&'src str, DictionaryData<'src>>,
 }
 
 /// We need to collect interface data during the first pass, to be used later.
@@ -59,6 +60,13 @@ pub(crate) struct NamespaceData<'src> {
     pub(crate) partial: bool,
     pub(crate) members: Vec<&'src NamespaceMember<'src>>,
     pub(crate) operations: BTreeMap<OperationId<'src>, OperationData<'src>>,
+}
+
+#[derive(Default)]
+pub(crate) struct DictionaryData<'src> {
+    /// Whether only partial namespaces were encountered
+    pub(crate) partials: Vec<&'src PartialDictionaryDefinition<'src>>,
+    pub(crate) definition: Option<&'src DictionaryDefinition<'src>>,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
@@ -99,6 +107,7 @@ impl<'src> FirstPass<'src, ()> for weedle::Definition<'src> {
 
         match self {
             Dictionary(dictionary) => dictionary.first_pass(record, ()),
+            PartialDictionary(dictionary) => dictionary.first_pass(record, ()),
             Enum(enum_) => enum_.first_pass(record, ()),
             IncludesStatement(includes) => includes.first_pass(record, ()),
             Interface(interface) => interface.first_pass(record, ()),
@@ -118,14 +127,19 @@ impl<'src> FirstPass<'src, ()> for weedle::Definition<'src> {
 
 impl<'src> FirstPass<'src, ()> for weedle::DictionaryDefinition<'src> {
     fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, (): ()) -> Result<()> {
-        if util::is_chrome_only(&self.attributes) {
-            return Ok(());
-        }
+        record.dictionaries.entry(self.identifier.0)
+            .or_default()
+            .definition = Some(self);
+        Ok(())
+    }
+}
 
-        if !record.dictionaries.insert(self.identifier.0) {
-            info!("Encountered multiple dictionary declarations: {}", self.identifier.0);
-        }
-
+impl<'src> FirstPass<'src, ()> for weedle::PartialDictionaryDefinition<'src> {
+    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, (): ()) -> Result<()> {
+        record.dictionaries.entry(self.identifier.0)
+            .or_default()
+            .partials
+            .push(self);
         Ok(())
     }
 }
@@ -153,7 +167,7 @@ impl<'src> FirstPass<'src, ()> for weedle::IncludesStatementDefinition<'src> {
         record
             .includes
             .entry(self.lhs_identifier.0)
-            .or_insert_with(Default::default)
+            .or_default()
             .insert(self.rhs_identifier.0);
 
         Ok(())
@@ -372,7 +386,7 @@ impl<'src> FirstPass<'src, ()> for weedle::InterfaceMixinDefinition<'src>{
             let mixin_data = record
                 .mixins
                 .entry(self.identifier.0)
-                .or_insert_with(Default::default);
+                .or_default();
             mixin_data.partial = false;
             mixin_data.members.extend(&self.members.body);
         }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -285,7 +285,7 @@ impl<'a> ToIdlType<'a> for Identifier<'a> {
             idl_type.to_idl_type(record)
         } else if record.interfaces.contains_key(self.0) {
             Some(IdlType::Interface(self.0))
-        } else if record.dictionaries.contains(self.0) {
+        } else if record.dictionaries.contains_key(self.0) {
             Some(IdlType::Dictionary(self.0))
         } else if record.enums.contains(self.0) {
             Some(IdlType::Enum(self.0))
@@ -467,7 +467,8 @@ impl<'a> IdlType<'a> {
             IdlType::Float32Array => Some(array("f32", pos)),
             IdlType::Float64Array => Some(array("f64", pos)),
 
-            IdlType::Interface(name) => {
+            IdlType::Interface(name) |
+            IdlType::Dictionary(name) => {
                 let ty = ident_ty(rust_ident(camel_case_ident(name).as_str()));
                 if pos == TypePosition::Argument {
                     Some(shared_ref(ty))
@@ -475,7 +476,6 @@ impl<'a> IdlType<'a> {
                     Some(ty)
                 }
             },
-            IdlType::Dictionary(name) => Some(ident_ty(rust_ident(camel_case_ident(name).as_str()))),
             IdlType::Enum(name) => Some(ident_ty(rust_ident(camel_case_ident(name).as_str()))),
 
             IdlType::Nullable(idl_type) => Some(option_ty(idl_type.to_syn_type(pos)?)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,6 +350,21 @@ impl From<bool> for JsValue {
     }
 }
 
+impl<'a, T> From<&'a T> for JsValue where T: JsCast {
+    fn from(s: &'a T) -> JsValue {
+        s.as_ref().clone()
+    }
+}
+
+impl<T> From<Option<T>> for JsValue where JsValue: From<T> {
+    fn from(s: Option<T>) -> JsValue {
+        match s {
+            Some(s) => s.into(),
+            None => JsValue::undefined(),
+        }
+    }
+}
+
 impl JsCast for JsValue {
     // everything is a `JsValue`!
     fn instanceof(_val: &JsValue) -> bool { true }


### PR DESCRIPTION
This commit adds support for generating bindings for dictionaries defined in
WebIDL. Dictionaries are associative arrays which are simply objects in JS with
named keys and some values. In Rust given a dictionary like:

    dictionary Foo {
        long field;
    };

we'll generate a struct like:

    pub struct Foo {
        obj: js_sys::Object,
    }

    impl Foo {
        pub fn new() -> Foo { /* make a blank object */ }

        pub fn field(&mut self, val: i32) -> &mut Self {
            // set the field using `js_sys::Reflect`
        }
    }

    // plus a bunch of AsRef, From, and wasm abi impls

At the same time this adds support for partial dictionaries and dictionary
inheritance. All dictionary fields are optional by default and hence only have
builder-style setters, but dictionaries can also have required fields. Required
fields are exposed as arguments to the `new` constructor.

Closes #241