### PR TITLE
Adds Extends to TypedArrays

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -967,6 +967,7 @@ extern "C" {
 // Int16Array
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Int16Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2592,6 +2592,7 @@ extern "C" {
 // Uint8ClampedArray
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Uint8ClampedArray;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2700,6 +2700,7 @@ extern "C" {
 // Uint32Array
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Uint32Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2647,6 +2647,7 @@ extern "C" {
 // Uint16Array
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Uint16Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -683,7 +683,6 @@ extern "C" {
 // Float32Array
 #[wasm_bindgen]
 extern "C" {
-    // TODO Uncomment this once TypedArray is added:
     #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Float32Array;
@@ -737,8 +736,7 @@ extern "C" {
 // Float64Array
 #[wasm_bindgen]
 extern "C" {
-    // TODO Uncomment this once TypedArray is added:
-    // #[wasm_bindgen(extends = Object, extends = TypedArray)]
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Float64Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2539,6 +2539,7 @@ extern {
 // Uint8Array
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Uint8Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1020,6 +1020,7 @@ extern "C" {
 // Int32Array
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Int32Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -684,7 +684,7 @@ extern "C" {
 #[wasm_bindgen]
 extern "C" {
     // TODO Uncomment this once TypedArray is added:
-    // #[wasm_bindgen(extends = Object, extends = TypedArray)]
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Float32Array;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -914,6 +914,7 @@ extern {
 // Int8Array
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Int8Array;
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -13,6 +13,7 @@ macro_rules! each {
         $m!(Int16Array);
         $m!(Int32Array);
         $m!(Float32Array);
+        $m!(Float64Array);
     )
 }
 
@@ -20,26 +21,13 @@ macro_rules! test_inheritence {
     ($arr:ident) => ({
         let arr = $arr::new(&JsValue::undefined());
         assert!(arr.is_instance_of::<$arr>());
+        let _: &Object = arr.as_ref();
         assert!(arr.is_instance_of::<Object>());        
     })
 }
 #[wasm_bindgen_test]
 fn inheritence() {
     each!(test_inheritence);
-}
-
-macro_rules! each {
-    ($m:ident) => (
-        $m!(Uint8Array);
-        $m!(Uint8ClampedArray);
-        $m!(Uint16Array);
-        $m!(Uint32Array);
-        $m!(Int8Array);
-        $m!(Int16Array);
-        $m!(Int32Array);
-        $m!(Float32Array);
-        $m!(Float64Array);
-    )
 }
 
 macro_rules! test_undefined {

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -11,6 +11,7 @@ macro_rules! each {
         $m!(Uint32Array);
         $m!(Int8Array);
         $m!(Int16Array);
+        $m!(Int32Array);
     )
 }
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -8,6 +8,7 @@ macro_rules! each {
         $m!(Uint8Array);
         $m!(Uint8ClampedArray);
         $m!(Uint16Array);
+        $m!(Uint32Array);
     )
 }
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -9,6 +9,7 @@ macro_rules! each {
         $m!(Uint8ClampedArray);
         $m!(Uint16Array);
         $m!(Uint32Array);
+        $m!(Int8Array);
     )
 }
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -1,6 +1,25 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
+use wasm_bindgen::JsCast;
 use js_sys::*;
+
+macro_rules! each {
+    ($m:ident) => (
+        $m!(Uint8Array);
+    )
+}
+
+macro_rules! test_inheritence {
+    ($arr:ident) => ({
+        let arr = $arr::new(&JsValue::undefined());
+        assert!(arr.is_instance_of::<Uint8Array>());
+        assert!(arr.is_instance_of::<Object>());        
+    })
+}
+#[wasm_bindgen_test]
+fn inheritence() {
+    each!(test_inheritence);
+}
 
 macro_rules! each {
     ($m:ident) => (

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -10,6 +10,7 @@ macro_rules! each {
         $m!(Uint16Array);
         $m!(Uint32Array);
         $m!(Int8Array);
+        $m!(Int16Array);
     )
 }
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -12,6 +12,7 @@ macro_rules! each {
         $m!(Int8Array);
         $m!(Int16Array);
         $m!(Int32Array);
+        $m!(Float32Array);
     )
 }
 

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -6,13 +6,14 @@ use js_sys::*;
 macro_rules! each {
     ($m:ident) => (
         $m!(Uint8Array);
+        $m!(Uint8ClampedArray);
     )
 }
 
 macro_rules! test_inheritence {
     ($arr:ident) => ({
         let arr = $arr::new(&JsValue::undefined());
-        assert!(arr.is_instance_of::<Uint8Array>());
+        assert!(arr.is_instance_of::<$arr>());
         assert!(arr.is_instance_of::<Object>());        
     })
 }

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -7,6 +7,7 @@ macro_rules! each {
     ($m:ident) => (
         $m!(Uint8Array);
         $m!(Uint8ClampedArray);
+        $m!(Uint16Array);
     )
 }
 


### PR DESCRIPTION
While the `UInt8Array` (and others) have the `TypedArray` in the prototype chain. 

`TypedArray` by itself is not known to `window` or `global`. I don't think we can test that here. 

Is there something that I am missing