### PR TITLE
js_sys: Add `#[derive(Clone, Debug)]` to `Promise`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4254,6 +4254,7 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
     #[wasm_bindgen(extends = Object)]
+    #[derive(Clone, Debug)]
     pub type Promise;
 
     /// Creates a new `Promise` with the provided executor `cb`


### PR DESCRIPTION
I think we just forgot this from earlier!