### PR TITLE
Add `#[inline]` for `IntoWasmAbi for ()`

### DIFF
--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -396,6 +396,7 @@ impl<T: FromWasmAbi> FromWasmAbi for Clamped<T> {
 impl IntoWasmAbi for () {
     type Abi = ();
 
+    #[inline]
     fn into_abi(self, _extra: &mut Stack) -> () {
         self
     }


### PR DESCRIPTION
No need for it to not be inlined, it literally compiles to nothing!