### PR TITLE
Purge a number of Mozilla-specific WebIDL

### DIFF
--- a/crates/web-sys/webidls/enabled/CSSMozDocumentRule.webidl
+++ b/crates/web-sys/webidls/enabled/CSSMozDocumentRule.webidl
@@ -3,8 +3,3 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
-// This is a non-standard interface for @-moz-document rules
-interface CSSMozDocumentRule : CSSConditionRule {
-  // XXX Add access to the URL list.
-};

--- a/crates/web-sys/webidls/enabled/Document.webidl
+++ b/crates/web-sys/webidls/enabled/Document.webidl
@@ -188,37 +188,6 @@ partial interface Document {
    * @see <https://developer.mozilla.org/en/DOM/document.releaseCapture>
    */
   void releaseCapture();
-  /**
-   * Use the given DOM element as the source image of target |-moz-element()|.
-   *
-   * This function introduces a new special ID (called "image element ID"),
-   * which is only used by |-moz-element()|, and associates it with the given
-   * DOM element.  Image elements ID's have the higher precedence than general
-   * HTML id's, so if |document.mozSetImageElement(<id>, <element>)| is called,
-   * |-moz-element(#<id>)| uses |<element>| as the source image even if there
-   * is another element with id attribute = |<id>|.  To unregister an image
-   * element ID |<id>|, call |document.mozSetImageElement(<id>, null)|.
-   *
-   * Example:
-   * <script>
-   *   canvas = document.createElement("canvas");
-   *   canvas.setAttribute("width", 100);
-   *   canvas.setAttribute("height", 100);
-   *   // draw to canvas
-   *   document.mozSetImageElement("canvasbg", canvas);
-   * </script>
-   * <div style="background-image: -moz-element(#canvasbg);"></div>
-   *
-   * @param aImageElementId an image element ID to associate with
-   * |aImageElement|
-   * @param aImageElement a DOM element to be used as the source image of
-   * |-moz-element(#aImageElementId)|. If this is null, the function will
-   * unregister the image element ID |aImageElementId|.
-   *
-   * @see <https://developer.mozilla.org/en/DOM/document.mozSetImageElement>
-   */
-  void mozSetImageElement(DOMString aImageElementId,
-                          Element? aImageElement);
 
   [ChromeOnly]
   readonly attribute URI? documentURIObject;
@@ -256,23 +225,11 @@ partial interface Document {
   // versions have it uppercase.
   [LenientSetter, Unscopable, Func="nsDocument::IsUnprefixedFullscreenEnabled"]
   readonly attribute boolean fullscreen;
-/*Non standard
-  [BinaryName="fullscreen"]
-  readonly attribute boolean mozFullScreen;
-*/
   [LenientSetter, Func="nsDocument::IsUnprefixedFullscreenEnabled", NeedsCallerType]
   readonly attribute boolean fullscreenEnabled;
-/*Non standard
-  [BinaryName="fullscreenEnabled", NeedsCallerType]
-  readonly attribute boolean mozFullScreenEnabled;
-*/
 
   [Func="nsDocument::IsUnprefixedFullscreenEnabled"]
   void exitFullscreen();
-/*Non standard
-  [BinaryName="exitFullscreen"]
-  void mozCancelFullScreen();
-*/
 
   // Events handlers
   [Func="nsDocument::IsUnprefixedFullscreenEnabled"]

--- a/crates/web-sys/webidls/enabled/DocumentOrShadowRoot.webidl
+++ b/crates/web-sys/webidls/enabled/DocumentOrShadowRoot.webidl
@@ -22,6 +22,4 @@ interface mixin DocumentOrShadowRoot {
   readonly attribute Element? pointerLockElement;
   [LenientSetter, Func="nsIDocument::IsUnprefixedFullscreenEnabled"]
   readonly attribute Element? fullscreenElement;
-  [BinaryName="fullscreenElement"]
-  readonly attribute Element? mozFullScreenElement;
 };

--- a/crates/web-sys/webidls/enabled/Element.webidl
+++ b/crates/web-sys/webidls/enabled/Element.webidl
@@ -97,16 +97,6 @@ interface Element : Node {
   readonly attribute float fontSizeInflation;
 
   // Selectors API
-  /**
-   * Returns whether this element would be selected by the given selector
-   * string.
-   *
-   * See <http://dev.w3.org/2006/webapi/selectors-api2/#matchesselector>
-   */
-/* Non standard
-  [Throws, Pure, BinaryName="matches"]
-  boolean mozMatchesSelector(DOMString selector);
-*/
 
   // Pointer events methods.
   [Throws, Pref="dom.w3c_pointer_events.enabled"]
@@ -211,11 +201,6 @@ partial interface Element {
   void scrollTo(optional ScrollToOptions options);
   void scrollBy(unrestricted double x, unrestricted double y);
   void scrollBy(optional ScrollToOptions options);
-  // mozScrollSnap is used by chrome to perform scroll snapping after the
-  // user performs actions that may affect scroll position
-  // mozScrollSnap is deprecated, to be replaced by a web accessible API, such
-  // as an extension to the ScrollOptions dictionary.  See bug 1137937.
-  [ChromeOnly] void mozScrollSnap();
 
   readonly attribute long clientTop;
   readonly attribute long clientLeft;
@@ -273,10 +258,6 @@ Element includes GeometryUtils;
 partial interface Element {
   [Throws, Func="nsDocument::IsUnprefixedFullscreenEnabled", NeedsCallerType]
   void requestFullscreen();
-/*Non standard
-  [Throws, BinaryName="requestFullscreen", NeedsCallerType]
-  void mozRequestFullScreen();
-*/
 };
 
 // https://w3c.github.io/pointerlock/#extensions-to-the-element-interface

--- a/crates/web-sys/webidls/enabled/HTMLCanvasElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLCanvasElement.webidl
@@ -40,16 +40,4 @@ partial interface HTMLCanvasElement {
   OffscreenCanvas transferControlToOffscreen();
 };
 
-[ChromeOnly]
-interface MozCanvasPrintState
-{
-  // A canvas rendering context.
-  readonly attribute nsISupports context;
-
-  // To be called when rendering to the context is done.
-  void done();
-};
-
-callback PrintCallback = void(MozCanvasPrintState ctx);
-
 callback BlobCallback = void(Blob? blob);

--- a/crates/web-sys/webidls/enabled/HTMLEmbedElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLEmbedElement.webidl
@@ -38,7 +38,3 @@ partial interface HTMLEmbedElement {
   [NeedsSubjectPrincipal]
   Document? getSVGDocument();
 };
-
-HTMLEmbedElement includes MozImageLoadingContent;
-HTMLEmbedElement includes MozFrameLoaderOwner;
-HTMLEmbedElement includes MozObjectLoadingContent;

--- a/crates/web-sys/webidls/enabled/HTMLFrameElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLFrameElement.webidl
@@ -34,5 +34,3 @@ interface HTMLFrameElement : HTMLElement {
   [CEReactions, TreatNullAs=EmptyString, SetterThrows]
   attribute DOMString marginWidth;
 };
-
-HTMLFrameElement includes MozFrameLoaderOwner;

--- a/crates/web-sys/webidls/enabled/HTMLIFrameElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLIFrameElement.webidl
@@ -59,11 +59,4 @@ partial interface HTMLIFrameElement {
   Document? getSVGDocument();
 };
 
-partial interface HTMLIFrameElement {
-  // nsIDOMMozBrowserFrame
-  [ChromeOnly,SetterThrows]
-           attribute boolean mozbrowser;
-};
-
-HTMLIFrameElement includes MozFrameLoaderOwner;
 HTMLIFrameElement includes BrowserElement;

--- a/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
@@ -147,8 +147,6 @@ partial interface HTMLInputElement {
            attribute DOMString useMap;
 };
 
-HTMLInputElement includes MozEditableElement;
-
 /*Non standard
 partial interface HTMLInputElement {
   [Pref="dom.input.dirpicker", SetterThrows]
@@ -167,8 +165,6 @@ partial interface HTMLInputElement {
   void chooseDirectory();
 };
 */
-
-HTMLInputElement includes MozImageLoadingContent;
 
 // Webkit/Blink
 partial interface HTMLInputElement {

--- a/crates/web-sys/webidls/enabled/HTMLObjectElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLObjectElement.webidl
@@ -77,16 +77,3 @@ partial interface HTMLObjectElement {
   [NeedsSubjectPrincipal]
   Document? getSVGDocument();
 };
-
-/**
- * Name:Value pair type used for passing parameters to NPAPI or javascript
- * plugins.
- */
-dictionary MozPluginParameter {
-  DOMString name = "";
-  DOMString value = "";
-};
-
-HTMLObjectElement includes MozImageLoadingContent;
-HTMLObjectElement includes MozFrameLoaderOwner;
-HTMLObjectElement includes MozObjectLoadingContent;

--- a/crates/web-sys/webidls/enabled/HTMLTextAreaElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLTextAreaElement.webidl
@@ -80,5 +80,3 @@ interface HTMLTextAreaElement : HTMLElement {
   [Throws]
   void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 };
-
-HTMLTextAreaElement includes MozEditableElement;

--- a/crates/web-sys/webidls/enabled/IDBDatabase.webidl
+++ b/crates/web-sys/webidls/enabled/IDBDatabase.webidl
@@ -41,8 +41,4 @@ partial interface IDBDatabase {
 
     [Exposed=Window, Throws, UseCounter]
     IDBRequest createMutableFile (DOMString name, optional DOMString type);
-
-    // this is deprecated due to renaming in the spec
-    [Exposed=Window, Throws, UseCounter]
-    IDBRequest mozCreateFileHandle (DOMString name, optional DOMString type); // now createMutableFile
 };

--- a/crates/web-sys/webidls/enabled/IDBIndex.webidl
+++ b/crates/web-sys/webidls/enabled/IDBIndex.webidl
@@ -58,12 +58,6 @@ interface IDBIndex {
 
 partial interface IDBIndex {
     [Throws]
-    IDBRequest mozGetAll (optional any key, [EnforceRange] optional unsigned long limit);
-
-    [Throws]
-    IDBRequest mozGetAllKeys (optional any key, [EnforceRange] optional unsigned long limit);
-
-    [Throws]
     IDBRequest getAll (optional any key, [EnforceRange] optional unsigned long limit);
 
     [Throws]

--- a/crates/web-sys/webidls/enabled/IDBObjectStore.webidl
+++ b/crates/web-sys/webidls/enabled/IDBObjectStore.webidl
@@ -59,10 +59,6 @@ interface IDBObjectStore {
 };
 
 partial interface IDBObjectStore {
-    // Success fires IDBTransactionEvent, result == array of values for given keys
-    [Throws]
-    IDBRequest mozGetAll (optional any key, [EnforceRange] optional unsigned long limit);
-
     [Throws]
     IDBRequest getAll (optional any key, [EnforceRange] optional unsigned long limit);
 

--- a/crates/web-sys/webidls/enabled/MediaSource.webidl
+++ b/crates/web-sys/webidls/enabled/MediaSource.webidl
@@ -42,6 +42,4 @@ interface MediaSource : EventTarget {
   [Throws]
   void clearLiveSeekableRange();
   static boolean isTypeSupported(DOMString type);
-  [ChromeOnly]
-  readonly attribute DOMString mozDebugReaderData;
 };

--- a/crates/web-sys/webidls/enabled/MediaStreamTrack.webidl
+++ b/crates/web-sys/webidls/enabled/MediaStreamTrack.webidl
@@ -58,10 +58,6 @@ dictionary MediaTrackConstraintSet {
     ConstrainBoolean noiseSuppression;
     ConstrainBoolean autoGainControl;
     ConstrainLong channelCount;
-
-    // Deprecated with warnings:
-    ConstrainBoolean mozNoiseSuppression;
-    ConstrainBoolean mozAutoGainControl;
 };
 
 dictionary MediaTrackConstraints : MediaTrackConstraintSet {

--- a/crates/web-sys/webidls/enabled/MozApplicationEvent.webidl
+++ b/crates/web-sys/webidls/enabled/MozApplicationEvent.webidl
@@ -3,14 +3,3 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-
-[Constructor(DOMString type, optional MozApplicationEventInit eventInitDict), ChromeOnly]
-interface MozApplicationEvent : Event
-{
-  readonly attribute DOMApplication? application;
-};
-
-dictionary MozApplicationEventInit : EventInit
-{
-  DOMApplication? application = null;
-};

--- a/crates/web-sys/webidls/enabled/Navigator.webidl
+++ b/crates/web-sys/webidls/enabled/Navigator.webidl
@@ -201,33 +201,6 @@ callback NavigatorUserMediaErrorCallback = void (MediaStreamError error);
 partial interface Navigator {
   [Throws, Func="Navigator::HasUserMediaSupport"]
   readonly attribute MediaDevices mediaDevices;
-
-  // Deprecated. Use mediaDevices.getUserMedia instead.
-  [Deprecated="NavigatorGetUserMedia", Throws,
-   Func="Navigator::HasUserMediaSupport",
-   NeedsCallerType]
-  void mozGetUserMedia(MediaStreamConstraints constraints,
-                       NavigatorUserMediaSuccessCallback successCallback,
-                       NavigatorUserMediaErrorCallback errorCallback);
-};
-
-// nsINavigatorUserMedia
-callback MozGetUserMediaDevicesSuccessCallback = void (nsIVariant? devices);
-partial interface Navigator {
-  [Throws, ChromeOnly]
-  void mozGetUserMediaDevices(MediaStreamConstraints constraints,
-                              MozGetUserMediaDevicesSuccessCallback onsuccess,
-                              NavigatorUserMediaErrorCallback onerror,
-                              // The originating innerWindowID is needed to
-                              // avoid calling the callbacks if the window has
-                              // navigated away. It is optional only as legacy.
-                              optional unsigned long long innerWindowID = 0,
-                              // The callID is needed in case of multiple
-                              // concurrent requests to find the right one.
-                              // It is optional only as legacy.
-                              // TODO: Rewrite to not need this method anymore,
-                              // now that devices are enumerated earlier.
-                              optional DOMString callID = "");
 };
 
 // Service Workers/Navigation Controllers
@@ -245,11 +218,6 @@ partial interface Navigator {
 partial interface Navigator {
   [Throws, Pref="dom.presentation.enabled", SameObject]
   readonly attribute Presentation? presentation;
-};
-
-partial interface Navigator {
-  [NewObject, Func="mozilla::dom::TCPSocket::ShouldTCPSocketExist"]
-  readonly attribute LegacyMozTCPSocket mozTCPSocket;
 };
 
 partial interface Navigator {

--- a/crates/web-sys/webidls/enabled/Notification.webidl
+++ b/crates/web-sys/webidls/enabled/Notification.webidl
@@ -67,7 +67,6 @@ dictionary NotificationOptions {
   DOMString icon = "";
   boolean requireInteraction = false;
   any data = null;
-  NotificationBehavior mozbehavior = null;
 };
 
 dictionary GetNotificationOptions {

--- a/crates/web-sys/webidls/enabled/Performance.webidl
+++ b/crates/web-sys/webidls/enabled/Performance.webidl
@@ -48,13 +48,6 @@ partial interface Performance {
   attribute EventHandler onresourcetimingbufferfull;
 };
 
-// GC microbenchmarks, pref-guarded, not for general use (bug 1125412)
-[Exposed=Window]
-partial interface Performance {
-  [Pref="dom.enable_memory_stats"]
-  readonly attribute object mozMemory;
-};
-
 // http://www.w3.org/TR/user-timing/
 [Exposed=(Window,Worker)]
 partial interface Performance {

--- a/crates/web-sys/webidls/enabled/RTCPeerConnection.webidl
+++ b/crates/web-sys/webidls/enabled/RTCPeerConnection.webidl
@@ -36,18 +36,6 @@ enum RTCIceConnectionState {
     "closed"
 };
 
-enum mozPacketDumpType {
-  "rtp", // dump unencrypted rtp as the MediaPipeline sees it
-  "srtp", // dump encrypted rtp as the MediaPipeline sees it
-  "rtcp", // dump unencrypted rtcp as the MediaPipeline sees it
-  "srtcp" // dump encrypted rtcp as the MediaPipeline sees it
-};
-
-callback mozPacketCallback = void (unsigned long level,
-                                   mozPacketDumpType type,
-                                   boolean sending,
-                                   ArrayBuffer packet);
-
 dictionary RTCDataChannelInit {
   boolean        ordered = true;
   unsigned short maxPacketLifeTime;
@@ -131,31 +119,6 @@ interface RTCPeerConnection : EventTarget  {
   sequence<RTCRtpSender> getSenders();
   sequence<RTCRtpReceiver> getReceivers();
   sequence<RTCRtpTransceiver> getTransceivers();
-
-  // test-only: for testing getContributingSources
-  [ChromeOnly]
-  DOMHighResTimeStamp mozGetNowInRtpSourceReferenceTime();
-  // test-only: for testing getContributingSources
-  [ChromeOnly]
-  void mozInsertAudioLevelForContributingSource(RTCRtpReceiver receiver,
-                                                unsigned long source,
-                                                DOMHighResTimeStamp timestamp,
-                                                boolean hasLevel,
-                                                byte level);
-  [ChromeOnly]
-  void mozAddRIDExtension(RTCRtpReceiver receiver, unsigned short extensionId);
-  [ChromeOnly]
-  void mozAddRIDFilter(RTCRtpReceiver receiver, DOMString rid);
-  [ChromeOnly]
-  void mozSetPacketCallback(mozPacketCallback callback);
-  [ChromeOnly]
-  void mozEnablePacketDump(unsigned long level,
-                           mozPacketDumpType type,
-                           boolean sending);
-  [ChromeOnly]
-  void mozDisablePacketDump(unsigned long level,
-                            mozPacketDumpType type,
-                            boolean sending);
 
   void close ();
   attribute EventHandler onnegotiationneeded;

--- a/crates/web-sys/webidls/enabled/RTCStatsReport.webidl
+++ b/crates/web-sys/webidls/enabled/RTCStatsReport.webidl
@@ -53,8 +53,6 @@ dictionary RTCInboundRTPStreamStats : RTCRTPStreamStats {
   unsigned long long bytesReceived;
   double jitter;
   unsigned long packetsLost;
-  long mozAvSyncDelay;
-  long mozJitterBufferDelay;
   long roundTripTime;
 
   // Video decoder measurement, not present in RTCP case
@@ -154,7 +152,6 @@ dictionary RTCIceCandidateStats : RTCStats {
   DOMString candidateId;
   DOMString ipAddress;
   DOMString transport;
-  DOMString mozLocalTransport; // needs standardization
   long portNumber;
   RTCStatsIceCandidateType candidateType;
 };
@@ -200,6 +197,4 @@ dictionary RTCStatsReportInternal {
  JSImplementation="@mozilla.org/dom/rtcstatsreport;1"]
 interface RTCStatsReport {
   readonly maplike<DOMString, object>;
-  [ChromeOnly]
-  readonly attribute DOMString mozPcid;
 };

--- a/crates/web-sys/webidls/enabled/Request.webidl
+++ b/crates/web-sys/webidls/enabled/Request.webidl
@@ -26,10 +26,6 @@ interface Request {
   readonly attribute RequestRedirect redirect;
   readonly attribute DOMString integrity;
 
-  // If a main-thread fetch() promise rejects, the error passed will be a
-  // nsresult code.
-  [ChromeOnly]
-  readonly attribute boolean mozErrors;
 
   [BinaryName="getOrCreateSignal"]
   readonly attribute AbortSignal signal;
@@ -54,9 +50,6 @@ dictionary RequestInit {
   RequestCache cache;
   RequestRedirect redirect;
   DOMString integrity;
-
-  [ChromeOnly]
-  boolean mozErrors;
 
   AbortSignal? signal;
 

--- a/crates/web-sys/webidls/enabled/SVGImageElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGImageElement.webidl
@@ -23,5 +23,4 @@ interface SVGImageElement : SVGGraphicsElement {
   readonly attribute SVGAnimatedPreserveAspectRatio preserveAspectRatio;
 };
 
-SVGImageElement includes MozImageLoadingContent;
 SVGImageElement includes SVGURIReference;

--- a/crates/web-sys/webidls/enabled/Screen.webidl
+++ b/crates/web-sys/webidls/enabled/Screen.webidl
@@ -27,32 +27,6 @@ interface Screen : EventTarget {
   readonly attribute long availTop;
   [Throws]
   readonly attribute long availLeft;
-
-  /**
-   * DEPRECATED, use ScreenOrientation API instead.
-   * Returns the current screen orientation.
-   * Can be: landscape-primary, landscape-secondary,
-   *         portrait-primary or portrait-secondary.
-   */
-  [NeedsCallerType]
-  readonly attribute DOMString mozOrientation;
-
-  attribute EventHandler onmozorientationchange;
-
-  /**
-   * DEPRECATED, use ScreenOrientation API instead.
-   * Lock screen orientation to the specified type.
-   */
-  [Throws]
-  boolean mozLockOrientation(DOMString orientation);
-  [Throws]
-  boolean mozLockOrientation(sequence<DOMString> orientation);
-
-  /**
-   * DEPRECATED, use ScreenOrientation API instead.
-   * Unlock the screen orientation.
-   */
-  void mozUnlockOrientation();
 };
 
 // https://w3c.github.io/screen-orientation

--- a/crates/web-sys/webidls/enabled/TCPSocket.webidl
+++ b/crates/web-sys/webidls/enabled/TCPSocket.webidl
@@ -27,18 +27,6 @@ enum TCPReadyState {
   "closed",
 };
 
-[NoInterfaceObject]
-interface LegacyMozTCPSocket {
-  /**
-   * Legacy constructor for API compatibility.
-   */
-  [Throws]
-  TCPSocket open(DOMString host, unsigned short port, optional SocketOptions options);
-
-  [Throws]
-  TCPServerSocket listen(unsigned short port, optional ServerSocketOptions options, optional unsigned short backlog = 0);
-};
-
 [Constructor(DOMString host, unsigned short port, optional SocketOptions options),
  Func="mozilla::dom::TCPSocket::ShouldTCPSocketExist",
  Exposed=(Window,System)]
@@ -108,7 +96,7 @@ interface TCPSocket : EventTarget {
    *         and the caller may wish to wait until the ondrain event
    *         handler has been called before buffering more data by more
    *         calls to send.
-   * 
+   *
    * @throws Throws if the ready state is not OPEN.
    */
   [Throws]
@@ -133,7 +121,7 @@ interface TCPSocket : EventTarget {
    *         and the caller may wish to wait until the ondrain event
    *         handler has been called before buffering more data by more
    *         calls to send.
-   * 
+   *
    * @throws Throws if the ready state is not OPEN.
    */
   [Throws]
@@ -206,5 +194,5 @@ interface TCPSocket : EventTarget {
    * If the "error" event was not dispatched before "close", then one of
    * the sides cleanly closed the connection.
    */
-  attribute EventHandler onclose;  
+  attribute EventHandler onclose;
 };

--- a/crates/web-sys/webidls/enabled/TreeBoxObject.webidl
+++ b/crates/web-sys/webidls/enabled/TreeBoxObject.webidl
@@ -6,7 +6,6 @@
  */
 
 // invalid widl
-//interface MozTreeView;
 //interface nsIScriptableRegion;
 
 dictionary TreeCellInfo {
@@ -22,14 +21,6 @@ interface TreeBoxObject : BoxObject {
    * Obtain the columns.
    */
   readonly attribute TreeColumns? columns;
-
-  /**
-   * The view that backs the tree and that supplies it with its data.
-   * It is dynamically settable, either using a view attribute on the
-   * tree tag or by setting this attribute to a new value.
-   */
-  [SetterThrows, NeedsCallerType]
-  attribute MozTreeView? view;
 
   /**
    * Whether or not we are currently focused.

--- a/crates/web-sys/webidls/enabled/WebrtcDeprecated.webidl
+++ b/crates/web-sys/webidls/enabled/WebrtcDeprecated.webidl
@@ -8,22 +8,3 @@
  * The declaration of each should match the declaration of the real, unprefixed
  * interface.  These aliases will be removed at some point (Bug 1155923).
  */
-
-[Deprecated="WebrtcDeprecatedPrefix",
- Pref="media.peerconnection.enabled",
- JSImplementation="@mozilla.org/dom/rtcicecandidate;1",
- Constructor(optional RTCIceCandidateInit candidateInitDict)]
-interface mozRTCIceCandidate : RTCIceCandidate {};
-
-[Deprecated="WebrtcDeprecatedPrefix",
- Pref="media.peerconnection.enabled",
- JSImplementation="@mozilla.org/dom/peerconnection;1",
- Constructor (optional RTCConfiguration configuration,
-              optional object? constraints)]
-interface mozRTCPeerConnection : RTCPeerConnection {};
-
-[Deprecated="WebrtcDeprecatedPrefix",
- Pref="media.peerconnection.enabled",
- JSImplementation="@mozilla.org/dom/rtcsessiondescription;1",
- Constructor(optional RTCSessionDescriptionInit descriptionInitDict)]
-interface mozRTCSessionDescription : RTCSessionDescription {};

--- a/crates/web-sys/webidls/enabled/Window.webidl
+++ b/crates/web-sys/webidls/enabled/Window.webidl
@@ -174,11 +174,6 @@ partial interface Window {
   void scrollTo(optional ScrollToOptions options);
   void scrollBy(unrestricted double x, unrestricted double y);
   void scrollBy(optional ScrollToOptions options);
-  // mozScrollSnap is used by chrome to perform scroll snapping after the
-  // user performs actions that may affect scroll position
-  // mozScrollSnap is deprecated, to be replaced by a web accessible API, such
-  // as an extension to the ScrollOptions dictionary.  See bug 1137937.
-  [ChromeOnly] void mozScrollSnap();
   // The four properties below are double per spec at the moment, but whether
   // that will continue is unclear.
   [Replaceable, Throws] readonly attribute double scrollX;

--- a/crates/web-sys/webidls/enabled/XMLHttpRequest.webidl
+++ b/crates/web-sys/webidls/enabled/XMLHttpRequest.webidl
@@ -12,7 +12,6 @@
 
 // invalid widl
 // interface InputStream;
-// interface MozChannel;
 // interface IID;
 
 enum XMLHttpRequestResponseType {
@@ -24,27 +23,7 @@ enum XMLHttpRequestResponseType {
   "text",
 };
 
-/**
- * Parameters for instantiating an XMLHttpRequest. They are passed as an
- * optional argument to the constructor:
- *
- *  new XMLHttpRequest({anon: true, system: true});
- */
-dictionary MozXMLHttpRequestParameters
-{
-  /**
-   * If true, the request will be sent without cookie and authentication
-   * headers.
-   */
-  boolean mozAnon = false;
-
-  /**
-   * If true, the same origin policy will not be enforced on the request.
-   */
-  boolean mozSystem = false;
-};
-
-[Constructor(optional MozXMLHttpRequestParameters params),
+[Constructor(),
  // There are apparently callers, specifically CoffeeScript, who do
  // things like this:
  //   c = new(window.ActiveXObject || XMLHttpRequest)("Microsoft.XMLHTTP")


### PR DESCRIPTION
Did a bunch of grepping for `moz*` and searched for "moz" in rustdoc,
deleting anything that looked mozilla-specific. Now there's nothing left
with the "moz" prefix in rustdoc!