### PR TITLE
Filter only for `RustDeprecated` in attrs

### DIFF
--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -679,6 +679,7 @@ pub fn get_rust_deprecated<'a>(ext_attrs: &Option<ExtendedAttributeList<'a>>)
                 _ => None,
             }
         })
+        .filter(|attr| attr.lhs_identifier.0 == "RustDeprecated")
         .filter_map(|ident| {
             match ident.rhs {
                 IdentifierOrString::String(s) => Some(s),


### PR DESCRIPTION
Previously any string-related attribute would emit a deprecation
warning!

cc #925