### PR TITLE
Fix exporting structs with `BorrowMut` in scope

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -165,7 +165,7 @@ impl ToTokens for ast::Struct {
                     let ptr = js as *mut WasmRefCell<#name>;
                     assert_not_null(ptr);
                     let js = Box::from_raw(ptr);
-                    js.borrow_mut(); // make sure no one's borrowing
+                    (*js).borrow_mut(); // make sure no one's borrowing
                     js.into_inner()
                 }
             }

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -1,3 +1,6 @@
+#[allow(unused_imports)] // test for #919
+use std::borrow::BorrowMut;
+
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 


### PR DESCRIPTION
Apparently the codegen wasn't precise enough such that a trait import
could cause method resolution to go awry!

Closes #919