### PR TITLE
Add ArrayBufferView & BufferSource; Enables Webcrypto API

### DIFF
--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -20,4 +20,4 @@ proc-macro2 = "0.4.8"
 quote = '0.6'
 syn = { version = '0.14', features = ['full'] }
 wasm-bindgen-backend = { version = "=0.2.19", path = "../backend" }
-weedle = "0.6"
+weedle = "0.7"

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -441,7 +441,7 @@ impl<'a> IdlType<'a> {
             | IdlType::DomString
             | IdlType::ByteString
             | IdlType::UsvString => match pos {
-                TypePosition::Argument => Some(shared_ref(ident_ty(raw_ident("str")))),
+                TypePosition::Argument => Some(shared_ref(ident_ty(raw_ident("str")), true)),
                 TypePosition::Return => Some(ident_ty(raw_ident("String"))),
             },
             IdlType::Object => {
@@ -456,15 +456,15 @@ impl<'a> IdlType<'a> {
                 Some(leading_colon_path_ty(path))
             },
             IdlType::DataView => None,
-            IdlType::Int8Array => Some(array("i8", pos)),
-            IdlType::Uint8Array => Some(array("u8", pos)),
+            IdlType::Int8Array => Some(array("i8", pos, true)),
+            IdlType::Uint8Array => Some(array("u8", pos, true)),
             IdlType::Uint8ClampedArray => None, // FIXME(#421)
-            IdlType::Int16Array => Some(array("i16", pos)),
-            IdlType::Uint16Array => Some(array("u16", pos)),
-            IdlType::Int32Array => Some(array("i32", pos)),
-            IdlType::Uint32Array => Some(array("u32", pos)),
-            IdlType::Float32Array => Some(array("f32", pos)),
-            IdlType::Float64Array => Some(array("f64", pos)),
+            IdlType::Int16Array => Some(array("i16", pos, true)),
+            IdlType::Uint16Array => Some(array("u16", pos, true)),
+            IdlType::Int32Array => Some(array("i32", pos, true)),
+            IdlType::Uint32Array => Some(array("u32", pos, true)),
+            IdlType::Float32Array => Some(array("f32", pos, true)),
+            IdlType::Float64Array => Some(array("f64", pos, true)),
 
             IdlType::ArrayBufferView | IdlType::BufferSource => {
                 let path = vec![rust_ident("js_sys"), rust_ident("Object")];
@@ -474,7 +474,7 @@ impl<'a> IdlType<'a> {
             | IdlType::Dictionary(name) => {
                 let ty = ident_ty(rust_ident(camel_case_ident(name).as_str()));
                 if pos == TypePosition::Argument {
-                    Some(shared_ref(ty))
+                    Some(shared_ref(ty, true))
                 } else {
                     Some(ty)
                 }
@@ -488,7 +488,7 @@ impl<'a> IdlType<'a> {
                 let path = vec![rust_ident("js_sys"), rust_ident("Promise")];
                 let ty = leading_colon_path_ty(path);
                 if pos == TypePosition::Argument {
-                    Some(shared_ref(ty))
+                    Some(shared_ref(ty, true))
                 } else {
                     Some(ty)
                 }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -466,9 +466,10 @@ impl<'a> IdlType<'a> {
             IdlType::Float32Array => Some(array("f32", pos)),
             IdlType::Float64Array => Some(array("f64", pos)),
 
-            // we alias ArrayBufferView & BufferSource to &u8 in Rust
-            IdlType::ArrayBufferView
-            | IdlType::BufferSource => Some(array("u8", pos)),
+            IdlType::ArrayBufferView | IdlType::BufferSource => {
+                let path = vec![rust_ident("js_sys"), rust_ident("Object")];
+                Some(leading_colon_path_ty(path))
+            },
             IdlType::Interface(name)
             | IdlType::Dictionary(name) => {
                 let ty = ident_ty(rust_ident(camel_case_ident(name).as_str()));
@@ -573,6 +574,8 @@ impl<'a> IdlType<'a> {
                 .iter()
                 .flat_map(|idl_type| idl_type.flatten())
                 .collect(),
+            IdlType::ArrayBufferView | IdlType::BufferSource =>
+                vec![IdlType::Object, IdlType::Uint8Array],
 
             idl_type @ _ => vec![idl_type.clone()],
         }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -40,6 +40,8 @@ pub(crate) enum IdlType<'a> {
     Uint32Array,
     Float32Array,
     Float64Array,
+    ArrayBufferView,
+    BufferSource,
 
     Interface(&'a str),
     Dictionary(&'a str),
@@ -116,6 +118,8 @@ impl<'a> ToIdlType<'a> for NonAnyType<'a> {
             NonAnyType::Float32Array(t) => t.to_idl_type(record),
             NonAnyType::Float64Array(t) => t.to_idl_type(record),
             NonAnyType::FrozenArrayType(t) => t.to_idl_type(record),
+            NonAnyType::ArrayBufferView(t) => t.to_idl_type(record),
+            NonAnyType::BufferSource(t) => t.to_idl_type(record),
             NonAnyType::RecordType(t) => t.to_idl_type(record),
             NonAnyType::Identifier(t) => t.to_idl_type(record),
         }
@@ -331,6 +335,8 @@ terms_to_idl_type! {
     Uint8ClampedArray => Uint8ClampedArray
     Float32Array => Float32Array
     Float64Array => Float64Array
+    ArrayBufferView => ArrayBufferView
+    BufferSource => BufferSource
     Error => Error
 }
 
@@ -369,6 +375,8 @@ impl<'a> IdlType<'a> {
             IdlType::Uint32Array => dst.push_str("u32_array"),
             IdlType::Float32Array => dst.push_str("f32_array"),
             IdlType::Float64Array => dst.push_str("f64_array"),
+            IdlType::ArrayBufferView => dst.push_str("array_buffer_view"),
+            IdlType::BufferSource => dst.push_str("buffer_source"),
 
             IdlType::Interface(name) => dst.push_str(&snake_case_ident(name)),
             IdlType::Dictionary(name) => dst.push_str(&snake_case_ident(name)),
@@ -458,7 +466,10 @@ impl<'a> IdlType<'a> {
             IdlType::Float32Array => Some(array("f32", pos)),
             IdlType::Float64Array => Some(array("f64", pos)),
 
-            | IdlType::Interface(name)
+            // we alias ArrayBufferView & BufferSource to &u8 in Rust
+            IdlType::ArrayBufferView
+            | IdlType::BufferSource => Some(array("u8", pos)),
+            IdlType::Interface(name)
             | IdlType::Dictionary(name) => {
                 let ty = ident_ty(rust_ident(camel_case_ident(name).as_str()));
                 if pos == TypePosition::Argument {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -240,7 +240,7 @@ impl<'src> FirstPassRecord<'src> {
             ..
         } = &kind {
             let mut res = Vec::with_capacity(idl_arguments.size_hint().0 + 1);
-            res.push(simple_fn_arg(raw_ident("self_"), shared_ref(ty.clone(), true)));
+            res.push(simple_fn_arg(raw_ident("self_"), shared_ref(ty.clone(), false)));
             res
         } else {
             Vec::with_capacity(idl_arguments.size_hint().0)

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -14,11 +14,11 @@ use first_pass::{FirstPassRecord, OperationId, OperationData, Signature};
 use idl_type::{IdlType, ToIdlType};
 
 /// Take a type and create an immutable shared reference to that type.
-pub(crate) fn shared_ref(ty: syn::Type) -> syn::Type {
+pub(crate) fn shared_ref(ty: syn::Type, mutable: bool) -> syn::Type {
     syn::TypeReference {
         and_token: Default::default(),
         lifetime: None,
-        mutability: None,
+        mutability: if mutable { Some(syn::token::Mut::default()) } else { None },
         elem: Box::new(ty),
     }.into()
 }
@@ -57,10 +57,10 @@ pub fn mdn_doc(class: &str, method: Option<&str>) -> String {
 }
 
 // Array type is borrowed for arguments (`&[T]`) and owned for return value (`Vec<T>`).
-pub(crate) fn array(base_ty: &str, pos: TypePosition) -> syn::Type {
+pub(crate) fn array(base_ty: &str, pos: TypePosition, mutable: bool) -> syn::Type {
     match pos {
         TypePosition::Argument => {
-            shared_ref(slice_ty(ident_ty(raw_ident(base_ty))))
+            shared_ref(slice_ty(ident_ty(raw_ident(base_ty))), mutable)
         }
         TypePosition::Return => {
             vec_ty(ident_ty(raw_ident(base_ty)))
@@ -240,7 +240,7 @@ impl<'src> FirstPassRecord<'src> {
             ..
         } = &kind {
             let mut res = Vec::with_capacity(idl_arguments.size_hint().0 + 1);
-            res.push(simple_fn_arg(raw_ident("self_"), shared_ref(ty.clone())));
+            res.push(simple_fn_arg(raw_ident("self_"), shared_ref(ty.clone(), true)));
             res
         } else {
             Vec::with_capacity(idl_arguments.size_hint().0)


### PR DESCRIPTION
_needs [Weedle#14](https://github.com/rustwasm/weedle/pull/14)_

Adds type definitions for `ArrayBufferView` and `BufferSource` to the parser; both are represented as `[u8]` in Rust for now (see comments below).

Among others, this means the Webcrypto and SubtleCrypto-APIs are now generated properly and accessible from rust.