### PR TITLE
Link to API docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ greet("World!");
 
 [**📚 Read the `wasm-bindgen` guide here! 📚**](https://rustwasm.github.io/wasm-bindgen)
 
+## API Docs
+
+- [wasm-bindgen](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/)
+- [js-sys](https://rustwasm.github.io/wasm-bindgen/api/web_sys/)
+- [web-sys](https://rustwasm.github.io/wasm-bindgen/api/js-sys/)
+
 ## License
 
 This project is licensed under either of

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ greet("World!");
 ## API Docs
 
 - [wasm-bindgen](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/)
-- [js-sys](https://rustwasm.github.io/wasm-bindgen/api/web_sys/)
-- [web-sys](https://rustwasm.github.io/wasm-bindgen/api/js-sys/)
+- [js-sys](https://rustwasm.github.io/wasm-bindgen/api/js_sys/)
+- [web-sys](https://rustwasm.github.io/wasm-bindgen/api/web_sys/)
 
 ## License
 


### PR DESCRIPTION
Just started moving a project from my own `externs` to `web-sys` and need to look at the docs to see how to call different methods.

Spent a few minutes trying to remember where the links were so wanted to add them to the README.

This PR adds those links to the `README`. A bit of extra README real estate, but feels worth it IMO.