### PR TITLE
Add support for Response constructors

### DIFF
--- a/crates/web-sys/tests/wasm/response.rs
+++ b/crates/web-sys/tests/wasm/response.rs
@@ -1,4 +1,12 @@
+extern crate futures;
+extern crate js_sys;
+extern crate wasm_bindgen_futures;
+
+use futures::Future;
+use js_sys::{ArrayBuffer, DataView};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::Response;
 
@@ -8,9 +16,27 @@ extern "C" {
 }
 
 #[wasm_bindgen_test]
-fn test_response() {
+fn test_response_from_js() {
     let response = new_response();
     assert!(!response.ok());
     assert!(!response.redirected());
     assert_eq!(response.status(), 501);
+}
+
+#[wasm_bindgen_test(async)]
+fn test_response_from_bytes() -> impl Future<Item = (), Error = JsValue> {
+    let mut bytes: [u8; 3] = [1, 3, 5];
+    let response = Response::new_with_opt_u8_array(Some(&mut bytes)).unwrap();
+    assert!(response.ok());
+    assert_eq!(response.status(), 200);
+
+    let buf_promise = response.array_buffer().unwrap();
+    JsFuture::from(buf_promise).map(move |buf_val| {
+        assert!(buf_val.is_instance_of::<ArrayBuffer>());
+        let array_buf: ArrayBuffer = buf_val.dyn_into().unwrap();
+        let data_view = DataView::new(&array_buf, 0, bytes.len());
+        for (i, byte) in bytes.iter().enumerate() {
+            assert_eq!(&data_view.get_uint8(i), byte);
+        }
+    })
 }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -73,7 +73,9 @@ impl<'a> ToIdlType<'a> for UnionType<'a> {
     fn to_idl_type(&self, record: &FirstPassRecord<'a>) -> Option<IdlType<'a>> {
         let mut idl_types = Vec::with_capacity(self.body.list.len());
         for t in &self.body.list {
-            idl_types.push(t.to_idl_type(record)?);
+            if let Some(idl_type) = t.to_idl_type(record) {
+                idl_types.push(idl_type);
+            }
         }
         Some(IdlType::Union(idl_types))
     }


### PR DESCRIPTION
I noticed that none of the [Response](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Response.html) constructors seemed to exist. It seems like this is because the constructor in [Response.webidl](https://github.com/rustwasm/wasm-bindgen/blob/master/crates/web-sys/webidls/enabled/Response.webidl#L12) accepts multiple types, and one of those types is `ReadableStream` which isn't defined yet. That causes an `Unrecognized type: ReadableStream` warning and all constructors for Response are omitted even though the other argument types could be supported.

I'm curious what you think is the best way to handle this.  This PR changes the function that converts `UnionType` to `IdlType::Union` to include any supported types instead of returning `None` when there is at least one unsupported type, but I'm not sure if that's a good idea.

