### PR TITLE
Fix `--no-modules` passing in `WebAssembly.Module`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -509,7 +509,10 @@ impl<'a> Context<'a> {
         let instantiation;
         const imports = {{ './{module}': __exports }};
         if (path_or_module instanceof WebAssembly.Module) {{
-            instantiation = WebAssembly.instantiate(path_or_module, imports);
+            instantiation = WebAssembly.instantiate(path_or_module, imports)
+                .then(instance => {{
+                    return {{ instance, module: module_or_path }}
+                }});
         }} else {{
             const data = fetch(path_or_module);
             if (typeof WebAssembly.instantiateStreaming === 'function') {{


### PR DESCRIPTION
This fixes a mistake in allowing a `WebAssembly.Module` to be passed to
the initialization function in `--no-modules` mode by ensuring that it
resolves to a map of an instance/module instead of just resolving to an
instance.