### PR TITLE
Implement support for WebIDL `Callback` types

### DIFF
--- a/crates/webidl-tests/array_buffer.rs
+++ b/crates/webidl-tests/array_buffer.rs
@@ -7,5 +7,5 @@ fn take_and_return_a_bunch_of_slices() {
     let f = ArrayBufferTest::new().unwrap();
     let x = f.get_buffer();
     f.set_buffer(None);
-    f.set_buffer(Some(x));
+    f.set_buffer(Some(&x));
 }

--- a/crates/webidl-tests/simple.js
+++ b/crates/webidl-tests/simple.js
@@ -146,3 +146,13 @@ global.MixinFoo = class MixinFoo {
 global.Overloads = class {
   foo() {}
 };
+
+global.InvokeCallback = class {
+  invoke(f) { f(); }
+  callAdd(f) {
+    return f(1, 2);
+  }
+  callRepeat(f) {
+    return f('ab', 4);
+  }
+};

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -1,4 +1,6 @@
 use wasm_bindgen_test::*;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 
 include!(concat!(env!("OUT_DIR"), "/simple.rs"));
 
@@ -123,4 +125,27 @@ fn overload_naming() {
     o.foo_with_arg_and_i32("x", 3);
     o.foo_with_arg_and_f32("x", 2.0);
     o.foo_with_arg_and_i16("x", 5);
+}
+
+#[wasm_bindgen_test]
+fn callback() {
+    let o = InvokeCallback::new().unwrap();
+    {
+        static mut HIT: bool = false;
+        let cb = Closure::wrap(Box::new(move || {
+            unsafe { HIT = true; }
+        }) as Box<FnMut()>);
+        o.invoke(cb.as_ref().unchecked_ref());
+        assert!(unsafe { HIT });
+    }
+
+    let cb = Closure::wrap(Box::new(move |a, b| {
+        a + b
+    }) as Box<FnMut(u32, u32) -> u32>);
+    assert_eq!(o.call_add(cb.as_ref().unchecked_ref()), 3);
+
+    let cb = Closure::wrap(Box::new(move |a: String, b| {
+        a.repeat(b)
+    }) as Box<FnMut(String, usize) -> String>);
+    assert_eq!(o.call_repeat(cb.as_ref().unchecked_ref()), "abababab");
 }

--- a/crates/webidl-tests/simple.webidl
+++ b/crates/webidl-tests/simple.webidl
@@ -95,3 +95,15 @@ interface Overloads {
   void foo(DOMString arg, optional long a);
   void foo(DOMString arg, (float or short) b);
 };
+
+callback MyCallback = any();
+callback AddCallback = long(long a, long b);
+callback RepeatCallback = DOMString(DOMString a, long cnt);
+callback GetAnswer = long();
+
+[Constructor()]
+interface InvokeCallback {
+  void invoke(MyCallback callback);
+  long callAdd(AddCallback callback);
+  DOMString callRepeat(RepeatCallback callback);
+};

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -138,7 +138,7 @@ fn builtin_idents() -> BTreeSet<Ident> {
         vec![
             "str", "char", "bool", "JsValue", "u8", "i8", "u16", "i16", "u32", "i32", "u64", "i64",
             "usize", "isize", "f32", "f64", "Result", "String", "Vec", "Option",
-            "ArrayBuffer", "Object", "Promise",
+            "ArrayBuffer", "Object", "Promise", "Function",
         ].into_iter()
             .map(|id| proc_macro2::Ident::new(id, proc_macro2::Span::call_site())),
     )

--- a/guide/src/web-sys.md
+++ b/guide/src/web-sys.md
@@ -5,4 +5,99 @@ source lives at `wasm-bindgen/crates/web-sys`.
 
 The `web-sys` crate is **entirely** mechanically generated inside `build.rs`
 using `wasm-bindgen`'s WebIDL frontend and the WebIDL interface definitions for
-Web APIs.
+Web APIs. This means that `web-sys` isn't always the most ergonomic crate to
+use, but it's intended to provide verified and correct bindings to the web
+platform, and then better interfaces can be iterated on crates.io!
+
+### Using `web-sys`
+
+Let's say you want to use an API defined on the web. Chances are this API is
+defined in `web-sys`, so let's go through some steps necessary to use it!
+
+First up, search the [api documentation][api] for your API. For example if
+we're looking for JS's [`fetch`][jsfetch] API we'd start out by [searching for
+`fetch`][search-fetch]. The first thing you'll probably notice is that there's
+no function called `fetch`! Fear not, though, as the API exists in multiple
+forms:
+
+* [`Window::fetch_with_str`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Window.html#method.fetch_with_str)
+* [`Window::fetch_with_request`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Window.html#method.fetch_with_request)
+* [`Window::fetch_with_str_and_init`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/str_and_inituct.Window.html#method.fetch_with_str_and_init)
+* [`Window::fetch_with_request_and_init`](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Window.html#method.fetch_with_request_and_init)
+
+What's happening here is that the [`fetch` function][fetchfn] actually supports
+multiple signatures of arguments, and we've taken the WebIDL definition for this
+function and expanded it to unique signatures in Rust (as Rust doesn't have
+function name overloading).
+
+When an API is selected it should have documentation pointing at MDN indicating
+what web API its binding. This is often a great way to double check arguments
+and such as well, MDN is a great resource! You'll also notice in the
+documentation that the API may require some `web-sys` Cargo features to be
+activated. For example [`fetch_with_str`] requires the `Window` feature to be
+activated. In general an API needs features corresponding to all the types
+you'll find in the signature to be activated.
+
+To load up this API let's depend on `web-sys`:
+
+```toml
+[dependencies]
+wasm-bindgen = "0.2"
+web-sys = { version = "0.1", features = ['Window'] }
+
+# Or optionally,
+# [target.wasm32-unknown-unknown.dependencies]
+# ...
+```
+
+> **Note**: Currently `web-sys` is not available on crates.io so you'll also
+> need to do this in your manifest:
+>
+> ```toml
+> [patch.crates-io]
+> web-sys = { git = 'https://github.com/rustwasm/wasm-bindgen' }
+> wasm-bindgen = { git = 'https://github.com/rustwasm/wasm-bindgen' }
+> ```
+
+And next up we can use the API like so:
+
+```rust
+extern crate web_sys;
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+use web_sys::Window;
+
+#[wasm_bindgen]
+pub fn run() {
+    let promise = Window::fetch_with_str("http://example.com/");
+    // ...
+}
+```
+
+and you should be good to go!
+
+### Type translations in `web-sys`
+
+Most of the types specified in WebIDL have relatively straightforward
+translations into `web-sys`, but it's worth calling out a few in particular:
+
+* `BufferSource` and `ArrayBufferView` - these two types show up in a number of
+  APIs that generally deal with a buffer of bytes. We bind them in `web-sys`
+  with two different types, `Object` and `&mut [u8]`. Using `Object` allows
+  passing in arbitrary JS values which represent a view of bytes (like any typed
+  array object), and `&mut [u8]` allows using a raw slice in Rust. Unfortunately
+  we must pessimistically assume that JS will modify all slices as we don't
+  currently have information of whether they're modified or not.
+
+* Callbacks are all represented as `js_sys::Function`. This means that all
+  callbacks going through `web-sys` are a raw JS value. You can work with this
+  by either juggling actual `js_sys::Function` instances or you can create a
+  `Closure<FnMut(...)>`, extract the underlying `JsValue` with `as_ref`, and
+  then use `JsCast::unchecked_ref` to convert it to a `js_sys::Function`.
+
+[api]: https://rustwasm.github.io/wasm-bindgen/api/web_sys/
+[jsfetch]: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+[search-fetch]: https://rustwasm.github.io/wasm-bindgen/api/web_sys/?search=fetch
+[fetchfn]: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch
+[`fetch_with_str`]: https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Window.html#method.fetch_with_str

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -191,7 +191,7 @@ impl<T> Closure<T>
     }
 }
 
-impl<T> AsRef<JsValue> for Closure<T> {
+impl<T: ?Sized> AsRef<JsValue> for Closure<T> {
     fn as_ref(&self) -> &JsValue {
         &self.js
     }


### PR DESCRIPTION
This commit adds support for the WebIDL `Callback` type by translating all
callbacks to the `js_sys::Function` type. This will enable passing raw JS values
into callbacks as well as Rust valus using the `Closure` type.

This commit doesn't currently implement "callback interfaces" in WebIDL, that's
left for a follow-up commit.