### PR TITLE
Add experimental support for `WeakRef`

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -10,6 +10,7 @@ extern crate failure;
 
 use std::any::Any;
 use std::collections::BTreeSet;
+use std::env;
 use std::fmt;
 use std::fs;
 use std::mem;
@@ -33,6 +34,9 @@ pub struct Bindgen {
     typescript: bool,
     demangle: bool,
     keep_debug: bool,
+    // Experimental support for `WeakRefGroup`, an upcoming ECMAScript feature.
+    // Currently only enable-able through an env var.
+    weak_refs: bool,
 }
 
 enum Input {
@@ -55,6 +59,7 @@ impl Bindgen {
             typescript: false,
             demangle: true,
             keep_debug: false,
+            weak_refs: env::var("WASM_BINDGEN_WEAKREF").is_ok(),
         }
     }
 


### PR DESCRIPTION
This commit adds experimental support for `WeakRef` to be used to automatically
free wasm objects instead of having to always call the `free` function manually.
Note that when enabled the `free` function for all exported objects is still
generated, it's just optionally invoked by the application.

Support isn't exposed through a CLI flag right now due to the early stages of
the `WeakRef` proposal, but the env var `WASM_BINDGEN_WEAKREF` can be used to
enable this generation. Upon doing so the output can then be edited slightly as
well to work in the SpiderMonkey shell and it looks like this is working!

Closes #704