### PR TITLE
Tweak some WebIDL type names in methods

### DIFF
--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -84,11 +84,11 @@ fn optional_and_union_arguments() {
     assert_eq!(f.m("abc"), "string, abc, boolean, true, number, 123, number, 456");
     assert_eq!(f.m_with_b("abc", false), "string, abc, boolean, false, number, 123, number, 456");
     assert_eq!(f.m_with_bool_and_i16("abc", false, 5), "string, abc, boolean, false, number, 5, number, 456");
-    assert_eq!(f.m_with_bool_and_dom_str("abc", false, "5"), "string, abc, boolean, false, string, 5, number, 456");
+    assert_eq!(f.m_with_bool_and_str("abc", false, "5"), "string, abc, boolean, false, string, 5, number, 456");
     assert_eq!(f.m_with_bool_and_i16_and_opt_i64("abc", false, 5, Some(10)), "string, abc, boolean, false, number, 5, bigint, 10");
     assert_eq!(f.m_with_bool_and_i16_and_opt_bool("abc", false, 5, Some(true)), "string, abc, boolean, false, number, 5, boolean, true");
-    assert_eq!(f.m_with_bool_and_dom_str_and_opt_i64("abc", false, "5", Some(10)), "string, abc, boolean, false, string, 5, bigint, 10");
-    assert_eq!(f.m_with_bool_and_dom_str_and_opt_bool("abc", false, "5", Some(true)), "string, abc, boolean, false, string, 5, boolean, true");
+    assert_eq!(f.m_with_bool_and_str_and_opt_i64("abc", false, "5", Some(10)), "string, abc, boolean, false, string, 5, bigint, 10");
+    assert_eq!(f.m_with_bool_and_str_and_opt_bool("abc", false, "5", Some(true)), "string, abc, boolean, false, string, 5, boolean, true");
 }
 
 #[wasm_bindgen_test]

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -348,13 +348,13 @@ impl<'a> IdlType<'a> {
             IdlType::UnsignedLong => dst.push_str("u32"),
             IdlType::LongLong => dst.push_str("i64"),
             IdlType::UnsignedLongLong => dst.push_str("u64"),
-            IdlType::Float => dst.push_str("f32"),
-            IdlType::UnrestrictedFloat => dst.push_str("unrestricted_f32"),
-            IdlType::Double => dst.push_str("f64"),
-            IdlType::UnrestrictedDouble => dst.push_str("unrestricted_f64"),
-            IdlType::DomString => dst.push_str("dom_str"),
-            IdlType::ByteString => dst.push_str("byte_str"),
-            IdlType::UsvString => dst.push_str("usv_str"),
+            IdlType::Float |
+            IdlType::UnrestrictedFloat => dst.push_str("f32"),
+            IdlType::Double |
+            IdlType::UnrestrictedDouble => dst.push_str("f64"),
+            IdlType::DomString |
+            IdlType::ByteString |
+            IdlType::UsvString => dst.push_str("str"),
             IdlType::Object => dst.push_str("object"),
             IdlType::Symbol => dst.push_str("symbol"),
             IdlType::Error => dst.push_str("error"),


### PR DESCRIPTION
Instead of `dom_str`, `byte_str`, and `usv_str`, emit `str` for all of them.
Similarly for `unrestricted_f64` just do `f64` instead. This reflects how we
interpret the types already in terms of Rust types and although technically
makes it possible to have name collisions in WebIDL they don't come up in
practice.