### PR TITLE
Adds support for #[wasm_bindgen(typescript_custom_section)].

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -22,6 +22,8 @@ pub struct Program {
     /// objects" in the sense that they represent a JS object with a particular
     /// shape in JIT parlance.
     pub dictionaries: Vec<Dictionary>,
+    /// custom typescript sections to be included in the definition file
+    pub typescript_custom_sections: Vec<String>,
 }
 
 /// A rust to js interface. Allows interaction with rust objects/functions

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -46,6 +46,7 @@ fn shared_program<'a>(prog: &'a ast::Program, intern: &'a Interner)
         imports: prog.imports.iter()
             .map(|a| shared_import(a, intern))
             .collect::<Result<Vec<_>, _>>()?,
+        typescript_custom_sections: prog.typescript_custom_sections.iter().map(|x| -> &'a str { &x }).collect(),
         // version: shared::version(),
         // schema_version: shared::SCHEMA_VERSION.to_string(),
     })

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2143,6 +2143,10 @@ impl<'a, 'b> SubContext<'a, 'b> {
         for s in self.program.structs.iter() {
             self.generate_struct(s)?;
         }
+        for s in self.program.typescript_custom_sections.iter() {
+            self.cx.typescript.push_str(s);
+            self.cx.typescript.push_str("\n\n");
+        }
 
         Ok(())
     }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -12,6 +12,7 @@ struct Program<'a> {
     enums: Vec<Enum<'a>>,
     imports: Vec<Import<'a>>,
     structs: Vec<Struct<'a>>,
+    typescript_custom_sections: Vec<&'a str>,
     // version: &'a str,
     // schema_version: &'a str,
 }

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -76,6 +76,7 @@
       - [`constructor`](./reference/attributes/on-rust-exports/constructor.md)
       - [`js_name = Blah`](./reference/attributes/on-rust-exports/js_name.md)
       - [`readonly`](./reference/attributes/on-rust-exports/readonly.md)
+      - [`typescript_custom_section`](./reference/attributes/on-rust-exports/typescript_custom_section.md)
 
 --------------------------------------------------------------------------------
 

--- a/guide/src/reference/attributes/on-rust-exports/typescript_custom_section.md
+++ b/guide/src/reference/attributes/on-rust-exports/typescript_custom_section.md
@@ -1,0 +1,34 @@
+# `typescript_custom_section`
+
+When added to a `const` `&'static str`, it will append the contents of the
+string to the `.d.ts` file exported by `wasm-bindgen-cli` (when the
+`--typescript` flag is enabled).
+
+```rust
+#[wasm_bindgen(typescript_custom_section)]
+const TS_APPEND_CONTENT: &'static str = r#"
+
+export type Coords = { "latitude": number, "longitude": number, }; 
+
+"#;
+```
+
+The primary target for this feature is for code generation. For example, you
+can author a macro that allows you to export a TypeScript definition alongside
+the definition of a struct or Rust type.
+
+```rust
+#[derive(MyTypescriptExport)]
+struct Coords {
+    latitude: u32,
+    longitude: u32,
+}
+```
+
+The proc_derive_macro "MyTypescriptExport" can export its own
+`#[wasm_bindgen(typescript_custom_section)]` section, which would then be
+picked up by wasm-bindgen-cli. This would be equivalent to the contents of
+the TS_APPEND_CONTENT string in the first example.
+
+This feature allows plain data objects to be typechecked in Rust and in
+TypeScript by outputing a type definition generated at compile time.


### PR DESCRIPTION
## Implementation

This diff adds an attribute "typescript_custom_section", inspired by wasm_custom_section. It allows you to annotate a static const string as an addition to `wasm-bindgen`'s generated TypeScript definition files.

```rust
#[wasm_bindgen(typescript_custom_section)]
const TS_INTERFACE_EXPORT: &'static str = r"
  interface Square { color: string; width: number; }
";

// Errors
#[wasm_bindgen]
const TS_INTERFACE_EXPORT = r"interface Square { color: string; width: number; } ";
#[wasm_bindgen(typescript_custom_section)]
const TS_INTERFACE_EXPORT: &'static [u8] = [100, 101, 98, 117, 103, 103, 101, 114, 59]
#[wasm_bindgen(typescript_custom_section)]
struct Square { color: String, width: usize }
```

When wasm-bindgen-cli is invoked with the --typescript parameter, the contents of all typescript_custom_section strings encountered during compilation are appended to the output `.d.ts` file. This allows Rust to be the source of truth for type definitions in both WebAssembly and Typescript, or route around missing functionality in `wasm-bindgen`. Most importantly, it enables external tooling to directly generate their own Typescript types.

## Motivation

`wasm-bindgen` exports JavaScript classes and enums that mirror the structure of Rust structs and (C-style) enums. It also exports TypeScript definitions when the `--typescript` flag is used. For types defined in Rust that you want to share a JSON-type definition for, you may only need to export a TypeScript definition that models it.

For example, sum types can't be exported to TypeScript just using wasm_bindgen:

```rust
#[wasm_bindgen]
enum Versions {
  V1,
  V2(String),
  V3{  arg1: bool, arg2: String, },
}
```

There is no concrete type in JavaScript that corresponds to a tagged union. But if we treat this as plain old JSON-encodable data (as when serializing using serde), we can actually create a Typescript type definition that lives alongside it to express all possible values:

```typescript
#[wasm_bindgen(typescript_custom_section)]
const TS_VERSIONS_EXPORT: &'static str = r#"

export type Versions =
  | { "tag": "V1" }
  | { "tag": "V2", "fields": string }
  | { "tag": "V3", "fields": { "arg1": bool, "arg2": string } }
  ;

"#;
```

The primary benefit is ensuring that Rust is the source of truth for shared type definitions (where the alternative is writing your own Typescript definition that must stay in sync with your Rust definition.) But we can leverage even stronger type guarantees, where Typescript gives you semantics that are similar to Rust's tagged unions:

```typescript
// All matches on a tagged union must be exhausted in TypeScript
switch (version.tag) {
  case 'V1': return 1;
  case 'V2': return 2;
  // would be a typescript error, because you didn't define a 'V3' case
}
```

Knowing that subcrates might want to define additional Typescript information is the motivating factor for `typescript_custom_section`. Rather than integrate advanced Typescript generation entirely into `wasm-bindgen`, we can pull this logic wholly into external libraries.

An example of this is [wasm-typescript-definition, a `#[derive(TypescriptDefinition)]` macro](https://github.com/tcr/wasm-typescript-definition) I wrote to try out typescript_custom_section. This enables serde-`Serialize`able values to export an equivalent TypeScript definition:

```rust
#[derive(Serialize, Deserialize, TypescriptDefinition)]
#[serde(tag = "tag", content = "fields")]
enum Versions {
  #[serde(rename = "Version1")]
  V1,
  #[serde(rename = "Version2")]
  V2(String),
  #[serde(rename = "Version3")]
  V3{  arg1: bool, arg2: String, },
}
```

In this case, the `#[derive(TypescriptDefinition)]` attribute would generate its own additional `#[wasm_bindgen(typescript_custom_section)]` section, which would be rolled into your resulting definitions file. It's then able to be used to typecheck user code.

Because this crate is intentionally serde-aware, it can export a Typescript definition that matches the serde encoding exactly. You could deserialize Rust values in Typescript with full typechecking, then return them to Rust with the same guarantee, just by using a type annotation. Using `typescript_custom_section`, no serde-aware logic needs to be added into wasm-bindgen to make this work.