### PR TITLE
Revert js-sys link change, added web-sys link

### DIFF
--- a/guide/src/web-sys/index.md
+++ b/guide/src/web-sys/index.md
@@ -1,6 +1,6 @@
 # The `web-sys` Crate
 
-The `web-sys` crate provides raw `wasm-bindgen` imports for all of the Web's
+[The `web-sys` crate][web-sys] provides raw `wasm-bindgen` imports for all of the Web's
 APIs. This includes:
 
 * `window.fetch`
@@ -13,11 +13,12 @@ It's sort of like the `libc` crate, but for the Web.
 
 It does *not* include the JavaScript APIs that are guaranteed to exist in all
 standards-compliant ECMAScript environments, such as `Array`, `Date`, and
-`eval`. Bindings for these APIs can be found in [the `web-sys` crate][web-sys].
+`eval`. Bindings for these APIs can be found in [the `js-sys` crate][js-sys].
 
 ## API Documentation
 
 [**Read the `web-sys` API documentation here!**][api]
 
 [api]: https://rustwasm.github.io/wasm-bindgen/api/web_sys/
+[js-sys]: https://crates.io/crates/js-sys
 [web-sys]: https://crates.io/crates/web-sys


### PR DESCRIPTION
Correction to Pull Request #1035

limira is correct, that particular paragraph is referencing another crate. Considering the wasm-bindgen tutorial links here for the web-sys crate I added another link to the correct cargo link.

Sorry for the mistake.