### PR TITLE
Don't worry about descriptive strings for malloc errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,7 +840,11 @@ pub mod __rt {
                 }
             }
 
-            super::throw_str("invalid malloc request");
+            if cfg!(debug_assertions) {
+                super::throw_str("invalid malloc request")
+            } else {
+                std::process::abort();
+            }
         }
 
         #[no_mangle]


### PR DESCRIPTION
This commit updates the `__wbindgen_malloc` shim to avoid throwing a
descriptive error in release mode. This is primarily done for two
reasons:

* If the function is gc'd out in release mode the `"invalid malloc
  request"` string is part of data and can't be gc'd automatically.

* In some esoteric JS environments `TextDecoder` isn't always available,
  and this relatively core function is very quick to bring in that
  requirement early on. For example some recent experimentation with
  WebAudio worklets shows that they currently don't have the
  `TextDecoder` type available!