### PR TITLE
Shrink binary size of distributed `wasm-bindgen`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,12 @@ matrix:
     - rust: nightly
       env: JOB=dist-linux TARGET=x86_64-unknown-linux-musl
       before_script: rustup target add $TARGET
-      script: cargo build --manifest-path crates/cli/Cargo.toml --release --target $TARGET --features vendored-openssl
+      script:
+        - cargo build --manifest-path crates/cli/Cargo.toml --release --target $TARGET --features vendored-openssl
+        # no need to ship debuginfo to users
+        - strip -g target/$TARGET/release/wasm-bindgen
+        - strip -g target/$TARGET/release/wasm-bindgen-test-runner
+        - strip -g target/$TARGET/release/wasm2es6js
       addons:
         apt:
           packages:

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -36,6 +36,10 @@ use failure::{Error, ResultExt};
 use parity_wasm::elements::{Deserialize, Module, Section};
 use wasm_bindgen_cli_support::Bindgen;
 
+// no need for jemalloc bloat in this binary (and we don't need speed)
+#[global_allocator]
+static ALLOC: std::alloc::System = std::alloc::System;
+
 mod headless;
 mod node;
 mod server;

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -13,6 +13,10 @@ use docopt::Docopt;
 use failure::Error;
 use wasm_bindgen_cli_support::Bindgen;
 
+// no need for jemalloc bloat in this binary (and we don't need speed)
+#[global_allocator]
+static ALLOC: std::alloc::System = std::alloc::System;
+
 const USAGE: &'static str = "
 Generating JS bindings for a wasm file
 

--- a/crates/cli/src/bin/wasm2es6js.rs
+++ b/crates/cli/src/bin/wasm2es6js.rs
@@ -11,6 +11,10 @@ use std::process;
 use docopt::Docopt;
 use failure::{Error, ResultExt};
 
+// no need for jemalloc bloat in this binary (and we don't need speed)
+#[global_allocator]
+static ALLOC: std::alloc::System = std::alloc::System;
+
 const USAGE: &'static str = "
 Converts a wasm file to an ES6 JS module
 


### PR DESCRIPTION
This shaves a little over 2MB off the download locally for Linux,
removing debuginfo (which no one's probably gonna use anyway) as well as
switching from jemalloc to the system allocator.