### PR TITLE
Add an accessor for wasm's own memory as a JS object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,9 @@ serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = { path = 'crates/test', version = '=0.2.17' }
+js-sys = { path = 'crates/js-sys', version = '0.2' }
 serde_derive = "1.0"
+wasm-bindgen-test = { path = 'crates/test', version = '=0.2.17' }
 wasm-bindgen-test-crate-a = { path = 'tests/crates/a' }
 wasm-bindgen-test-crate-b = { path = 'tests/crates/b' }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -380,6 +380,18 @@ impl<'a> Context<'a> {
             ))
         })?;
 
+        self.bind("__wbindgen_memory", &|me| {
+            me.expose_add_heap_object();
+            let mem = me.memory();
+            Ok(format!(
+                "
+                function() {{
+                    return addHeapObject({});
+                }}
+                ", mem
+            ))
+        })?;
+
         self.create_memory_export();
         self.unexport_unused_internal_exports();
         self.gc()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,8 @@ externs! {
     fn __wbindgen_json_parse(ptr: *const u8, len: usize) -> u32;
     fn __wbindgen_json_serialize(idx: u32, ptr: *mut *mut u8) -> usize;
     fn __wbindgen_jsval_eq(a: u32, b: u32) -> u32;
+
+    fn __wbindgen_memory() -> u32;
 }
 
 impl Clone for JsValue {
@@ -559,6 +561,13 @@ impl<T: FromWasmAbi + 'static> Deref for JsStatic<T> {
 pub fn throw(s: &str) -> ! {
     unsafe {
         __wbindgen_throw(s.as_ptr(), s.len());
+    }
+}
+
+/// Returns a handle to this wasm instance's `WebAssembly.Memory`
+pub fn memory() -> JsValue {
+    unsafe {
+        JsValue { idx: __wbindgen_memory() }
     }
 }
 

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -1,5 +1,7 @@
+use wasm_bindgen::{self, JsCast};
 use wasm_bindgen_test::*;
 use wasm_bindgen::prelude::*;
+use js_sys::{WebAssembly, Uint8Array};
 
 #[wasm_bindgen(module = "tests/wasm/api.js")]
 extern {
@@ -134,4 +136,18 @@ pub fn eq_test1(a: &JsValue) -> bool {
 fn null_keeps_working() {
     assert_null(JsValue::null());
     assert_null(JsValue::null());
+}
+
+#[wasm_bindgen_test]
+fn memory_accessor_appears_to_work() {
+    let data = 3u32;
+    let ptr = &data as *const u32 as u32;
+
+    let my_mem = wasm_bindgen::memory();
+    let mem = my_mem.dyn_into::<WebAssembly::Memory>().unwrap();
+    let buf = mem.buffer();
+    let slice = Uint8Array::new(&buf);
+    let mut v = Vec::new();
+    slice.subarray(ptr, ptr + 4).for_each(&mut |val, _, _| v.push(val));
+    assert_eq!(v, [3, 0, 0, 0]);
 }

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -1,5 +1,6 @@
 #![cfg(target_arch = "wasm32")]
 
+extern crate js_sys;
 extern crate wasm_bindgen_test;
 extern crate wasm_bindgen;
 extern crate wasm_bindgen_test_crate_a;


### PR DESCRIPTION
In addition to closing #495 this'll be useful eventually when instantiating
multiple wasm modules from Rust as you'd now be able to acquire a reference to
the current module in Rust itself.

Closes #495