### PR TITLE
Add tests for the wasm-gc crate 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,6 +167,16 @@ matrix:
       script: cargo test -p ui-tests
       if: branch = master
 
+    # wasm-gc tests work alright
+    - name: "test wasm-bindgen-gc crate"
+      install:
+        - git clone https://github.com/WebAssembly/wabt
+        - mkdir -p wabt/build
+        - (cd wabt/wabt && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=sccache -DCMAKE_CXX_COMPILER_ARG1=c++ && cmake --build . -- -j4)
+        - export PATH=$PATH:`pwd`/wabt/build
+      script: cargo test -p wasm-bindgen-gc
+      if: branch = master
+
     # Dist linux binary
     - name: "dist: Linux (x86_64-unknown-linux-musl)"
       env: JOB=dist-linux TARGET=x86_64-unknown-linux-musl

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ matrix:
       install:
         - git clone https://github.com/WebAssembly/wabt
         - mkdir -p wabt/build
-        - (cd wabt/wabt && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=sccache -DCMAKE_CXX_COMPILER_ARG1=c++ && cmake --build . -- -j4)
+        - (cd wabt/build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=sccache -DCMAKE_CXX_COMPILER_ARG1=c++ -DBUILD_TESTS=OFF && cmake --build . -- -j4)
         - export PATH=$PATH:`pwd`/wabt/build
       script: cargo test -p wasm-bindgen-gc
       if: branch = master

--- a/crates/gc/Cargo.toml
+++ b/crates/gc/Cargo.toml
@@ -14,3 +14,14 @@ Support for removing unused items from a wasm executable
 parity-wasm = "0.35.1"
 log = "0.4"
 rustc-demangle = "0.1.9"
+
+[dev-dependencies]
+rayon = "1.0.2"
+tempfile = "3.0.4"
+
+[lib]
+doctest = false
+
+[[test]]
+name = 'all'
+harness = false

--- a/crates/gc/src/bitvec.rs
+++ b/crates/gc/src/bitvec.rs
@@ -29,6 +29,15 @@ impl BitSet {
         }
     }
 
+    pub fn remove(&mut self, i: &u32) {
+        let i = *i as usize;
+        let idx = i / BITS;
+        let bit = 1 << (i % BITS);
+        if let Some(slot) = self.bits.get_mut(idx) {
+            *slot &= !bit;
+        }
+    }
+
     pub fn contains(&self, i: &u32) -> bool {
         let i = *i as usize;
         let idx = i / BITS;

--- a/crates/gc/tests/all.rs
+++ b/crates/gc/tests/all.rs
@@ -1,0 +1,146 @@
+extern crate parity_wasm;
+extern crate rayon;
+extern crate tempfile;
+extern crate wasm_bindgen_gc;
+
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use rayon::prelude::*;
+use parity_wasm::elements::Module;
+use tempfile::NamedTempFile;
+
+struct Test {
+    input: PathBuf,
+}
+
+fn main() {
+    let mut tests = Vec::new();
+    find_tests(&mut tests, "tests/wat".as_ref());
+
+    run_tests(&tests);
+}
+
+fn find_tests(tests: &mut Vec<Test>, path: &Path) {
+    for entry in path.read_dir().unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if entry.file_type().unwrap().is_dir() {
+            find_tests(tests, &path);
+            continue
+        }
+
+        if path.extension().and_then(|s| s.to_str()) == Some("wat") {
+            tests.push(Test {
+                input: path,
+            });
+        }
+    }
+}
+
+fn run_tests(tests: &[Test]) {
+    println!("");
+
+    let results = tests.par_iter()
+        .map(|test| {
+            run_test(test).map_err(|e| (test, e.to_string()))
+        })
+        .collect::<Vec<_>>();
+
+    let mut bad = false;
+    for result in results {
+        let (test, err) = match result {
+            Ok(()) => continue,
+            Err(p) => p,
+        };
+        println!("fail: {} - {}", test.input.display(), err);
+        bad = true;
+    }
+    if bad {
+        std::process::exit(2);
+    }
+
+    println!("\nall good!");
+}
+
+fn run_test(test: &Test) -> Result<(), Box<Error>> {
+    println!("test {}", test.input.display());
+
+    let f = NamedTempFile::new()?;
+    let input = fs::read_to_string(&test.input)?;
+    let expected = extract_expected(&input);
+    let status = Command::new("wat2wasm")
+        .arg("--debug-names")
+        .arg(&test.input)
+        .arg("-o")
+        .arg(f.path())
+        .status()?;
+    if !status.success() {
+        return Err(io::Error::new(io::ErrorKind::Other, "failed to run wat2wasm").into())
+    }
+
+    let wasm = fs::read(f.path())?;
+    let mut module: Module = parity_wasm::deserialize_buffer(&wasm)?;
+    module = match module.parse_names() {
+        Ok(m) => m,
+        Err((_, m)) => m,
+    };
+    wasm_bindgen_gc::Config::new().run(&mut module);
+    let wasm = parity_wasm::serialize(module)?;
+    fs::write(f.path(), wasm)?;
+
+    let status = Command::new("wasm2wat")
+        .arg(&f.path())
+        .stderr(Stdio::inherit())
+        .output()?;
+    if !status.status.success() {
+        return Err(io::Error::new(io::ErrorKind::Other, "failed to run wasm2wat").into())
+    }
+    let actual = String::from_utf8(status.stdout)?;
+    let actual = actual.trim();
+
+    if env::var("BLESS_TESTS").is_ok() {
+        fs::write(&test.input, generate_blesssed(&input, &actual))?;
+    } else {
+        if actual != expected {
+            println!("{:?} {:?}", actual, expected);
+            return Err(io::Error::new(io::ErrorKind::Other,
+                                      "test failed").into())
+        }
+    }
+
+    Ok(())
+}
+
+fn extract_expected(input: &str) -> String {
+    input.lines()
+        .filter(|l| l.starts_with(";; "))
+        .skip_while(|l| !l.contains("STDOUT"))
+        .skip(1)
+        .take_while(|l| !l.contains("STDOUT"))
+        .map(|l| &l[3..])
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn generate_blesssed(input: &str, actual: &str) -> String {
+    let mut input = input.lines()
+        .filter(|l| !l.starts_with(";;"))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string();
+    input.push_str("\n\n");
+    input.push_str(";; STDOUT (update this section with `BLESS_TESTS=1` while running tests)\n");
+    for line in actual.lines() {
+        input.push_str(";; ");
+        input.push_str(line);
+        input.push_str("\n");
+    }
+    input.push_str(";; STDOUT\n");
+    return input
+}

--- a/crates/gc/tests/all.rs
+++ b/crates/gc/tests/all.rs
@@ -75,6 +75,7 @@ fn run_test(test: &Test) -> Result<(), Box<Error>> {
     let expected = extract_expected(&input);
     let status = Command::new("wat2wasm")
         .arg("--debug-names")
+        .arg("--enable-bulk-memory")
         .arg(&test.input)
         .arg("-o")
         .arg(f.path())
@@ -94,6 +95,7 @@ fn run_test(test: &Test) -> Result<(), Box<Error>> {
     fs::write(f.path(), wasm)?;
 
     let status = Command::new("wasm2wat")
+        .arg("--enable-bulk-memory")
         .arg(&f.path())
         .stderr(Stdio::inherit())
         .output()?;

--- a/crates/gc/tests/wat/dont-remove-func1.wat
+++ b/crates/gc/tests/wat/dont-remove-func1.wat
@@ -1,0 +1,11 @@
+(module
+  (func $foo)
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0))
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/dont-remove-func2.wat
+++ b/crates/gc/tests/wat/dont-remove-func2.wat
@@ -1,0 +1,16 @@
+(module
+  (func $foo
+    call $bar
+    )
+  (func $bar)
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     call $bar)
+;;   (func $bar (type 0))
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/import-and-type.wat
+++ b/crates/gc/tests/wat/import-and-type.wat
@@ -1,0 +1,21 @@
+(module
+  (import "" "" (func (param i32)))
+
+  (func $foo
+    i32.const 0
+    call 0
+    )
+
+  (start $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func (param i32)))
+;;   (type (;1;) (func))
+;;   (import "" "" (func (;0;) (type 0)))
+;;   (func $foo (type 1)
+;;     i32.const 0
+;;     call 0)
+;;   (start 1))
+;; STDOUT

--- a/crates/gc/tests/wat/import-memory.wat
+++ b/crates/gc/tests/wat/import-memory.wat
@@ -1,0 +1,8 @@
+(module
+  (import "" "a" (memory 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (import "" "a" (memory (;0;) 0)))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-data.wat
+++ b/crates/gc/tests/wat/keep-data.wat
@@ -1,0 +1,10 @@
+(module
+  (memory 0 1)
+  (data (i32.const 0) "foo")
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (memory (;0;) 0 1)
+;;   (data (;0;) (i32.const 0) "foo"))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-global.wat
+++ b/crates/gc/tests/wat/keep-global.wat
@@ -1,0 +1,11 @@
+(module
+  (global i32 (i32.const 0))
+
+  (export "foo" (global 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (global (;0;) i32 (i32.const 0))
+;;   (export "foo" (global 0)))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-memory.wat
+++ b/crates/gc/tests/wat/keep-memory.wat
@@ -1,0 +1,8 @@
+(module
+  (memory 0 17)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (memory (;0;) 0 17))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-passive-memory-segment.wat
+++ b/crates/gc/tests/wat/keep-passive-memory-segment.wat
@@ -1,0 +1,27 @@
+(module
+  (memory 0 10)
+
+  (func $foo
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.init 0
+  )
+
+  (data passive "wut")
+
+  (start $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     i32.const 0
+;;     i32.const 0
+;;     i32.const 0
+;;     memory.init 0)
+;;   (memory (;0;) 0 10)
+;;   (start 0)
+;;   (data (;0;) passive "wut"))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-passive-segment.wat
+++ b/crates/gc/tests/wat/keep-passive-segment.wat
@@ -1,0 +1,30 @@
+(module
+  (import "" "" (table 0 1 anyfunc))
+
+  (func $foo
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.init 0
+  )
+
+  (func $bar)
+
+  (elem passive $bar)
+
+  (start $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (import "" "" (table (;0;) 0 1 anyfunc))
+;;   (func $foo (type 0)
+;;     i32.const 0
+;;     i32.const 0
+;;     i32.const 0
+;;     table.init 0)
+;;   (func $bar (type 0))
+;;   (start 0)
+;;   (elem (;0;) passive $bar))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-set-global.wat
+++ b/crates/gc/tests/wat/keep-set-global.wat
@@ -1,0 +1,23 @@
+(module
+
+  (global (mut i32) (i32.const 0))
+
+  (start $foo)
+
+  (func $bar)
+  (func $foo
+    i32.const 1
+    set_global 0
+    )
+  (func $baz)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     i32.const 1
+;;     set_global 0)
+;;   (global (;0;) (mut i32) (i32.const 0))
+;;   (start 0))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-start.wat
+++ b/crates/gc/tests/wat/keep-start.wat
@@ -1,0 +1,14 @@
+(module
+  (start $foo)
+
+  (func $bar)
+  (func $foo)
+  (func $baz)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0))
+;;   (start 0))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-table.wat
+++ b/crates/gc/tests/wat/keep-table.wat
@@ -1,0 +1,10 @@
+(module
+  (table 0 17 anyfunc)
+  (export "foo" (table 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (table (;0;) 0 17 anyfunc)
+;;   (export "foo" (table 0)))
+;; STDOUT

--- a/crates/gc/tests/wat/keep-table2.wat
+++ b/crates/gc/tests/wat/keep-table2.wat
@@ -1,0 +1,17 @@
+(module
+  (table 0 17 anyfunc)
+  (func $foo
+    i32.const 0
+    call_indirect)
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     i32.const 0
+;;     call_indirect (type 0))
+;;   (table (;0;) 0 17 anyfunc)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/locals-compressed.wat
+++ b/crates/gc/tests/wat/locals-compressed.wat
@@ -1,0 +1,39 @@
+(module
+  (func $foo
+    (local i32 f32 i32 f64 i64 i32 f32 i64 i32 f32 f64)
+
+    get_local 0
+    get_local 1
+    get_local 2
+    get_local 3
+    get_local 4
+    get_local 5
+    get_local 6
+    get_local 7
+    get_local 8
+    get_local 9
+    get_local 10
+    unreachable
+    )
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     (local i32 i32 i32 i32 f32 f32 f32 f64 f64 i64 i64)
+;;     get_local 0
+;;     get_local 4
+;;     get_local 1
+;;     get_local 7
+;;     get_local 9
+;;     get_local 2
+;;     get_local 5
+;;     get_local 10
+;;     get_local 3
+;;     get_local 6
+;;     get_local 8
+;;     unreachable)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/preserve-local1.wat
+++ b/crates/gc/tests/wat/preserve-local1.wat
@@ -1,0 +1,16 @@
+(module
+  (func $foo (result i32)
+    (local i32)
+    get_local 0
+    )
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func (result i32)))
+;;   (func $foo (type 0) (result i32)
+;;     (local i32)
+;;     get_local 0)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/preserve-local2.wat
+++ b/crates/gc/tests/wat/preserve-local2.wat
@@ -1,0 +1,18 @@
+(module
+  (func $foo (param i32)
+    (local i32)
+    get_local 0
+    set_local 1
+    )
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func (param i32)))
+;;   (func $foo (type 0) (param i32)
+;;     (local i32)
+;;     get_local 0
+;;     set_local 1)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/preserve-local3.wat
+++ b/crates/gc/tests/wat/preserve-local3.wat
@@ -1,0 +1,18 @@
+(module
+  (func $foo (param i32) (result i32)
+    (local i32)
+    get_local 0
+    tee_local 1
+    )
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func (param i32) (result i32)))
+;;   (func $foo (type 0) (param i32) (result i32)
+;;     (local i32)
+;;     get_local 0
+;;     tee_local 1)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/remove-func.wat
+++ b/crates/gc/tests/wat/remove-func.wat
@@ -1,0 +1,7 @@
+(module
+  (func $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/remove-heap-base.wat
+++ b/crates/gc/tests/wat/remove-heap-base.wat
@@ -1,0 +1,9 @@
+(module
+  (global i32 (i32.const 0))
+
+  (export "__heap_base" (global 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/remove-import-function.wat
+++ b/crates/gc/tests/wat/remove-import-function.wat
@@ -1,0 +1,26 @@
+(module
+  (import "" "a" (func $i1))
+  (import "" "b" (func $i2))
+  (import "" "c" (func $i3))
+
+  (func $bar)
+
+  (func $foo
+    call $i1
+    call $i3)
+
+  (func $baz)
+
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (import "" "a" (func $i1 (type 0)))
+;;   (import "" "c" (func $i3 (type 0)))
+;;   (func $foo (type 0)
+;;     call $i1
+;;     call $i3)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/remove-import-global.wat
+++ b/crates/gc/tests/wat/remove-import-global.wat
@@ -1,0 +1,7 @@
+(module
+  (import "" "" (global i32))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/remove-import-globals.wat
+++ b/crates/gc/tests/wat/remove-import-globals.wat
@@ -1,0 +1,35 @@
+(module
+  (import "" "a" (global i32))
+  (import "" "b" (global i32))
+  (import "" "c" (global i32))
+
+  (global i32 (i32.const 1))
+  (global i32 (i32.const 2))
+
+  (func $foo
+    get_global 0
+    drop
+    get_global 2
+    drop
+    get_global 4
+    drop
+    )
+
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (import "" "a" (global (;0;) i32))
+;;   (import "" "c" (global (;1;) i32))
+;;   (func $foo (type 0)
+;;     get_global 0
+;;     drop
+;;     get_global 1
+;;     drop
+;;     get_global 2
+;;     drop)
+;;   (global (;2;) i32 (i32.const 2))
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/remove-import-table.wat
+++ b/crates/gc/tests/wat/remove-import-table.wat
@@ -1,0 +1,11 @@
+(module
+  (import "" "" (table 0 1 anyfunc))
+
+  (func $foo)
+
+  (elem (i32.const 1) $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/remove-local.wat
+++ b/crates/gc/tests/wat/remove-local.wat
@@ -1,0 +1,13 @@
+(module
+  (func $foo
+    (local i32)
+    )
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0))
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/remove-passive-memory-segment.wat
+++ b/crates/gc/tests/wat/remove-passive-memory-segment.wat
@@ -1,0 +1,18 @@
+(module
+  (memory 0 10)
+
+  (func $foo
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.init 0
+  )
+
+  (data passive "wut")
+
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (memory (;0;) 0 10))
+;; STDOUT

--- a/crates/gc/tests/wat/remove-table.wat
+++ b/crates/gc/tests/wat/remove-table.wat
@@ -1,0 +1,7 @@
+(module
+  (table 0 17 anyfunc)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/remove-unused-passive-segment.wat
+++ b/crates/gc/tests/wat/remove-unused-passive-segment.wat
@@ -1,0 +1,11 @@
+(module
+  (import "" "" (table 0 1 anyfunc))
+
+  (func $foo)
+
+  (elem passive $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/remove-unused-type.wat
+++ b/crates/gc/tests/wat/remove-unused-type.wat
@@ -1,0 +1,34 @@
+(module
+  (type (func))
+  (type (func (param i32)))
+  (type (func (param i32)))
+  (type (func (result i32)))
+
+  (func $f1 (type 0))
+  (func $f2 (type 1))
+  (func $f3 (type 2))
+  (func $f4 (type 3)
+    i32.const 0
+  )
+
+  (export "a" (func $f1))
+  (export "b" (func $f2))
+  (export "c" (func $f3))
+  (export "d" (func $f4))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (type (;1;) (func (param i32)))
+;;   (type (;2;) (func (result i32)))
+;;   (func $f1 (type 0))
+;;   (func $f2 (type 1) (param i32))
+;;   (func $f3 (type 1) (param i32))
+;;   (func $f4 (type 2) (result i32)
+;;     i32.const 0)
+;;   (export "a" (func $f1))
+;;   (export "b" (func $f2))
+;;   (export "c" (func $f3))
+;;   (export "d" (func $f4)))
+;; STDOUT

--- a/crates/gc/tests/wat/renumber-data-segment.wat
+++ b/crates/gc/tests/wat/renumber-data-segment.wat
@@ -1,0 +1,29 @@
+(module
+  (memory 0 10)
+
+  (func $foo
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.init 1
+  )
+
+  (data passive "wut")
+  (data passive "wut2")
+  (data passive "wut3")
+
+  (start $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     i32.const 0
+;;     i32.const 0
+;;     i32.const 0
+;;     memory.init 0)
+;;   (memory (;0;) 0 10)
+;;   (start 0)
+;;   (data (;0;) passive "wut2"))
+;; STDOUT

--- a/crates/gc/tests/wat/renumber-functions.wat
+++ b/crates/gc/tests/wat/renumber-functions.wat
@@ -1,0 +1,16 @@
+(module
+  (func
+    call 2)
+  (func)
+  (func)
+  (export "foo" (func 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func (;0;) (type 0)
+;;     call 1)
+;;   (func (;1;) (type 0))
+;;   (export "foo" (func 0)))
+;; STDOUT

--- a/crates/gc/tests/wat/renumber-globals.wat
+++ b/crates/gc/tests/wat/renumber-globals.wat
@@ -1,0 +1,16 @@
+(module
+  (global i32 (i32.const 0))
+  (global i32 (i32.const 0))
+  (func (result i32)
+    get_global 1)
+  (export "foo" (func 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func (result i32)))
+;;   (func (;0;) (type 0) (result i32)
+;;     get_global 0)
+;;   (global (;0;) i32 (i32.const 0))
+;;   (export "foo" (func 0)))
+;; STDOUT

--- a/crates/gc/tests/wat/renumber-locals.wat
+++ b/crates/gc/tests/wat/renumber-locals.wat
@@ -1,0 +1,16 @@
+(module
+  (func $foo (result i32)
+    (local i32 i32)
+    get_local 1
+    )
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func (result i32)))
+;;   (func $foo (type 0) (result i32)
+;;     (local i32)
+;;     get_local 0)
+;;   (export "foo" (func $foo)))
+;; STDOUT

--- a/crates/gc/tests/wat/renumber-passive-segment.wat
+++ b/crates/gc/tests/wat/renumber-passive-segment.wat
@@ -1,0 +1,32 @@
+(module
+  (import "" "" (table 0 1 anyfunc))
+
+  (func $foo
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.init 1
+  )
+
+  (func $bar)
+  (func $bar2)
+
+  (elem passive $bar)
+  (elem passive $bar2)
+
+  (start $foo)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (import "" "" (table (;0;) 0 1 anyfunc))
+;;   (func $foo (type 0)
+;;     i32.const 0
+;;     i32.const 0
+;;     i32.const 0
+;;     table.init 0)
+;;   (func $bar2 (type 0))
+;;   (start 0)
+;;   (elem (;0;) passive $bar2))
+;; STDOUT

--- a/crates/gc/tests/wat/renumber-types.wat
+++ b/crates/gc/tests/wat/renumber-types.wat
@@ -1,0 +1,13 @@
+(module
+  (type (func (result i32)))
+  (type (func))
+  (func (type 1))
+  (export "foo" (func 0))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func (;0;) (type 0))
+;;   (export "foo" (func 0)))
+;; STDOUT

--- a/crates/gc/tests/wat/smoke.wat
+++ b/crates/gc/tests/wat/smoke.wat
@@ -1,0 +1,5 @@
+(module)
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/table-elem.wat
+++ b/crates/gc/tests/wat/table-elem.wat
@@ -1,0 +1,15 @@
+(module
+  (func $foo
+    i32.const 0
+    call_indirect
+    )
+
+  (func $bar)
+
+  (table 0 10 anyfunc)
+  (elem (i32.const 0) $bar)
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module)
+;; STDOUT

--- a/crates/gc/tests/wat/table-elem2.wat
+++ b/crates/gc/tests/wat/table-elem2.wat
@@ -1,0 +1,25 @@
+(module
+  (func $foo
+    i32.const 0
+    call_indirect
+    )
+
+  (func $bar)
+
+  (table 0 10 anyfunc)
+  (elem (i32.const 0) $bar)
+
+  (export "foo" (func $foo))
+  )
+
+;; STDOUT (update this section with `BLESS_TESTS=1` while running tests)
+;; (module
+;;   (type (;0;) (func))
+;;   (func $foo (type 0)
+;;     i32.const 0
+;;     call_indirect (type 0))
+;;   (func $bar (type 0))
+;;   (table (;0;) 0 10 anyfunc)
+;;   (export "foo" (func $foo))
+;;   (elem (;0;) (i32.const 0) $bar))
+;; STDOUT


### PR DESCRIPTION
This commit adds a test harness and the beginnings of a test suite for
the crate that performs GC over a wasm module. This crate historically
has had zero tests because it was thought that it would no longer be
used once LLD landed with `--gc-sections`, but `wasm-bindgen` has come
to rely more and more on `wasm-gc` for various purposes.

The last release of `wasm-bindgen` was also released with a bug in the
recently refactored support in the `wasm-gc` crate, providing a perfect
time and motivation to start writing some tests!

All tests added here are `*.wat` files which contain the expected output
after the gc pass is executed. Tests are automatically updated with
`BLESS_TESTS=1` in the environment, which is the expected way to
generate the output for each test.