### PR TITLE
Improve codegen for `Closure<T>`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -325,9 +325,13 @@ impl<'a> Context<'a> {
             Ok(String::from(
                 "
                 function(i) {
-                    let obj = getObject(i).original;
-                    obj.a = obj.b = 0;
+                    const obj = getObject(i).original;
                     dropRef(i);
+                    if (obj.cnt-- == 1) {
+                        obj.a = 0;
+                        return 1;
+                    }
+                    return 0;
                 }
                 ",
             ))
@@ -335,13 +339,7 @@ impl<'a> Context<'a> {
 
         self.bind("__wbindgen_cb_forget", &|me| {
             me.expose_drop_ref();
-            Ok(String::from(
-                "
-                function(i) {
-                    dropRef(i);
-                }
-                ",
-            ))
+            Ok("dropRef".to_string())
         })?;
 
         self.bind("__wbindgen_json_parse", &|me| {

--- a/crates/wasm-interpreter/src/lib.rs
+++ b/crates/wasm-interpreter/src/lib.rs
@@ -347,6 +347,8 @@ impl Interpreter {
                         self.descriptor_table_idx = Some(self.stack.pop().unwrap() as u32);
                         self.stack.pop();
                         self.stack.pop();
+                        self.stack.pop();
+                        self.stack.pop();
                         self.stack.push(0);
                     } else {
                         self.call(*idx, sections);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,11 +445,11 @@ externs! {
     fn __wbindgen_throw(a: *const u8, b: usize) -> !;
     fn __wbindgen_rethrow(a: u32) -> !;
 
-    fn __wbindgen_cb_drop(idx: u32) -> ();
+    fn __wbindgen_cb_drop(idx: u32) -> u32;
     fn __wbindgen_cb_forget(idx: u32) -> ();
 
     fn __wbindgen_describe(v: u32) -> ();
-    fn __wbindgen_describe_closure(a: u32, b: u32, c: u32) -> u32;
+    fn __wbindgen_describe_closure(a: u32, b: u32, c: u32, d: u32, e: u32) -> u32;
 
     fn __wbindgen_json_parse(ptr: *const u8, len: usize) -> u32;
     fn __wbindgen_json_serialize(idx: u32, ptr: *mut *mut u8) -> usize;

--- a/tests/wasm/closures.js
+++ b/tests/wasm/closures.js
@@ -91,3 +91,9 @@ exports.string_arguments_call = a => {
 exports.string_ret_call = a => {
     assert.strictEqual(a('foo'), 'foobar');
 };
+
+let DROP_DURING_CALL = null;
+exports.drop_during_call_save = f => {
+  DROP_DURING_CALL = f;
+};
+exports.drop_during_call_call = () => DROP_DURING_CALL();


### PR DESCRIPTION
This commit improves the codegen for `Closure<T>`, primarily for ZST
where the closure doesn't actually capture anything. Previously
`wasm-bindgen` would unconditionally allocate an `Rc` for a fat pointer,
meaning that it would always hit the allocator even when the `Box<T>`
didn't actually contain an allocation. Now the reference count for the
closure is stored on the JS object rather than in Rust.

Some more advanced tests were added along the way to ensure that
functionality didn't regress, and otherwise the calling convention for
`Closure` changed a good deal but should still be the same user-facing.
The primary change was that the reference count reaching zero may cause
JS to need to run the destructor. It simply returns this information in
`Drop for Closure` and otherwise when calling it now also retains a
function pointer that runs the destructor.

Closes #874