### PR TITLE
Support `#[wasm_bindgen(setter, js_name = ...)]` 

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -689,6 +689,7 @@ fn function_from_decl(
         ast::Function {
             name: js_name.map(|s| s.0.to_string()).unwrap_or(decl_name.to_string()),
             name_span: js_name.map(|s| s.1).unwrap_or(decl_name.span()),
+            renamed_via_js_name: js_name.is_some(),
             arguments,
             ret,
             rust_vis: vis,

--- a/crates/macro/ui-tests/invalid-setter.rs
+++ b/crates/macro/ui-tests/invalid-setter.rs
@@ -1,0 +1,19 @@
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    type A;
+
+    #[wasm_bindgen(setter, method)]
+    fn a(this: &A, b: i32);
+
+    #[wasm_bindgen(setter = x, method)]
+    fn b(this: &A, b: i32);
+
+    #[wasm_bindgen(setter, method, js_name = x)]
+    fn c(this: &A, b: i32);
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/invalid-setter.stderr
+++ b/crates/macro/ui-tests/invalid-setter.stderr
@@ -4,11 +4,5 @@ error: setters must start with `set_`, found: a
 10 |     fn a(this: &A, b: i32);
    |        ^
 
-error: setters must start with `set_`, found: x
-  --> $DIR/invalid-setter.rs:15:46
-   |
-15 |     #[wasm_bindgen(setter, method, js_name = x)]
-   |                                              ^
-
-error: aborting due to 2 previous errors
+error: aborting due to previous error
 

--- a/crates/macro/ui-tests/invalid-setter.stderr
+++ b/crates/macro/ui-tests/invalid-setter.stderr
@@ -1,0 +1,14 @@
+error: setters must start with `set_`, found: a
+  --> $DIR/invalid-setter.rs:10:8
+   |
+10 |     fn a(this: &A, b: i32);
+   |        ^
+
+error: setters must start with `set_`, found: x
+  --> $DIR/invalid-setter.rs:15:46
+   |
+15 |     #[wasm_bindgen(setter, method, js_name = x)]
+   |                                              ^
+
+error: aborting due to 2 previous errors
+

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -4,7 +4,7 @@ use std::ptr;
 use backend;
 use backend::util::{ident_ty, leading_colon_path_ty, raw_ident, rust_ident};
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
-use proc_macro2::Ident;
+use proc_macro2::{Ident, Span};
 use syn;
 use weedle;
 use weedle::attribute::{ExtendedAttributeList, ExtendedAttribute};
@@ -304,6 +304,8 @@ impl<'src> FirstPassRecord<'src> {
         Some(backend::ast::ImportFunction {
             function: backend::ast::Function {
                 name: js_name.to_string(),
+                name_span: Span::call_site(),
+                renamed_via_js_name: false,
                 arguments,
                 ret: ret.clone(),
                 rust_attrs: vec![],

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -53,8 +53,12 @@ extern {
     fn new() -> RenameProperties;
     #[wasm_bindgen(getter = a, method)]
     fn test(this: &RenameProperties) -> i32;
+    #[wasm_bindgen(getter, method, js_name = a)]
+    fn test2(this: &RenameProperties) -> i32;
     #[wasm_bindgen(setter = a, method)]
     fn another(this: &RenameProperties, a: i32);
+    #[wasm_bindgen(setter, method, js_name = a)]
+    fn another2(this: &RenameProperties, a: i32);
 
     /// dox
     pub type AssertImportDenyDocsWorks;
@@ -154,6 +158,8 @@ fn rename_setter_getter() {
     assert_eq!(a.test(), 1);
     a.another(2);
     assert_eq!(a.test(), 2);
+    a.another2(3);
+    assert_eq!(a.test2(), 3);
 }
 
 /// dox


### PR DESCRIPTION
Previously we'd require the explicit `js_name` to *also* start with
`set_`, but when explicitly specified it shouldn't be mangled at all!

Closes #584 


Note that along the way this also improve the error message we get from failures to infer names.