### PR TITLE
Fix generated shims if APIs don't exist

### DIFF
--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -104,3 +104,4 @@ exports.assert_dead_import_not_generated = function() {
 
 exports.import_inside_function_works = function() {};
 exports.import_inside_private_module = function() {};
+exports.should_call_undefined_functions = () => false;

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -50,6 +50,7 @@ extern "C" {
 
     fn unused_import();
     fn assert_dead_import_not_generated();
+    fn should_call_undefined_functions() -> bool;
 }
 
 #[wasm_bindgen]
@@ -203,4 +204,31 @@ mod private {
         }
         import_inside_private_module();
     }
+}
+
+#[wasm_bindgen]
+extern {
+    fn something_not_defined_in_the_environment();
+
+    type TypeThatIsNotDefined;
+    #[wasm_bindgen(constructor)]
+    fn new() -> TypeThatIsNotDefined;
+    #[wasm_bindgen(method)]
+    fn method(this: &TypeThatIsNotDefined);
+    #[wasm_bindgen(method, getter)]
+    fn property(this: &TypeThatIsNotDefined) -> u32;
+    #[wasm_bindgen(method, setter)]
+    fn set_property(this: &TypeThatIsNotDefined, val: u32);
+}
+
+#[wasm_bindgen_test]
+fn undefined_function_is_ok() {
+    if !should_call_undefined_functions() {
+        return
+    }
+    something_not_defined_in_the_environment();
+
+    let x = TypeThatIsNotDefined::new();
+    x.method();
+    x.set_property(x.property());
 }


### PR DESCRIPTION
This commit fixes instantiation of the wasm module even if some of the
improted APIs don't exist. This extends the functionality initially
added in #409 to attempt to gracefully allow importing values from the
environment which don't actually exist in all contexts. In addition to
nonexistent methods being handled now entire nonexistent types are now
also handled.

I suspect that eventually we'll add a CLI flag to `wasm-bindgen` to say
"I assert everything exists, don't check it" to trim out the extra JS
glue generated here. In the meantime though this'll pave the way for a
wasm-bindgen shim to be instantiated in both a web worker and the main
thread, while using DOM-like APIs only on the main thread.