### PR TITLE
Eliminate duplicate types in the type section

### DIFF
--- a/crates/gc/Cargo.toml
+++ b/crates/gc/Cargo.toml
@@ -11,6 +11,6 @@ Support for removing unused items from a wasm executable
 """
 
 [dependencies]
-parity-wasm = "0.35"
+parity-wasm = "0.35.1"
 log = "0.4"
 rustc-demangle = "0.1.9"


### PR DESCRIPTION
This commit updates the `wasm-gc` pass of wasm-bindgen to eliminate
duplicate types in the type section, effectively enabling a gc of the
type section itself. The main purpose here is ensure that code generated
by `wasm-bindgen` itself doesn't have to go too far out of its way to
deduplicate at generation time, but rather it can rely on the gc pass to
clean up.

Note that this currently depends on paritytech/parity-wasm#231, but this
can be updated if that ends up not landing.