### PR TITLE
Move all methods on `Window` back to methods

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -98,10 +98,6 @@ pub enum ImportFunctionKind {
         ty: syn::Type,
         kind: MethodKind,
     },
-    ScopedMethod {
-        ty: syn::Type,
-        operation: Operation,
-    },
     Normal,
 }
 
@@ -432,14 +428,8 @@ impl ImportFunction {
                     }
                 };
                 Some(shared::MethodData {
-                    class: Some(class.clone()),
+                    class: class.clone(),
                     kind,
-                })
-            }
-            ImportFunctionKind::ScopedMethod { ref operation, .. } => {
-                Some(shared::MethodData {
-                    class: None,
-                    kind: shared::MethodKind::Operation(shared_operation(operation)),
                 })
             }
             ImportFunctionKind::Normal => None,

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1065,15 +1065,15 @@ impl ToTokens for ast::Const {
             // again no suffix
             // panics on +-inf, nan
             FloatLiteral(f) => {
-                let f = Literal::f64_unsuffixed(f);
+                let f = Literal::f64_suffixed(f);
                 quote!(#f)
             },
             SignedIntegerLiteral(i) => {
-                let i = Literal::i64_unsuffixed(i);
+                let i = Literal::i64_suffixed(i);
                 quote!(#i)
             },
             UnsignedIntegerLiteral(i) => {
-                let i = Literal::u64_unsuffixed(i);
+                let i = Literal::u64_suffixed(i);
                 quote!(#i)
             },
             Null => unimplemented!(),

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -779,9 +779,6 @@ impl TryToTokens for ast::ImportFunction {
                 }
                 class_ty = Some(ty);
             }
-            ast::ImportFunctionKind::ScopedMethod { ref ty, .. } => {
-                class_ty = Some(ty);
-            }
             ast::ImportFunctionKind::Normal => {}
         }
         let vis = &self.function.rust_vis;

--- a/crates/backend/src/defined.rs
+++ b/crates/backend/src/defined.rs
@@ -256,7 +256,6 @@ impl ImportedTypes for ast::ImportFunctionKind {
     {
         match self {
             ast::ImportFunctionKind::Method { ty, .. } => ty.imported_types(f),
-            ast::ImportFunctionKind::ScopedMethod { ty, .. } => ty.imported_types(f),
             ast::ImportFunctionKind::Normal => {}
         }
     }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2001,30 +2001,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
             }
         };
 
-        let class = match &method_data.class {
-            Some(class) => self.import_name(info, class)?,
-            None => {
-                let op = match &method_data.kind {
-                    shared::MethodKind::Operation(op) => op,
-                    shared::MethodKind::Constructor => {
-                        bail!("\"no class\" methods cannot be constructors")
-                    }
-                };
-                match &op.kind {
-                    shared::OperationKind::Regular => {
-                        return Ok(import.function.name.to_string())
-                    }
-                    shared::OperationKind::Getter(g) => {
-                        return Ok(format!("(() => {})", g));
-                    }
-                    shared::OperationKind::Setter(g) => {
-                        return Ok(format!("(v => {} = v)", g));
-                    }
-                    _ => bail!("\"no class\" methods must be regular/getter/setter"),
-                }
-
-            }
-        };
+        let class = self.import_name(info, &method_data.class)?;
         let op = match &method_data.kind {
             shared::MethodKind::Constructor => return Ok(format!("new {}", class)),
             shared::MethodKind::Operation(op) => op,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -510,7 +510,6 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a Option<String>)> for syn::ForeignItemFn
 
         let shim = {
             let ns = match kind {
-                ast::ImportFunctionKind::ScopedMethod { .. } |
                 ast::ImportFunctionKind::Normal => (0, "n"),
                 ast::ImportFunctionKind::Method { ref class, .. } => (1, &class[..]),
             };

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -51,7 +51,7 @@ pub struct ImportFunction {
 
 #[derive(Deserialize, Serialize)]
 pub struct MethodData {
-    pub class: Option<String>,
+    pub class: String,
     pub kind: MethodKind,
 }
 

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -17,4 +17,15 @@ extern crate wasm_bindgen;
 extern crate js_sys;
 use js_sys::Object;
 
+#[cfg(feature = "Window")]
+pub fn window() -> Option<Window> {
+    use wasm_bindgen::{JsValue, JsCast};
+
+    js_sys::Function::new_no_args("return this")
+        .call0(&JsValue::undefined())
+        .ok()?
+        .dyn_into::<Window>()
+        .ok()
+}
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -15,52 +15,14 @@
 
 extern crate wasm_bindgen;
 extern crate js_sys;
+
 use js_sys::Object;
 
 #[cfg(feature = "Window")]
 pub fn window() -> Option<Window> {
-    use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering::SeqCst};
-    use wasm_bindgen::{JsValue, JsCast};
+    use wasm_bindgen::JsCast;
 
-    // Cached `Box<JsValue>`, if we've already executed this.
-    //
-    // 0 = not calculated
-    // 1 = `None`
-    // n = Some(n) == Some(Box<JsValue>)
-    static WINDOW: AtomicUsize = ATOMIC_USIZE_INIT;
-
-    match WINDOW.load(SeqCst) {
-        0 => {}
-        1 => return None,
-        n => return unsafe { Some((*(n as *const JsValue)).clone().unchecked_into()) },
-    }
-
-    // Ok we don't have a cached value, let's load one! Manufacture a function
-    // to get access to the `this` context and see if it's an instance of
-    // `Window`.
-    //
-    // Note that we avoid `unwrap()` on `call0` to avoid code size bloat, we
-    // just handle the `Err` case as returning `None`.
-    let window = js_sys::Function::new_no_args("return this")
-        .call0(&JsValue::undefined())
-        .ok()
-        .and_then(|w| w.dyn_into::<Window>().ok());
-
-    match &window {
-        None => WINDOW.store(1, SeqCst),
-        Some(window) => {
-            let window: &JsValue = window.as_ref();
-            let ptr: *mut JsValue = Box::into_raw(Box::new(window.clone()));
-            match WINDOW.compare_exchange(0, ptr as usize, SeqCst, SeqCst) {
-                // We stored out value, relinquishing ownership of `ptr`
-                Ok(_) => {}
-                // Another thread one, drop our value
-                Err(_) => unsafe { drop(Box::from_raw(ptr)) },
-            }
-        }
-    }
-
-    window
+    js_sys::global().dyn_into::<Window>().ok()
 }
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/crates/web-sys/tests/wasm/location.rs
+++ b/crates/web-sys/tests/wasm/location.rs
@@ -1,56 +1,60 @@
 use wasm_bindgen_test::*;
-use web_sys::Window;
+use web_sys::{self, Location};
+
+fn location() -> Location {
+    web_sys::window().unwrap().location()
+}
 
 #[wasm_bindgen_test]
 fn href() {
-    let loc = Window::location();
+    let loc = location();
     loc.href().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn origin() {
-    let loc = Window::location();
+    let loc = location();
     loc.origin().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn protocol() {
-    let loc = Window::location();
+    let loc = location();
     loc.protocol().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn host() {
-    let loc = Window::location();
+    let loc = location();
     loc.host().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn hostname() {
-    let loc = Window::location();
+    let loc = location();
     loc.hostname().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn port() {
-    let loc = Window::location();
+    let loc = location();
     loc.port().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn pathname() {
-    let loc = Window::location();
+    let loc = location();
     loc.pathname().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn search() {
-    let loc = Window::location();
+    let loc = location();
     loc.search().unwrap();
 }
 
 #[wasm_bindgen_test]
 fn hash() {
-    let loc = Window::location();
+    let loc = location();
     loc.hash().unwrap();
 }

--- a/crates/webidl-tests/global.js
+++ b/crates/webidl-tests/global.js
@@ -1,4 +1,8 @@
-global.global_no_args = () => 3;
-global.global_with_args = (a, b) => a + b;
-global.global_attribute = 'x';
+const map = {
+  global_no_args: () => 3,
+  global_with_args: (a, b) => a + b,
+  global_attribute: 'x',
+};
+
+global.get_global = () => map;
 

--- a/crates/webidl-tests/global.rs
+++ b/crates/webidl-tests/global.rs
@@ -1,13 +1,20 @@
 use js_sys::Object;
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
 include!(concat!(env!("OUT_DIR"), "/global.rs"));
 
+#[wasm_bindgen]
+extern {
+    fn get_global() -> Global;
+}
+
 #[wasm_bindgen_test]
 fn works() {
-    assert_eq!(Global::global_no_args(), 3);
-    assert_eq!(Global::global_with_args("a", "b"), "ab");
-    assert_eq!(Global::global_attribute(), "x");
-    Global::set_global_attribute("y");
-    assert_eq!(Global::global_attribute(), "y");
+    let x = get_global();
+    assert_eq!(x.global_no_args(), 3);
+    assert_eq!(x.global_with_args("a", "b"), "ab");
+    assert_eq!(x.global_attribute(), "x");
+    x.set_global_attribute("y");
+    assert_eq!(x.global_attribute(), "y");
 }

--- a/crates/webidl-tests/simple.js
+++ b/crates/webidl-tests/simple.js
@@ -87,7 +87,11 @@ global.Unforgeable = class Unforgeable {
   }
 };
 
-global.m = () => 123;
+global.GlobalMethod = class {
+  m() { return 123; }
+};
+
+global.get_global_method = () => new GlobalMethod();
 
 global.Indexing = function () {
   return new Proxy({}, {

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -72,9 +72,16 @@ fn nullable_method() {
     assert!(f.opt(None) == None);
 }
 
+#[wasm_bindgen]
+extern {
+    fn get_global_method() -> GlobalMethod;
+}
+
+
 #[wasm_bindgen_test]
 fn global_method() {
-    assert_eq!(GlobalMethod::m(), 123);
+    let x = get_global_method();
+    assert_eq!(x.m(), 123);
 }
 
 #[wasm_bindgen_test]

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -44,7 +44,6 @@ pub(crate) struct FirstPassRecord<'src> {
 pub(crate) struct InterfaceData<'src> {
     /// Whether only partial interfaces were encountered
     pub(crate) partial: bool,
-    pub(crate) global: bool,
     pub(crate) attributes: Vec<&'src AttributeInterfaceMember<'src>>,
     pub(crate) consts: Vec<&'src ConstMember<'src>>,
     pub(crate) operations: BTreeMap<OperationId<'src>, OperationData<'src>>,
@@ -372,12 +371,6 @@ fn process_interface_attribute<'src>(
                 &None,
                 false,
             );
-        }
-        ExtendedAttribute::Ident(id) if id.lhs_identifier.0 == "Global" => {
-            record.interfaces.get_mut(self_name).unwrap().global = true;
-        }
-        ExtendedAttribute::IdentList(id) if id.identifier.0 == "Global" => {
-            record.interfaces.get_mut(self_name).unwrap().global = true;
         }
         _ => {}
     }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -305,6 +305,14 @@ impl<'a> ToIdlType<'a> for Identifier<'a> {
                 name: self.0,
                 single_function: data.single_function,
             })
+        } else if self.0 == "WindowProxy" {
+            // See this for more info:
+            //
+            // https://html.spec.whatwg.org/multipage/window-object.html#windowproxy
+            //
+            // namely this seems to be "legalese" for "this is a `Window`", so
+            // let's translate it as such.
+            Some(IdlType::Interface("Window"))
         } else {
             warn!("Unrecognized type: {}", self.0);
             None

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -554,18 +554,11 @@ impl<'src> FirstPassRecord<'src> {
             None => false,
         };
 
-        let global = self
-            .interfaces
-            .get(self_name)
-            .map(|interface_data| interface_data.global)
-            .unwrap_or(false);
-
         for mut import_function in self.create_getter(
             identifier,
             &type_.type_,
             self_name,
             is_static,
-            global,
             attrs,
             container_attrs,
         ) {
@@ -581,7 +574,6 @@ impl<'src> FirstPassRecord<'src> {
                 &type_.type_,
                 self_name,
                 is_static,
-                global,
                 attrs,
                 container_attrs,
             ) {
@@ -602,7 +594,7 @@ impl<'src> FirstPassRecord<'src> {
         op_data: &OperationData<'src>,
     ) {
         let import_function_kind = |opkind| {
-            self.import_function_kind(self_name, data.global, op_data.is_static, opkind)
+            self.import_function_kind(self_name, op_data.is_static, opkind)
         };
         let kind = match id {
             OperationId::Constructor(ctor_name) => {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -630,6 +630,18 @@ fn has_named_attribute(list: Option<&ExtendedAttributeList>, attribute: &str) ->
     })
 }
 
+fn has_ident_attribute(list: Option<&ExtendedAttributeList>, ident: &str) -> bool {
+    let list = match list {
+        Some(list) => list,
+        None => return false,
+    };
+    list.body.list.iter().any(|attr| match attr {
+        ExtendedAttribute::Ident(id) => id.lhs_identifier.0 == ident,
+        ExtendedAttribute::IdentList(id) => id.identifier.0 == ident,
+        _ => false,
+    })
+}
+
 /// ChromeOnly is for things that are only exposed to privileged code in Firefox.
 pub fn is_chrome_only(ext_attrs: &Option<ExtendedAttributeList>) -> bool {
     has_named_attribute(ext_attrs.as_ref(), "ChromeOnly")
@@ -646,7 +658,8 @@ pub fn is_structural(
     container_attrs: Option<&ExtendedAttributeList>,
 ) -> bool {
     has_named_attribute(item_attrs, "Unforgeable") ||
-        has_named_attribute(container_attrs, "Unforgeable")
+        has_named_attribute(container_attrs, "Unforgeable") ||
+        has_ident_attribute(container_attrs, "Global")
 }
 
 /// Whether a webidl object is marked as throwing.

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -316,7 +316,6 @@ impl<'src> FirstPassRecord<'src> {
             structural,
             shim: {
                 let ns = match kind {
-                    backend::ast::ImportFunctionKind::ScopedMethod { .. } |
                     backend::ast::ImportFunctionKind::Normal => "",
                     backend::ast::ImportFunctionKind::Method { ref class, .. } => class,
                 };
@@ -334,12 +333,11 @@ impl<'src> FirstPassRecord<'src> {
         ty: &weedle::types::Type<'src>,
         self_name: &str,
         is_static: bool,
-        global: bool,
         attrs: &Option<ExtendedAttributeList>,
         container_attrs: Option<&ExtendedAttributeList>,
     ) -> Option<backend::ast::ImportFunction> {
         let kind = backend::ast::OperationKind::Getter(Some(raw_ident(name)));
-        let kind = self.import_function_kind(self_name, global, is_static, kind);
+        let kind = self.import_function_kind(self_name, is_static, kind);
         let ret = ty.to_idl_type(self)?;
         self.create_one_function(
             &name,
@@ -361,12 +359,11 @@ impl<'src> FirstPassRecord<'src> {
         field_ty: &weedle::types::Type<'src>,
         self_name: &str,
         is_static: bool,
-        global: bool,
         attrs: &Option<ExtendedAttributeList>,
         container_attrs: Option<&ExtendedAttributeList>,
     ) -> Option<backend::ast::ImportFunction> {
         let kind = backend::ast::OperationKind::Setter(Some(raw_ident(name)));
-        let kind = self.import_function_kind(self_name, global, is_static, kind);
+        let kind = self.import_function_kind(self_name, is_static, kind);
         let field_ty = field_ty.to_idl_type(self)?;
         self.create_one_function(
             &name,
@@ -384,7 +381,6 @@ impl<'src> FirstPassRecord<'src> {
     pub fn import_function_kind(
         &self,
         self_name: &str,
-        global: bool,
         is_static: bool,
         operation_kind: backend::ast::OperationKind,
     ) -> backend::ast::ImportFunctionKind {
@@ -393,17 +389,10 @@ impl<'src> FirstPassRecord<'src> {
             kind: operation_kind,
         };
         let ty = ident_ty(rust_ident(camel_case_ident(&self_name).as_str()));
-        if global {
-            backend::ast::ImportFunctionKind::ScopedMethod {
-                ty,
-                operation,
-            }
-        } else {
-            backend::ast::ImportFunctionKind::Method {
-                class: self_name.to_string(),
-                ty,
-                kind: backend::ast::MethodKind::Operation(operation),
-            }
+        backend::ast::ImportFunctionKind::Method {
+            class: self_name.to_string(),
+            ty,
+            kind: backend::ast::MethodKind::Operation(operation),
         }
     }
 

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::JsCast;
 
 #[wasm_bindgen]
 pub fn draw() {
-    let document = web_sys::Window::document().unwrap();
+    let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();
     let canvas: web_sys::HtmlCanvasElement = canvas
         .dyn_into::<web_sys::HtmlCanvasElement>()

--- a/examples/fetch/build.sh
+++ b/examples/fetch/build.sh
@@ -8,3 +8,6 @@ cargo +nightly build --target wasm32-unknown-unknown
 cargo +nightly run --manifest-path ../../crates/cli/Cargo.toml \
   --bin wasm-bindgen -- \
   ../../target/wasm32-unknown-unknown/debug/fetch.wasm --out-dir .
+
+npm install
+npm run serve

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -1,10 +1,11 @@
 {
   "scripts": {
-    "serve": "webpack-serve ./webpack.config.js"
+    "serve": "webpack-dev-server"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.16.5",
-    "webpack-serve": "^2.0.2"
+    "webpack": "^4.11.1",
+    "webpack-cli": "^2.0.10",
+    "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{Request, RequestInit, RequestMode, Response, Window};
+use web_sys::{Request, RequestInit, RequestMode, Response};
 
 /// A struct to hold some data from the github Branch API.
 ///
@@ -57,7 +57,8 @@ pub fn run() -> Promise {
         .set("Accept", "application/vnd.github.v3+json")
         .unwrap();
 
-    let request_promise = Window::fetch_with_request(&request);
+    let window = web_sys::window().unwrap();
+    let request_promise = window.fetch_with_request(&request);
 
     let future = JsFuture::from(request_promise)
         .and_then(|resp_value| {

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::JsCast;
 
 #[wasm_bindgen]
 pub fn main() {
-    let document = web_sys::Window::document().unwrap();
+    let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document
         .create_element("canvas")
         .unwrap()

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -3,11 +3,6 @@
 //! This module defines the `Closure` type which is used to pass "owned
 //! closures" from Rust to JS. Some more details can be found on the `Closure`
 //! type itself.
-<<<<<<< a37fa45100baddc36695cbf01110bcd9ab638065
-=======
-//!
-//! The `nightly` feature is required for the `Closure` type to be used.
->>>>>>> Tweak more `Closure` docs
 
 use std::cell::UnsafeCell;
 #[cfg(feature = "nightly")]


### PR DESCRIPTION
As brought up in https://github.com/rustwasm/wasm-bindgen/issues/834 these are both fallible (in the worker context `Window` isn't defined) and you can also have multiple `Window` objects!

Closes #834 