### PR TITLE
feat(js-sys) Implement `String.replace(&str, …)`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3082,11 +3082,18 @@ extern "C" {
     ///
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
     #[wasm_bindgen(method, js_class = "String")]
-    pub fn replace(this: &JsString, pattern: &RegExp, replacement: &str) -> JsString;
+    pub fn replace(this: &JsString, pattern: &str, replacement: &str) -> JsString;
 
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
     #[wasm_bindgen(method, js_class = "String", js_name = replace)]
-    pub fn replace_function(this: &JsString, pattern: &RegExp, replacement: &Function) -> JsString;
+    pub fn replace_with_function(this: &JsString, pattern: &str, replacement: &Function) -> JsString;
+
+    #[wasm_bindgen(method, js_class = "String", js_name = replace)]
+    pub fn replace_by_pattern(this: &JsString, pattern: &RegExp, replacement: &str) -> JsString;
+
+    /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
+    #[wasm_bindgen(method, js_class = "String", js_name = replace)]
+    pub fn replace_by_pattern_with_function(this: &JsString, pattern: &RegExp, replacement: &Function) -> JsString;
 
     /// The search() method executes a search for a match between
     /// a regular expression and this String object.

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -288,14 +288,24 @@ fn repeat() {
 #[wasm_bindgen_test]
 fn replace() {
     let js = JsString::from("The quick brown fox jumped over the lazy dog. If the dog reacted, was it really lazy?");
+    let result = js.replace("dog", "ferret");
+
+    assert_eq!(result, "The quick brown fox jumped over the lazy ferret. If the dog reacted, was it really lazy?");
+
+    let js = JsString::from("borderTop");
+    let result = js.replace_with_function("T", &get_replacer_function());
+
+    assert_eq!(result, "border-top");
+
+    let js = JsString::from("The quick brown fox jumped over the lazy dog. If the dog reacted, was it really lazy?");
     let re = RegExp::new("dog", "g");
-    let result = js.replace(&re, "ferret");
+    let result = js.replace_by_pattern(&re, "ferret");
 
     assert_eq!(result, "The quick brown fox jumped over the lazy ferret. If the ferret reacted, was it really lazy?");
 
     let js = JsString::from("borderTop");
     let re = RegExp::new("[A-Z]", "g");
-    let result = js.replace_function(&re, &get_replacer_function());
+    let result = js.replace_by_pattern_with_function(&re, &get_replacer_function());
 
     assert_eq!(result, "border-top");
 }


### PR DESCRIPTION
In `String.replace(needle, haystack)`, `needle` can be a string or a regular expression. So far, only the regular expression type is supported. This patch implements the string type.

I'm not sure about the namings though.