### PR TITLE
Clean up indentation and blanks in the generated --no-modules JavaScript

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -417,7 +417,7 @@ impl<'a> Context<'a> {
 
         let mut js = if self.config.no_modules {
             format!(
-                    "
+                    "\
                     (function() {{
                         var wasm;
                         const __exports = {{}};
@@ -438,8 +438,7 @@ impl<'a> Context<'a> {
                             }});
                         }};
                         self.{global_name} = Object.assign(init, __exports);
-                    }})();
-                    ",
+                    }})();",
                     globals = self.globals,
                     module = module_name,
                     global_name = self.config.no_modules_global

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -388,10 +388,12 @@ fn reset_indentation(s: &str) -> String {
             indent = indent.saturating_sub(1);
         }
         let extra = if line.starts_with(':') || line.starts_with('?') { 1 } else { 0 };
-        for _ in 0..indent + extra {
-            dst.push_str("    ");
+        if !line.is_empty() {
+            for _ in 0..indent + extra {
+                dst.push_str("    ");
+            }
+            dst.push_str(line);
         }
-        dst.push_str(line);
         dst.push_str("\n");
         if line.ends_with('{') {
             indent += 1;


### PR DESCRIPTION
Avoid emitting indentation on blank lines (to avoid trailing
whitespace), and avoid extra blank lines at the start and end of the
file.