### PR TITLE
Fixed link to the correct crate

### DIFF
--- a/guide/src/web-sys/index.md
+++ b/guide/src/web-sys/index.md
@@ -13,11 +13,11 @@ It's sort of like the `libc` crate, but for the Web.
 
 It does *not* include the JavaScript APIs that are guaranteed to exist in all
 standards-compliant ECMAScript environments, such as `Array`, `Date`, and
-`eval`. Bindings for these APIs can be found in [the `js-sys` crate][js-sys].
+`eval`. Bindings for these APIs can be found in [the `web-sys` crate][web-sys].
 
 ## API Documentation
 
 [**Read the `web-sys` API documentation here!**][api]
 
 [api]: https://rustwasm.github.io/wasm-bindgen/api/web_sys/
-[js-sys]: https://crates.io/crates/js-sys
+[web-sys]: https://crates.io/crates/web-sys


### PR DESCRIPTION
Was originally linking to the wrong crate.