### PR TITLE
Object get descriptors

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2031,6 +2031,13 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Object, js_name = getOwnPropertyDescriptor)]
     pub fn get_own_property_descriptor(obj: &Object, prop: &JsValue) -> JsValue;
 
+    /// The Object.getOwnPropertyDescriptors() method returns all own
+    /// property descriptors of a given object.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors)
+    #[wasm_bindgen(static_method_of = Object, js_name = getOwnPropertyDescriptors)]
+    pub fn get_own_property_descriptors(obj: &Object) -> JsValue;
+
     /// The `hasOwnProperty()` method returns a boolean indicating whether the
     /// object has the specified property as its own property (as opposed to
     /// inheriting it).

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2022,6 +2022,15 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Object)]
     pub fn freeze(value: &Object) -> Object;
 
+    /// The Object.getOwnPropertyDescriptor() method returns a
+    /// property descriptor for an own property (that is, one directly
+    /// present on an object and not in the object's prototype chain)
+    /// of a given object.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor)
+    #[wasm_bindgen(static_method_of = Object, js_name = getOwnPropertyDescriptor)]
+    pub fn get_own_property_descriptor(obj: &Object, prop: &JsValue) -> JsValue;
+
     /// The `hasOwnProperty()` method returns a boolean indicating whether the
     /// object has the specified property as its own property (as opposed to
     /// inheriting it).

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -115,6 +115,14 @@ fn get_own_property_descriptor() {
 }
 
 #[wasm_bindgen_test]
+fn get_own_property_descriptors() {
+    let foo = foo_42();
+    let descriptors = Object::get_own_property_descriptors(&foo);
+    let foo_desc = Reflect::get(&descriptors, &"foo".into());
+    assert_eq!(PropertyDescriptor::from(foo_desc).value(), 42);
+}
+
+#[wasm_bindgen_test]
 fn has_own_property() {
     assert!(foo_42().has_own_property(&"foo".into()));
     assert!(!foo_42().has_own_property(&"bar".into()));

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -13,6 +13,10 @@ extern "C" {
     type DefinePropertyAttrs;
     #[wasm_bindgen(method, setter, structural)]
     fn set_value(this: &DefinePropertyAttrs, val: &JsValue);
+
+    type PropertyDescriptor;
+    #[wasm_bindgen(method, getter, structural)]
+    fn value(this: &PropertyDescriptor) -> JsValue;
 }
 
 #[wasm_bindgen(module = "tests/wasm/Object.js")]
@@ -99,6 +103,15 @@ fn define_properties() {
     let foo = Object::define_properties(&foo, &props);
     assert!(foo.has_own_property(&"bar".into()));
     assert!(foo.has_own_property(&"car".into()));
+}
+
+#[wasm_bindgen_test]
+fn get_own_property_descriptor() {
+    let foo = foo_42();
+    let desc = Object::get_own_property_descriptor(&foo, &"foo".into());
+    assert_eq!(PropertyDescriptor::from(desc).value(), 42);
+    let desc = Object::get_own_property_descriptor(&foo, &"bar".into());
+    assert!(PropertyDescriptor::from(desc).value().is_undefined());
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Adds bindings for `Object.getOwnPropertyDescriptor()` and `Object.getOwnPropertyDescriptors()`.

#275 