### PR TITLE
Fix the `no_modules` example by fixing `--browser`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1088,6 +1088,8 @@ impl<'a> Context<'a> {
                 ", s)
             );
             self.global(&format!("let cached{0} = new l{0}('utf-8');", s));
+        } else {
+            self.global(&format!("let cached{0} = new {0}('utf-8');", s));
         }
     }
 

--- a/examples/no_modules/index.html
+++ b/examples/no_modules/index.html
@@ -30,7 +30,9 @@
 
       // here we tell bindgen the path to the wasm file so it can run
       // initialization and return to us a promise when it's done
-      wasm_bindgen('./no_modules_bg.wasm').then(run);
+      wasm_bindgen('./no_modules_bg.wasm')
+        .then(run)
+        .catch(console.error);
     </script>
   </body>
 </html>


### PR DESCRIPTION
Recent refactorings forgot a case of emitting code for
`cachedTextDecoder`!