### PR TITLE
webidl: Remove support for Uint8ClampedArray

### DIFF
--- a/crates/webidl-tests/array.rs
+++ b/crates/webidl-tests/array.rs
@@ -14,7 +14,6 @@ fn take_and_return_a_bunch_of_slices() {
     assert_eq!(f.i16(&[1, 2]), [3, 4, 5]);
     assert_eq!(f.i32(&[1, 2]), [3, 4, 5]);
     assert_eq!(f.u8(&[1, 2]), [3, 4, 5]);
-    assert_eq!(f.u8_clamped(&[1, 2]), [3, 4, 5]);
     assert_eq!(f.u16(&[1, 2]), [3, 4, 5]);
     assert_eq!(f.u32(&[1, 2]), [3, 4, 5]);
 }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -459,7 +459,7 @@ impl<'a> IdlType<'a> {
             IdlType::DataView => None,
             IdlType::Int8Array => Some(array("i8", pos)),
             IdlType::Uint8Array => Some(array("u8", pos)),
-            IdlType::Uint8ClampedArray => Some(array("u8", pos)),
+            IdlType::Uint8ClampedArray => None, // FIXME(#421)
             IdlType::Int16Array => Some(array("i16", pos)),
             IdlType::Uint16Array => Some(array("u16", pos)),
             IdlType::Int32Array => Some(array("i32", pos)),


### PR DESCRIPTION
Our bindings currently translate this to `&[u8]` which is actually `Uint8Array`.
We'll need to fix #421 before supporting this.