### PR TITLE
Don't use JSON for custom section format

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -19,6 +19,5 @@ lazy_static = "1.0.0"
 log = "0.4"
 proc-macro2 = "0.4.8"
 quote = '0.6'
-serde_json = "1.0"
-syn = { version = '0.15', features = ['full', 'visit'] }
+syn = { version = '0.15', features = ['full'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.25" }

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -1,0 +1,368 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use proc_macro2::{Ident, Span};
+
+use Diagnostic;
+use ast;
+
+pub fn encode(program: &ast::Program) -> Result<Vec<u8>, Diagnostic> {
+    let mut e = Encoder::new();
+    let i = Interner::new();
+    shared_program(program, &i)?.encode(&mut e);
+    Ok(e.finish())
+}
+
+struct Interner {
+    map: RefCell<HashMap<Ident, String>>,
+}
+
+impl Interner {
+    fn new() -> Interner {
+        Interner { map: RefCell::new(HashMap::new()) }
+    }
+
+    fn intern(&self, s: &Ident) -> &str {
+        let mut map = self.map.borrow_mut();
+        if let Some(s) = map.get(s) {
+            return unsafe { &*(&**s as *const str) }
+        }
+        map.insert(s.clone(), s.to_string());
+        unsafe { &*(&*map[s] as *const str) }
+    }
+
+    fn intern_str(&self, s: &str) -> &str {
+        self.intern(&Ident::new(s, Span::call_site()))
+    }
+}
+
+fn shared_program<'a>(prog: &'a ast::Program, intern: &'a Interner)
+    -> Result<Program<'a>, Diagnostic>
+{
+    Ok(Program {
+        exports: prog.exports.iter().map(|a| shared_export(a, intern)).collect(),
+        structs: prog.structs.iter().map(|a| shared_struct(a, intern)).collect(),
+        enums: prog.enums.iter().map(|a| shared_enum(a, intern)).collect(),
+        imports: prog.imports.iter()
+            .map(|a| shared_import(a, intern))
+            .collect::<Result<Vec<_>, _>>()?,
+        // version: shared::version(),
+        // schema_version: shared::SCHEMA_VERSION.to_string(),
+    })
+}
+
+fn shared_export<'a>(export: &'a ast::Export, intern: &'a Interner) -> Export<'a> {
+    let (method, consumed) = match export.method_self {
+        Some(ast::MethodSelf::ByValue) => (true, true),
+        Some(_) => (true, false),
+        None => (false, false),
+    };
+    Export {
+        class: export.class.as_ref().map(|s| intern.intern(s)),
+        method,
+        consumed,
+        is_constructor: export.is_constructor,
+        function: shared_function(&export.function, intern),
+        comments: export.comments.iter().map(|s| &**s).collect(),
+    }
+}
+
+fn shared_function<'a>(func: &'a ast::Function, _intern: &'a Interner) -> Function<'a> {
+    Function {
+        name: &func.name,
+    }
+}
+
+fn shared_enum<'a>(e: &'a ast::Enum, intern: &'a Interner) -> Enum<'a> {
+    Enum {
+        name: intern.intern(&e.name),
+        variants: e.variants.iter().map(|v| shared_variant(v, intern)).collect(),
+        comments: e.comments.iter().map(|s| &**s).collect(),
+    }
+}
+
+fn shared_variant<'a>(v: &'a ast::Variant, intern: &'a Interner) -> EnumVariant<'a> {
+    EnumVariant {
+        name: intern.intern(&v.name),
+        value: v.value,
+    }
+}
+
+fn shared_import<'a>(i: &'a ast::Import, intern: &'a Interner)
+    -> Result<Import<'a>, Diagnostic>
+{
+    Ok(Import {
+        module: i.module.as_ref().map(|s| &**s),
+        js_namespace: i.js_namespace.as_ref().map(|s| intern.intern(s)),
+        kind: shared_import_kind(&i.kind, intern)?,
+    })
+}
+
+fn shared_import_kind<'a>(i: &'a ast::ImportKind, intern: &'a Interner)
+    -> Result<ImportKind<'a>, Diagnostic>
+{
+    Ok(match i {
+        ast::ImportKind::Function(f) => ImportKind::Function(shared_import_function(f, intern)?),
+        ast::ImportKind::Static(f) => ImportKind::Static(shared_import_static(f, intern)),
+        ast::ImportKind::Type(f) => ImportKind::Type(shared_import_type(f, intern)),
+        ast::ImportKind::Enum(f) => ImportKind::Enum(shared_import_enum(f, intern)),
+    })
+}
+
+fn shared_import_function<'a>(i: &'a ast::ImportFunction, intern: &'a Interner)
+    -> Result<ImportFunction<'a>, Diagnostic>
+{
+    let method = match &i.kind {
+        ast::ImportFunctionKind::Method { class, kind, ..  } => {
+            let kind = match kind {
+                ast::MethodKind::Constructor => MethodKind::Constructor,
+                ast::MethodKind::Operation(ast::Operation { is_static, kind }) => {
+                    let is_static = *is_static;
+                    let kind = match kind {
+                        ast::OperationKind::Regular => OperationKind::Regular,
+                        ast::OperationKind::Getter(g) => {
+                            let g = g.as_ref().map(|g| intern.intern(g));
+                            OperationKind::Getter(
+                                g.unwrap_or_else(|| i.infer_getter_property()),
+                            )
+                        }
+                        ast::OperationKind::Setter(s) => {
+                            let s = s.as_ref().map(|s| intern.intern(s));
+                            OperationKind::Setter(match s {
+                                Some(s) => s,
+                                None => intern.intern_str(&i.infer_setter_property()?),
+                            })
+                        }
+                        ast::OperationKind::IndexingGetter => OperationKind::IndexingGetter,
+                        ast::OperationKind::IndexingSetter => OperationKind::IndexingSetter,
+                        ast::OperationKind::IndexingDeleter => OperationKind::IndexingDeleter,
+                    };
+                    MethodKind::Operation(Operation { is_static, kind })
+                }
+            };
+            Some(MethodData {
+                class,
+                kind,
+            })
+        }
+        ast::ImportFunctionKind::Normal => None,
+    };
+
+    Ok(ImportFunction {
+        shim: intern.intern(&i.shim),
+        catch: i.catch,
+        method,
+        structural: i.structural,
+        function: shared_function(&i.function, intern),
+        variadic: i.variadic,
+    })
+}
+
+fn shared_import_static<'a>(i: &'a ast::ImportStatic, intern: &'a Interner)
+    -> ImportStatic<'a>
+{
+    ImportStatic {
+        name: &i.js_name,
+        shim: intern.intern(&i.shim),
+    }
+}
+
+fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner)
+    -> ImportType<'a>
+{
+    ImportType {
+        name: &i.js_name,
+        instanceof_shim: &i.instanceof_shim,
+        vendor_prefixes: i.vendor_prefixes.iter()
+            .map(|x| intern.intern(x))
+            .collect(),
+    }
+}
+
+fn shared_import_enum<'a>(_i: &'a ast::ImportEnum, _intern: &'a Interner)
+    -> ImportEnum
+{
+    ImportEnum {}
+}
+
+fn shared_struct<'a>(s: &'a ast::Struct, intern: &'a Interner) -> Struct<'a> {
+    Struct {
+        name: intern.intern(&s.name),
+        fields: s.fields.iter().map(|s| shared_struct_field(s, intern)).collect(),
+        comments: s.comments.iter().map(|s| &**s).collect(),
+    }
+}
+
+fn shared_struct_field<'a>(s: &'a ast::StructField, intern: &'a Interner)
+    -> StructField<'a>
+{
+    StructField {
+        name: intern.intern(&s.name),
+        readonly: s.readonly,
+        comments: s.comments.iter().map(|s| &**s).collect(),
+    }
+}
+
+trait Encode {
+    fn encode(&self, dst: &mut Encoder);
+}
+
+struct Encoder {
+    dst: Vec<u8>,
+}
+
+impl Encoder {
+    fn new() -> Encoder {
+        Encoder {
+            dst: vec![0, 0, 0, 0],
+        }
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        let len = self.dst.len() - 4;
+        self.dst[0] = (len >> 0) as u8;
+        self.dst[1] = (len >> 8) as u8;
+        self.dst[2] = (len >> 16) as u8;
+        self.dst[3] = (len >> 24) as u8;
+        self.dst
+    }
+
+    fn byte(&mut self, byte: u8) {
+        self.dst.push(byte);
+    }
+}
+
+impl Encode for bool {
+    fn encode(&self, dst: &mut Encoder) {
+        dst.byte(*self as u8);
+    }
+}
+
+impl Encode for u32 {
+    fn encode(&self, dst: &mut Encoder) {
+        let mut val = *self;
+        while (val >> 7) != 0 {
+            dst.byte((val as u8) | 0x80);
+            val >>= 7;
+        }
+        assert_eq!(val >> 7, 0);
+        dst.byte(val as u8);
+    }
+}
+
+impl Encode for usize {
+    fn encode(&self, dst: &mut Encoder) {
+        assert!(*self <= u32::max_value() as usize);
+        (*self as u32).encode(dst);
+    }
+}
+
+impl<'a> Encode for &'a [u8] {
+    fn encode(&self, dst: &mut Encoder) {
+        self.len().encode(dst);
+        dst.dst.extend_from_slice(*self);
+    }
+}
+
+impl<'a> Encode for &'a str {
+    fn encode(&self, dst: &mut Encoder) {
+        self.as_bytes().encode(dst);
+    }
+}
+
+impl<T: Encode> Encode for Vec<T> {
+    fn encode(&self, dst: &mut Encoder) {
+        self.len().encode(dst);
+        for item in self {
+            item.encode(dst);
+        }
+    }
+}
+
+impl<T: Encode> Encode for Option<T> {
+    fn encode(&self, dst: &mut Encoder) {
+        match self {
+            None => dst.byte(0),
+            Some(val) => {
+                dst.byte(1);
+                val.encode(dst)
+            }
+        }
+    }
+}
+
+macro_rules! encode_struct {
+    ($name:ident ($($lt:tt)*) $($field:ident: $ty:ty,)*) => {
+        struct $name $($lt)* {
+            $($field: $ty,)*
+        }
+
+        impl $($lt)* Encode for $name $($lt)* {
+            fn encode(&self, _dst: &mut Encoder) {
+                $(self.$field.encode(_dst);)*
+            }
+        }
+    }
+}
+
+macro_rules! encode_enum {
+    ($name:ident ($($lt:tt)*) $($fields:tt)*) => (
+        enum $name $($lt)* { $($fields)* }
+
+        impl$($lt)* Encode for $name $($lt)* {
+            fn encode(&self, dst: &mut Encoder) {
+                use self::$name::*;
+                encode_enum!(@arms self dst (0) () $($fields)*)
+            }
+        }
+    );
+
+    (@arms $me:ident $dst:ident ($cnt:expr) ($($arms:tt)*)) => (
+        encode_enum!(@expr match $me { $($arms)* })
+    );
+
+    (@arms $me:ident $dst:ident ($cnt:expr) ($($arms:tt)*) $name:ident, $($rest:tt)*) => (
+        encode_enum!(
+            @arms
+            $me
+            $dst
+            ($cnt+1)
+            ($($arms)* $name => $dst.byte($cnt),)
+            $($rest)*
+        )
+    );
+
+    (@arms $me:ident $dst:ident ($cnt:expr) ($($arms:tt)*) $name:ident($t:ty), $($rest:tt)*) => (
+        encode_enum!(
+            @arms
+            $me
+            $dst
+            ($cnt+1)
+            ($($arms)* $name(val) => { $dst.byte($cnt); val.encode($dst) })
+            $($rest)*
+        )
+    );
+
+    (@expr $e:expr) => ($e);
+}
+
+macro_rules! encode_api {
+    () => ();
+    (struct $name:ident<'a> { $($fields:tt)* } $($rest:tt)*) => (
+        encode_struct!($name (<'a>) $($fields)*);
+        encode_api!($($rest)*);
+    );
+    (struct $name:ident { $($fields:tt)* } $($rest:tt)*) => (
+        encode_struct!($name () $($fields)*);
+        encode_api!($($rest)*);
+    );
+    (enum $name:ident<'a> { $($variants:tt)* } $($rest:tt)*) => (
+        encode_enum!($name (<'a>) $($variants)*);
+        encode_api!($($rest)*);
+    );
+    (enum $name:ident { $($variants:tt)* } $($rest:tt)*) => (
+        encode_enum!($name () $($variants)*);
+        encode_api!($($rest)*);
+    );
+}
+shared_api!(encode_api);

--- a/crates/backend/src/lib.rs
+++ b/crates/backend/src/lib.rs
@@ -6,15 +6,15 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-backend/0.2")]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 extern crate proc_macro2;
 #[macro_use]
 extern crate quote;
-extern crate serde_json;
 extern crate syn;
+#[macro_use]
+extern crate lazy_static;
 
+#[macro_use]
 extern crate wasm_bindgen_shared as shared;
 
 pub use codegen::TryToTokens;
@@ -25,5 +25,6 @@ mod error;
 
 pub mod ast;
 mod codegen;
+mod encode;
 pub mod defined;
 pub mod util;

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -14,8 +14,6 @@ Shared support for the wasm-bindgen-cli package, an internal dependency
 base64 = "0.9"
 failure = "0.1.2"
 parity-wasm = "0.34"
-serde = "1.0"
-serde_json = "1.0"
 tempfile = "3.0"
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.25' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.25' }

--- a/crates/cli-support/src/decode.rs
+++ b/crates/cli-support/src/decode.rs
@@ -1,0 +1,147 @@
+use std::str;
+
+pub trait Decode<'src>: Sized {
+    fn decode(data: &mut &'src [u8]) -> Self;
+
+    fn decode_all(mut data: &'src [u8]) -> Self {
+        let ret = Self::decode(&mut data);
+        assert!(data.len() == 0);
+        return ret
+    }
+}
+
+fn get<'a>(b: &mut &'a [u8]) -> u8 {
+    let r = b[0];
+    *b = &b[1..];
+    return r
+}
+
+impl<'src> Decode<'src> for bool {
+    fn decode(data: &mut &'src [u8]) -> Self {
+        get(data) != 0
+    }
+}
+
+impl<'src> Decode<'src> for u32 {
+    fn decode(data: &mut &'src [u8]) -> Self {
+        let mut cur = 0;
+        let mut offset = 0;
+        loop {
+            let byte = get(data);
+            cur |= ((byte & 0x7f) as u32) << offset;
+            if byte & 0x80 == 0 {
+                break cur
+            }
+            offset += 7;
+        }
+    }
+}
+
+impl<'src> Decode<'src> for &'src str {
+    fn decode(data: &mut &'src [u8]) -> &'src str {
+        let n = u32::decode(data);
+        let (a, b) = data.split_at(n as usize);
+        *data = b;
+        str::from_utf8(a).unwrap()
+    }
+}
+
+impl<'src, T: Decode<'src>> Decode<'src> for Vec<T> {
+    fn decode(data: &mut &'src [u8]) -> Self {
+        let n = u32::decode(data);
+        let mut v = Vec::with_capacity(n as usize);
+        for _ in 0..n {
+            v.push(Decode::decode(data));
+        }
+        v
+    }
+}
+
+impl<'src, T: Decode<'src>> Decode<'src> for Option<T> {
+    fn decode(data: &mut &'src [u8]) -> Self {
+        match get(data) {
+            0 => None,
+            1 => Some(Decode::decode(data)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+macro_rules! decode_struct {
+    ($name:ident ($($lt:tt)*) $($field:ident: $ty:ty,)*) => {
+        pub struct $name <$($lt)*> {
+            $(pub $field: $ty,)*
+        }
+
+        impl <'a> Decode<'a> for $name <$($lt)*> {
+            fn decode(_data: &mut &'a [u8]) -> Self {
+                $name {
+                    $($field: Decode::decode(_data),)*
+                }
+            }
+        }
+    }
+}
+
+macro_rules! decode_enum {
+    ($name:ident ($($lt:tt)*) $($fields:tt)*) => (
+        pub enum $name <$($lt)*> { $($fields)* }
+
+        impl <'a> Decode<'a> for $name <$($lt)*> {
+            fn decode(data: &mut &'a [u8]) -> Self {
+                use self::$name::*;
+                decode_enum!(@arms data dst (0) () $($fields)*)
+            }
+        }
+    );
+
+    (@arms $data:ident $dst:ident ($cnt:expr) ($($arms:tt)*)) => (
+        decode_enum!(@expr match get($data) { $($arms)* _ => unreachable!() })
+    );
+
+    (@arms $data:ident $dst:ident ($cnt:expr) ($($arms:tt)*) $name:ident, $($rest:tt)*) => (
+        decode_enum!(
+            @arms
+            $data
+            $dst
+            ($cnt+1)
+            ($($arms)* n if n == $cnt => $name, )
+            $($rest)*
+        )
+    );
+
+    (@arms $data:ident $dst:ident ($cnt:expr) ($($arms:tt)*) $name:ident($t:ty), $($rest:tt)*) => (
+        decode_enum!(
+            @arms
+            $data
+            $dst
+            ($cnt+1)
+            ($($arms)* n if n == $cnt => $name(Decode::decode($data)), )
+            $($rest)*
+        )
+    );
+
+    (@expr $e:expr) => ($e);
+}
+
+macro_rules! decode_api {
+    () => ();
+    (struct $name:ident<'a> { $($fields:tt)* } $($rest:tt)*) => (
+        decode_struct!($name ('a) $($fields)*);
+        decode_api!($($rest)*);
+    );
+    (struct $name:ident { $($fields:tt)* } $($rest:tt)*) => (
+        decode_struct!($name () $($fields)*);
+        decode_api!($($rest)*);
+    );
+    (enum $name:ident<'a> { $($variants:tt)* } $($rest:tt)*) => (
+        decode_enum!($name ('a) $($variants)*);
+        decode_api!($($rest)*);
+    );
+    (enum $name:ident { $($variants:tt)* } $($rest:tt)*) => (
+        decode_enum!($name () $($variants)*);
+        decode_api!($($rest)*);
+    );
+}
+
+shared_api!(decode_api);

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -15,7 +15,7 @@ spans = ["wasm-bindgen-backend/spans"]
 extra-traits = ["syn/extra-traits"]
 
 [dependencies]
-syn = { version = '0.15.0', features = ['full'] }
+syn = { version = '0.15.0', features = ['visit'] }
 quote = '0.6'
 proc-macro2 = "0.4.9"
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.25" }

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -10,7 +10,3 @@ description = """
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
 dependency.
 """
-
-[dependencies]
-serde_derive = "1"
-serde = "1"

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -1,139 +1,118 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-shared/0.2")]
 
-#[macro_use]
-extern crate serde_derive;
-
 // The schema is so unstable right now we just force it to change whenever this
 // package's version changes, which happens on all publishes.
 pub const SCHEMA_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-#[derive(Deserialize)]
-pub struct ProgramOnlySchema {
-    pub schema_version: String,
-    pub version: String,
+#[macro_export]
+macro_rules! shared_api {
+    ($mac:ident) => ($mac! {
+struct Program<'a> {
+    exports: Vec<Export<'a>>,
+    enums: Vec<Enum<'a>>,
+    imports: Vec<Import<'a>>,
+    structs: Vec<Struct<'a>>,
+    // version: &'a str,
+    // schema_version: &'a str,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct Program {
-    pub exports: Vec<Export>,
-    pub enums: Vec<Enum>,
-    pub imports: Vec<Import>,
-    pub structs: Vec<Struct>,
-    pub version: String,
-    pub schema_version: String,
+struct Import<'a> {
+    module: Option<&'a str>,
+    js_namespace: Option<&'a str>,
+    kind: ImportKind<'a>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct Import {
-    pub module: Option<String>,
-    pub js_namespace: Option<String>,
-    pub kind: ImportKind,
-}
-
-#[derive(Deserialize, Serialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
-pub enum ImportKind {
-    Function(ImportFunction),
-    Static(ImportStatic),
-    Type(ImportType),
+enum ImportKind<'a> {
+    Function(ImportFunction<'a>),
+    Static(ImportStatic<'a>),
+    Type(ImportType<'a>),
     Enum(ImportEnum),
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct ImportFunction {
-    pub shim: String,
-    pub catch: bool,
-    pub variadic: bool,
-    pub method: Option<MethodData>,
-    pub structural: bool,
-    pub function: Function,
+struct ImportFunction<'a> {
+    shim: &'a str,
+    catch: bool,
+    variadic: bool,
+    method: Option<MethodData<'a>>,
+    structural: bool,
+    function: Function<'a>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct MethodData {
-    pub class: String,
-    pub kind: MethodKind,
+struct MethodData<'a> {
+    class: &'a str,
+    kind: MethodKind<'a>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub enum MethodKind {
+enum MethodKind<'a> {
     Constructor,
-    Operation(Operation),
+    Operation(Operation<'a>),
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct Operation {
-    pub is_static: bool,
-    pub kind: OperationKind,
+struct Operation<'a> {
+    is_static: bool,
+    kind: OperationKind<'a>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub enum OperationKind {
+enum OperationKind<'a> {
     Regular,
-    Getter(String),
-    Setter(String),
+    Getter(&'a str),
+    Setter(&'a str),
     IndexingGetter,
     IndexingSetter,
     IndexingDeleter,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct ImportStatic {
-    pub name: String,
-    pub shim: String,
+struct ImportStatic<'a> {
+    name: &'a str,
+    shim: &'a str,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct ImportType {
-    pub name: String,
-    pub instanceof_shim: String,
-    pub vendor_prefixes: Vec<String>,
+struct ImportType<'a> {
+    name: &'a str,
+    instanceof_shim: &'a str,
+    vendor_prefixes: Vec<&'a str>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct ImportEnum {}
+struct ImportEnum {}
 
-#[derive(Deserialize, Serialize)]
-pub struct Export {
-    pub class: Option<String>,
-    pub method: bool,
-    pub consumed: bool,
-    pub is_constructor: bool,
-    pub function: Function,
-    pub comments: Vec<String>,
+struct Export<'a> {
+    class: Option<&'a str>,
+    method: bool,
+    consumed: bool,
+    is_constructor: bool,
+    function: Function<'a>,
+    comments: Vec<&'a str>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct Enum {
-    pub name: String,
-    pub variants: Vec<EnumVariant>,
-    pub comments: Vec<String>,
+struct Enum<'a> {
+    name: &'a str,
+    variants: Vec<EnumVariant<'a>>,
+    comments: Vec<&'a str>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct EnumVariant {
-    pub name: String,
-    pub value: u32,
+struct EnumVariant<'a> {
+    name: &'a str,
+    value: u32,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct Function {
-    pub name: String,
+struct Function<'a> {
+    name: &'a str,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct Struct {
-    pub name: String,
-    pub fields: Vec<StructField>,
-    pub comments: Vec<String>,
+struct Struct<'a> {
+    name: &'a str,
+    fields: Vec<StructField<'a>>,
+    comments: Vec<&'a str>,
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct StructField {
-    pub name: String,
-    pub readonly: bool,
-    pub comments: Vec<String>,
+struct StructField<'a> {
+    name: &'a str,
+    readonly: bool,
+    comments: Vec<&'a str>,
 }
+}) // end of mac case
+
+} // end of mac definition
 
 pub fn new_function(struct_name: &str) -> String {
     let mut name = format!("__wbg_");


### PR DESCRIPTION
This commit migrates away from using Serde for the custom section in
wasm executables. This is a refactoring of a purely-internal data
structure to `wasm-bindgen` and should have no visible functional change
on users.

The motivation for this commit is two fold:

* First, the compile times using `serde_json` and `serde_derive` for the
  syntax extension isn't the most fun.
* Second, eventually we're going to want to stablize the layout of the
  custom section, and it's highly unlikely to be json!

Primarily, though, the intention of this commit is to improve the
cold-cache compile time of `wasm-bindgen` by ensuring that for new users
this project builds as quickly as possible. By removing some heavyweight
dependencies from the procedural macro, `serde`, `serde_derive`, and
`serde_json`, we're able to get a pretty nice build time improvement for
the `wasm-bindgen` crate itself:

|             | single-core build | parallel build |
|-------------|-------------------|----------------|
| master      |             36.5s |          17.3s |
| this commit |             20.5s |          11.8s |

These are't really end-all-be-all wins but they're much better
especially on the spectrum of weaker CPUs (in theory modeled by the
single-core case showing we have 42% less CPU work in theory).