### PR TITLE
Remove compiler warnings in todo example

### DIFF
--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -13,6 +13,7 @@ askama = "0.7.2"
 js-sys = "0.3.5"
 wasm-bindgen = "0.2.28"
 askama = "0.7.2"
+console_error_panic_hook = "0.1"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/todomvc/src/controller.rs
+++ b/examples/todomvc/src/controller.rs
@@ -140,14 +140,11 @@ impl Controller {
     /// Set all items to complete or active.
     fn toggle_all(&mut self, completed: bool) {
         let mut vals = Vec::new();
-        self.store
-            .find(
-                ItemQuery::EmptyItemQuery,
-            ).map(|data| {
-                for item in data.iter() {
-                    vals.push(item.id.clone());
-                }
-            });
+        self.store.find(ItemQuery::EmptyItemQuery).map(|data| {
+            for item in data.iter() {
+                vals.push(item.id.clone());
+            }
+        });
         for id in vals.iter() {
             self.toggle_completed(id.to_string(), completed);
         }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -1,7 +1,6 @@
 //! # TODO MVC
 //!
 //! A [TODO MVC](https://todomvc.com/) implementation written using [web-sys](https://rustwasm.github.io/wasm-bindgen/web-sys/overview.html)
-#![warn(missing_docs)]
 
 extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
@@ -11,6 +10,7 @@ extern crate web_sys;
 use std::rc::Rc;
 
 extern crate askama;
+extern crate console_error_panic_hook;
 
 /// Controller of the program
 pub mod controller;
@@ -65,5 +65,6 @@ fn app(name: &str) {
 /// Entry point into the program from JavaScript
 #[wasm_bindgen]
 pub fn run() {
+    console_error_panic_hook::set_once();
     app("todos-wasmbindgen");
 }

--- a/examples/todomvc/src/store.rs
+++ b/examples/todomvc/src/store.rs
@@ -70,7 +70,8 @@ impl Store {
         if let Ok(storage_string) = JSON::stringify(&JsValue::from(array)) {
             let storage_string: String = storage_string.to_string().into();
             self.local_storage
-                .set_item(&self.name, storage_string.as_str());
+                .set_item(&self.name, storage_string.as_str())
+                .unwrap();
         }
     }
 
@@ -82,7 +83,12 @@ impl Store {
     ///	 // data will contain items whose completed properties are true
     /// ```
     pub fn find(&mut self, query: ItemQuery) -> Option<ItemListSlice> {
-        Some(self.data.iter().filter(|todo| query.matches(*todo)).collect())
+        Some(
+            self.data
+                .iter()
+                .filter(|todo| query.matches(*todo))
+                .collect(),
+        )
     }
 
     /// Update an item in the Store.
@@ -161,12 +167,10 @@ pub struct ItemList {
     list: Vec<Item>,
 }
 impl ItemList {
-    fn into_iter(self) -> std::vec::IntoIter<Item> {
-        self.list.into_iter()
-    }
     fn retain<F>(&mut self, f: F)
     where
-      F: FnMut(&Item) -> bool {
+        F: FnMut(&Item) -> bool,
+    {
         self.list.retain(f);
     }
     fn iter_mut(&mut self) -> std::slice::IterMut<Item> {

--- a/examples/todomvc/src/template.rs
+++ b/examples/todomvc/src/template.rs
@@ -1,5 +1,5 @@
-use store::{ItemList, ItemListTrait, Item};
 use askama::Template as AskamaTemplate;
+use store::{ItemList, ItemListTrait};
 
 #[derive(AskamaTemplate)]
 #[template(path = "row.html")]
@@ -8,7 +8,6 @@ struct RowTemplate<'a> {
     title: &'a str,
     completed: bool,
 }
-
 
 #[derive(AskamaTemplate)]
 #[template(path = "itemsLeft.html")]
@@ -46,9 +45,7 @@ impl Template {
     ///
     /// Returns the contents for an "items left" indicator
     pub fn item_counter(active_todos: usize) -> String {
-        let items_left = ItemsLeftTemplate {
-            active_todos
-        };
+        let items_left = ItemsLeftTemplate { active_todos };
         if let Ok(res) = items_left.render() {
             res
         } else {


### PR DESCRIPTION
- Simplify usage of elements into element.rs
- Fix a bug with focus not working on edit.

I'm currently ignoring Results from the DOM as for most cases I don't really think there is much recovery, perhaps they should behave like a panic?