### PR TITLE
Update parity-wasm dependency

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -13,7 +13,7 @@ Shared support for the wasm-bindgen-cli package, an internal dependency
 [dependencies]
 base64 = "0.9"
 failure = "0.1.2"
-parity-wasm = "0.32"
+parity-wasm = "0.34"
 serde = "1.0"
 serde_json = "1.0"
 tempfile = "3.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,7 +18,7 @@ docopt = "1.0"
 env_logger = "0.5"
 failure = "0.1.2"
 log = "0.4"
-parity-wasm = "0.32"
+parity-wasm = "0.34"
 rouille = { version = "2.1.0", default-features = false }
 serde = "1.0"
 serde_derive = "1.0"

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -126,7 +126,7 @@ fn rmain() -> Result<(), Error> {
     let mut b = Bindgen::new();
     b.debug(debug)
         .nodejs(node)
-        .input_module(module, wasm, |w| parity_wasm::serialize(w).unwrap())
+        .input_module(module, wasm)
         .keep_debug(false)
         .generate(&tmpdir)
         .context("executing `wasm-bindgen` over the wasm file")?;

--- a/crates/gc/Cargo.toml
+++ b/crates/gc/Cargo.toml
@@ -11,6 +11,6 @@ Support for removing unused items from a wasm executable
 """
 
 [dependencies]
-parity-wasm = "0.32"
+parity-wasm = "0.34"
 log = "0.4"
 rustc-demangle = "0.1.9"

--- a/crates/gc/src/lib.rs
+++ b/crates/gc/src/lib.rs
@@ -354,6 +354,7 @@ impl<'a> LiveContext<'a> {
             ValueType::I64 => {}
             ValueType::F32 => {}
             ValueType::F64 => {}
+            ValueType::V128 => {}
         }
     }
 

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -11,7 +11,7 @@ Micro-interpreter optimized for wasm-bindgen's use case
 """
 
 [dependencies]
-parity-wasm = "0.32"
+parity-wasm = "0.34"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
While doing this, make `parity-wasm` a public dependency of all crates
instead of using the `Any` trick as that's not really needed any more.