### PR TITLE
Implement the `Iterator` trait for JS iterators

### DIFF
--- a/crates/js-sys/tests/wasm/Set.rs
+++ b/crates/js-sys/tests/wasm/Set.rs
@@ -89,3 +89,31 @@ fn set_inheritance() {
     assert!(set.is_instance_of::<Object>());
     let _: &Object = set.as_ref();
 }
+
+#[wasm_bindgen_test]
+fn keys() {
+    let set = Set::new(&JsValue::undefined());
+    set.add(&1.into());
+    set.add(&2.into());
+    set.add(&3.into());
+
+    let list = set.keys().into_iter().map(|e| e.unwrap()).collect::<Vec<_>>();
+    assert_eq!(list.len(), 3);
+    assert!(list.iter().any(|l| *l == 1));
+    assert!(list.iter().any(|l| *l == 2));
+    assert!(list.iter().any(|l| *l == 3));
+}
+
+#[wasm_bindgen_test]
+fn values() {
+    let set = Set::new(&JsValue::undefined());
+    set.add(&1.into());
+    set.add(&2.into());
+    set.add(&3.into());
+
+    let list = set.values().into_iter().map(|e| e.unwrap()).collect::<Vec<_>>();
+    assert_eq!(list.len(), 3);
+    assert!(list.iter().any(|l| *l == 1));
+    assert!(list.iter().any(|l| *l == 2));
+    assert!(list.iter().any(|l| *l == 3));
+}


### PR DESCRIPTION
This commit implements the standard library's `Iterator` trait for the
`js_sys::Iterator` type, using the iterator protocol described on [MDN]

Closes #777

[MDN]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols