### PR TITLE
doc(readme) Add links to doc & clean

### DIFF
--- a/crates/js-sys/README.md
+++ b/crates/js-sys/README.md
@@ -1,8 +1,7 @@
 # `js-sys`
 
+[API documentation](https://rustwasm.github.io/wasm-bindgen/api/js_sys/)
+
 Raw bindings to JS global APIs for projects using `wasm-bindgen`. This crate is
 handwritten and intended to work in *all* JS environments like browsers and
 Node.js.
-
-Progress for this crate can be tracked at
-[#275](https://github.com/rustwasm/wasm-bindgen/issues/275).


### PR DESCRIPTION
This patch adds a link to the crate's documentation. It also removes a reference to #275, which is closed now.