### PR TITLE
Add an optimization to directly wire up imported functions

### DIFF
--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -6,7 +6,7 @@ use descriptor::{Descriptor, Function};
 /// Helper struct for manufacturing a shim in JS used to translate Rust types to
 /// JS, then invoking an imported JS function.
 pub struct Rust2Js<'a, 'b: 'a> {
-    cx: &'a mut Context<'b>,
+    pub cx: &'a mut Context<'b>,
 
     /// Arguments of the JS shim that we're generating, aka the variables passed
     /// from Rust which are only numbers.
@@ -497,6 +497,42 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             ),
         };
         Ok(())
+    }
+
+    /// Returns whether this shim won't actually do anything when called other
+    /// than forward the invocation somewhere else.
+    ///
+    /// This is used as an optimization to wire up imports directly where
+    /// possible and avoid a shim in some circumstances.
+    pub fn is_noop(&self) -> bool {
+        let Rust2Js {
+            // fields which may affect whether we do nontrivial work
+            catch,
+            finally,
+            js_arguments,
+            prelude,
+            ret_expr,
+            variadic,
+            shim_arguments,
+
+            // all other fields, listed explicitly here so if one is added we'll
+            // trigger a nonexhaustive error.
+            arg_idx: _,
+            cx: _,
+            global_idx: _,
+        } = self;
+
+        !catch &&
+            !variadic &&
+            prelude.is_empty() &&
+            finally.is_empty() &&
+            // make sure our faux return expression is "simple" by not
+            // performing any sort of transformation on the return value
+            (ret_expr == "JS;" || ret_expr == "return JS;") &&
+            // similarly we want to make sure that all the arguments are simply
+            // forwarded from the shim we would generate to the import,
+            // requiring no transformations
+            js_arguments == shim_arguments
     }
 
     pub fn finish(&self, invoc: &ImportTarget) -> Result<String, Error> {

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -194,6 +194,7 @@ impl Bindgen {
                 memory_init: None,
                 imported_functions: Default::default(),
                 imported_statics: Default::default(),
+                direct_imports: Default::default(),
             };
             for program in programs.iter() {
                 js::SubContext {

--- a/crates/webidl-tests/build.rs
+++ b/crates/webidl-tests/build.rs
@@ -30,13 +30,13 @@ fn main() {
 
                 #[wasm_bindgen(module = r"{}")]
                 extern {{
-                    fn not_actually_a_function{1}();
+                    fn not_actually_a_function{1}(x: &str);
                 }}
 
                 #[wasm_bindgen_test]
                 fn foo() {{
                     if ::std::env::var("NOT_GONNA_WORK").is_ok() {{
-                        not_actually_a_function{1}();
+                        not_actually_a_function{1}("foo");
                     }}
                 }}
             }}

--- a/tests/wasm/vendor_prefix.rs
+++ b/tests/wasm/vendor_prefix.rs
@@ -3,7 +3,7 @@ use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/vendor_prefix.js")]
 extern "C" {
-    fn import_me();
+    fn import_me(x: &str);
 }
 
 #[wasm_bindgen]
@@ -32,7 +32,7 @@ extern "C" {
 
 #[wasm_bindgen_test]
 pub fn polyfill_works() {
-    import_me();
+    import_me("foo");
 
     assert_eq!(MySpecialApi::new().foo(), 123);
     assert_eq!(MySpecialApi2::new().foo(), 124);


### PR DESCRIPTION
This commit adds an optimization to `wasm-bindgen` to directly import
and invoke other modules' functions from the wasm module, rather than
going through a shim in the imported bindings. This will be an important
optimization in the future for the host bindings proposal, but for now
it's largely just a proof-of-concept to show that we can do it and is
unlikely to bring about many performance benefits.

The implementation in this commit is largely refactoring to reorganize a
bit how functions are imported, but the implementation happens in
`generate_import_function`.

With this commit, 71/287 imports in the `tests/wasm/main.rs` suite get
hooked up directly to the ES modules, no shims needed!