### PR TITLE
Renamed the binding to `document` as `wbg_document`

### DIFF
--- a/crates/test/src/rt/browser.rs
+++ b/crates/test/src/rt/browser.rs
@@ -17,7 +17,8 @@ pub struct Browser {
 #[wasm_bindgen]
 extern {
     type HTMLDocument;
-    static document: HTMLDocument;
+    #[wasm_bindgen(js_name = document)]
+    static wbg_document: HTMLDocument;
     #[wasm_bindgen(method, structural)]
     fn getElementById(this: &HTMLDocument, id: &str) -> Element;
 
@@ -36,7 +37,7 @@ impl Browser {
     /// Creates a new instance of `Browser`, assuming that its APIs will work
     /// (requires `Node::new()` to have return `None` first).
     pub fn new() -> Browser {
-        let pre = document.getElementById("output");
+        let pre = wbg_document.getElementById("output");
         pre.set_inner_html("");
         Browser {
             pre,


### PR DESCRIPTION
When `wasm-bindgen-test` is used to test user code which declares bindings to `static document`, duplicate js bindings to it are generated. It is caused due to internal bindings used in `wasm-bindgen-test`.

Fixes #714 