### PR TITLE
Try to speed up CI with sccache

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,10 @@ install:
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V
+  - appveyor-retry appveyor DownloadFile https://github.com/mozilla/sccache/releases/download/0.2.7/sccache-0.2.7-x86_64-pc-windows-msvc.tar.gz
+  - tar xzf sccache-0.2.7-x86_64-pc-windows-msvc.tar.gz
+  - set PATH=%PATH%;%CD%/sccache-0.2.7-x86_64-pc-windows-msvc
+  - set RUSTC_WRAPPER=sccache
 
 build: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,16 @@ INSTALL_AWS: &INSTALL_AWS
     export PATH=$HOME/.local/bin:$PATH
     mkdir -p ~/$TRAVIS_BUILD_NUMBER
 
+before_install:
+  - target=x86_64-unknown-linux-musl
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then target=x86_64-apple-darwin; fi
+  - curl -L https://github.com/mozilla/sccache/releases/download/0.2.7/sccache-0.2.7-$target.tar.gz | tar xzf -
+  - export PATH=$PATH:`pwd`/sccache-0.2.7-$target
+  - export RUSTC_WRAPPER=sccache
+
+after_script:
+  - sccache -s
+
 matrix:
   include:
     # Tests for wasm-bindgen itself pass


### PR DESCRIPTION
This configures sccache for Linux/OSX/Windows in an attempt to speed up
CI by reusing the results of previous builds, cached on the network with
`sccache`.