### PR TITLE
Fix bindings for classes only referenced through struct fields

### DIFF
--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -132,3 +132,7 @@ exports.js_js_rename = () => {
     (new wasm.JsRename()).bar();
     wasm.classes_foo();
 };
+
+exports.js_access_fields = () => {
+    assert.ok((new wasm.AccessFieldFoo()).bar instanceof wasm.AccessFieldBar);
+};

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -20,6 +20,7 @@ extern "C" {
     fn js_readonly_fields();
     fn js_double_consume();
     fn js_js_rename();
+    fn js_access_fields();
 }
 
 #[wasm_bindgen_test]
@@ -351,3 +352,30 @@ impl JsRename {
 
 #[wasm_bindgen(js_name = classes_foo)]
 pub fn foo() {}
+
+
+#[wasm_bindgen]
+pub struct AccessFieldFoo {
+    pub bar: AccessFieldBar,
+}
+
+#[wasm_bindgen]
+#[derive(Copy, Clone)]
+pub struct AccessFieldBar {
+    value: u32,
+}
+
+#[wasm_bindgen]
+impl AccessFieldFoo {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> AccessFieldFoo {
+        AccessFieldFoo {
+            bar: AccessFieldBar { value: 2 },
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+fn access_fields() {
+    js_access_fields();
+}


### PR DESCRIPTION
The bindings generation for a class would accidentally omit the `__wrap`
function if it was only discovered very late in the process that
`__wrap` was needed, after we'd already passed the point where we needed
to have decided that.

This commit moves struct field generation of bindings much earlier in
the binding generation process which should ensure everything is all
hooked up by the time we generate the classes themselves.

Closes #949