### PR TITLE
Implement support for `js_class` on exported types

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -29,8 +29,10 @@ pub struct Program {
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 #[derive(Clone)]
 pub struct Export {
-    /// The javascript class name.
-    pub class: Option<Ident>,
+    /// The struct name, in Rust, this is attached to
+    pub rust_class: Option<Ident>,
+    /// The class name in JS this is attached to
+    pub js_class: Option<String>,
     /// The type of `self` (either `self`, `&self`, or `&mut self`)
     pub method_self: Option<MethodSelf>,
     /// Whether or not this export is flagged as a constructor, returning an
@@ -176,7 +178,8 @@ pub struct Function {
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 #[derive(Clone)]
 pub struct Struct {
-    pub name: Ident,
+    pub rust_name: Ident,
+    pub js_name: String,
     pub fields: Vec<StructField>,
     pub comments: Vec<String>,
 }
@@ -264,9 +267,9 @@ impl Export {
     /// name and class name, if the function belongs to a javascript class.
     pub(crate) fn rust_symbol(&self) -> Ident {
         let mut generated_name = String::from("__wasm_bindgen_generated");
-        if let Some(class) = &self.class {
+        if let Some(class) = &self.js_class {
             generated_name.push_str("_");
-            generated_name.push_str(&class.to_string());
+            generated_name.push_str(class);
         }
         generated_name.push_str("_");
         generated_name.push_str(&self.function.name.to_string());
@@ -278,8 +281,8 @@ impl Export {
     /// "high level" form before calling the actual function.
     pub(crate) fn export_name(&self) -> String {
         let fn_name = self.function.name.to_string();
-        match &self.class {
-            Some(class) => shared::struct_function_export_name(&class.to_string(), &fn_name),
+        match &self.js_class {
+            Some(class) => shared::struct_function_export_name(class, &fn_name),
             None => shared::free_function_export_name(&fn_name),
         }
     }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -118,8 +118,8 @@ impl TryToTokens for ast::Program {
 
 impl ToTokens for ast::Struct {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let name = &self.name;
-        let name_str = name.to_string();
+        let name = &self.rust_name;
+        let name_str = self.js_name.to_string();
         let name_len = name_str.len() as u32;
         let name_chars = name_str.chars().map(|c| c as u32);
         let new_fn = Ident::new(&shared::new_function(&name_str), Span::call_site());
@@ -328,7 +328,7 @@ impl TryToTokens for ast::Export {
         let name = &self.rust_name;
         let receiver = match self.method_self {
             Some(ast::MethodSelf::ByValue) => {
-                let class = self.class.as_ref().unwrap();
+                let class = self.rust_class.as_ref().unwrap();
                 arg_conversions.push(quote! {
                     let me = unsafe {
                         <#class as ::wasm_bindgen::convert::FromWasmAbi>::from_abi(
@@ -340,7 +340,7 @@ impl TryToTokens for ast::Export {
                 quote! { me.#name }
             }
             Some(ast::MethodSelf::RefMutable) => {
-                let class = self.class.as_ref().unwrap();
+                let class = self.rust_class.as_ref().unwrap();
                 arg_conversions.push(quote! {
                     let mut me = unsafe {
                         <#class as ::wasm_bindgen::convert::RefMutFromWasmAbi>
@@ -354,7 +354,7 @@ impl TryToTokens for ast::Export {
                 quote! { me.#name }
             }
             Some(ast::MethodSelf::RefShared) => {
-                let class = self.class.as_ref().unwrap();
+                let class = self.rust_class.as_ref().unwrap();
                 arg_conversions.push(quote! {
                     let me = unsafe {
                         <#class as ::wasm_bindgen::convert::RefFromWasmAbi>
@@ -367,7 +367,7 @@ impl TryToTokens for ast::Export {
                 });
                 quote! { me.#name }
             }
-            None => match &self.class {
+            None => match &self.rust_class {
                 Some(class) => quote! { #class::#name },
                 None => quote! { #name },
             },

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -58,7 +58,7 @@ fn shared_export<'a>(export: &'a ast::Export, intern: &'a Interner) -> Export<'a
         None => (false, false),
     };
     Export {
-        class: export.class.as_ref().map(|s| intern.intern(s)),
+        class: export.js_class.as_ref().map(|s| &**s),
         method,
         consumed,
         is_constructor: export.is_constructor,
@@ -187,7 +187,7 @@ fn shared_import_enum<'a>(_i: &'a ast::ImportEnum, _intern: &'a Interner)
 
 fn shared_struct<'a>(s: &'a ast::Struct, intern: &'a Interner) -> Struct<'a> {
     Struct {
-        name: intern.intern(&s.name),
+        name: &s.js_name,
         fields: s.fields.iter().map(|s| shared_struct_field(s, intern)).collect(),
         comments: s.comments.iter().map(|s| &**s).collect(),
     }

--- a/guide/src/reference/attributes/on-rust-exports/js_class.md
+++ b/guide/src/reference/attributes/on-rust-exports/js_class.md
@@ -1,0 +1,28 @@
+# `js_class = Blah`
+
+The `js_class` attribute is used to indicate that all the methods inside an
+`impl` block should be attached to the specified JS class instead of inferring
+it from the self type in the `impl` block. The `js_class` attribute is most
+frequently paired with [the `js_name` attribute](js_name.html) on structs:
+
+```rust
+#[wasm_bindgen(js_name = Foo)]
+pub struct JsFoo { /* ... */ }
+
+#[wasm_bindgen(js_class = Foo)]
+impl JsFoo {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> JsFoo { /* ... */ }
+
+    pub fn foo(&self) { /* ... */ }
+}
+```
+
+which is accessed like:
+
+```rust
+import { Foo } from './my_module';
+
+const x = new Foo();
+x.foo();
+```

--- a/guide/src/reference/attributes/on-rust-exports/js_name.md
+++ b/guide/src/reference/attributes/on-rust-exports/js_name.md
@@ -22,3 +22,33 @@ import { doTheThing } from './my_module';
 const x = doTheThing();
 console.log(x);
 ```
+
+Like imports, `js_name` can also be used to rename types exported to JS:
+
+```rust
+#[wasm_bindgen(js_name = Foo)]
+pub struct JsFoo {
+    // ..
+}
+```
+
+to be accessed like:
+
+```js
+import { Foo } from './my_module';
+
+// ...
+```
+
+Note that attaching methods to the JS class `Foo` should be done via the
+[`js_class` attribute](js_class.html):
+
+```rust
+#[wasm_bindgen(js_name = Foo)]
+pub struct JsFoo { /* ... */ }
+
+#[wasm_bindgen(js_class = Foo)]
+impl JsFoo {
+    // ...
+}
+```

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -136,3 +136,10 @@ exports.js_js_rename = () => {
 exports.js_access_fields = () => {
     assert.ok((new wasm.AccessFieldFoo()).bar instanceof wasm.AccessFieldBar);
 };
+
+exports.js_renamed_export = () => {
+    const x = new wasm.JsRenamedExport();
+    assert.ok(x.x === 3);
+    x.foo();
+    x.bar(x);
+};

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -21,6 +21,7 @@ extern "C" {
     fn js_double_consume();
     fn js_js_rename();
     fn js_access_fields();
+    fn js_renamed_export();
 }
 
 #[wasm_bindgen_test]
@@ -378,4 +379,30 @@ impl AccessFieldFoo {
 #[wasm_bindgen_test]
 fn access_fields() {
     js_access_fields();
+}
+
+#[wasm_bindgen(js_name = JsRenamedExport)]
+pub struct RenamedExport {
+    pub x: u32,
+}
+
+#[wasm_bindgen(js_class = JsRenamedExport)]
+impl RenamedExport {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> RenamedExport{
+        RenamedExport {
+            x: 3,
+        }
+    }
+    pub fn foo(&self) {
+    }
+
+    pub fn bar(&self, other: &RenamedExport) {
+        drop(other);
+    }
+}
+
+#[wasm_bindgen_test]
+fn renamed_export() {
+    js_renamed_export();
 }


### PR DESCRIPTION
Allow defining types which have different names in Rust than they have
in JS! (just like can be done with imported types)

Closes #1010