### PR TITLE
Add a flag to remove the wasm name section

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -35,6 +35,7 @@ pub struct Bindgen {
     typescript: bool,
     demangle: bool,
     keep_debug: bool,
+    remove_name_section: bool,
     // Experimental support for `WeakRefGroup`, an upcoming ECMAScript feature.
     // Currently only enable-able through an env var.
     weak_refs: bool,
@@ -62,6 +63,7 @@ impl Bindgen {
             typescript: false,
             demangle: true,
             keep_debug: false,
+            remove_name_section: false,
             weak_refs: env::var("WASM_BINDGEN_WEAKREF").is_ok(),
             threads: threads_config(),
         }
@@ -121,6 +123,11 @@ impl Bindgen {
 
     pub fn keep_debug(&mut self, keep_debug: bool) -> &mut Bindgen {
         self.keep_debug = keep_debug;
+        self
+    }
+
+    pub fn remove_name_section(&mut self, remove: bool) -> &mut Bindgen {
+        self.remove_name_section = remove;
         self
     }
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -37,6 +37,7 @@ Options:
     --debug                  Include otherwise-extraneous debug checks in output
     --no-demangle            Don't demangle Rust symbol names
     --keep-debug             Keep debug sections in wasm files
+    --remove-name-section    Remove the debugging `name` section of the file
     -V --version             Print the version number of wasm-bindgen
 ";
 
@@ -52,6 +53,7 @@ struct Args {
     flag_version: bool,
     flag_no_demangle: bool,
     flag_no_modules_global: Option<String>,
+    flag_remove_name_section: bool,
     flag_keep_debug: bool,
     arg_input: Option<PathBuf>,
 }
@@ -92,6 +94,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .debug(args.flag_debug)
         .demangle(!args.flag_no_demangle)
         .keep_debug(args.flag_keep_debug)
+        .remove_name_section(args.flag_remove_name_section)
         .typescript(typescript);
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name);


### PR DESCRIPTION
This commit adds a `--remove-name-section` flag to the `wasm-bindgen`
command which will remove the `name` section of the wasm file, used to
indicate the names of functions typically used in debugging. This flag
is off-by-default and will primarily be controlled by wasm-pack,
typically being passed by default with `wasm-pack build --release`.

Closes #1021