### PR TITLE
Add tests for internal imports now working

### DIFF
--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -101,3 +101,6 @@ exports.assert_dead_import_not_generated = function() {
   const bindings = fs.readFileSync(filename);
   assert.ok(!bindings.includes("unused_import"));
 };
+
+exports.import_inside_function_works = function() {};
+exports.import_inside_private_module = function() {};

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -175,3 +175,31 @@ fn rename_static_with_string() {
 fn dead_imports_not_generated() {
     assert_dead_import_not_generated();
 }
+
+#[wasm_bindgen_test]
+#[cfg(feature = "nightly")]
+fn import_inside_function_works() {
+    #[wasm_bindgen(module = "tests/wasm/imports.js")]
+    extern {
+        fn import_inside_function_works();
+    }
+    import_inside_function_works();
+}
+
+#[wasm_bindgen_test]
+#[cfg(feature = "nightly")]
+fn private_module_imports_work() {
+    private::foo();
+}
+
+mod private {
+    use wasm_bindgen::prelude::*;
+
+    pub fn foo() {
+        #[wasm_bindgen(module = "tests/wasm/imports.js")]
+        extern {
+            fn import_inside_private_module();
+        }
+        import_inside_private_module();
+    }
+}


### PR DESCRIPTION
These compiler bugs have now been fixed on nightly, so we just need to
wait for the bug fixes to ride the trains to be available to everyone!

Closes #201