### PR TITLE
Fix the `constructor` and `catch` attributes combined

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -486,7 +486,7 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a Option<String>)> for syn::ForeignItemFn
 
             ast::ImportFunctionKind::Method { class, ty, kind }
         } else if opts.constructor() {
-            let class = match wasm.ret {
+            let class = match js_ret {
                 Some(ref ty) => ty,
                 _ => bail_span!(self, "constructor returns must be bare types"),
             };

--- a/tests/wasm/import_class.js
+++ b/tests/wasm/import_class.js
@@ -123,3 +123,11 @@ exports.run_rust_option_tests = function() {
   assert.strictEqual(wasm.rust_return_none(), undefined);
   assert.strictEqual(wasm.rust_return_some() === undefined, false);
 };
+
+exports.CatchConstructors = class {
+  constructor(x) {
+    if (x == 0) {
+      throw new Error('bad!');
+    }
+  }
+};

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -76,6 +76,10 @@ extern {
     fn return_undefined() -> Option<Options>;
     fn return_some() -> Option<Options>;
     fn run_rust_option_tests();
+
+    type CatchConstructors;
+    #[wasm_bindgen(constructor, catch)]
+    fn new(x: u32) -> Result<CatchConstructors, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -198,4 +202,10 @@ pub fn rust_return_none() -> Option<Options> {
 #[wasm_bindgen]
 pub fn rust_return_some() -> Option<Options> {
     Some(Options::new())
+}
+
+#[wasm_bindgen_test]
+fn catch_constructors() {
+    assert!(CatchConstructors::new(0).is_err());
+    assert!(CatchConstructors::new(1).is_ok());
 }


### PR DESCRIPTION
This commit fixes annotations that include both the `constructor` and `catch`
attributes on imported types, ensuring that we infer the right type being
returned after extracting the first type parameter of the `Result`.

Closes #735