### PR TITLE
Add extends attributes for js_sys:Generator

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -885,6 +885,7 @@ impl Function {
 // Generator
 #[wasm_bindgen]
 extern {
+    #[wasm_bindgen(extends = Object)]
     #[derive(Clone, Debug)]
     pub type Generator;
 

--- a/crates/js-sys/tests/wasm/Generator.rs
+++ b/crates/js-sys/tests/wasm/Generator.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
+use wasm_bindgen::JsCast;
 use js_sys::*;
 
 #[wasm_bindgen(module = "tests/wasm/Generator.js")]
@@ -55,4 +56,11 @@ fn throw() {
     let next = GeneratorResult::from(gen.next(&JsValue::undefined()).unwrap());
     assert!(next.value().is_undefined());
     assert!(next.done());
+}
+
+#[wasm_bindgen_test]
+fn generator_inheritance() {
+    let gen = dummy_generator();
+    
+    assert!(gen.is_instance_of::<Object>());
 }


### PR DESCRIPTION
Part of #670 

I'm pretty new to working with JS Generators and as near as I can tell they just inherit from Object and that's it but I would love a second pair of eyes on that to confirm. 

Thanks!