### PR TITLE
Add support for modules importing memory

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -200,6 +200,7 @@ impl Bindgen {
                 module: &mut module,
                 function_table_needed: false,
                 interpreter: &mut instance,
+                memory_init: None,
             };
             for program in programs.iter() {
                 js::SubContext {

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -150,19 +150,6 @@ impl Output {
         if let Some(i) = self.module.import_section() {
             let mut set = HashSet::new();
             for entry in i.entries() {
-                match *entry.external() {
-                    External::Function(_) => {}
-                    External::Table(_) => {
-                        bail!("wasm imports a table which isn't supported yet");
-                    }
-                    External::Memory(_) => {
-                        bail!("wasm imports memory which isn't supported yet");
-                    }
-                    External::Global(_) => {
-                        bail!("wasm imports globals which aren't supported yet");
-                    }
-                }
-
                 if !set.insert(entry.module()) {
                     continue;
                 }


### PR DESCRIPTION
The default of Rust wasm binaries is to export the memory that they contain, but
LLD also supports an `--import-memory` option where memory is imported into a
module instead. It's looking like importing memory is along the lines of how
shared memory wasm modules will work (they'll all import the same memory).

This commit adds support to wasm-bindgen to support modules which import memory.
Memory accessors are tweaked to no longer always assume that the wasm module
exports its memory. Additionally JS bindings will create a `memory` option
automatically because LLD always imports memory from an `env` module which won't
actually exist.