### PR TITLE
Remove `Module` node from the backend AST

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -19,8 +19,6 @@ pub struct Program {
     pub structs: Vec<Struct>,
     /// rust consts
     pub consts: Vec<Const>,
-    /// rust submodules
-    pub modules: Vec<Module>,
     /// "dictionaries", generated for WebIDL, which are basically just "typed
     /// objects" in the sense that they represent a JS object with a particular
     /// shape in JIT parlance.
@@ -250,18 +248,6 @@ pub enum ConstValue {
     Null,
 }
 
-/// A rust module
-///
-/// This exists to give the ability to namespace js imports.
-#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
-#[derive(Clone)]
-pub struct Module {
-    pub vis: syn::Visibility,
-    pub name: Ident,
-    /// js -> rust interfaces
-    pub imports: Vec<Import>,
-}
-
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 #[derive(Clone)]
 pub struct Dictionary {
@@ -284,8 +270,6 @@ impl Program {
             structs: self.structs.iter().map(|a| a.shared()).collect(),
             enums: self.enums.iter().map(|a| a.shared()).collect(),
             imports: self.imports.iter()
-                // add in imports from inside modules
-                .chain(self.modules.iter().flat_map(|m| m.imports.iter()))
                 .map(|a| a.shared())
                 .collect::<Result<_, Diagnostic>>()?,
             version: shared::version(),

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -69,11 +69,6 @@ impl TryToTokens for ast::Program {
         for c in self.consts.iter() {
             c.to_tokens(tokens);
         }
-        for m in self.modules.iter() {
-            if let Err(e) = m.try_to_tokens(tokens) {
-                errors.push(e);
-            }
-        }
         for d in self.dictionaries.iter() {
             d.to_tokens(tokens);
         }
@@ -1098,30 +1093,6 @@ impl ToTokens for ast::Const {
         } else {
             declaration.to_tokens(tokens);
         }
-    }
-}
-
-impl<'a> TryToTokens for ast::Module {
-    fn try_to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostic> {
-        for import in &self.imports {
-            DescribeImport(&import.kind).to_tokens(tokens);
-        }
-        let vis = &self.vis;
-        let name = &self.name;
-        let mut errors = Vec::new();
-        let mut body = TokenStream::new();
-        for import in &self.imports {
-            if let Err(e) = import.kind.try_to_tokens(&mut body) {
-                errors.push(e);
-            }
-        }
-        Diagnostic::from_vec(errors)?;
-        (quote!{
-            #vis mod #name {
-                #body
-            }
-        }).to_tokens(tokens);
-        Ok(())
     }
 }
 


### PR DESCRIPTION
This is a roundabout way to say that this addresses the last comment on #23,
namely if you only use the `console` submodule from `web_sys` it doesn't
actually link correctly!

The problem here has to do with codegen units and the compiler. The compiler
will create a codegen unit for each `mod` in the source code. If a codegen unit
isn't actually used, then the codegen unit is removed from the final link step.
This causes problems for web-sys where the JSON description of our program was
part of the main CGU but not in each submodule, so when submodules were only
used the descriptor program in the main CGU was not included.

The fix in this commit is to instead generate a descriptor program in the
submodule itself instead of leaving it in the main CGU. By removing the `Module`
node in the AST this naturally happens as the descriptor is only generated in
the same module as all other associated items.