### PR TITLE
Only generate JS null checks in debug mode

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -985,7 +985,7 @@ impl ToTokens for ast::Enum {
                     _extra: &mut ::wasm_bindgen::convert::Stack,
                 ) -> Self {
                     #(#cast_clauses else)* {
-                        ::wasm_bindgen::throw("invalid enum value passed")
+                        ::wasm_bindgen::throw_str("invalid enum value passed")
                     }
                 }
             }

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -68,11 +68,13 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
     /// passed should be `this.ptr`.
     pub fn method(&mut self, method: bool, consumed: bool) -> &mut Self {
         if method {
-            self.prelude(
-                "if (this.ptr === 0) {
-                    throw new Error('Attempt to use a moved value');
-                }",
-            );
+            if self.cx.config.debug {
+                self.prelude(
+                    "if (this.ptr === 0) {
+                        throw new Error('Attempt to use a moved value');
+                    }",
+                );
+            }
             if consumed {
                 self.prelude(
                     "\

--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -85,7 +85,8 @@ exports.custom_type_return_2 = function() {
 };
 
 exports.touch_custom_type = function() {
-  assert.throws(() => CUSTOM_TYPE.touch(), /Attempt to use a moved value/);
+  assert.throws(() => CUSTOM_TYPE.touch(),
+    /Attempt to use a moved value|null pointer passed to rust/);
 };
 
 exports.interpret_2_as_custom_type = function() {

--- a/tests/wasm/validate_prt.js
+++ b/tests/wasm/validate_prt.js
@@ -5,14 +5,16 @@ const useMoved = () => {
     const apple = new wasm.Fruit('apple');
     apple.name();
     wasm.eat(apple);
-    assert.throws(() => apple.name(), /Attempt to use a moved value/);
+    assert.throws(() => apple.name(),
+      /Attempt to use a moved value|null pointer passed to rust/);
 };
 
 const moveMoved = () => {
     const pear = new wasm.Fruit('pear');
     pear.name();
     wasm.eat(pear);
-    assert.throws(() => wasm.eat(pear), /Attempt to use a moved value/);
+    assert.throws(() => wasm.eat(pear),
+      /Attempt to use a moved value|null pointer passed to rust/);
 };
 
 exports.js_works = () => {


### PR DESCRIPTION
In non-debug mode Rust is already checking these pointers, so let's only
generate the relevant code in debug mode.