### PR TITLE
Expand LongLong to `(i32 or f64)` instead of `i64`

### DIFF
--- a/crates/webidl-tests/consts.rs
+++ b/crates/webidl-tests/consts.rs
@@ -26,11 +26,6 @@ fn ints() {
     assert_eq!(ConstLong::IMAX, i32::max_value());
     assert_eq!(ConstLong::UMIN, u32::min_value());
     assert_eq!(ConstLong::UMAX, u32::max_value());
-
-    assert_eq!(ConstLongLong::IMIN, i64::min_value());
-    assert_eq!(ConstLongLong::IMAX, i64::max_value());
-    assert_eq!(ConstLongLong::UMIN, u64::min_value());
-    assert_eq!(ConstLongLong::UMAX, u64::max_value());
 }
 
 #[wasm_bindgen_test]

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -86,9 +86,11 @@ fn optional_and_union_arguments() {
     assert_eq!(f.m_with_b("abc", false), "string, abc, boolean, false, number, 123, number, 456");
     assert_eq!(f.m_with_b_and_i16("abc", false, 5), "string, abc, boolean, false, number, 5, number, 456");
     assert_eq!(f.m_with_b_and_str("abc", false, "5"), "string, abc, boolean, false, string, 5, number, 456");
-    assert_eq!(f.m_with_b_and_i16_and_opt_i64("abc", false, 5, Some(10)), "string, abc, boolean, false, number, 5, bigint, 10");
+    assert_eq!(f.m_with_b_and_i16_and_opt_i32("abc", false, 5, Some(10)), "string, abc, boolean, false, number, 5, number, 10");
+    assert_eq!(f.m_with_b_and_i16_and_opt_f64("abc", false, 5, Some(10.0)), "string, abc, boolean, false, number, 5, number, 10");
     assert_eq!(f.m_with_b_and_i16_and_opt_bool("abc", false, 5, Some(true)), "string, abc, boolean, false, number, 5, boolean, true");
-    assert_eq!(f.m_with_b_and_str_and_opt_i64("abc", false, "5", Some(10)), "string, abc, boolean, false, string, 5, bigint, 10");
+    assert_eq!(f.m_with_b_and_str_and_opt_i32("abc", false, "5", Some(10)), "string, abc, boolean, false, string, 5, number, 10");
+    assert_eq!(f.m_with_b_and_str_and_opt_f64("abc", false, "5", Some(12.0)), "string, abc, boolean, false, string, 5, number, 12");
     assert_eq!(f.m_with_b_and_str_and_opt_bool("abc", false, "5", Some(true)), "string, abc, boolean, false, string, 5, boolean, true");
 }
 

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -449,8 +449,8 @@ impl<'a> IdlType<'a> {
             IdlType::UnsignedShort => Some(ident_ty(raw_ident("u16"))),
             IdlType::Long => Some(ident_ty(raw_ident("i32"))),
             IdlType::UnsignedLong => Some(ident_ty(raw_ident("u32"))),
-            IdlType::LongLong => Some(ident_ty(raw_ident("i64"))),
-            IdlType::UnsignedLongLong => Some(ident_ty(raw_ident("u64"))),
+            IdlType::LongLong => None,
+            IdlType::UnsignedLongLong => None,
             IdlType::Float => Some(ident_ty(raw_ident("f32"))),
             IdlType::UnrestrictedFloat => Some(ident_ty(raw_ident("f32"))),
             IdlType::Double => Some(ident_ty(raw_ident("f64"))),
@@ -581,6 +581,12 @@ impl<'a> IdlType<'a> {
             }
             IdlType::BufferSource => {
                 vec![IdlType::BufferSource, IdlType::Uint8ArrayMut]
+            }
+            IdlType::LongLong => {
+                vec![IdlType::Long, IdlType::Double]
+            }
+            IdlType::UnsignedLongLong => {
+                vec![IdlType::UnsignedLong, IdlType::Double]
             }
             idl_type @ _ => vec![idl_type.clone()],
         }


### PR DESCRIPTION
This commit tweaks WebIDL expansion of the "long long" and "unsigned long long"
types to expand to a union of an 32-bit integer and a double. This reflects how
almost none of the APIs on the web today actually work with a `BigInt` (what the
previous Rust type of `i64` translates to) and how JS itself fundamentally
operates with these APIs.

Eventually this may not be necessary if we can natively connect to C++ engines
with the `i64` type, but until that day comes this should provide more useful
interfaces as they shoudl work in all browsers.

Closes #800