### PR TITLE
examples: add param to console_log build

### DIFF
--- a/examples/console_log/build.sh
+++ b/examples/console_log/build.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-cargo build --target wasm32-unknown-unknown
+cargo +nightly build --target wasm32-unknown-unknown
 cargo run --manifest-path ../../crates/cli/Cargo.toml \
   --bin wasm-bindgen -- \
   ../../target/wasm32-unknown-unknown/debug/console_log.wasm --out-dir .


### PR DESCRIPTION
This PR adds the `+nightly` param to the console_log `build.sh` file.

I don't know if this is a problem only in my PC, but when I tried to run without the `+nightly` param it didn't work.

Sorry if I'm making a PR in wrong format, but I really didn't find instructions about PRs.