### PR TITLE
Skip args in overloaded method names if all same

### DIFF
--- a/crates/web-sys/tests/wasm/console.rs
+++ b/crates/web-sys/tests/wasm/console.rs
@@ -3,6 +3,6 @@ use web_sys::console;
 
 #[wasm_bindgen_test]
 fn test_console() {
-    console::time_using_label("test label");
-    console::time_end_using_label("test label");
+    console::time_with_label("test label");
+    console::time_end_with_label("test label");
 }

--- a/crates/web-sys/tests/wasm/dom_point.rs
+++ b/crates/web-sys/tests/wasm/dom_point.rs
@@ -4,7 +4,7 @@ use web_sys::{DomPoint, DomPointReadOnly};
 
 #[wasm_bindgen_test]
 fn dom_point() {
-    let x = DomPoint::new_using_x_and_y_and_z_and_w(1.0, 2.0, 3.0, 4.0).unwrap();
+    let x = DomPoint::new_with_x_and_y_and_z_and_w(1.0, 2.0, 3.0, 4.0).unwrap();
     assert_eq!(x.x(), 1.0);
     x.set_x(1.5);
     assert_eq!(x.x(), 1.5);
@@ -24,7 +24,7 @@ fn dom_point() {
 
 #[wasm_bindgen_test]
 fn dom_point_readonly() {
-    let x = DomPoint::new_using_x_and_y_and_z_and_w(1.0, 2.0, 3.0, 4.0).unwrap();
+    let x = DomPoint::new_with_x_and_y_and_z_and_w(1.0, 2.0, 3.0, 4.0).unwrap();
     let x = DomPointReadOnly::from(JsValue::from(x));
     assert_eq!(x.x(), 1.0);
     assert_eq!(x.y(), 2.0);

--- a/crates/web-sys/tests/wasm/option_element.rs
+++ b/crates/web-sys/tests/wasm/option_element.rs
@@ -3,7 +3,7 @@ use web_sys::HtmlOptionElement;
 
 #[wasm_bindgen_test]
 fn test_option_element() {
-    let option = HtmlOptionElement::new_using_text_and_value_and_default_selected_and_selected(
+    let option = HtmlOptionElement::new_with_text_and_value_and_default_selected_and_selected(
       "option_text",
       "option_value",
       false,

--- a/crates/web-sys/tests/wasm/table_element.rs
+++ b/crates/web-sys/tests/wasm/table_element.rs
@@ -99,7 +99,7 @@ fn test_table_element() {
   );
 
   table
-    .insert_row_using_index(0)
+    .insert_row_with_index(0)
     .expect("Failed to insert row at index 0");
   assert!(
     table.rows().length() == 1,

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -50,7 +50,7 @@ fn static_property() {
 }
 
 #[wasm_bindgen_test]
-fn one_method_using_an_undefined_import_doesnt_break_all_other_methods() {
+fn one_method_with_an_undefined_import_doesnt_break_all_other_methods() {
     let f = UndefinedMethod::new().unwrap();
     assert!(f.ok_method());
 }
@@ -81,14 +81,14 @@ fn indexing() {
 #[wasm_bindgen_test]
 fn optional_and_union_arguments() {
     let f = OptionalAndUnionArguments::new().unwrap();
-    assert_eq!(f.m_using_a("abc"), "string, abc, boolean, true, number, 123, number, 456");
-    assert_eq!(f.m_using_a_and_b("abc", false), "string, abc, boolean, false, number, 123, number, 456");
-    assert_eq!(f.m_using_dom_str_and_bool_and_i16("abc", false, 5), "string, abc, boolean, false, number, 5, number, 456");
-    assert_eq!(f.m_using_dom_str_and_bool_and_dom_str("abc", false, "5"), "string, abc, boolean, false, string, 5, number, 456");
-    assert_eq!(f.m_using_dom_str_and_bool_and_i16_and_opt_i64("abc", false, 5, Some(10)), "string, abc, boolean, false, number, 5, bigint, 10");
-    assert_eq!(f.m_using_dom_str_and_bool_and_i16_and_opt_bool("abc", false, 5, Some(true)), "string, abc, boolean, false, number, 5, boolean, true");
-    assert_eq!(f.m_using_dom_str_and_bool_and_dom_str_and_opt_i64("abc", false, "5", Some(10)), "string, abc, boolean, false, string, 5, bigint, 10");
-    assert_eq!(f.m_using_dom_str_and_bool_and_dom_str_and_opt_bool("abc", false, "5", Some(true)), "string, abc, boolean, false, string, 5, boolean, true");
+    assert_eq!(f.m("abc"), "string, abc, boolean, true, number, 123, number, 456");
+    assert_eq!(f.m_with_b("abc", false), "string, abc, boolean, false, number, 123, number, 456");
+    assert_eq!(f.m_with_bool_and_i16("abc", false, 5), "string, abc, boolean, false, number, 5, number, 456");
+    assert_eq!(f.m_with_bool_and_dom_str("abc", false, "5"), "string, abc, boolean, false, string, 5, number, 456");
+    assert_eq!(f.m_with_bool_and_i16_and_opt_i64("abc", false, 5, Some(10)), "string, abc, boolean, false, number, 5, bigint, 10");
+    assert_eq!(f.m_with_bool_and_i16_and_opt_bool("abc", false, 5, Some(true)), "string, abc, boolean, false, number, 5, boolean, true");
+    assert_eq!(f.m_with_bool_and_dom_str_and_opt_i64("abc", false, "5", Some(10)), "string, abc, boolean, false, string, 5, bigint, 10");
+    assert_eq!(f.m_with_bool_and_dom_str_and_opt_bool("abc", false, "5", Some(true)), "string, abc, boolean, false, string, 5, boolean, true");
 }
 
 #[wasm_bindgen_test]

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -273,9 +273,13 @@ impl<'src> FirstPassRecord<'src> {
             let rust_name = if possibilities.len() > 1 {
                 let mut rust_name = rust_name.clone();
                 let mut first = true;
-                for ((argument_name, _, _), idl_type) in arguments.iter().zip(idl_types) {
+                let iter = arguments.iter().zip(idl_types).enumerate();
+                for (i, ((argument_name, _, _), idl_type)) in iter {
+                    if possibilities.iter().all(|p| p.get(i) == Some(idl_type)) {
+                        continue
+                    }
                     if first {
-                        rust_name.push_str("_using_");
+                        rust_name.push_str("_with_");
                         first = false;
                     } else {
                         rust_name.push_str("_and_");

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -20,7 +20,7 @@ pub fn draw() {
         .unwrap();
 
     let context = canvas
-        .get_context_using_context_id("2d")
+        .get_context("2d")
         .unwrap()
         .unwrap()
         .dyn_into::<web_sys::CanvasRenderingContext2D>()
@@ -29,43 +29,43 @@ pub fn draw() {
     context.begin_path();
 
     // Draw the outer circle.
-    context.arc_using_x_and_y_and_radius_and_start_angle_and_end_angle(
+    context.arc(
         75.0,
         75.0,
         50.0,
         0.0,
         f64::consts::PI * 2.0,
-    );
+    ).unwrap();
 
     // Draw the mouth.
     context.move_to(110.0, 75.0);
-    context.arc_using_x_and_y_and_radius_and_start_angle_and_end_angle(
+    context.arc(
         75.0,
         75.0,
         35.0,
         0.0,
         f64::consts::PI,
-    );
+    ).unwrap();
 
     // Draw the left eye.
     context.move_to(65.0, 65.0);
-    context.arc_using_x_and_y_and_radius_and_start_angle_and_end_angle(
+    context.arc(
         60.0,
         65.0,
         5.0,
         0.0,
         f64::consts::PI * 2.0,
-    );
+    ).unwrap();
 
     // Draw the right eye.
     context.move_to(95.0, 65.0);
-    context.arc_using_x_and_y_and_radius_and_start_angle_and_end_angle(
+    context.arc(
         90.0,
         65.0,
         5.0,
         0.0,
         f64::consts::PI * 2.0,
-    );
+    ).unwrap();
 
     context.stroke();
 }

--- a/examples/webaudio/src/lib.rs
+++ b/examples/webaudio/src/lib.rs
@@ -81,22 +81,22 @@ impl FmOsc {
             // connect them up:
 
             // The primary oscillator is routed through the gain node, so that it can control the overall output volume
-            primary_node.connect_with_destination_and_output_and_input_using_destination(gain.as_ref());
+            primary_node.connect_with_destination_and_output_and_input(gain.as_ref()).unwrap();
             // Then connect the gain node to the AudioContext destination (aka your speakers)
-            gain_node.connect_with_destination_and_output_and_input_using_destination(destination_node);
+            gain_node.connect_with_destination_and_output_and_input(destination_node).unwrap();
 
             // the FM oscillator is connected to its own gain node, so it can control the amount of modulation
-            fm_osc_node.connect_with_destination_and_output_and_input_using_destination(fm_gain.as_ref());
+            fm_osc_node.connect_with_destination_and_output_and_input(fm_gain.as_ref()).unwrap();
 
             // Connect the FM oscillator to the frequency parameter of the main oscillator, so that the
             // FM node can modulate its frequency
-            fm_gain_node.connect_with_destination_and_output_using_destination(&primary.frequency());
+            fm_gain_node.connect_with_destination_and_output(&primary.frequency()).unwrap();
         }
 
 
         // start the oscillators!
-        AsRef::<AudioScheduledSourceNode>::as_ref(&primary).start();
-        AsRef::<AudioScheduledSourceNode>::as_ref(&fm_osc).start();
+        AsRef::<AudioScheduledSourceNode>::as_ref(&primary).start().unwrap();
+        AsRef::<AudioScheduledSourceNode>::as_ref(&fm_osc).start().unwrap();
 
         FmOsc {
             ctx,


### PR DESCRIPTION
This commit updates how we name overloaded methods. Previously all argument
names were concatenated, but after this commit it only concatenates argument
names where at least one possibility has a different type. Otherwise if all
possibilities have the same type name it in theory isn't adding too much more
information!

Additionally this commit also switches to using `_with_` consistently everywhere
instead of `_with_` for constructors and `_using_` for methods.

Closes #712