### PR TITLE
Fix our WebIDL for Safari

### DIFF
--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -12,6 +12,7 @@
 //! require.
 
 #![doc(html_root_url = "https://docs.rs/web-sys/0.2")]
+#![allow(deprecated)]
 
 extern crate js_sys;
 extern crate wasm_bindgen;

--- a/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
@@ -32,7 +32,12 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
     attribute double loopStart;
     attribute double loopEnd;
 
+    attribute EventHandler onended;
+
     [Throws]
     void start(optional double when = 0, optional double grainOffset = 0,
                optional double grainDuration);
+
+    [Throws]
+    void stop (optional double when = 0);
 };

--- a/crates/web-sys/webidls/enabled/AudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/AudioContext.webidl
@@ -37,3 +37,5 @@ interface AudioContext : BaseAudioContext {
     [NewObject, Throws]
     MediaStreamAudioDestinationNode createMediaStreamDestination();
 };
+
+AudioContext includes rustBaseAudioContext;

--- a/crates/web-sys/webidls/enabled/AudioScheduledSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioScheduledSourceNode.webidl
@@ -10,7 +10,13 @@
  * liability, trademark and document use rules apply.
  */
 
+[RustDeprecated="doesn't exist in Safari, use parent class methods instead"]
 interface AudioScheduledSourceNode : AudioNode {
+};
+
+AudioScheduledSourceNode includes rustAudioScheduledSourceNode;
+
+interface mixin rustAudioScheduledSourceNode {
                     attribute EventHandler onended;
     [Throws]
     void start (optional double when = 0);

--- a/crates/web-sys/webidls/enabled/BaseAudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/BaseAudioContext.webidl
@@ -19,7 +19,13 @@ enum AudioContextState {
     "closed"
 };
 
+[RustDeprecated="doesn't exist in Safari, use `AudioContext` instead now"]
 interface BaseAudioContext : EventTarget {
+};
+
+BaseAudioContext includes rustBaseAudioContext;
+
+interface mixin rustBaseAudioContext {
     readonly        attribute AudioDestinationNode destination;
     readonly        attribute float                sampleRate;
     readonly        attribute double               currentTime;

--- a/crates/web-sys/webidls/enabled/ConstantSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/ConstantSourceNode.webidl
@@ -19,3 +19,5 @@ dictionary ConstantSourceOptions {
 interface ConstantSourceNode :  AudioScheduledSourceNode {
     readonly        attribute AudioParam   offset;
 };
+
+ConstantSourceNode includes rustAudioScheduledSourceNode;

--- a/crates/web-sys/webidls/enabled/OfflineAudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/OfflineAudioContext.webidl
@@ -29,3 +29,5 @@ interface OfflineAudioContext : BaseAudioContext {
     readonly        attribute unsigned long length;
                     attribute EventHandler  oncomplete;
 };
+
+OfflineAudioContext includes rustBaseAudioContext;

--- a/crates/web-sys/webidls/enabled/OscillatorNode.webidl
+++ b/crates/web-sys/webidls/enabled/OscillatorNode.webidl
@@ -37,3 +37,5 @@ interface OscillatorNode : AudioScheduledSourceNode {
 
     void setPeriodicWave(PeriodicWave periodicWave);
 };
+
+OscillatorNode includes rustAudioScheduledSourceNode;

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -44,6 +44,7 @@ pub(crate) struct FirstPassRecord<'src> {
 pub(crate) struct InterfaceData<'src> {
     /// Whether only partial interfaces were encountered
     pub(crate) partial: bool,
+    pub(crate) deprecated: Option<String>,
     pub(crate) attributes: Vec<&'src AttributeInterfaceMember<'src>>,
     pub(crate) consts: Vec<&'src ConstMember<'src>>,
     pub(crate) operations: BTreeMap<OperationId<'src>, OperationData<'src>>,
@@ -311,6 +312,8 @@ impl<'src> FirstPass<'src, ()> for weedle::InterfaceDefinition<'src> {
             interface_data.partial = false;
             interface_data.superclass = self.inheritance.map(|s| s.identifier.0);
             interface_data.definition_attributes = self.attributes.as_ref();
+            interface_data.deprecated = util::get_rust_deprecated(&self.attributes)
+                .map(|s| s.to_string());
         }
         if let Some(attrs) = &self.attributes {
             for attr in attrs.body.list.iter() {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -7,7 +7,7 @@ use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use proc_macro2::{Ident, Span};
 use syn;
 use weedle;
-use weedle::attribute::{ExtendedAttribute, ExtendedAttributeList};
+use weedle::attribute::{ExtendedAttribute, ExtendedAttributeList, IdentifierOrString};
 use weedle::literal::{ConstValue, FloatLit, IntegerLit};
 
 use first_pass::{FirstPassRecord, OperationData, OperationId, Signature};
@@ -664,6 +664,29 @@ pub fn is_chrome_only(ext_attrs: &Option<ExtendedAttributeList>) -> bool {
 /// Whether a webidl object is marked as a no interface object.
 pub fn is_no_interface_object(ext_attrs: &Option<ExtendedAttributeList>) -> bool {
     has_named_attribute(ext_attrs.as_ref(), "NoInterfaceObject")
+}
+
+pub fn get_rust_deprecated<'a>(ext_attrs: &Option<ExtendedAttributeList<'a>>)
+    -> Option<&'a str>
+{
+    ext_attrs.as_ref()?
+        .body
+        .list
+        .iter()
+        .filter_map(|attr| {
+            match attr {
+                ExtendedAttribute::Ident(id) => Some(id),
+                _ => None,
+            }
+        })
+        .filter_map(|ident| {
+            match ident.rhs {
+                IdentifierOrString::String(s) => Some(s),
+                IdentifierOrString::Identifier(_) => None,
+            }
+        })
+        .next()
+        .map(|s| s.0)
 }
 
 /// Whether a webidl object is marked as structural.

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -16,8 +16,6 @@ features = [
   'AudioDestinationNode',
   'AudioNode',
   'AudioParam',
-  'AudioScheduledSourceNode',
-  'BaseAudioContext',
   'GainNode',
   'OscillatorNode',
   'OscillatorType',


### PR DESCRIPTION
This commit employs the strategy described in #908 to apply a
non-breaking change to fix WebIDL to be compatible with all browsers,
including Safari.

The problem here is that `BaseAudioContext` and `AudioScheduledSourceNode`
are not types in Safari, but they are types in Firefox/Chrome. The fix
here was to move the contents of these two interfaces into mixins, and
then include the mixins in all classes which inherit from these two
classes. That should have the same effect as defining the methods
inherently on the original interface.

Additionally a special `[RustDeprecated]` attribute to WebIDL was added
to signify interfaces this has happened to. Currently it's directly
tailored towards this case of "this intermediate class doesn't exist in
all browsers", but we may want to refine and extend the deprecation
message over time.

Although it's possible we could do this as a breaking change to
`web-sys` I'm hoping that we can do this as a non-breaking change for
now and then eventually on the next breaking release batch all these
changes together, deleting the intermediate classes. This is also
hopefully a good trial run for how stable web-sys can be when it's
actually stable!

cc #897
cc #908