### PR TITLE
Fix reference to unexisting method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,8 +241,9 @@ impl JsValue {
     /// value into wasm linear memory, encoded as UTF-8, and returns it as a
     /// Rust `String`.
     ///
-    /// To avoid the copying and re-encoding, consider the `as_js_string()`
-    /// method instead.
+    /// To avoid the copying and re-encoding, consider the
+    /// `JsString::try_from()` function from [js-sys](https://docs.rs/js-sys)
+    /// instead.
     ///
     /// If this JS value is not an instance of a string or if it's not valid
     /// utf-8 then this returns `None`.


### PR DESCRIPTION
`as_js_string` was removed in 6eef5f7b52563198870a9eee04fd225085f1b07c. AFAIK there's no reliable way to doc to external crates in documentation so I can't link directly to `try_from`.