### PR TITLE
Add devicePixelRatio to Window

### DIFF
--- a/crates/web-sys/webidls/enabled/Window.webidl
+++ b/crates/web-sys/webidls/enabled/Window.webidl
@@ -198,6 +198,7 @@ partial interface Window {
   [Throws, NeedsCallerType] attribute any screenY;
   [Throws, NeedsCallerType] attribute any outerWidth;
   [Throws, NeedsCallerType] attribute any outerHeight;
+  [Replaceable] readonly attribute double devicePixelRatio;
 };
 
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html


### PR DESCRIPTION
This PR adds the missing `devicePixelRatio` property to the WebIDL definition of `Window`.
Source: https://drafts.csswg.org/cssom-view/#extensions-to-the-window-interface