### PR TITLE
Ensure that `JsValue` isn't considered `Send`

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1042,11 +1042,9 @@ impl ToTokens for ast::ImportStatic {
                 fn init() -> #ty {
                     panic!("cannot access imported statics on non-wasm targets")
                 }
-                static mut _VAL: ::wasm_bindgen::__rt::core::cell::UnsafeCell<Option<#ty>> =
-                    ::wasm_bindgen::__rt::core::cell::UnsafeCell::new(None);
+                thread_local!(static _VAL: #ty = init(););
                 ::wasm_bindgen::JsStatic {
-                    __inner: unsafe { &_VAL },
-                    __init: init,
+                    __inner: &_VAL,
                 }
             };
         }).to_tokens(into);

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -214,7 +214,7 @@ impl<T> Closure<T>
         };
 
         Closure {
-            js: ManuallyDrop::new(JsValue { idx }),
+            js: ManuallyDrop::new(JsValue::_new(idx)),
             data: ManuallyDrop::new(data),
         }
     }

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -337,7 +337,7 @@ impl FromWasmAbi for JsValue {
 
     #[inline]
     unsafe fn from_abi(js: u32, _extra: &mut Stack) -> JsValue {
-        JsValue { idx: js }
+        JsValue::_new(js)
     }
 }
 
@@ -356,7 +356,7 @@ impl RefFromWasmAbi for JsValue {
 
     #[inline]
     unsafe fn ref_from_abi(js: u32, _extra: &mut Stack) -> Self::Anchor {
-        ManuallyDrop::new(JsValue { idx: js })
+        ManuallyDrop::new(JsValue::_new(js))
     }
 }
 


### PR DESCRIPTION
The `JsValue` type wraps a slab/heap of js objects which is managed by
the wasm-bindgen shim, and everything here is not actually able to cross
any thread boundaries. When wasm actually has threads, for example, each
thread will have to have its own slab of objects generated by
wasm-bindgen, and indices in one slab aren't valid in any other slabs.

This is technically a breaking change because `JsValue` was previously
`Send` and `Sync`, but I'm hoping that in practice this isn't actually a
breaking change because nothing in wasm can be using threads which in
theory shouldn't activate the `Send` and/or `Sync` bounds.