### PR TITLE
Make `to_idl_type` infallible

### DIFF
--- a/crates/web-sys/tests/wasm/response.rs
+++ b/crates/web-sys/tests/wasm/response.rs
@@ -1,4 +1,12 @@
+extern crate futures;
+extern crate js_sys;
+extern crate wasm_bindgen_futures;
+
+use futures::Future;
+use js_sys::{ArrayBuffer, DataView};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::Response;
 
@@ -8,9 +16,27 @@ extern "C" {
 }
 
 #[wasm_bindgen_test]
-fn test_response() {
+fn test_response_from_js() {
     let response = new_response();
     assert!(!response.ok());
     assert!(!response.redirected());
     assert_eq!(response.status(), 501);
+}
+
+#[wasm_bindgen_test(async)]
+fn test_response_from_bytes() -> impl Future<Item = (), Error = JsValue> {
+    let mut bytes: [u8; 3] = [1, 3, 5];
+    let response = Response::new_with_opt_u8_array(Some(&mut bytes)).unwrap();
+    assert!(response.ok());
+    assert_eq!(response.status(), 200);
+
+    let buf_promise = response.array_buffer().unwrap();
+    JsFuture::from(buf_promise).map(move |buf_val| {
+        assert!(buf_val.is_instance_of::<ArrayBuffer>());
+        let array_buf: ArrayBuffer = buf_val.dyn_into().unwrap();
+        let data_view = DataView::new(&array_buf, 0, bytes.len());
+        for (i, byte) in bytes.iter().enumerate() {
+            assert_eq!(&data_view.get_uint8(i), byte);
+        }
+    })
 }

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -353,7 +353,7 @@ impl<'src> FirstPassRecord<'src> {
         // use argument position now as we're just binding setters
         let ty = field
             .type_
-            .to_idl_type(self)?
+            .to_idl_type(self)
             .to_syn_type(TypePosition::Argument)?;
 
         // Slice types aren't supported because they don't implement
@@ -459,11 +459,7 @@ impl<'src> FirstPassRecord<'src> {
         self_name: &'src str,
         member: &'src weedle::interface::ConstMember<'src>,
     ) {
-        let idl_type = match member.const_type.to_idl_type(self) {
-            Some(idl_type) => idl_type,
-            None => return,
-        };
-
+        let idl_type = member.const_type.to_idl_type(self);
         let ty = match idl_type.to_syn_type(TypePosition::Return) {
             Some(ty) => ty,
             None => {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -336,7 +336,7 @@ impl<'src> FirstPassRecord<'src> {
     ) -> Option<backend::ast::ImportFunction> {
         let kind = backend::ast::OperationKind::Getter(Some(raw_ident(name)));
         let kind = self.import_function_kind(self_name, is_static, kind);
-        let ret = ty.to_idl_type(self)?;
+        let ret = ty.to_idl_type(self);
         self.create_one_function(
             &name,
             &snake_case_ident(name),
@@ -366,7 +366,7 @@ impl<'src> FirstPassRecord<'src> {
     ) -> Option<backend::ast::ImportFunction> {
         let kind = backend::ast::OperationKind::Setter(Some(raw_ident(name)));
         let kind = self.import_function_kind(self_name, is_static, kind);
-        let field_ty = field_ty.to_idl_type(self)?;
+        let field_ty = field_ty.to_idl_type(self);
         self.create_one_function(
             &name,
             &format!("set_{}", name).to_snake_case(),
@@ -431,10 +431,7 @@ impl<'src> FirstPassRecord<'src> {
                     );
                     signatures.push((signature, idl_args.clone()));
                 }
-                match arg.ty.to_idl_type(self) {
-                    Some(t) => idl_args.push(t),
-                    None => continue 'outer,
-                }
+                idl_args.push(arg.ty.to_idl_type(self));
             }
             signatures.push((signature, idl_args));
         }
@@ -517,10 +514,7 @@ impl<'src> FirstPassRecord<'src> {
             // TODO: overloads probably never change return types, so we should
             //       do this much earlier to avoid all the above work if
             //       possible.
-            let ret_ty = match signature.orig.ret.to_idl_type(self) {
-                Some(ty) => ty,
-                None => continue,
-            };
+            let ret_ty = signature.orig.ret.to_idl_type(self);
 
             let mut rust_name = snake_case_ident(name);
             let mut first = true;


### PR DESCRIPTION
This commit makes the `to_idl_type` infallible, returning a new enum
variant, `UnknownInterface`, in the one location that we still return
`None`. By making this infallible we can ensure that expansion of unions
which have unknown types still generate methods for all the variants
which we actually have all the methods for!