### PR TITLE
Translate WebIDL `promise` type to `js_sys::Promise`

### DIFF
--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -481,7 +481,15 @@ impl<'a> IdlType<'a> {
             IdlType::Nullable(idl_type) => Some(option_ty(idl_type.to_syn_type(pos)?)),
             IdlType::FrozenArray(_idl_type) => None,
             IdlType::Sequence(_idl_type) => None,
-            IdlType::Promise(_idl_type) => None,
+            IdlType::Promise(_idl_type) => {
+                let path = vec![rust_ident("js_sys"), rust_ident("Promise")];
+                let ty = leading_colon_path_ty(path);
+                if pos == TypePosition::Argument {
+                    Some(shared_ref(ty))
+                } else {
+                    Some(ty)
+                }
+            }
             IdlType::Record(_idl_type_from, _idl_type_to) => None,
             IdlType::Union(_idl_types) => None,
 

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -117,7 +117,7 @@ fn compile_ast(mut ast: backend::ast::Program) -> String {
         vec![
             "str", "char", "bool", "JsValue", "u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64",
             "usize", "isize", "f32", "f64", "Result", "String", "Vec", "Option",
-            "ArrayBuffer", "Object",
+            "ArrayBuffer", "Object", "Promise",
         ].into_iter()
             .map(|id| proc_macro2::Ident::new(id, proc_macro2::Span::call_site())),
     );


### PR DESCRIPTION
This does involve us losing the type argument present in the WebIDL, but for now
that should be fine as we're exposing low-level bindings and it's not otherwise
clear whether having a typed wrapper is a great option. Usage of `JsCast` can
convert the incoming value to a different object fairly easily.

The purpose of the `web-sys` crate is to expose functionality of the web, not
necessarily take an opinionated stance on how it should be exposed. In that
sense it should be able to work with the `Promise` as you would a typed promise
in terms of no functionality is left out. That being said we'll likely want to
be sure to reconsider this before 1.0-stabilizing the `web-sys` crate!