### PR TITLE
Add binding for String.prototype.localeCompare

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2996,6 +2996,14 @@ extern "C" {
     #[wasm_bindgen(method, js_class = "String", js_name = lastIndexOf)]
     pub fn last_index_of(this: &JsString, search_value: &str, from_index: i32) -> i32;
 
+    /// The localeCompare() method returns a number indicating whether
+    /// a reference string comes before or after or is the same as
+    /// the given string in sort order.
+    ///
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
+    #[wasm_bindgen(method, js_class = "String", js_name = localeCompare)]
+    pub fn locale_compare(this: &JsString, compare_string: &str, locales: &Array, options: &Object) -> i32;
+
     /// The normalize() method returns the Unicode Normalization Form
     /// of a given string (if the value isn't a string, it will be converted to one first).
     ///

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3070,14 +3070,14 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleLowerCase
     #[wasm_bindgen(method, js_class = "String", js_name = toLocaleLowerCase)]
-    pub fn to_locale_lower_case(this: &JsString, local: Option<&str>) -> JsString;
+    pub fn to_locale_lower_case(this: &JsString, locale: Option<&str>) -> JsString;
 
     /// The toLocaleUpperCase() method returns the calling string value converted to upper case,
     /// according to any locale-specific case mappings.
     ///
     /// https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/toLocaleUpperCase
     #[wasm_bindgen(method, js_class = "String", js_name = toLocaleUpperCase)]
-    pub fn to_locale_upper_case(this: &JsString, local: Option<&str>) -> JsString;
+    pub fn to_locale_upper_case(this: &JsString, locale: Option<&str>) -> JsString;
 
     /// The `toLowerCase()` method returns the calling string value
     /// converted to lower case.

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -136,6 +136,70 @@ fn last_index_of() {
 }
 
 #[wasm_bindgen_test]
+fn locale_compare() {
+    let a = "résumé";
+    let b = "RESUME";
+    let js_a = JsString::from(a);
+    let js_b = JsString::from(b);
+    let locales = Array::new();
+    let options = Object::new();
+
+    assert_eq!(js_a.locale_compare(a, &locales, &options), 0);
+    assert_eq!(js_b.locale_compare(b, &locales, &options), 0);
+    assert!(js_a.locale_compare(b, &locales, &options) > 0);
+    assert!(js_b.locale_compare(a, &locales, &options) < 0);
+
+    locales.push(&"en".into());
+    Reflect::set(options.as_ref(), &"sensitivity".into(), &"base".into());
+
+    assert_eq!(js_a.locale_compare(a, &locales, &options), 0);
+    assert_eq!(js_a.locale_compare(b, &locales, &options), 0);
+    assert_eq!(js_b.locale_compare(a, &locales, &options), 0);
+    assert_eq!(js_b.locale_compare(b, &locales, &options), 0);
+
+    let a = "ä";
+    let z = "z";
+    let js_a = JsString::from(a);
+    let js_z = JsString::from(z);
+    let locales_de = Array::of1(&"de".into());
+    let locales_sv = Array::of1(&"sv".into());
+    let options = Object::new();
+
+    assert_eq!(js_a.locale_compare(a, &locales_de, &options), 0);
+    assert_eq!(js_z.locale_compare(z, &locales_de, &options), 0);
+    assert!(js_a.locale_compare(z, &locales_de, &options) < 0);
+    assert!(js_z.locale_compare(a, &locales_de, &options) > 0);
+
+    assert_eq!(js_a.locale_compare(a, &locales_sv, &options), 0);
+    assert_eq!(js_z.locale_compare(z, &locales_sv, &options), 0);
+    assert!(js_a.locale_compare(z, &locales_sv, &options) < 0);
+    assert!(js_z.locale_compare(a, &locales_sv, &options) > 0);
+
+    let two = "2";
+    let ten = "10";
+    let js_two = JsString::from(two);
+    let js_ten = JsString::from(ten);
+    let locales = Array::new();
+    let options = Object::new();
+
+    assert_eq!(js_two.locale_compare(two, &locales, &options), 0);
+    assert_eq!(js_ten.locale_compare(ten, &locales, &options), 0);
+    assert!(js_two.locale_compare(ten, &locales, &options) > 0);
+    assert!(js_ten.locale_compare(two, &locales, &options) < 0);
+
+    locales.push(&"en-u-kn-true".into());
+
+    assert!(js_two.locale_compare(ten, &locales, &options) < 0);
+    assert!(js_ten.locale_compare(two, &locales, &options) > 0);
+
+    let locales = Array::new();
+    Reflect::set(options.as_ref(), &"numeric".into(), &JsValue::TRUE);
+
+    assert!(js_two.locale_compare(ten, &locales, &options) < 0);
+    assert!(js_ten.locale_compare(two, &locales, &options) > 0);
+}
+
+#[wasm_bindgen_test]
 fn normalize() {
     let js = JsString::from("\u{1E9B}\u{0323}");
 


### PR DESCRIPTION
I went with a similar signature to those in `Intl` but let me know if you have a more convenient suggestion.

cc @twilco 