### PR TITLE
Add `catch(console.error)` to all examples

### DIFF
--- a/examples/add/index.js
+++ b/examples/add/index.js
@@ -1,4 +1,6 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
 const rust = import('./add');
-rust.then(m => alert('1 + 2 = ' + m.add(1, 2)));
+rust
+  .then(m => alert('1 + 2 = ' + m.add(1, 2)))
+  .catch(console.error);

--- a/examples/canvas/index.js
+++ b/examples/canvas/index.js
@@ -1,5 +1,5 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example.
-import('./canvas').then(canvas => {
-  canvas.draw();
-});
+import('./canvas')
+  .then(canvas => canvas.draw())
+  .catch(console.error);

--- a/examples/char/index.js
+++ b/examples/char/index.js
@@ -4,13 +4,15 @@ let imp = import('./char.js');
 let mod;
 
 let counters = [];
-imp.then(wasm => {
-    mod = wasm;
-    addCounter();
-    let b = document.getElementById('add-counter');
-    if (!b) throw new Error('Unable to find #add-counter');
-    b.addEventListener('click', ev => addCounter());
-});
+imp
+  .then(wasm => {
+      mod = wasm;
+      addCounter();
+      let b = document.getElementById('add-counter');
+      if (!b) throw new Error('Unable to find #add-counter');
+      b.addEventListener('click', ev => addCounter());
+  })
+  .catch(console.error);
 
 function addCounter() {
     let ctr = mod.Counter.new(randomChar(), 0);

--- a/examples/closures/index.js
+++ b/examples/closures/index.js
@@ -1,4 +1,6 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
 const rust = import('./closures');
-rust.then(m => m.run());
+rust
+  .then(m => m.run())
+  .catch(console.error);

--- a/examples/console_log/index.js
+++ b/examples/console_log/index.js
@@ -2,4 +2,6 @@
 // example
 const rust = import('./console_log');
 
-rust.then(m => m.run());
+rust
+  .then(m => m.run())
+  .catch(console.error);

--- a/examples/dom/index.js
+++ b/examples/dom/index.js
@@ -1,4 +1,6 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
 const rust = import('./dom');
-rust.then(m => m.run());
+rust
+  .then(m => m.run())
+  .catch(console.error);

--- a/examples/fetch/index.js
+++ b/examples/fetch/index.js
@@ -1,11 +1,12 @@
 const rust = import('./fetch');
 
+rust
+  .then(m => {
+      m.run().then((data) => {
+          console.log(data);
 
-rust.then(m => {
-    m.run().then((data) => {
-        console.log(data);
-
-        console.log("The latest commit to the wasm-bindgen %s branch is:", data.name);
-        console.log("%s, authored by %s <%s>", data.commit.sha, data.commit.commit.author.name, data.commit.commit.author.email);
-    })
-});
+          console.log("The latest commit to the wasm-bindgen %s branch is:", data.name);
+          console.log("%s, authored by %s <%s>", data.commit.sha, data.commit.commit.author.name, data.commit.commit.author.email);
+      })
+  })
+  .catch(console.error);

--- a/examples/hello_world/index.js
+++ b/examples/hello_world/index.js
@@ -3,4 +3,6 @@
 // will work here one day as well!
 const rust = import('./hello_world');
 
-rust.then(m => m.greet('World!'));
+rust
+  .then(m => m.greet('World!'))
+  .catch(console.error);

--- a/examples/import_js/index.js
+++ b/examples/import_js/index.js
@@ -2,4 +2,6 @@
 // example
 const rust = import('./import_js');
 
-rust.then(m => m.run());
+rust
+  .then(m => m.run())
+  .catch(console.error);

--- a/examples/julia_set/index.js
+++ b/examples/julia_set/index.js
@@ -2,7 +2,7 @@ import('./julia_set')
     .then(wasm => {
         const canvas = document.getElementById('drawing');
         const ctx = canvas.getContext('2d');
-        
+
         const realInput = document.getElementById('real');
         const imaginaryInput = document.getElementById('imaginary');
         const renderBtn = document.getElementById('render');
@@ -12,6 +12,7 @@ import('./julia_set')
             const imaginary = parseFloat(imaginaryInput.value) || 0;
             wasm.draw(ctx, 600, 600, real, imaginary);
         });
-        
+
         wasm.draw(ctx, 600, 600, -0.15, 0.65);
-    });
+    })
+    .catch(console.error);

--- a/examples/paint/index.js
+++ b/examples/paint/index.js
@@ -1,5 +1,5 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example.
-import('./wasm_bindgen_paint').then(paint => {
-  paint.main();
-});
+import('./wasm_bindgen_paint')
+  .then(paint => paint.main())
+  .catch(console.error);

--- a/examples/performance/index.js
+++ b/examples/performance/index.js
@@ -1,4 +1,6 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
 const rust = import('./performance');
-rust.then(m => m.run());
+rust
+  .then(m => m.run())
+  .catch(console.error);

--- a/examples/wasm-in-wasm/index.js
+++ b/examples/wasm-in-wasm/index.js
@@ -1,4 +1,6 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
 const rust = import('./wasm_in_wasm');
-rust.then(m => m.run());
+rust
+  .then(m => m.run())
+  .catch(console.error);

--- a/examples/webaudio/index.js
+++ b/examples/webaudio/index.js
@@ -1,38 +1,40 @@
-import('./webaudio').then(rust_module => {
-  let fm = null;
+import('./webaudio')
+  .then(rust_module => {
+    let fm = null;
 
-  const play_button = document.getElementById("play");
-  play_button.addEventListener("click", event => {
-    if (fm === null) {
-      fm = new rust_module.FmOsc();
-      fm.set_note(50);
-      fm.set_fm_frequency(0);
-      fm.set_fm_amount(0);
-      fm.set_gain(0.8);
-    } else {
-      fm.free();
-      fm = null;
-    }
-  });
+    const play_button = document.getElementById("play");
+    play_button.addEventListener("click", event => {
+      if (fm === null) {
+        fm = new rust_module.FmOsc();
+        fm.set_note(50);
+        fm.set_fm_frequency(0);
+        fm.set_fm_amount(0);
+        fm.set_gain(0.8);
+      } else {
+        fm.free();
+        fm = null;
+      }
+    });
 
-  const primary_slider = document.getElementById("primary_input");
-  primary_slider.addEventListener("input", event => {
-    if (fm) {
-      fm.set_note(event.target.value);
-    }
-  });
+    const primary_slider = document.getElementById("primary_input");
+    primary_slider.addEventListener("input", event => {
+      if (fm) {
+        fm.set_note(event.target.value);
+      }
+    });
 
-  const fm_freq = document.getElementById("fm_freq");
-  fm_freq.addEventListener("input", event => {
-    if (fm) {
-      fm.set_fm_frequency(event.target.value);
-    }
-  });
+    const fm_freq = document.getElementById("fm_freq");
+    fm_freq.addEventListener("input", event => {
+      if (fm) {
+        fm.set_fm_frequency(event.target.value);
+      }
+    });
 
-  const fm_amount = document.getElementById("fm_amount");
-  fm_amount.addEventListener("input", event => {
-    if (fm) {
-      fm.set_fm_amount(event.target.value);
-    }
-  });
-});
+    const fm_amount = document.getElementById("fm_amount");
+    fm_amount.addEventListener("input", event => {
+      if (fm) {
+        fm.set_fm_amount(event.target.value);
+      }
+    });
+  })
+  .catch(console.error);

--- a/examples/webgl/index.js
+++ b/examples/webgl/index.js
@@ -1,5 +1,5 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example.
-import('./webgl').then(webgl => {
-  webgl.draw();
-});
+import('./webgl')
+  .then(webgl => webgl.draw())
+  .catch(console.error);


### PR DESCRIPTION
Some examples have been failing to load in some browsers, and this
ensures that whenever the promise to load Rust code fails we log any
errors happening instead of accidentally failing silently.

This helped debug a bit in #897