### PR TITLE
Fix missing WindowOrWorkerGlobalScope partial interface mixins.

### DIFF
--- a/crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl
@@ -43,25 +43,25 @@ interface mixin WindowOrWorkerGlobalScope {
 };
 
 // https://fetch.spec.whatwg.org/#fetch-method
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
   [NewObject, NeedsCallerType]
   Promise<Response> fetch(RequestInfo input, optional RequestInit init);
 };
 
 // https://w3c.github.io/webappsec-secure-contexts/#monkey-patching-global-object
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
   readonly attribute boolean isSecureContext;
 };
 
 // http://w3c.github.io/IndexedDB/#factory-interface
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
    // readonly attribute IDBFactory indexedDB;
    [Throws]
    readonly attribute IDBFactory? indexedDB;
 };
 
 // https://w3c.github.io/ServiceWorker/#self-caches
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
   [Throws, Func="mozilla::dom::DOMPrefs::DOMCachesEnabled", SameObject]
   readonly attribute CacheStorage caches;
 };


### PR DESCRIPTION
Without the `mixin` keyword, wasm_bindgen_webidl would report:

    Partial interface WindowOrWorkerGlobalScope missing non-partial interface

Also, including the "mixin" keyword here is consistent with the official
webidl spec (for example see https://fetch.spec.whatwg.org/#fetch-method).

The most important thing this change unlocks is the `fetch` method (CC #449)