### PR TITLE
web-sys: Add support for `Global`-scope methods

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -99,6 +99,10 @@ pub enum ImportFunctionKind {
         ty: syn::Type,
         kind: MethodKind,
     },
+    ScopedMethod {
+        ty: syn::Type,
+        operation: Operation,
+    },
     Normal,
 }
 
@@ -407,6 +411,29 @@ impl ImportFunction {
     }
 
     fn shared(&self) -> shared::ImportFunction {
+        let shared_operation = |operation: &Operation| {
+            let is_static = operation.is_static;
+            let kind = match &operation.kind {
+                OperationKind::Regular => shared::OperationKind::Regular,
+                OperationKind::Getter(g) => {
+                    let g = g.as_ref().map(|g| g.to_string());
+                    shared::OperationKind::Getter(
+                        g.unwrap_or_else(|| self.infer_getter_property()),
+                        )
+                }
+                OperationKind::Setter(s) => {
+                    let s = s.as_ref().map(|s| s.to_string());
+                    shared::OperationKind::Setter(
+                        s.unwrap_or_else(|| self.infer_setter_property()),
+                        )
+                }
+                OperationKind::IndexingGetter => shared::OperationKind::IndexingGetter,
+                OperationKind::IndexingSetter => shared::OperationKind::IndexingSetter,
+                OperationKind::IndexingDeleter => shared::OperationKind::IndexingDeleter,
+            };
+            shared::Operation { is_static, kind }
+        };
+
         let method = match self.kind {
             ImportFunctionKind::Method {
                 ref class,
@@ -415,32 +442,19 @@ impl ImportFunction {
             } => {
                 let kind = match kind {
                     MethodKind::Constructor => shared::MethodKind::Constructor,
-                    MethodKind::Operation(Operation { is_static, kind }) => {
-                        let is_static = *is_static;
-                        let kind = match kind {
-                            OperationKind::Regular => shared::OperationKind::Regular,
-                            OperationKind::Getter(g) => {
-                                let g = g.as_ref().map(|g| g.to_string());
-                                shared::OperationKind::Getter(
-                                    g.unwrap_or_else(|| self.infer_getter_property()),
-                                )
-                            }
-                            OperationKind::Setter(s) => {
-                                let s = s.as_ref().map(|s| s.to_string());
-                                shared::OperationKind::Setter(
-                                    s.unwrap_or_else(|| self.infer_setter_property()),
-                                )
-                            }
-                            OperationKind::IndexingGetter => shared::OperationKind::IndexingGetter,
-                            OperationKind::IndexingSetter => shared::OperationKind::IndexingSetter,
-                            OperationKind::IndexingDeleter => shared::OperationKind::IndexingDeleter,
-                        };
-                        shared::MethodKind::Operation(shared::Operation { is_static, kind })
+                    MethodKind::Operation(op) => {
+                        shared::MethodKind::Operation(shared_operation(op))
                     }
                 };
                 Some(shared::MethodData {
-                    class: class.clone(),
+                    class: Some(class.clone()),
                     kind,
+                })
+            }
+            ImportFunctionKind::ScopedMethod { ref operation, .. } => {
+                Some(shared::MethodData {
+                    class: None,
+                    kind: shared::MethodKind::Operation(shared_operation(operation)),
                 })
             }
             ImportFunctionKind::Normal => None,

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -784,6 +784,9 @@ impl TryToTokens for ast::ImportFunction {
                 }
                 class_ty = Some(ty);
             }
+            ast::ImportFunctionKind::ScopedMethod { ref ty, .. } => {
+                class_ty = Some(ty);
+            }
             ast::ImportFunctionKind::Normal => {}
         }
         let vis = &self.function.rust_vis;

--- a/crates/backend/src/defined.rs
+++ b/crates/backend/src/defined.rs
@@ -246,6 +246,7 @@ impl ImportedTypes for ast::ImportFunctionKind {
     {
         match self {
             ast::ImportFunctionKind::Method { ty, .. } => ty.imported_types(f),
+            ast::ImportFunctionKind::ScopedMethod { ty, .. } => ty.imported_types(f),
             ast::ImportFunctionKind::Normal => {}
         }
     }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -514,6 +514,7 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a Option<String>)> for syn::ForeignItemFn
 
         let shim = {
             let ns = match kind {
+                ast::ImportFunctionKind::ScopedMethod { .. } |
                 ast::ImportFunctionKind::Normal => (0, "n"),
                 ast::ImportFunctionKind::Method { ref class, .. } => (1, &class[..]),
             };

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -48,7 +48,7 @@ pub struct ImportFunction {
 
 #[derive(Deserialize, Serialize)]
 pub struct MethodData {
-    pub class: String,
+    pub class: Option<String>,
     pub kind: MethodKind,
 }
 

--- a/crates/webidl-tests/global.js
+++ b/crates/webidl-tests/global.js
@@ -1,0 +1,4 @@
+global.global_no_args = () => 3;
+global.global_with_args = (a, b) => a + b;
+global.global_attribute = 'x';
+

--- a/crates/webidl-tests/global.rs
+++ b/crates/webidl-tests/global.rs
@@ -1,0 +1,12 @@
+use wasm_bindgen_test::*;
+
+include!(concat!(env!("OUT_DIR"), "/global.rs"));
+
+#[wasm_bindgen_test]
+fn works() {
+    assert_eq!(Global::global_no_args(), 3);
+    assert_eq!(Global::global_with_args("a", "b"), "ab");
+    assert_eq!(Global::global_attribute(), "x");
+    Global::set_global_attribute("y");
+    assert_eq!(Global::global_attribute(), "y");
+}

--- a/crates/webidl-tests/global.webidl
+++ b/crates/webidl-tests/global.webidl
@@ -1,0 +1,6 @@
+[Global=x]
+interface Global {
+  unsigned long global_no_args();
+  DOMString global_with_args(DOMString a, DOMString b);
+  attribute DOMString global_attribute;
+};

--- a/crates/webidl-tests/main.rs
+++ b/crates/webidl-tests/main.rs
@@ -10,3 +10,4 @@ pub mod namespace;
 pub mod simple;
 pub mod throws;
 pub mod dictionary;
+pub mod global;

--- a/crates/webidl-tests/simple.js
+++ b/crates/webidl-tests/simple.js
@@ -87,11 +87,7 @@ global.Unforgeable = class Unforgeable {
   }
 };
 
-global.GlobalMethod = class GlobalMethod {
-  constructor() {
-    this.m = () => 123;
-  }
-};
+global.m = () => 123;
 
 global.Indexing = function () {
   return new Proxy({}, {

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -64,8 +64,7 @@ fn nullable_method() {
 
 #[wasm_bindgen_test]
 fn global_method() {
-    let f = GlobalMethod::new().unwrap();
-    assert_eq!(f.m(), 123);
+    assert_eq!(GlobalMethod::m(), 123);
 }
 
 #[wasm_bindgen_test]

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -591,6 +591,11 @@ fn member_attribute<'src>(
 
     let is_structural = util::is_structural(attrs);
     let throws = util::throws(attrs);
+    let global = first_pass
+        .interfaces
+        .get(self_name)
+        .map(|interface_data| interface_data.global)
+        .unwrap_or(false);
 
     for import_function in first_pass.create_getter(
         identifier,
@@ -599,6 +604,7 @@ fn member_attribute<'src>(
         is_static,
         is_structural,
         throws,
+        global,
     ) {
         program.imports.push(wrap_import_function(import_function));
     }
@@ -611,6 +617,7 @@ fn member_attribute<'src>(
             is_static,
             is_structural,
             throws,
+            global,
         ) {
             program.imports.push(wrap_import_function(import_function));
         }
@@ -712,6 +719,12 @@ fn member_operation<'src>(
         operation_ids.push(id);
     }
 
+    let global = first_pass
+        .interfaces
+        .get(self_name)
+        .map(|interface_data| interface_data.global)
+        .unwrap_or(false);
+
     for id in operation_ids {
         let methods = first_pass
             .create_basic_method(
@@ -724,15 +737,10 @@ fn member_operation<'src>(
                     OperationId::IndexingGetter |
                     OperationId::IndexingSetter |
                     OperationId::IndexingDeleter => true,
-                    _ => {
-                        first_pass
-                            .interfaces
-                            .get(self_name)
-                            .map(|interface_data| interface_data.global)
-                            .unwrap_or(false)
-                    }
+                    _ => false,
                 },
                 util::throws(attrs),
+                global,
             );
 
         for method in methods {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -297,6 +297,7 @@ impl<'src> FirstPassRecord<'src> {
             let rust_name = rust_ident(&rust_name);
             let shim = {
                 let ns = match kind {
+                    backend::ast::ImportFunctionKind::ScopedMethod { .. } |
                     backend::ast::ImportFunctionKind::Normal => "",
                     backend::ast::ImportFunctionKind::Method { ref class, .. } => class,
                 };
@@ -389,6 +390,7 @@ impl<'src> FirstPassRecord<'src> {
         is_static: bool,
         structural: bool,
         catch: bool,
+        global: bool,
     ) -> Vec<backend::ast::ImportFunction> {
         let (overloaded, same_argument_names) = self.get_operation_overloading(
             arguments,
@@ -410,20 +412,26 @@ impl<'src> FirstPassRecord<'src> {
             first_pass::OperationId::IndexingSetter => "set",
             first_pass::OperationId::IndexingDeleter => "delete",
         };
-
-        let kind = backend::ast::ImportFunctionKind::Method {
-            class: self_name.to_string(),
-            ty: ident_ty(rust_ident(camel_case_ident(&self_name).as_str())),
-            kind: backend::ast::MethodKind::Operation(backend::ast::Operation {
-                is_static,
-                kind: match &operation_id {
-                    first_pass::OperationId::Constructor => panic!("constructors are unsupported"),
-                    first_pass::OperationId::Operation(_) => backend::ast::OperationKind::Regular,
-                    first_pass::OperationId::IndexingGetter => backend::ast::OperationKind::IndexingGetter,
-                    first_pass::OperationId::IndexingSetter => backend::ast::OperationKind::IndexingSetter,
-                    first_pass::OperationId::IndexingDeleter => backend::ast::OperationKind::IndexingDeleter,
-                },
-            }),
+        let operation_kind = match &operation_id {
+            first_pass::OperationId::Constructor => panic!("constructors are unsupported"),
+            first_pass::OperationId::Operation(_) => backend::ast::OperationKind::Regular,
+            first_pass::OperationId::IndexingGetter => backend::ast::OperationKind::IndexingGetter,
+            first_pass::OperationId::IndexingSetter => backend::ast::OperationKind::IndexingSetter,
+            first_pass::OperationId::IndexingDeleter => backend::ast::OperationKind::IndexingDeleter,
+        };
+        let operation = backend::ast::Operation { is_static, kind: operation_kind };
+        let ty = ident_ty(rust_ident(camel_case_ident(&self_name).as_str()));
+        let kind = if global {
+            backend::ast::ImportFunctionKind::ScopedMethod {
+                ty,
+                operation,
+            }
+        } else {
+            backend::ast::ImportFunctionKind::Method {
+                class: self_name.to_string(),
+                ty,
+                kind: backend::ast::MethodKind::Operation(operation),
+            }
         };
 
         let ret = match return_type.to_idl_type(self) {
@@ -591,19 +599,29 @@ impl<'src> FirstPassRecord<'src> {
         is_static: bool,
         is_structural: bool,
         catch: bool,
+        global: bool,
     ) -> Vec<backend::ast::ImportFunction> {
         let ret = match ty.to_idl_type(self) {
             None => return Vec::new(),
             Some(idl_type) => idl_type,
         };
+        let operation = backend::ast::Operation {
+            is_static,
+            kind: backend::ast::OperationKind::Getter(Some(raw_ident(name))),
+        };
+        let ty = ident_ty(rust_ident(camel_case_ident(&self_name).as_str()));
 
-        let kind = backend::ast::ImportFunctionKind::Method {
-            class: self_name.to_string(),
-            ty: ident_ty(rust_ident(camel_case_ident(&self_name).as_str())),
-            kind: backend::ast::MethodKind::Operation(backend::ast::Operation {
-                is_static,
-                kind: backend::ast::OperationKind::Getter(Some(raw_ident(name))),
-            }),
+        let kind = if global {
+            backend::ast::ImportFunctionKind::ScopedMethod {
+                ty,
+                operation,
+            }
+        } else {
+            backend::ast::ImportFunctionKind::Method {
+                class: self_name.to_string(),
+                ty,
+                kind: backend::ast::MethodKind::Operation(operation),
+            }
         };
         let doc_comment = Some(format!("The `{}` getter\n\n{}", name, mdn_doc(self_name, Some(name))));
 
@@ -614,19 +632,30 @@ impl<'src> FirstPassRecord<'src> {
     pub fn create_setter(
         &self,
         name: &str,
-        ty: weedle::types::Type,
+        field_ty: weedle::types::Type,
         self_name: &str,
         is_static: bool,
         is_structural: bool,
         catch: bool,
+        global: bool,
     ) -> Vec<backend::ast::ImportFunction> {
-        let kind = backend::ast::ImportFunctionKind::Method {
-            class: self_name.to_string(),
-            ty: ident_ty(rust_ident(camel_case_ident(&self_name).as_str())),
-            kind: backend::ast::MethodKind::Operation(backend::ast::Operation {
-                is_static,
-                kind: backend::ast::OperationKind::Setter(Some(raw_ident(name))),
-            }),
+        let operation = backend::ast::Operation {
+            is_static,
+            kind: backend::ast::OperationKind::Setter(Some(raw_ident(name))),
+        };
+        let ty = ident_ty(rust_ident(camel_case_ident(&self_name).as_str()));
+
+        let kind = if global {
+            backend::ast::ImportFunctionKind::ScopedMethod {
+                ty,
+                operation,
+            }
+        } else {
+            backend::ast::ImportFunctionKind::Method {
+                class: self_name.to_string(),
+                ty,
+                kind: backend::ast::MethodKind::Operation(operation),
+            }
         };
         let doc_comment = Some(format!("The `{}` setter\n\n{}", name, mdn_doc(self_name, Some(name))));
 
@@ -636,7 +665,7 @@ impl<'src> FirstPassRecord<'src> {
             false,
             &[(
                 name,
-                match ty.to_idl_type(self) {
+                match field_ty.to_idl_type(self) {
                     None => return Vec::new(),
                     Some(idl_type) => idl_type,
                 },

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -7,12 +7,8 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 #[wasm_bindgen]
-extern "C" {
-    static document: web_sys::Document;
-}
-
-#[wasm_bindgen]
 pub fn draw() {
+    let document = web_sys::Window::document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();
     let canvas: web_sys::HtmlCanvasElement = canvas
         .dyn_into::<web_sys::HtmlCanvasElement>()

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -41,11 +41,6 @@ pub struct Signature {
 }
 
 #[wasm_bindgen]
-extern "C" {
-    static window: Window;
-}
-
-#[wasm_bindgen]
 pub fn run() -> Promise {
     let mut request_options = RequestInit::new();
     request_options.method("GET");
@@ -56,7 +51,7 @@ pub fn run() -> Promise {
     // the RequestInit struct will eventually support setting headers, but that's missing right now
     req.headers().set("Accept", "application/vnd.github.v3+json").unwrap();
 
-    let req_promise = window.fetch_with_request(&req);
+    let req_promise = Window::fetch_with_request(&req);
 
     let to_return = JsFuture::from(req_promise).and_then(|resp_value| {
         // resp_value is a Response object


### PR DESCRIPTION
This commit adds further support for the `Global` attribute to not only emit
structural accessors but also emit functions that don't take `&self`. All
methods on a `[Global]` interface will not require `&self` and will call
functions and/or access properties on the global scope.

This should enable things like:

    Window::location() // returns `Location`
    Window::fetch(...) // invokes the `fetch` function

Closes #659