### PR TITLE
Bump dependency on parity-wasm to 0.32.0

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -13,7 +13,7 @@ Shared support for the wasm-bindgen-cli package, an internal dependency
 [dependencies]
 base64 = "0.9"
 failure = "0.1.2"
-parity-wasm = "0.31"
+parity-wasm = "0.32"
 serde = "1.0"
 serde_json = "1.0"
 tempfile = "3.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ docopt = "1.0"
 env_logger = "0.5"
 failure = "0.1.2"
 log = "0.4"
-parity-wasm = "0.31"
+parity-wasm = "0.32"
 rouille = { version = "2.1.0", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -11,7 +11,7 @@ Micro-interpreter optimized for wasm-bindgen's use case
 """
 
 [dependencies]
-parity-wasm = "0.31"
+parity-wasm = "0.32"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Brings support for atomic instructions!