### PR TITLE
Consistently use `extern "C"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use wasm_bindgen::prelude::*;
 
 // Import the `window.alert` function from the Web.
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn alert(s: &str);
 }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -184,7 +184,7 @@ impl ToTokens for ast::Struct {
                     );
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    extern {
+                    extern "C" {
                         fn #new_fn(ptr: u32) -> u32;
                     }
 
@@ -206,7 +206,7 @@ impl ToTokens for ast::Struct {
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             #[no_mangle]
             #[doc(hidden)]
-            pub unsafe extern fn #free_fn(ptr: u32) {
+            pub unsafe extern "C" fn #free_fn(ptr: u32) {
                 <#name as ::wasm_bindgen::convert::FromWasmAbi>::from_abi(
                     ptr,
                     &mut ::wasm_bindgen::convert::GlobalStack::new(),
@@ -260,7 +260,7 @@ impl ToTokens for ast::StructField {
             #[no_mangle]
             #[doc(hidden)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            pub unsafe extern fn #getter(js: u32)
+            pub unsafe extern "C" fn #getter(js: u32)
                 -> <#ty as ::wasm_bindgen::convert::IntoWasmAbi>::Abi
             {
                 use wasm_bindgen::__rt::{WasmRefCell, assert_not_null};
@@ -296,7 +296,7 @@ impl ToTokens for ast::StructField {
             #[no_mangle]
             #[doc(hidden)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            pub unsafe extern fn #setter(
+            pub unsafe extern "C" fn #setter(
                 js: u32,
                 val: <#ty as ::wasm_bindgen::convert::FromWasmAbi>::Abi,
             ) {
@@ -455,7 +455,7 @@ impl TryToTokens for ast::Export {
             #[export_name = #export_name]
             #[allow(non_snake_case)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            pub extern fn #generated_name(#(#args),*) #ret_ty {
+            pub extern "C" fn #generated_name(#(#args),*) #ret_ty {
                 // Scope all local variables to be destroyed after we call the
                 // function to ensure that `#convert_ret`, if it panics, doesn't
                 // leak anything.
@@ -634,7 +634,7 @@ impl ToTokens for ast::ImportType {
                     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
                     fn instanceof(val: &JsValue) -> bool {
                         #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                        extern {
+                        extern "C" {
                             fn #instanceof_shim(val: u32) -> u32;
                         }
                         unsafe {
@@ -927,7 +927,7 @@ impl TryToTokens for ast::ImportFunction {
             #[doc = #doc_comment]
             #vis fn #rust_name(#me #(#arguments),*) #ret {
                 #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                extern {
+                extern "C" {
                     fn #import_name(#(#abi_arguments),*) -> #abi_ret;
                 }
                 unsafe {
@@ -1056,7 +1056,7 @@ impl ToTokens for ast::ImportStatic {
                 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
                 fn init() -> #ty {
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    extern {
+                    extern "C" {
                         fn #shim_name() -> <#ty as ::wasm_bindgen::convert::FromWasmAbi>::Abi;
                     }
                     unsafe {
@@ -1321,7 +1321,7 @@ impl<'a, T: ToTokens> ToTokens for Descriptor<'a, T> {
             #[allow(non_snake_case)]
             #[doc(hidden)]
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            pub extern fn #name() {
+            pub extern "C" fn #name() {
                 use wasm_bindgen::describe::*;
                 // See definition of `link_mem_intrinsics` for what this is doing
                 ::wasm_bindgen::__rt::link_mem_intrinsics();

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -67,7 +67,7 @@ pub fn wasm_bindgen_test(
     tokens.extend(
         (quote! {
             #[no_mangle]
-            pub extern fn #name(cx: *const ::wasm_bindgen_test::__rt::Context) {
+            pub extern "C" fn #name(cx: *const ::wasm_bindgen_test::__rt::Context) {
                 unsafe {
                     let cx = &*cx;
                     let test_name = concat!(module_path!(), "::", stringify!(#ident));

--- a/crates/web-sys/tests/wasm/menu_element.rs
+++ b/crates/web-sys/tests/wasm/menu_element.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::HtmlMenuElement;
 
 #[wasm_bindgen(module = "./tests/wasm/element.js")]
-extern {
+extern "C" {
     fn new_menu() -> HtmlMenuElement;
 }
 

--- a/crates/web-sys/tests/wasm/menu_item_element.rs
+++ b/crates/web-sys/tests/wasm/menu_item_element.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::HtmlMenuItemElement;
 
 #[wasm_bindgen(module = "./tests/wasm/element.js")]
-extern {
+extern "C" {
     fn new_menuitem() -> HtmlMenuItemElement;
 }
 

--- a/crates/webidl-tests/build.rs
+++ b/crates/webidl-tests/build.rs
@@ -29,7 +29,7 @@ fn main() {
                 use wasm_bindgen_test::*;
 
                 #[wasm_bindgen(module = r"{}")]
-                extern {{
+                extern "C" {{
                     fn not_actually_a_function{1}(x: &str);
                 }}
 

--- a/guide/src/contributing/design/describe.md
+++ b/guide/src/contributing/design/describe.md
@@ -39,7 +39,7 @@ In addition to the shims we talked about above which JS generates the macro
 
 ```
 #[no_mangle]
-pub extern fn __wbindgen_describe_greet() {
+pub extern "C" fn __wbindgen_describe_greet() {
     <Fn(&str)>::describe();
 }
 ```

--- a/guide/src/contributing/design/exporting-rust-struct.md
+++ b/guide/src/contributing/design/exporting-rust-struct.md
@@ -95,13 +95,13 @@ let's take a look at that.
 // original input to `#[wasm_bindgen]` omitted ...
 
 #[export_name = "foo_new"]
-pub extern fn __wasm_bindgen_generated_Foo_new(arg0: i32) -> u32
+pub extern "C" fn __wasm_bindgen_generated_Foo_new(arg0: i32) -> u32
     let ret = Foo::new(arg0);
     Box::into_raw(Box::new(WasmRefCell::new(ret))) as u32
 }
 
 #[export_name = "foo_get"]
-pub extern fn __wasm_bindgen_generated_Foo_get(me: u32) -> i32 {
+pub extern "C" fn __wasm_bindgen_generated_Foo_get(me: u32) -> i32 {
     let me = me as *mut WasmRefCell<Foo>;
     wasm_bindgen::__rt::assert_not_null(me);
     let me = unsafe { &*me };
@@ -109,7 +109,7 @@ pub extern fn __wasm_bindgen_generated_Foo_get(me: u32) -> i32 {
 }
 
 #[export_name = "foo_set"]
-pub extern fn __wasm_bindgen_generated_Foo_set(me: u32, arg1: i32) {
+pub extern "C" fn __wasm_bindgen_generated_Foo_set(me: u32, arg1: i32) {
     let me = me as *mut WasmRefCell<Foo>;
     ::wasm_bindgen::__rt::assert_not_null(me);
     let me = unsafe { &*me };
@@ -117,7 +117,7 @@ pub extern fn __wasm_bindgen_generated_Foo_set(me: u32, arg1: i32) {
 }
 
 #[no_mangle]
-pub unsafe extern fn __wbindgen_foo_free(me: u32) {
+pub unsafe extern "C" fn __wbindgen_foo_free(me: u32) {
     let me = me as *mut WasmRefCell<Foo>;
     wasm_bindgen::__rt::assert_not_null(me);
     (*me).borrow_mut(); // ensure no active borrows

--- a/guide/src/contributing/design/exporting-rust.md
+++ b/guide/src/contributing/design/exporting-rust.md
@@ -87,12 +87,12 @@ at a mostly abbreviated and/or "simplified" in the sense of this is what it
 compiles down to:
 
 ```rust
-pub extern fn greet(a: &str) -> String {
+pub extern "C" fn greet(a: &str) -> String {
     format!("Hello, {}!", a)
 }
 
 #[export_name = "greet"]
-pub extern fn __wasm_bindgen_generated_greet(
+pub extern "C" fn __wasm_bindgen_generated_greet(
     arg0_ptr: *const u8,
     arg0_len: usize,
 ) -> *mut String {

--- a/guide/src/contributing/design/importing-js-struct.md
+++ b/guide/src/contributing/design/importing-js-struct.md
@@ -10,7 +10,7 @@ As usual though, let's dive into an example!
 
 ```rust
 #[wasm_bindgen(module = "./bar")]
-extern {
+extern "C" {
     type Bar;
 
     #[wasm_bindgen(constructor)]
@@ -125,7 +125,7 @@ pub struct Bar {
 
 impl Bar {
     fn new() -> Bar {
-        extern {
+        extern "C" {
             fn __wbg_s_Bar_new() -> u32;
         }
         unsafe {
@@ -135,7 +135,7 @@ impl Bar {
     }
 
     fn another_function() -> i32 {
-        extern {
+        extern "C" {
             fn __wbg_s_Bar_another_function() -> i32;
         }
         unsafe {
@@ -144,7 +144,7 @@ impl Bar {
     }
 
     fn get(&self) -> i32 {
-        extern {
+        extern "C" {
             fn __wbg_s_Bar_get(ptr: u32) -> i32;
         }
         unsafe {
@@ -155,7 +155,7 @@ impl Bar {
     }
 
     fn set(&self, val: i32) {
-        extern {
+        extern "C" {
             fn __wbg_s_Bar_set(ptr: u32, val: i32);
         }
         unsafe {
@@ -165,7 +165,7 @@ impl Bar {
     }
 
     fn property(&self) -> i32 {
-        extern {
+        extern "C" {
             fn __wbg_s_Bar_property(ptr: u32) -> i32;
         }
         unsafe {
@@ -176,7 +176,7 @@ impl Bar {
     }
 
     fn set_property(&self, val: i32) {
-        extern {
+        extern "C" {
             fn __wbg_s_Bar_set_property(ptr: u32, val: i32);
         }
         unsafe {

--- a/guide/src/contributing/design/importing-js.md
+++ b/guide/src/contributing/design/importing-js.md
@@ -9,7 +9,7 @@ greetings in JS but call it from Rust. We might have, for example:
 
 ```rust
 #[wasm_bindgen(module = "./greet")]
-extern {
+extern "C" {
     fn greet(a: &str) -> String;
 }
 
@@ -51,8 +51,8 @@ generated Rust as well. Like before this is simplified from what's actually
 generated.
 
 ```rust
-extern fn greet(a: &str) -> String {
-    extern {
+extern "C" fn greet(a: &str) -> String {
+    extern "C" {
         fn __wbg_f_greet(a_ptr: *const u8, a_len: usize, ret_len: *mut usize) -> *mut u8;
     }
     unsafe {

--- a/guide/src/contributing/design/js-objects-in-rust.md
+++ b/guide/src/contributing/design/js-objects-in-rust.md
@@ -86,7 +86,7 @@ pub fn foo(a: &JsValue) {
 }
 
 #[export_name = "foo"]
-pub extern fn __wasm_bindgen_generated_foo(arg0: u32) {
+pub extern "C" fn __wasm_bindgen_generated_foo(arg0: u32) {
     let arg0 = unsafe {
         ManuallyDrop::new(JsValue::__from_idx(arg0))
     };
@@ -189,7 +189,7 @@ pub fn foo(a: JsValue) {
 }
 
 #[export_name = "foo"]
-pub extern fn __wasm_bindgen_generated_foo(arg0: u32) {
+pub extern "C" fn __wasm_bindgen_generated_foo(arg0: u32) {
     let arg0 = unsafe {
         JsValue::__from_idx(arg0)
     };

--- a/guide/src/examples/import-js.md
+++ b/guide/src/examples/import-js.md
@@ -5,7 +5,7 @@
 [online]: https://rustwasm.github.io/wasm-bindgen/exbuild/import_js/
 [code]: https://github.com/rustwasm/wasm-bindgen/tree/master/examples/import_js
 
-The `#[wasm_bindgen]` attribute can be used on `extern { .. }` blocks to import
+The `#[wasm_bindgen]` attribute can be used on `extern "C" { .. }` blocks to import
 functionality from JS. This is how the `js-sys` and the `web-sys` crates are
 built, but you can also use it in your own crate!
 

--- a/guide/src/reference/attributes/on-js-imports/catch.md
+++ b/guide/src/reference/attributes/on-js-imports/catch.md
@@ -6,7 +6,7 @@ attached to any imported function or method, and the function must return a
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     // `catch` on a standalone function.
     #[wasm_bindgen(catch)]
     fn foo() -> Result<(), JsValue>;

--- a/guide/src/reference/attributes/on-js-imports/constructor.md
+++ b/guide/src/reference/attributes/on-js-imports/constructor.md
@@ -7,7 +7,7 @@ used in the generated glue:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Shoes;
 
     #[wasm_bindgen(constructor)]

--- a/guide/src/reference/attributes/on-js-imports/extends.md
+++ b/guide/src/reference/attributes/on-js-imports/extends.md
@@ -7,7 +7,7 @@ the inheritance hierarchy:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Foo;
 
     #[wasm_bindgen(extends = Foo)]
@@ -33,7 +33,7 @@ the types.
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Foo;
 
     #[wasm_bindgen(extends = Foo)]

--- a/guide/src/reference/attributes/on-js-imports/final.md
+++ b/guide/src/reference/attributes/on-js-imports/final.md
@@ -21,7 +21,7 @@ today:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Foo;
     #[wasm_bindgen(method)]
     fn bar(this: &Foo, argument: &str) -> JsValue;
@@ -47,7 +47,7 @@ If we instead, however, write this:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Foo;
     #[wasm_bindgen(method, final)] // note the change here
     fn bar(this: &Foo, argument: &str) -> JsValue;

--- a/guide/src/reference/attributes/on-js-imports/getter-and-setter.md
+++ b/guide/src/reference/attributes/on-js-imports/getter-and-setter.md
@@ -24,7 +24,7 @@ We would import this with the following `#[wasm_bindgen]` attributes:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type TheDude;
 
     #[wasm_bindgen(method, getter)]
@@ -48,7 +48,7 @@ example the below is equivalent to the above:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type TheDude;
 
     #[wasm_bindgen(method, getter = white_russians)]

--- a/guide/src/reference/attributes/on-js-imports/index.md
+++ b/guide/src/reference/attributes/on-js-imports/index.md
@@ -1,5 +1,5 @@
 # `#[wasm_bindgen]` on JavaScript Imports
 
 This section enumerates the attributes available for customizing bindings for
-JavaScript functions and classes imported into Rust within an `extern { ... }`
+JavaScript functions and classes imported into Rust within an `extern "C" { ... }`
 block.

--- a/guide/src/reference/attributes/on-js-imports/indexing-getter-setter-deleter.md
+++ b/guide/src/reference/attributes/on-js-imports/indexing-getter-setter-deleter.md
@@ -58,7 +58,7 @@ on methods:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Foo;
     static foo: Foo;
 

--- a/guide/src/reference/attributes/on-js-imports/js_class.md
+++ b/guide/src/reference/attributes/on-js-imports/js_class.md
@@ -6,7 +6,7 @@ Rust side.
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     // We don't want to import JS strings as `String`, since Rust already has a
     // `String` type in its prelude, so rename it as `JsString`.
     #[wasm_bindgen(js_name = String)]

--- a/guide/src/reference/attributes/on-js-imports/js_name.md
+++ b/guide/src/reference/attributes/on-js-imports/js_name.md
@@ -8,7 +8,7 @@ snake-cased Rust identifier:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_name = jsOftenUsesCamelCase)]
     fn js_often_uses_camel_case() -> u32;
 }
@@ -20,7 +20,7 @@ identifiers, in which case `js_name = "some string"` is used instead of `js_name
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_name = "$$$")]
     fn cash_money() -> u32;
 }
@@ -30,7 +30,7 @@ polymorphic JavaScript functions:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console, js_name = log)]
     fn console_log_str(s: &str);
 
@@ -50,7 +50,7 @@ Note that if you use `js_name` when importing a type you'll also need to use the
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_name = String)]
     type JsString;
     #[wasm_bindgen(method, getter, js_class = "String")]

--- a/guide/src/reference/attributes/on-js-imports/js_namespace.md
+++ b/guide/src/reference/attributes/on-js-imports/js_namespace.md
@@ -8,7 +8,7 @@ name (like a class or function name) it'll be accessed through this namespace.
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
 }

--- a/guide/src/reference/attributes/on-js-imports/method.md
+++ b/guide/src/reference/attributes/on-js-imports/method.md
@@ -6,7 +6,7 @@ which is a shared reference to an imported JavaScript type.
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Set;
 
     #[wasm_bindgen(method)]

--- a/guide/src/reference/attributes/on-js-imports/module.md
+++ b/guide/src/reference/attributes/on-js-imports/module.md
@@ -5,7 +5,7 @@ example,
 
 ```rust
 #[wasm_bindgen(module = "wu/tang/clan")]
-extern {
+extern "C" {
     type ThirtySixChambers;
 }
 ```
@@ -21,7 +21,7 @@ instead. For example,
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn illmatic() -> u32;
 }
 ```

--- a/guide/src/reference/attributes/on-js-imports/static_method_of.md
+++ b/guide/src/reference/attributes/on-js-imports/static_method_of.md
@@ -6,7 +6,7 @@ to JavaScript's `Date.now()` static method, one would use this attribute:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Date;
 
     #[wasm_bindgen(static_method_of = Date)]

--- a/guide/src/reference/attributes/on-js-imports/structural.md
+++ b/guide/src/reference/attributes/on-js-imports/structural.md
@@ -18,7 +18,7 @@ dynamically walked on every access.
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     type Duck;
 
     #[wasm_bindgen(method, structural)]

--- a/guide/src/reference/attributes/on-js-imports/variadic.md
+++ b/guide/src/reference/attributes/on-js-imports/variadic.md
@@ -28,7 +28,7 @@ function as variadic:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(variadic)]
     fn sum(args: &[i32]) -> i32;
 }

--- a/guide/src/reference/attributes/on-js-imports/vendor_prefix.md
+++ b/guide/src/reference/attributes/on-js-imports/vendor_prefix.md
@@ -9,7 +9,7 @@ For example to use `AudioContext` you might do:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(vendor_prefix = webkit)]
     type AudioContext;
 

--- a/guide/src/reference/no-esm.md
+++ b/guide/src/reference/no-esm.md
@@ -13,7 +13,7 @@ also [follow along in the repository][repo].
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn alert(msg: &str);
 }
 

--- a/guide/src/reference/passing-rust-closures-to-js.md
+++ b/guide/src/reference/passing-rust-closures-to-js.md
@@ -18,7 +18,7 @@ FnMut` trait objects:
 // Import JS functions that take closures
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn takes_immutable_closure(f: &Fn());
 
     fn takes_mutable_closure(f: &mut FnMut());
@@ -44,7 +44,7 @@ Closures also support arguments and return values like exports do, for example:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn takes_closure_that_takes_int_and_returns_string(x: &Fn(u32) -> String);
 }
 
@@ -80,7 +80,7 @@ as arguments and returns.
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn setInterval(closure: &Closure<FnMut()>, millis: u32) -> f64;
     fn cancelInterval(token: f64);
 

--- a/guide/src/reference/rust-targets.md
+++ b/guide/src/reference/rust-targets.md
@@ -32,7 +32,7 @@ will unconditionally panic on non-wasm targets. For example:
 
 ```rust
 #[wasm_bindgen]
-extern {
+extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
 }

--- a/guide/src/whirlwind-tour/basic-usage.md
+++ b/guide/src/whirlwind-tour/basic-usage.md
@@ -43,7 +43,7 @@ extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-extern {
+extern "C" {
     fn alert(s: &str);
 }
 

--- a/guide/src/whirlwind-tour/what-else-can-we-do.md
+++ b/guide/src/whirlwind-tour/what-else-can-we-do.md
@@ -55,7 +55,7 @@ pub struct Bar {
 }
 
 #[wasm_bindgen(module = "./index")] // what ES6 module to import from
-extern {
+extern "C" {
     fn bar_on_reset(to: &str, opaque: &JsValue);
 
     // We can import classes and annotate functionality on those classes as well

--- a/guide/src/whirlwind-tour/what-just-happened.md
+++ b/guide/src/whirlwind-tour/what-just-happened.md
@@ -15,7 +15,7 @@ the attribute also serializes some information to the output artifact which
 
 There's a more thorough explanation below of the various bits and pieces of the
 attribute, but it suffices for now to say that you can attach it to free
-functions, structs, impl blocks for those structs and `extern { ... }` blocks.
+functions, structs, impl blocks for those structs and `extern "C" { ... }` blocks.
 Some Rust features like generics, lifetime parameters, etc, aren't supported on
 functions tagged with `#[wasm_bindgen]` right now.
 

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -39,7 +39,7 @@ use throw_str;
 ///
 /// ```rust,no_run
 /// #[wasm_bindgen]
-/// extern {
+/// extern "C" {
 ///     fn setTimeout(closure: &Closure<FnMut()>, time: u32);
 ///
 ///     #[wasm_bindgen(js_namespace = console)]
@@ -188,7 +188,7 @@ impl<T> Closure<T>
         // See crates/cli-support/src/js/closures.rs for a more information
         // about what's going on here.
 
-        extern fn describe<T: WasmClosure + ?Sized>() {
+        extern "C" fn describe<T: WasmClosure + ?Sized>() {
             inform(CLOSURE);
             T::describe()
         }
@@ -328,7 +328,7 @@ macro_rules! doit {
             #[inline]
             fn invoke_fn() -> u32 {
                 #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                     $($var: <$var as FromWasmAbi>::Abi),*
@@ -355,7 +355,7 @@ macro_rules! doit {
 
             #[inline]
             fn destroy_fn() -> u32 {
-                unsafe extern fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                 ) {
@@ -379,7 +379,7 @@ macro_rules! doit {
             #[inline]
             fn invoke_fn() -> u32 {
                 #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                     $($var: <$var as FromWasmAbi>::Abi),*
@@ -407,7 +407,7 @@ macro_rules! doit {
 
             #[inline]
             fn destroy_fn() -> u32 {
-                unsafe extern fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                 ) {

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -13,7 +13,7 @@ macro_rules! stack_closures {
 
             fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                     $($var: <$var as FromWasmAbi>::Abi),*
@@ -50,7 +50,7 @@ macro_rules! stack_closures {
 
             fn into_abi(self, extra: &mut Stack) -> u32 {
                 #[allow(non_snake_case)]
-                unsafe extern fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn invoke<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                     $($var: <$var as FromWasmAbi>::Abi),*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,14 +447,14 @@ macro_rules! externs {
     ($(fn $name:ident($($args:tt)*) -> $ret:ty;)*) => (
         #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
         #[link(wasm_import_module = "__wbindgen_placeholder__")]
-        extern {
+        extern "C" {
             $(fn $name($($args)*) -> $ret;)*
         }
 
         $(
             #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
             #[allow(unused_variables)]
-            unsafe extern fn $name($($args)*) -> $ret {
+            unsafe extern "C" fn $name($($args)*) -> $ret {
                 panic!("function not implemented on non-wasm32 targets")
             }
         )*
@@ -554,7 +554,7 @@ impl Drop for JsValue {
 ///
 /// ```ignore
 /// #[wasm_bindgen]
-/// extern {
+/// extern "C" {
 ///     static console: JsValue;
 /// }
 /// ```
@@ -816,7 +816,7 @@ pub mod __rt {
         use std::mem;
 
         #[no_mangle]
-        pub extern fn __wbindgen_malloc(size: usize) -> *mut u8 {
+        pub extern "C" fn __wbindgen_malloc(size: usize) -> *mut u8 {
             let align = mem::align_of::<usize>();
             if let Ok(layout) = Layout::from_size_align(size, align) {
                 unsafe {
@@ -839,7 +839,7 @@ pub mod __rt {
         }
 
         #[no_mangle]
-        pub unsafe extern fn __wbindgen_free(ptr: *mut u8, size: usize) {
+        pub unsafe extern "C" fn __wbindgen_free(ptr: *mut u8, size: usize) {
             // This happens for zero-length slices, and in that case `ptr` is
             // likely bogus so don't actually send this to the system allocator
             if size == 0 {

--- a/tests/wasm/slice.rs
+++ b/tests/wasm/slice.rs
@@ -52,7 +52,7 @@ fn export() {
 macro_rules! import_macro {
     ($(($rust:ident, $js:ident, $i:ident))*) => ($(
         #[wasm_bindgen(module = "tests/wasm/slice.js")]
-        extern {
+        extern "C" {
             fn $js(a: &[$i]) -> Vec<$i>;
         }
 
@@ -113,7 +113,7 @@ macro_rules! import_mut_macro {
     ($(($rust:ident, $js:ident, $i:ident))*) => (
         $(
             #[wasm_bindgen(module = "tests/wasm/slice.js")]
-            extern {
+            extern "C" {
                 fn $js(a: &mut [$i]);
             }
 


### PR DESCRIPTION
This is what rustfmt favors, so let's favor it too!

Closes #1042