### PR TITLE
Fix WebIDL mixin attributes on `Window`

### DIFF
--- a/crates/web-sys/tests/wasm/indexeddb.rs
+++ b/crates/web-sys/tests/wasm/indexeddb.rs
@@ -1,0 +1,8 @@
+use wasm_bindgen_test::*;
+use web_sys;
+
+#[wasm_bindgen_test]
+fn accessor_works() {
+    let window = web_sys::window().unwrap();
+    assert!(window.indexed_db().unwrap().is_some());
+}

--- a/crates/web-sys/tests/wasm/main.rs
+++ b/crates/web-sys/tests/wasm/main.rs
@@ -55,3 +55,4 @@ pub mod style_element;
 pub mod table_element;
 pub mod title_element;
 pub mod xpath_result;
+pub mod indexeddb;

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -568,7 +568,7 @@ impl<'src> FirstPassRecord<'src> {
                     &member.type_,
                     member.identifier.0,
                     &member.attributes,
-                    mixin_data.definition_attributes,
+                    data.definition_attributes,
                 );
             }
         }


### PR DESCRIPTION
Previously the "container attribute" were set to the attributes of the
mixin itself, but we want the container attributes to be that of the
type which includes the mixin (like `Window`) as those attributes
contain information about whether or not bindings are `structural`.

The end result with this is that the `structural` tag is now used for
properties on `Window`, correctly generating setters/getters.

Closes #904