### PR TITLE
Removed buffer copy from webgl example

### DIFF
--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -47,9 +47,10 @@ pub fn draw() {
 
     let vertices: [f32; 9] = [-0.7, -0.7, 0.0, 0.7, -0.7, 0.0, 0.0, 0.7, 0.0];
     let memory_buffer = wasm_bindgen::memory().dyn_into::<WebAssembly::Memory>().unwrap().buffer();
+    let verticles_location = vertices.as_ptr() as u32 / 4;
     let vert_array = js_sys::Float32Array::new(&memory_buffer).subarray(
-        &vertices as *const f32 as u32 / 4,
-        &vertices as *const f32 as u32 / 4 + vertices.len() as u32,
+        verticles_location,
+        verticles_location + vertices.len() as u32,
     );
 
     let buffer = context.create_buffer().unwrap();

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -47,10 +47,10 @@ pub fn draw() {
 
     let vertices: [f32; 9] = [-0.7, -0.7, 0.0, 0.7, -0.7, 0.0, 0.0, 0.7, 0.0];
     let memory_buffer = wasm_bindgen::memory().dyn_into::<WebAssembly::Memory>().unwrap().buffer();
-    let verticles_location = vertices.as_ptr() as u32 / 4;
+    let vertices_location = vertices.as_ptr() as u32 / 4;
     let vert_array = js_sys::Float32Array::new(&memory_buffer).subarray(
-        verticles_location,
-        verticles_location + vertices.len() as u32,
+        vertices_location,
+        vertices_location + vertices.len() as u32,
     );
 
     let buffer = context.create_buffer().unwrap();

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -5,12 +5,7 @@ extern crate web_sys;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{WebGlProgram, WebGlRenderingContext, WebGlShader};
-
-#[wasm_bindgen]
-extern {
-    #[wasm_bindgen(js_namespace = Reflect)]
-    fn get(obj: &JsValue, member: &str) -> JsValue;
-}
+use js_sys::{WebAssembly};
 
 #[wasm_bindgen]
 pub fn draw() {
@@ -51,7 +46,8 @@ pub fn draw() {
     context.use_program(Some(&program));
 
     let vertices: [f32; 9] = [-0.7, -0.7, 0.0, 0.7, -0.7, 0.0, 0.0, 0.7, 0.0];
-    let vert_array = js_sys::Float32Array::new(&get(&wasm_bindgen::memory(), "buffer")).subarray(
+    let memory_buffer = wasm_bindgen::memory().dyn_into::<WebAssembly::Memory>().unwrap().buffer();
+    let vert_array = js_sys::Float32Array::new(&memory_buffer).subarray(
         &vertices as *const f32 as u32 / 4,
         &vertices as *const f32 as u32 / 4 + vertices.len() as u32,
     );


### PR DESCRIPTION
Change webgl example to use a buffer wrapping instead of copying.

Please scrutinize as I'm both a Rust and wasm-bindgen newbie, and I couldn't get the example to compile locally on Windows (running "wasm-pack build" I got error: failed to read `\\?\C:\...\github\wasm-bindgen\crates/cli\Cargo.toml`) so I tested for errors by compiling it in a side-project instead against latest published versions.