### PR TITLE
Flag a trivial `JsValue` constructor as `#[inline]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ impl JsValue {
         _marker: marker::PhantomData,
     };
 
+    #[inline]
     fn _new(idx: u32) -> JsValue {
         JsValue {
             idx,


### PR DESCRIPTION
No reason this shouldn't be inlined in optimized builds!