### PR TITLE
Don't enable `nightly` feature of `proc-macro2`

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -11,7 +11,7 @@ Backend code generation of the wasm-bindgen tool
 """
 
 [features]
-spans = ["proc-macro2/nightly"]
+spans = []
 extra-traits = ["syn/extra-traits"]
 
 [dependencies]

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -11,7 +11,7 @@ The part of the implementation of the `#[wasm_bindgen]` attribute that is not in
 """
 
 [features]
-spans = ["proc-macro2/nightly", "wasm-bindgen-backend/spans"]
+spans = ["wasm-bindgen-backend/spans"]
 extra-traits = ["syn/extra-traits"]
 
 [dependencies]

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 
 [dependencies]
-proc-macro2 = { version = "0.4", features = ['nightly'] }
+proc-macro2 = "0.4"
 quote = "0.6"
 
 [lib]


### PR DESCRIPTION
This is no longer needed as of rustc 1.30.0 and the `proc-macro2` crate will now
automatically detect whether it can use spans or not!