### PR TITLE
Remove temporary object allocation

### DIFF
--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -155,7 +155,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 format!("{}({})", func, name)
             };
             self.prelude(&format!(
-                "const [ptr{i}, len{i}] = {val};",
+                "const ptr{i} = {val};\nconst len{i} = WASM_VECTOR_LEN;",
                 i = i,
                 val = val,
             ));

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -328,7 +328,8 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
             self.ret_expr = format!(
                 "\
                 {}
-                const [retptr, retlen] = {};
+                const retptr = {};
+                const retlen = WASM_VECTOR_LEN;
                 const mem = getUint32Memory();
                 mem[ret / 4] = retptr;
                 mem[ret / 4 + 1] = retlen;


### PR DESCRIPTION
When returning a ptr/length for allocations and such wasm-bindgen's
generated JS would previously return an array with two elements. It
turns out this doesn't optimize well in all engines! (See #1031). It
looks like we can optimize the array destructuring a bit more, but this
is all generated code which doesn't need to be too readable so we can
also remove the temporary allocation entirely and just pass the second
element of this array through a global instead of the return value.

Closes #1031