### PR TITLE
web-sys: allow unused import warning

### DIFF
--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate js_sys;
 extern crate wasm_bindgen;
 
+#[allow(unused_imports)]
 use js_sys::Object;
 
 #[cfg(feature = "Window")]


### PR DESCRIPTION
This import is only used if some features get used and it is way easier to just quiet the warning when those features aren't used than to try and `cfg` this import.