### PR TITLE
update to "webpack-cli": "^3.1.1"

### DIFF
--- a/examples/add/package.json
+++ b/examples/add/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/char/package.json
+++ b/examples/char/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.8.3",
-    "webpack-cli": "^2.1.3",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.4"
   }
 }

--- a/examples/closures/package.json
+++ b/examples/closures/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/console_log/package.json
+++ b/examples/console_log/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/dom/package.json
+++ b/examples/dom/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/duck-typed-interfaces/package.json
+++ b/examples/duck-typed-interfaces/package.json
@@ -4,7 +4,7 @@
   },
   "devDependencies": {
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/guide-supported-types-examples/package.json
+++ b/examples/guide-supported-types-examples/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/hello_world/package.json
+++ b/examples/hello_world/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/import_js/package.json
+++ b/examples/import_js/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/julia_set/package.json
+++ b/examples/julia_set/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.0.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/paint/package.json
+++ b/examples/paint/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/performance/package.json
+++ b/examples/performance/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/wasm-in-wasm/package.json
+++ b/examples/wasm-in-wasm/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/wasm2js/package.json
+++ b/examples/wasm2js/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/webaudio/package.json
+++ b/examples/webaudio/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.16.5",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/examples/webgl/package.json
+++ b/examples/webgl/package.json
@@ -5,7 +5,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.11.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/guide/src/whirlwind-tour/basic-usage.md
+++ b/guide/src/whirlwind-tour/basic-usage.md
@@ -124,7 +124,7 @@ Next, define our JS dependencies by creating a `package.json`:
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.0.1",
-    "webpack-cli": "^2.0.10",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",
     "webpack": "^4.17.1",
-    "webpack-cli": "^3.1.0",
+    "webpack-cli": "^3.1.1",
     "webpack-dev-server": "^3.1.6"
   }
 }


### PR DESCRIPTION
replaced using VS Code regex search
"webpack-cli": "\^\S+"
"webpack-cli": "^3.1.1"

Every example was failing on an error like this:
```
> @ serve /Users/cameron/rs/wasm-bindgen/examples/hello_world
> webpack-dev-server

/Users/cameron/rs/wasm-bindgen/examples/hello_world/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description,
				                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/Users/cameron/rs/wasm-bindgen/examples/hello_world/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at Object.<anonymous> (/Users/cameron/rs/wasm-bindgen/examples/hello_world/node_modules/webpack-dev-server/bin/webpack-dev-server.js:84:40)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:279:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:752:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @ serve: `webpack-dev-server`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ serve script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cameron/.npm/_logs/2018-09-26T01_15_40_142Z-debug.log
```