### PR TITLE
Assert all attributes are used by default 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ std = []
 serde-serialize = ["serde", "serde_json", "std"]
 nightly = []
 
+# Whether or not the `#[wasm_bindgen]` macro is strict and generates an error on
+# all unused attributes
+strict-macro = ["wasm-bindgen-macro/strict-macro"]
+
 # This is only for debugging wasm-bindgen! No stability guarantees, so enable
 # this at your own peril!
 xxx_debug_only_print_generated_code = ["wasm-bindgen-macro/xxx_debug_only_print_generated_code"]

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -5,7 +5,7 @@ use syn::parse::Error;
 #[macro_export]
 macro_rules! err_span {
     ($span:expr, $($msg:tt)*) => (
-        $crate::Diagnostic::span_error(&$span, format!($($msg)*))
+        $crate::Diagnostic::spanned_error(&$span, format!($($msg)*))
     )
 }
 
@@ -43,7 +43,16 @@ impl Diagnostic {
         }
     }
 
-    pub fn span_error<T: Into<String>>(node: &ToTokens, text: T) -> Diagnostic {
+    pub fn span_error<T: Into<String>>(span: Span, text: T) -> Diagnostic {
+        Diagnostic {
+            inner: Repr::Single {
+                text: text.into(),
+                span: Some((span, span)),
+            },
+        }
+    }
+
+    pub fn spanned_error<T: Into<String>>(node: &ToTokens, text: T) -> Diagnostic {
         Diagnostic {
             inner: Repr::Single {
                 text: text.into(),

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -13,6 +13,7 @@ The part of the implementation of the `#[wasm_bindgen]` attribute that is not in
 [features]
 spans = ["wasm-bindgen-backend/spans"]
 extra-traits = ["syn/extra-traits"]
+strict-macro = []
 
 [dependencies]
 syn = { version = '0.15.0', features = ['visit'] }

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -20,6 +20,7 @@ mod parser;
 
 /// Takes the parsed input from a `#[wasm_bindgen]` macro and returns the generated bindings
 pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diagnostic> {
+    parser::reset_attrs_used();
     let item = syn::parse2::<syn::Item>(input)?;
     let opts = syn::parse2(attr)?;
 
@@ -27,5 +28,11 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
     let mut program = backend::ast::Program::default();
     item.macro_parse(&mut program, (Some(opts), &mut tokens))?;
     program.try_to_tokens(&mut tokens)?;
+
+    // If we successfully got here then we should have used up all attributes
+    // and considered all of them to see if they were used. If one was forgotten
+    // that's a bug on our end, so sanity check here.
+    parser::assert_all_attrs_checked();
+
     Ok(tokens)
 }

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 [features]
 spans = ["wasm-bindgen-macro-support/spans"]
 xxx_debug_only_print_generated_code = []
+strict-macro = ["wasm-bindgen-macro-support/strict-macro"]
 
 [dependencies]
 wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.28" }

--- a/crates/macro/ui-tests/Cargo.toml
+++ b/crates/macro/ui-tests/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 harness = false
 
 [dependencies]
-wasm-bindgen = { path = "../../.." }
+wasm-bindgen = { path = "../../..", features = ["strict-macro"] }
 
 [dev-dependencies]
 compiletest_rs = "0.3"

--- a/crates/macro/ui-tests/unused-attributes.rs
+++ b/crates/macro/ui-tests/unused-attributes.rs
@@ -1,0 +1,11 @@
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+impl A {
+    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method)]
+    pub fn foo() {
+    }
+}

--- a/crates/macro/ui-tests/unused-attributes.stderr
+++ b/crates/macro/ui-tests/unused-attributes.stderr
@@ -1,0 +1,14 @@
+error: unused #[wasm_bindgen] attribute
+ --> $DIR/unused-attributes.rs:7:20
+  |
+7 |     #[wasm_bindgen(method)]
+  |                    ^^^^^^
+
+error: unused #[wasm_bindgen] attribute
+ --> $DIR/unused-attributes.rs:8:20
+  |
+8 |     #[wasm_bindgen(method)]
+  |                    ^^^^^^
+
+error: aborting due to 2 previous errors
+

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -32,7 +32,8 @@ extern "C" {
     fn switch_methods_a();
     fn switch_methods_b();
     type SwitchMethods;
-    #[wasm_bindgen(constructor, final)]
+    #[wasm_bindgen(constructor)]
+    #[wasm_bindgen(final)]
     fn new() -> SwitchMethods;
     #[wasm_bindgen(js_namespace = SwitchMethods, final)]
     fn a();

--- a/tests/wasm/validate_prt.rs
+++ b/tests/wasm/validate_prt.rs
@@ -13,7 +13,6 @@ pub struct Fruit {
 
 #[wasm_bindgen]
 impl Fruit {
-    #[wasm_bindgen(method)]
     pub fn name(&self) -> String {
         self.name.clone()
     }


### PR DESCRIPTION
This commit implements a system that will assert that all
`#[wasm_bindgen]` attributes are actually used during compilation. This
should help ensure that we don't sneak in stray attributes that don't
actually end up having any meaning, and hopefully make it a bit easier
to learn `#[wasm_bindgen]`!