### PR TITLE
Don't use path dependencies in examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,3 +83,6 @@ members = [
 
 [patch.crates-io]
 wasm-bindgen = { path = '.' }
+wasm-bindgen-futures = { path = 'crates/futures' }
+js-sys = { path = 'crates/js-sys' }
+web-sys = { path = 'crates/web-sys' }

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "add"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-js-sys = { path = "../../crates/js-sys" }
-wasm-bindgen = { path = "../.." }
+js-sys = "0.3.4"
+wasm-bindgen = "0.2.27"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'CanvasRenderingContext2d',
   'Document',

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
 name = "char"
 version = "0.1.0"
-authors = ["Robert Masen <r@robertmasen.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-# Here we're using a path dependency to use what's already in this repository,
-# but you'd use the commented out version below if you're copying this into your
-# project.
-wasm-bindgen = { path = "../.." }
-#wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.27"

--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "closures"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
-js-sys = { path = "../../crates/js-sys" }
+wasm-bindgen = "0.2.27"
+js-sys = "0.3.4"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'CssStyleDeclaration',
   'Document',

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "console_log"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
-web-sys = { path = '../../crates/web-sys', features = ['console'] }
+wasm-bindgen = "0.2.27"
+web-sys = { version = "0.3.4", features = ['console'] }

--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -7,10 +7,10 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"
 
 [dependencies.web-sys]
-path = '../../crates/web-sys'
+version = "0.3.4"
 features = [
   'Document',
   'Element',

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -8,14 +8,14 @@ crate-type = ["cdylib"]
 
 [dependencies]
 futures = "0.1.20"
-wasm-bindgen = { path = "../..", features = ["serde-serialize"]  }
-js-sys = { path = "../../crates/js-sys" }
-wasm-bindgen-futures = { path = "../../crates/futures" }
+wasm-bindgen = { version = "0.2.27", features = ["serde-serialize"]  }
+js-sys = "0.3.4"
+wasm-bindgen-futures = "0.3.4"
 serde = "^1.0.59"
 serde_derive = "^1.0.59"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'Headers',
   'Request',

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "guide-supported-types-examples"
 version = "0.1.0"
-authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -7,8 +7,4 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-# Here we're using a path dependency to use what's already in this repository,
-# but you'd use the commented out version below if you're copying this into your
-# project.
-wasm-bindgen = { path = "../.." }
-#wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.27"

--- a/examples/import_js/Cargo.toml
+++ b/examples/import_js/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "import_js"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"

--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "julia_set"
 version = "0.1.0"
-authors = ["Marcin Baraniecki <marcinbar1@gmail.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"
 
 [dependencies.web-sys]
-path = '../../crates/web-sys'
+version = "0.3.4"
 features = [
   'ImageData',
   'CanvasRenderingContext2d',

--- a/examples/no_modules/Cargo.toml
+++ b/examples/no_modules/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "no_modules"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-js-sys = { path = "../../crates/js-sys" }
-wasm-bindgen = { path = "../.." }
+js-sys = "0.3.4"
+wasm-bindgen = "0.2.27"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'CanvasRenderingContext2d',
   'CssStyleDeclaration',

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -7,9 +7,9 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"
 humantime = "1"
 
 [dependencies.web-sys]
-path = '../../crates/web-sys'
+version = "0.3.4"
 features = ['Window', 'Performance', 'PerformanceTiming']

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -9,13 +9,13 @@ crate-type = ["cdylib"]
 [dependencies]
 console_error_panic_hook = "0.1"
 futures = "0.1"
-js-sys = { path = '../../crates/js-sys' }
+js-sys = "0.3.4"
 raytracer = { git = 'https://github.com/alexcrichton/raytracer', branch = 'update-deps' }
-wasm-bindgen = { path = "../..", features = ['serde-serialize'] }
-wasm-bindgen-futures = { path = '../../crates/futures' }
+wasm-bindgen = { version = "0.2.27", features = ['serde-serialize'] }
+wasm-bindgen-futures = "0.3.4"
 
 [dependencies.web-sys]
-path = '../../crates/web-sys'
+version = "0.3.4"
 features = [
   'CanvasRenderingContext2d',
   'ErrorEvent',

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -10,12 +10,12 @@ crate-type = ["cdylib"]
 askama = "0.7.2"
 
 [dependencies]
-js-sys = { path = "../../crates/js-sys" }
-wasm-bindgen = { path = "../../" }
+js-sys = "0.3.4"
+wasm-bindgen = "0.2.27"
 askama = "0.7.2"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'console',
   'CssStyleDeclaration',

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "wasm-in-wasm"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
-js-sys = { path = "../../crates/js-sys" }
+wasm-bindgen = "0.2.27"
+js-sys = "0.3.4"

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -1,14 +1,10 @@
 [package]
 name = "wasm2js"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+authors = ["The wasm-bindgen Developers"]
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-# Here we're using a path dependency to use what's already in this repository,
-# but you'd use the commented out version below if you're copying this into your
-# project.
-wasm-bindgen = { path = "../.." }
-#wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.27"

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -7,10 +7,10 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { path = "../.." }
+wasm-bindgen = "0.2.27"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'AudioContext',
   'AudioDestinationNode',

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -7,11 +7,11 @@ authors = ["The wasm-bindgen Developers"]
 crate-type = ["cdylib"]
 
 [dependencies]
-js-sys = { path = "../../crates/js-sys" }
-wasm-bindgen = { path = "../.." }
+js-sys = "0.3.4"
+wasm-bindgen = "0.2.27"
 
 [dependencies.web-sys]
-path = "../../crates/web-sys"
+version = "0.3.4"
 features = [
   'Document',
   'Element',

--- a/publish.rs
+++ b/publish.rs
@@ -57,13 +57,14 @@ fn main() {
     let mut crates = Vec::new();
     crates.push(read_crate("./Cargo.toml".as_ref()));
     find_crates("crates".as_ref(), &mut crates);
+    find_crates("examples".as_ref(), &mut crates);
 
     let pos = CRATES_TO_PUBLISH.iter()
         .chain(CRATES_TO_AVOID_PUBLISH)
         .enumerate()
         .map(|(i, c)| (*c, i))
         .collect::<HashMap<_, _>>();
-    crates.sort_by_key(|krate| pos[&krate.name[..]]);
+    crates.sort_by_key(|krate| pos.get(&krate.name[..]));
 
     match &env::args().nth(1).expect("must have one argument")[..] {
         "bump" => {
@@ -89,6 +90,8 @@ fn find_crates(dir: &Path, dst: &mut Vec<Crate>) {
             .chain(CRATES_TO_AVOID_PUBLISH)
             .any(|c| krate.name == *c)
         {
+            dst.push(krate);
+        } else if dir.iter().any(|s| s == "examples") {
             dst.push(krate);
         } else {
             panic!("failed to find {:?} in whitelist or blacklist", krate.name);


### PR DESCRIPTION
This commit updates all examples to not use `path` dependencies but
rather use versioned dependencies like would typically be found in the
wild. This should hopefully make the examples more copy-pastable and
less alien to onlookers!

The development of the examples remains the same where they continue to
use the `wasm-bindgen`, `js-sys`, `web-sys`, etc from in-tree. The
workspace-level `[patch]` section ensures that they use the in-tree
versions instead of the crates.io versions.