### PR TITLE
Add extends to js sys Intl.Collater, Intl.DateTimeFormat, Intl.NumberFormat, and Intl.PluralRules

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3496,7 +3496,7 @@ pub mod Intl {
         /// that enable language sensitive number formatting.
         ///
         /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat
-        #[wasm_bindgen(js_namespace = Intl)]
+        #[wasm_bindgen(extends = Object, js_namespace = Intl)]
         #[derive(Clone, Debug)]
         pub type NumberFormat;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3445,7 +3445,7 @@ pub mod Intl {
         /// that enable language-sensitive date and time formatting.
         ///
         /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
-        #[wasm_bindgen(js_namespace = Intl)]
+        #[wasm_bindgen(extends = Object, js_namespace = Intl)]
         #[derive(Clone, Debug)]
         pub type DateTimeFormat;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3546,7 +3546,7 @@ pub mod Intl {
         /// that enable plural sensitive formatting and plural language rules.
         ///
         /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules
-        #[wasm_bindgen(js_namespace = Intl)]
+        #[wasm_bindgen(extends = Object, js_namespace = Intl)]
         #[derive(Clone, Debug)]
         pub type PluralRules;
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3401,7 +3401,7 @@ pub mod Intl {
         /// that enable language sensitive string comparison.
         ///
         /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator
-        #[wasm_bindgen(js_namespace = Intl)]
+        #[wasm_bindgen(extends = Object, js_namespace = Intl)]
         #[derive(Clone, Debug)]
         pub type Collator;
 

--- a/crates/js-sys/tests/wasm/Intl.rs
+++ b/crates/js-sys/tests/wasm/Intl.rs
@@ -54,6 +54,10 @@ fn date_time_format() {
 
     let a = Intl::DateTimeFormat::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+
+    assert!(c.is_instance_of::<Intl::DateTimeFormat>());
+    assert!(c.is_instance_of::<Object>());
+    let _: &Object = c.as_ref();
 }
 
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/Intl.rs
+++ b/crates/js-sys/tests/wasm/Intl.rs
@@ -87,6 +87,10 @@ fn plural_rules() {
     assert!(r.resolved_options().is_instance_of::<Object>());
     assert_eq!(r.select(1_f64), "one");
 
-    let r = Intl::PluralRules::supported_locales_of(&locales, &opts);
-    assert!(r.is_instance_of::<Array>());
+    let a = Intl::PluralRules::supported_locales_of(&locales, &opts);
+    assert!(a.is_instance_of::<Array>());
+
+    assert!(r.is_instance_of::<Intl::PluralRules>());
+    assert!(r.is_instance_of::<Object>());
+    let _: &Object = r.as_ref();
 }

--- a/crates/js-sys/tests/wasm/Intl.rs
+++ b/crates/js-sys/tests/wasm/Intl.rs
@@ -72,6 +72,10 @@ fn number_format() {
 
     let a = Intl::NumberFormat::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+
+    assert!(n.is_instance_of::<Intl::NumberFormat>());
+    assert!(n.is_instance_of::<Object>());
+    let _: &Object = n.as_ref();
 }
 
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/Intl.rs
+++ b/crates/js-sys/tests/wasm/Intl.rs
@@ -35,6 +35,10 @@ fn collator() {
 
     let a = Intl::Collator::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+
+    assert!(c.is_instance_of::<Intl::Collator>());
+    assert!(c.is_instance_of::<Object>());
+    let _: &Object = c.as_ref();
 }
 
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/Intl.rs
+++ b/crates/js-sys/tests/wasm/Intl.rs
@@ -35,6 +35,13 @@ fn collator() {
 
     let a = Intl::Collator::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+}
+
+#[wasm_bindgen_test]
+fn collator_inheritance() {
+    let locales = Array::of1(&JsValue::from("en-US"));
+    let opts = Object::new();
+    let c = Intl::Collator::new(&locales, &opts);
 
     assert!(c.is_instance_of::<Intl::Collator>());
     assert!(c.is_instance_of::<Object>());
@@ -54,6 +61,13 @@ fn date_time_format() {
 
     let a = Intl::DateTimeFormat::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+}
+
+#[wasm_bindgen_test]
+fn date_time_format_inheritance() {
+    let locales = Array::of1(&JsValue::from("en-US"));
+    let opts = Object::new();
+    let c = Intl::DateTimeFormat::new(&locales, &opts);
 
     assert!(c.is_instance_of::<Intl::DateTimeFormat>());
     assert!(c.is_instance_of::<Object>());
@@ -72,6 +86,13 @@ fn number_format() {
 
     let a = Intl::NumberFormat::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+}
+
+#[wasm_bindgen_test]
+fn number_format_inheritance() {
+    let locales = Array::of1(&JsValue::from("en-US"));
+    let opts = Object::new();
+    let n = Intl::NumberFormat::new(&locales, &opts);
 
     assert!(n.is_instance_of::<Intl::NumberFormat>());
     assert!(n.is_instance_of::<Object>());
@@ -89,6 +110,13 @@ fn plural_rules() {
 
     let a = Intl::PluralRules::supported_locales_of(&locales, &opts);
     assert!(a.is_instance_of::<Array>());
+}
+
+#[wasm_bindgen_test]
+fn plural_rules_inheritance() {
+    let locales = Array::of1(&JsValue::from("en-US"));
+    let opts = Object::new();
+    let r = Intl::PluralRules::new(&locales, &opts);
 
     assert!(r.is_instance_of::<Intl::PluralRules>());
     assert!(r.is_instance_of::<Object>());


### PR DESCRIPTION
Part of #670 

Added ```extends = Object``` and accompanying tests to all of the Int.* bindings in js-sys. I did all of them as individual commits but would be happy to squash them into one commit if that would be preferred.

Cheers!
