### PR TITLE
Allow returning `Result` from functions 

### DIFF
--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -34,6 +34,7 @@ tys! {
     RUST_STRUCT
     CHAR
     OPTIONAL
+    UNIT
 }
 
 #[derive(Debug)]
@@ -61,12 +62,13 @@ pub enum Descriptor {
     RustStruct(String),
     Char,
     Option(Box<Descriptor>),
+    Unit,
 }
 
 #[derive(Debug)]
 pub struct Function {
     pub arguments: Vec<Descriptor>,
-    pub ret: Option<Descriptor>,
+    pub ret: Descriptor,
 }
 
 #[derive(Debug)]
@@ -128,6 +130,7 @@ impl Descriptor {
                 Descriptor::RustStruct(name)
             }
             CHAR => Descriptor::Char,
+            UNIT => Descriptor::Unit,
             other => panic!("unknown descriptor: {}", other),
         }
     }
@@ -295,12 +298,10 @@ impl Function {
         let arguments = (0..get(data))
             .map(|_| Descriptor::_decode(data))
             .collect::<Vec<_>>();
-        let ret = if get(data) == 0 {
-            None
-        } else {
-            Some(Descriptor::_decode(data))
-        };
-        Function { arguments, ret }
+        Function {
+            arguments,
+            ret: Descriptor::_decode(data),
+        }
     }
 }
 

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -390,15 +390,12 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
         Ok(self)
     }
 
-    pub fn ret(&mut self, ret: &Option<Descriptor>) -> Result<&mut Self, Error> {
-        let ty = match *ret {
-            Some(ref t) => t,
-            None => {
-                self.ret_ty = "void".to_string();
-                self.ret_expr = format!("return RET;");
-                return Ok(self);
-            }
-        };
+    pub fn ret(&mut self, ty: &Descriptor) -> Result<&mut Self, Error> {
+        if let Descriptor::Unit = ty {
+            self.ret_ty = "void".to_string();
+            self.ret_expr = format!("return RET;");
+            return Ok(self);
+        }
 
         let (ty, optional) = match ty {
             Descriptor::Option(t) => (&**t, true),

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -393,6 +393,11 @@ impl<'a> Context<'a> {
             ))
         })?;
 
+        self.bind("__wbindgen_rethrow", &|me| {
+            me.expose_take_object();
+            Ok(String::from("function(idx) { throw takeObject(idx); }"))
+        })?;
+
         self.create_memory_export();
         self.unexport_unused_internal_exports();
         closures::rewrite(self)?;
@@ -626,7 +631,9 @@ impl<'a> Context<'a> {
 
             let set = {
                 let mut cx = Js2Rust::new(&field.name, self);
-                cx.method(true, false).argument(&descriptor)?.ret(&None)?;
+                cx.method(true, false)
+                    .argument(&descriptor)?
+                    .ret(&Descriptor::Unit)?;
                 ts_dst.push_str(&format!(
                     "{}{}: {}\n",
                     if field.readonly { "readonly " } else { "" },
@@ -637,7 +644,7 @@ impl<'a> Context<'a> {
             };
             let (get, _ts, js_doc) = Js2Rust::new(&field.name, self)
                 .method(true, false)
-                .ret(&Some(descriptor))?
+                .ret(&descriptor)?
                 .finish("", &format!("wasm.{}", wasm_getter));
             if !dst.ends_with("\n") {
                 dst.push_str("\n");

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -285,14 +285,11 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         Ok(())
     }
 
-    fn ret(&mut self, ret: &Option<Descriptor>) -> Result<(), Error> {
-        let ty = match *ret {
-            Some(ref t) => t,
-            None => {
-                self.ret_expr = "JS;".to_string();
-                return Ok(());
-            }
-        };
+    fn ret(&mut self, ty: &Descriptor) -> Result<(), Error> {
+        if let Descriptor::Unit = ty {
+            self.ret_expr = "JS;".to_string();
+            return Ok(());
+        }
         let (ty, optional) = match ty {
             Descriptor::Option(t) => (&**t, true),
             _ => (ty, false),

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -726,13 +726,14 @@ impl<'a> MacroParse<(Option<BindgenAttrs>, &'a mut TokenStream)> for syn::Item {
                 }
                 let comments = extract_doc_comments(&f.attrs);
                 f.to_tokens(tokens);
+                let opts = opts.unwrap_or_default();
                 program.exports.push(ast::Export {
                     class: None,
                     method_self: None,
                     constructor: None,
                     comments,
                     rust_name: f.ident.clone(),
-                    function: f.convert(opts.unwrap_or_default())?,
+                    function: f.convert(opts)?,
                 });
             }
             syn::Item::Struct(mut s) => {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -30,6 +30,7 @@
     - [`String`](./reference/types/string.md)
     - [Number Slices](./reference/types/number-slices.md)
     - [Boxed Number Slices](./reference/types/boxed-number-slices.md)
+    - [`Result<T, JsValue>`](./reference/types/result.md)
   - [`#[wasm_bindgen]` Attributes](./reference/attributes/index.md)
     - [On JavaScript Imports](./reference/attributes/on-js-imports/index.md)
       - [`catch`](./reference/attributes/on-js-imports/catch.md)

--- a/guide/src/reference/types/result.md
+++ b/guide/src/reference/types/result.md
@@ -1,0 +1,20 @@
+# `Result<T, JsValue>`
+
+| `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value | `Option<T>` parameter | `Option<T>` return value | JavaScript representation |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| No | No | No | No | No | Yes | Same as `T`, or an exception |
+
+The `Result` type can be returned from functions exported to JS as well as
+closures in Rust. Only `Result<T, JsValue>` is supported where `T` can be
+converted to JS. Whenever `Ok(val)` is encountered it's converted to JS and
+handed off, and whenever `Err(error)` is encountered an exception is thrown in
+JS with `error`.
+
+You can use `Result` to enable handling of JS exceptions with `?` in Rust,
+naturally propagating it upwards to the wasm boundary. Furthermore you can also
+return custom types in Rust so long as they're all convertible to `JsValue`.
+
+Note that if you import a JS function with `Result` you need
+`#[wasm_bindgen(catch)]` to be annotated on the import (unlike exported
+functions, which require no extra annotation). This may not be necessary in the
+future though and it may work "as is"!.

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -1,134 +1,80 @@
-#![allow(const_err)] // FIXME(rust-lang/rust#52603)
-
 use core::mem;
 
-use convert::{FromWasmAbi, IntoWasmAbi, GlobalStack, Stack};
-use throw;
+use convert::{FromWasmAbi, IntoWasmAbi, GlobalStack, Stack, ReturnWasmAbi};
+use throw_str;
 
 macro_rules! stack_closures {
     ($( ($($var:ident)*) )*) => ($(
         impl<'a, 'b, $($var,)* R> IntoWasmAbi for &'a (Fn($($var),*) -> R + 'b)
             where $($var: FromWasmAbi,)*
-                  R: IntoWasmAbi
+                  R: ReturnWasmAbi
         {
             type Abi = u32;
 
             fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: IntoWasmAbi>(
+                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                     $($var: <$var as FromWasmAbi>::Abi),*
-                ) -> <R as IntoWasmAbi>::Abi {
+                ) -> <R as ReturnWasmAbi>::Abi {
                     if a == 0 {
-                        throw("closure invoked recursively or destroyed already");
+                        throw_str("closure invoked recursively or destroyed already");
                     }
-                    let f: &Fn($($var),*) -> R = mem::transmute((a, b));
-                    let mut _stack = GlobalStack::new();
-                    $(
-                        let $var = <$var as FromWasmAbi>::from_abi($var, &mut _stack);
-                    )*
-                    f($($var),*).into_abi(&mut GlobalStack::new())
+                    // Scope all local variables before we call `return_abi` to
+                    // ensure they're all destroyed as `return_abi` may throw
+                    let ret = {
+                        let f: &Fn($($var),*) -> R = mem::transmute((a, b));
+                        let mut _stack = GlobalStack::new();
+                        $(
+                            let $var = <$var as FromWasmAbi>::from_abi($var, &mut _stack);
+                        )*
+                        f($($var),*)
+                    };
+                    ret.return_abi(&mut GlobalStack::new())
                 }
                 unsafe {
                     let (a, b): (usize, usize) = mem::transmute(self);
                     extra.push(a as u32);
                     extra.push(b as u32);
                     invoke::<$($var,)* R> as u32
-                }
-            }
-        }
-
-        impl<'a, 'b, $($var,)*> IntoWasmAbi for &'a (Fn($($var),*) + 'b)
-            where $($var: FromWasmAbi,)*
-        {
-            type Abi = u32;
-
-            fn into_abi(self, extra: &mut Stack) -> u32 {
-                #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* >(
-                    a: usize,
-                    b: usize,
-                    $($var: <$var as FromWasmAbi>::Abi),*
-                ) {
-                    if a == 0 {
-                        throw("closure invoked recursively or destroyed already");
-                    }
-                    let f: &Fn($($var),*) = mem::transmute((a, b));
-                    let mut _stack = GlobalStack::new();
-                    $(
-                        let $var = <$var as FromWasmAbi>::from_abi($var, &mut _stack);
-                    )*
-                    f($($var),*)
-                }
-                unsafe {
-                    let (a, b): (usize, usize) = mem::transmute(self);
-                    extra.push(a as u32);
-                    extra.push(b as u32);
-                    invoke::<$($var,)*> as u32
                 }
             }
         }
 
         impl<'a, 'b, $($var,)* R> IntoWasmAbi for &'a mut (FnMut($($var),*) -> R + 'b)
             where $($var: FromWasmAbi,)*
-                  R: IntoWasmAbi
+                  R: ReturnWasmAbi
         {
             type Abi = u32;
 
             fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: IntoWasmAbi>(
+                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                     $($var: <$var as FromWasmAbi>::Abi),*
-                ) -> <R as IntoWasmAbi>::Abi {
+                ) -> <R as ReturnWasmAbi>::Abi {
                     if a == 0 {
-                        throw("closure invoked recursively or destroyed already");
+                        throw_str("closure invoked recursively or destroyed already");
                     }
-                    let f: &mut FnMut($($var),*) -> R = mem::transmute((a, b));
-                    let mut _stack = GlobalStack::new();
-                    $(
-                        let $var = <$var as FromWasmAbi>::from_abi($var, &mut _stack);
-                    )*
-                    f($($var),*).into_abi(&mut GlobalStack::new())
+                    // Scope all local variables before we call `return_abi` to
+                    // ensure they're all destroyed as `return_abi` may throw
+                    let ret = {
+                        let f: &mut FnMut($($var),*) -> R = mem::transmute((a, b));
+                        let mut _stack = GlobalStack::new();
+                        $(
+                            let $var = <$var as FromWasmAbi>::from_abi($var, &mut _stack);
+                        )*
+                        f($($var),*)
+                    };
+                    ret.return_abi(&mut GlobalStack::new())
                 }
                 unsafe {
                     let (a, b): (usize, usize) = mem::transmute(self);
                     extra.push(a as u32);
                     extra.push(b as u32);
                     invoke::<$($var,)* R> as u32
-                }
-            }
-        }
-
-        impl<'a, 'b, $($var,)*> IntoWasmAbi for &'a mut (FnMut($($var),*) + 'b)
-            where $($var: FromWasmAbi,)*
-        {
-            type Abi = u32;
-
-            fn into_abi(self, extra: &mut Stack) -> u32 {
-                #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* >(
-                    a: usize,
-                    b: usize,
-                    $($var: <$var as FromWasmAbi>::Abi),*
-                ) {
-                    if a == 0 {
-                        throw("closure invoked recursively or destroyed already");
-                    }
-                    let f: &mut FnMut($($var),*) = mem::transmute((a, b));
-                    let mut _stack = GlobalStack::new();
-                    $(
-                        let $var = <$var as FromWasmAbi>::from_abi($var, &mut _stack);
-                    )*
-                    f($($var),*)
-                }
-                unsafe {
-                    let (a, b): (usize, usize) = mem::transmute(self);
-                    extra.push(a as u32);
-                    extra.push(b as u32);
-                    invoke::<$($var,)*> as u32
                 }
             }
         }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -39,6 +39,7 @@ tys! {
     RUST_STRUCT
     CHAR
     OPTIONAL
+    UNIT
 }
 
 #[inline(always)] // see `interpret.rs` in the the cli-support crate
@@ -152,19 +153,7 @@ macro_rules! doit {
                 inform(FUNCTION);
                 inform(cnt!($($var)*));
                 $(<$var as WasmDescribe>::describe();)*
-                inform(1);
                 <R as WasmDescribe>::describe();
-            }
-        }
-
-        impl<'a, $($var,)* > WasmDescribe for Fn($($var),*) + 'a
-            where $($var: WasmDescribe,)*
-        {
-            fn describe() {
-                inform(FUNCTION);
-                inform(cnt!($($var)*));
-                $(<$var as WasmDescribe>::describe();)*
-                inform(0);
             }
         }
 
@@ -176,19 +165,7 @@ macro_rules! doit {
                 inform(FUNCTION);
                 inform(cnt!($($var)*));
                 $(<$var as WasmDescribe>::describe();)*
-                inform(1);
                 <R as WasmDescribe>::describe();
-            }
-        }
-
-        impl<'a, $($var,)* > WasmDescribe for FnMut($($var),*) + 'a
-            where $($var: WasmDescribe,)*
-        {
-            fn describe() {
-                inform(FUNCTION);
-                inform(cnt!($($var)*));
-                $(<$var as WasmDescribe>::describe();)*
-                inform(0);
             }
         }
     )*)
@@ -209,5 +186,19 @@ impl<T: WasmDescribe> WasmDescribe for Option<T> {
     fn describe() {
         inform(OPTIONAL);
         T::describe();
+    }
+}
+
+impl WasmDescribe for () {
+    fn describe() {
+        inform(UNIT)
+    }
+}
+
+// Note that this is only for `ReturnWasmAbi for Result<T, JsValue>`, which
+// throws the result, so we only need to inform about the `T`.
+impl<T: WasmDescribe> WasmDescribe for Result<T, JsValue> {
+    fn describe() {
+        T::describe()
     }
 }

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -26,6 +26,7 @@ pub mod math;
 pub mod node;
 pub mod option;
 pub mod optional_primitives;
+pub mod rethrow;
 pub mod simple;
 pub mod slice;
 pub mod structural;

--- a/tests/wasm/rethrow.js
+++ b/tests/wasm/rethrow.js
@@ -1,0 +1,14 @@
+const wasm = require('wasm-bindgen-test.js');
+const assert = require('assert');
+
+exports.call_throw_one = function() {
+  try {
+    wasm.throw_one();
+  } catch (e) {
+    assert.strictEqual(e, 1);
+  }
+};
+
+exports.call_ok = function() {
+  wasm.nothrow();
+};

--- a/tests/wasm/rethrow.rs
+++ b/tests/wasm/rethrow.rs
@@ -1,0 +1,28 @@
+use wasm_bindgen_test::*;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(module = "tests/wasm/rethrow.js")]
+extern {
+    fn call_throw_one();
+    fn call_ok();
+}
+
+#[wasm_bindgen_test]
+fn err_works() {
+    call_throw_one();
+}
+
+#[wasm_bindgen]
+pub fn throw_one() -> Result<u32, JsValue> {
+    Err(1.into())
+}
+
+#[wasm_bindgen_test]
+fn ok_works() {
+    call_ok();
+}
+
+#[wasm_bindgen]
+pub fn nothrow() -> Result<u32, JsValue> {
+    Ok(1)
+}


### PR DESCRIPTION
This commit adds support for exporting a function defined in Rust that returns a
`Result`, translating the `Ok` variant to the actual return value and the `Err`
variant to an exception that's thrown in JS.

The support for return types and descriptors was rejiggered a bit to be a bit
more abstract and more well suited for this purpose. We no longer distinguish
between functions with a return value and those without a return value.
Additionally a new trait, `ReturnWasmAbi`, is used for converting return values.
This trait is an internal implementation detail, however, and shouldn't surface
itself to users much (if at all).

Closes #841