### PR TITLE
webidl: All interfaces implicitly extend `Object`

### DIFF
--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -15,5 +15,6 @@
 
 extern crate wasm_bindgen;
 extern crate js_sys;
+use js_sys::Object;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/web-sys/tests/wasm/event.rs
+++ b/crates/web-sys/tests/wasm/event.rs
@@ -1,6 +1,7 @@
 use futures::future::Future;
-use js_sys::Promise;
+use js_sys::{Object, Promise};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::Event;
@@ -15,6 +16,10 @@ fn event() -> impl Future<Item = (), Error = JsValue> {
     JsFuture::from(new_event())
         .map(Event::from)
         .map(|event| {
+            // All DOM interfaces should inherit from `Object`.
+            assert!(event.is_instance_of::<Object>());
+            let _: &Object = event.as_ref();
+
             // These should match `new Event`.
             assert!(event.bubbles());
             assert!(event.cancelable());

--- a/crates/webidl-tests/array.rs
+++ b/crates/webidl-tests/array.rs
@@ -1,3 +1,4 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/array.rs"));

--- a/crates/webidl-tests/array_buffer.rs
+++ b/crates/webidl-tests/array_buffer.rs
@@ -1,3 +1,4 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/array_buffer.rs"));

--- a/crates/webidl-tests/callbacks.rs
+++ b/crates/webidl-tests/callbacks.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen_test::*;
-use js_sys::Function;
+use js_sys::{Function, Object};
 
 include!(concat!(env!("OUT_DIR"), "/callbacks.rs"));
 

--- a/crates/webidl-tests/consts.rs
+++ b/crates/webidl-tests/consts.rs
@@ -1,3 +1,4 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/consts.rs"));

--- a/crates/webidl-tests/enums.rs
+++ b/crates/webidl-tests/enums.rs
@@ -1,3 +1,4 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/enums.rs"));

--- a/crates/webidl-tests/global.rs
+++ b/crates/webidl-tests/global.rs
@@ -1,3 +1,4 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/global.rs"));

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -1,8 +1,16 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
 include!(concat!(env!("OUT_DIR"), "/simple.rs"));
+
+#[wasm_bindgen_test]
+fn interfaces_inherit_from_object() {
+    let m = Method::new(42.0).unwrap();
+    assert!(m.is_instance_of::<Object>());
+    let _: &Object = m.as_ref();
+}
 
 #[wasm_bindgen_test]
 fn method() {

--- a/crates/webidl-tests/throws.rs
+++ b/crates/webidl-tests/throws.rs
@@ -1,3 +1,4 @@
+use js_sys::Object;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/throws.rs"));


### PR DESCRIPTION
This information is embedded within the algorithm for constructing interfaces and their prototypes in the section for ECMAScript glue in the WebIDL spec...

This really *should* make the `wasm_bindgen_backend::ast::ImportType::extends` member from a `Vec<Ident>` into a `Vec<syn::Path>` so that we could use `js_sys::Object` in the extends field, but that is a huge pain because then the `ImportedTypes` trait needs to be changed, and all of its implementers, etc...