### PR TITLE
Remove the need for a `ConstructorToken`

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -34,11 +34,9 @@ pub struct Export {
     pub class: Option<Ident>,
     /// The type of `self` (either `self`, `&self`, or `&mut self`)
     pub method_self: Option<MethodSelf>,
-    /// The name of the constructor function (e.g. new).
-    ///
-    /// This allows javascript to expose an `Object` interface, where calling
-    /// the constructor maps correctly to rust.
-    pub constructor: Option<String>,
+    /// Whether or not this export is flagged as a constructor, returning an
+    /// instance of the `impl` type
+    pub is_constructor: bool,
     /// The rust function
     pub function: Function,
     /// Comments extracted from the rust source.
@@ -317,7 +315,7 @@ impl Export {
             class: self.class.as_ref().map(|s| s.to_string()),
             method,
             consumed,
-            constructor: self.constructor.clone(),
+            is_constructor: self.is_constructor,
             function: self.function.shared(),
             comments: self.comments.clone(),
         }

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -232,7 +232,8 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             if arg.is_by_ref() {
                 bail!("cannot invoke JS functions with custom ref types yet")
             }
-            let assign = format!("let c{0} = {1}.__construct({0});", abi, class);
+            self.cx.require_class_wrap(class);
+            let assign = format!("let c{0} = {1}.__wrap({0});", abi, class);
             self.prelude(&assign);
             self.js_arguments.push(format!("c{}", abi));
             return Ok(());

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -29,7 +29,7 @@ pub fn spawn(
             // native ESM support for wasm modules.
             await wasm.booted;
 
-            const cx = Context.new();
+            const cx = new Context();
             window.console_log_redirect = __wbgtest_console_log;
             window.console_error_redirect = __wbgtest_console_error;
 

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -729,7 +729,7 @@ impl<'a> MacroParse<(Option<BindgenAttrs>, &'a mut TokenStream)> for syn::Item {
                 program.exports.push(ast::Export {
                     class: None,
                     method_self: None,
-                    constructor: None,
+                    is_constructor: false,
                     comments,
                     rust_name: f.ident.clone(),
                     function: f.convert(opts)?,
@@ -852,12 +852,6 @@ impl<'a, 'b> MacroParse<()> for (&'a Ident, &'b mut syn::ImplItem) {
         let opts = BindgenAttrs::find(&mut method.attrs)?;
         let comments = extract_doc_comments(&method.attrs);
         let is_constructor = opts.constructor();
-        let constructor = if is_constructor {
-            Some(method.sig.ident.to_string())
-        } else {
-            None
-        };
-
         let (function, method_self) = function_from_decl(
             opts.js_name().unwrap_or(&method.sig.ident.to_string()),
             Box::new(method.sig.decl.clone()),
@@ -870,7 +864,7 @@ impl<'a, 'b> MacroParse<()> for (&'a Ident, &'b mut syn::ImplItem) {
         program.exports.push(ast::Export {
             class: Some(class.clone()),
             method_self,
-            constructor,
+            is_constructor,
             function,
             comments,
             rust_name: method.sig.ident.clone(),

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -97,7 +97,7 @@ pub struct Export {
     pub class: Option<String>,
     pub method: bool,
     pub consumed: bool,
-    pub constructor: Option<String>,
+    pub is_constructor: bool,
     pub function: Function,
     pub comments: Vec<String>,
 }

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -2,7 +2,7 @@ const wasm = require('wasm-bindgen-test.js');
 const assert = require('assert');
 
 exports.js_simple = () => {
-    const r = wasm.ClassesSimple.new();
+    const r = new wasm.ClassesSimple();
     assert.strictEqual(r.add(0), 0);
     assert.strictEqual(r.add(1), 1);
     assert.strictEqual(r.add(1), 2);
@@ -70,7 +70,8 @@ exports.js_constructors = () => {
     assert.strictEqual(foo.get_number(), 1);
     foo.free();
 
-    const foo2 = wasm.ConstructorsFoo.new(2);
+    assert.strictEqual(wasm.ConstructorsBar.new, undefined);
+    const foo2 = new wasm.ConstructorsFoo(2);
     assert.strictEqual(foo2.get_number(), 2);
     foo2.free();
 
@@ -78,7 +79,8 @@ exports.js_constructors = () => {
     assert.strictEqual(bar.get_sum(), 7);
     bar.free();
 
-    const bar2 = wasm.ConstructorsBar.other_name(5, 6);
+    assert.strictEqual(wasm.ConstructorsBar.other_name, undefined);
+    const bar2 = new wasm.ConstructorsBar(5, 6);
     assert.strictEqual(bar2.get_sum(), 11);
     bar2.free();
 
@@ -121,12 +123,12 @@ exports.js_readonly_fields = () => {
 };
 
 exports.js_double_consume = () => {
-    const r = wasm.DoubleConsume.new();
+    const r = new wasm.DoubleConsume();
     assert.throws(() => r.consume(r), /Attempt to use a moved value/);
 };
 
 
 exports.js_js_rename = () => {
-    wasm.JsRename.new().bar();
+    (new wasm.JsRename()).bar();
     wasm.classes_foo();
 };


### PR DESCRIPTION
This commit removes the need for an injected `ConstructorToken` type and
also cleans up the story we have for generating constructors a bit.
After this commit a `constructor()` is omitted entirely if we're in
non-debug mode and there's no actual listed constructor. Additionally we
don't deal with splat arguments and rerouting constructors, Nick was
kind enough to enlighten me about `Object.create` which is creating an
instance without running the constructor!

Instances of an exported type are now created through one of two
methods:

* If `#[wasm_bindgen(constructor)]` is present, then a `constructor` is
  generated with the appropriate signature. If a constructor is not
  present and we're in debug mode, a throwing constructor is generated.
  If we're in release mode and there's no constructor, no constructor is
  generated.

* Otherwise if a binding returns an instance of a type (or otherwise
  needs to manfuacture an instance, then it will cause an internal
  `__wrap` function to be generated. This function will use
  `Object.create` to create an instance without running the constructor.

This should ideally clean up our generated JS for classes quite a bit,
making it much more lean-and-mean!