### PR TITLE
Add a `#[wasm_bindgen(start)]` attribute

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -46,6 +46,9 @@ pub struct Export {
     pub comments: Vec<String>,
     /// The name of the rust function/method on the rust side.
     pub rust_name: Ident,
+    /// Whether or not this function should be flagged as the wasm start
+    /// function.
+    pub start: bool,
 }
 
 /// The 3 types variations of `self`.

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -82,6 +82,7 @@ fn shared_export<'a>(export: &'a ast::Export, intern: &'a Interner) -> Export<'a
         is_constructor: export.is_constructor,
         function: shared_function(&export.function, intern),
         comments: export.comments.iter().map(|s| &**s).collect(),
+        start: export.start,
     }
 }
 

--- a/crates/cli-support/src/wasm_utils.rs
+++ b/crates/cli-support/src/wasm_utils.rs
@@ -1,0 +1,104 @@
+use std::mem;
+
+use parity_wasm::elements::*;
+
+pub struct Remap<F>(pub F);
+
+impl<F> Remap<F> where F: FnMut(u32) -> u32 {
+    pub fn remap_module(&mut self, module: &mut Module) {
+        for section in module.sections_mut() {
+            match section {
+                Section::Export(e) => self.remap_export_section(e),
+                Section::Element(e) => self.remap_element_section(e),
+                Section::Code(e) => self.remap_code_section(e),
+                Section::Start(i) => {
+                    self.remap_idx(i);
+                }
+                Section::Name(n) => self.remap_name_section(n),
+                _ => {}
+            }
+        }
+    }
+
+    fn remap_export_section(&mut self, section: &mut ExportSection) {
+        for entry in section.entries_mut() {
+            self.remap_export_entry(entry);
+        }
+    }
+
+    fn remap_export_entry(&mut self, entry: &mut ExportEntry) {
+        match entry.internal_mut() {
+            Internal::Function(i) => {
+                self.remap_idx(i);
+            }
+            _ => {}
+        }
+    }
+
+    fn remap_element_section(&mut self, section: &mut ElementSection) {
+        for entry in section.entries_mut() {
+            self.remap_element_entry(entry);
+        }
+    }
+
+    fn remap_element_entry(&mut self, entry: &mut ElementSegment) {
+        for member in entry.members_mut() {
+            self.remap_idx(member);
+        }
+    }
+
+    fn remap_code_section(&mut self, section: &mut CodeSection) {
+        for body in section.bodies_mut() {
+            self.remap_func_body(body);
+        }
+    }
+
+    fn remap_func_body(&mut self, body: &mut FuncBody) {
+        self.remap_instructions(body.code_mut());
+    }
+
+    fn remap_instructions(&mut self, code: &mut Instructions) {
+        for instr in code.elements_mut() {
+            self.remap_instruction(instr);
+        }
+    }
+
+    fn remap_instruction(&mut self, instr: &mut Instruction) {
+        match instr {
+            Instruction::Call(i) => {
+                self.remap_idx(i);
+            }
+            _ => {}
+        }
+    }
+
+    fn remap_name_section(&mut self, names: &mut NameSection) {
+        match names {
+            NameSection::Function(f) => self.remap_function_name_section(f),
+            NameSection::Local(f) => self.remap_local_name_section(f),
+            _ => {}
+        }
+    }
+
+    fn remap_function_name_section(&mut self, names: &mut FunctionNameSection) {
+        let map = names.names_mut();
+        let new = IndexMap::with_capacity(map.len());
+        for (mut idx, name) in mem::replace(map, new) {
+            self.remap_idx(&mut idx);
+            map.insert(idx, name);
+        }
+    }
+
+    fn remap_local_name_section(&mut self, names: &mut LocalNameSection) {
+        let map = names.local_names_mut();
+        let new = IndexMap::with_capacity(map.len());
+        for (mut idx, name) in mem::replace(map, new) {
+            self.remap_idx(&mut idx);
+            map.insert(idx, name);
+        }
+    }
+
+    fn remap_idx(&mut self, idx: &mut u32) {
+        *idx = (self.0)(*idx);
+    }
+}

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -132,6 +132,7 @@ fn rmain() -> Result<(), Error> {
         .nodejs(node)
         .input_module(module, wasm)
         .keep_debug(false)
+        .emit_start(false)
         .generate(&tmpdir)
         .context("executing `wasm-bindgen` over the wasm file")?;
     shell.clear();

--- a/crates/macro/ui-tests/start-function.rs
+++ b/crates/macro/ui-tests/start-function.rs
@@ -1,0 +1,12 @@
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn foo() {}
+
+#[wasm_bindgen(start)]
+pub fn foo2(x: u32) {}
+
+#[wasm_bindgen(start)]
+pub fn foo3<T>() {}

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -1,0 +1,14 @@
+error: the start function cannot have arguments
+ --> $DIR/start-function.rs:9:13
+  |
+9 | pub fn foo2(x: u32) {}
+  |             ^^^^^^
+
+error: the start function cannot have generics
+  --> $DIR/start-function.rs:12:12
+   |
+12 | pub fn foo3<T>() {}
+   |            ^^^
+
+error: aborting due to 2 previous errors
+

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -84,6 +84,7 @@ macro_rules! shared_api {
             is_constructor: bool,
             function: Function<'a>,
             comments: Vec<&'a str>,
+            start: bool,
         }
 
         struct Enum<'a> {

--- a/examples/canvas/index.js
+++ b/examples/canvas/index.js
@@ -1,5 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example.
 import('./canvas')
-  .then(canvas => canvas.draw())
   .catch(console.error);

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -6,8 +6,8 @@ use std::f64;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-#[wasm_bindgen]
-pub fn draw() {
+#[wasm_bindgen(start)]
+pub fn start() {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();
     let canvas: web_sys::HtmlCanvasElement = canvas

--- a/examples/closures/index.js
+++ b/examples/closures/index.js
@@ -1,6 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./closures');
-rust
-  .then(m => m.run())
+import('./closures')
   .catch(console.error);

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -7,7 +7,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{Document, Element, HtmlElement, Window};
 
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn run() -> Result<(), JsValue> {
     let window = web_sys::window().expect("should have a window in this context");
     let document = window.document().expect("window should have a document");

--- a/examples/console_log/index.js
+++ b/examples/console_log/index.js
@@ -1,7 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./console_log');
-
-rust
-  .then(m => m.run())
+import('./console_log')
   .catch(console.error);

--- a/examples/console_log/src/lib.rs
+++ b/examples/console_log/src/lib.rs
@@ -3,7 +3,7 @@ extern crate web_sys;
 
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn run() {
     bare_bones();
     using_a_macro();

--- a/examples/dom/index.js
+++ b/examples/dom/index.js
@@ -1,6 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./dom');
-rust
-  .then(m => m.run())
+import('./dom')
   .catch(console.error);

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -4,7 +4,7 @@ extern crate web_sys;
 use wasm_bindgen::prelude::*;
 
 // Called by our JS entry point to run the example
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn run() -> Result<(), JsValue> {
     // Use `web_sys`'s global `window` function to get a handle on the global
     // window object.

--- a/examples/import_js/index.js
+++ b/examples/import_js/index.js
@@ -1,7 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./import_js');
-
-rust
-  .then(m => m.run())
+import('./import_js')
   .catch(console.error);

--- a/examples/import_js/src/lib.rs
+++ b/examples/import_js/src/lib.rs
@@ -26,7 +26,7 @@ extern "C" {
     fn log(s: &str);
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn run() {
     log(&format!("Hello, {}!", name()));
 

--- a/examples/no_modules/index.html
+++ b/examples/no_modules/index.html
@@ -27,7 +27,6 @@
           // initialization and return to us a promise when it's done
           // also, we can use 'await' on the returned promise
           await wasm_bindgen('./no_modules_bg.wasm');
-          wasm_bindgen.run();
       });
     </script>
   </body>

--- a/examples/no_modules/src/lib.rs
+++ b/examples/no_modules/src/lib.rs
@@ -4,8 +4,8 @@ extern crate web_sys;
 use wasm_bindgen::prelude::*;
 
 // Called by our JS entry point to run the example
-#[wasm_bindgen]
-pub fn run() -> Result<(), JsValue> {
+#[wasm_bindgen(start)]
+pub fn main() -> Result<(), JsValue> {
     // Use `web_sys`'s global `window` function to get a handle on the global
     // window object.
     let window = web_sys::window().expect("no global `window` exists");

--- a/examples/paint/index.js
+++ b/examples/paint/index.js
@@ -1,5 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example.
 import('./wasm_bindgen_paint')
-  .then(paint => paint.main())
   .catch(console.error);

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -7,8 +7,8 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
-#[wasm_bindgen]
-pub fn main() -> Result<(), JsValue> {
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document
         .create_element("canvas")?

--- a/examples/performance/index.js
+++ b/examples/performance/index.js
@@ -1,6 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./performance');
-rust
-  .then(m => m.run())
+import('./performance')
   .catch(console.error);

--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -17,8 +17,7 @@ macro_rules! console_log {
     ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
 }
 
-// Called by our JS entry point to run the example
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn run() {
     let window = web_sys::window().expect("should have a window in this context");
     let performance = window

--- a/examples/wasm-in-wasm/index.js
+++ b/examples/wasm-in-wasm/index.js
@@ -1,6 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./wasm_in_wasm');
-rust
-  .then(m => m.run())
+import('./wasm_in_wasm')
   .catch(console.error);

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -18,7 +18,7 @@ macro_rules! console_log {
 
 const WASM: &[u8] = include_bytes!("add.wasm");
 
-#[wasm_bindgen]
+#[wasm_bindgen(start)]
 pub fn run() -> Result<(), JsValue> {
     console_log!("instantiating a new wasm module directly");
     let my_memory = wasm_bindgen::memory()

--- a/examples/webgl/index.js
+++ b/examples/webgl/index.js
@@ -1,5 +1,4 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example.
 import('./webgl')
-  .then(webgl => webgl.draw())
   .catch(console.error);

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -7,8 +7,8 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{WebGlProgram, WebGlRenderingContext, WebGlShader};
 
-#[wasm_bindgen]
-pub fn draw() -> Result<(), JsValue> {
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();
     let canvas: web_sys::HtmlCanvasElement = canvas.dyn_into::<web_sys::HtmlCanvasElement>()?;

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -76,6 +76,7 @@
       - [`constructor`](./reference/attributes/on-rust-exports/constructor.md)
       - [`js_name = Blah`](./reference/attributes/on-rust-exports/js_name.md)
       - [`readonly`](./reference/attributes/on-rust-exports/readonly.md)
+      - [`start`](./reference/attributes/on-rust-exports/start.md)
       - [`typescript_custom_section`](./reference/attributes/on-rust-exports/typescript_custom_section.md)
 
 --------------------------------------------------------------------------------

--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -1,0 +1,31 @@
+# `start`
+
+When attached to a `pub` function this attribute will configure the `start`
+section of the wasm executable to be emitted, executing the tagged function as
+soon as the wasm module is instantiated.
+
+```rust
+#[wasm_bindgen(start)]
+pub fn main() {
+    // executed automatically ...
+}
+```
+
+The `start` section of the wasm executable will be configured to execute the
+`main` function here as soon as it can. Note that due to various practical
+limitations today the start section of the executable may not literally point to
+`main`, but the `main` function here should be started up automatically when the
+wasm module is loaded.
+
+There's a few caveats to be aware of when using the `start` attribute:
+
+* The `start` function must take no arguments and must either return `()` or
+  `Result<(), JsValue>`
+* Only one `start` function can be placed into a module, including its
+  dependencies. If more than one is specified then `wasm-bindgen` will fail when
+  the CLI is run. It's recommended that only applications use this attribute.
+* The `start` function will not be executed when testing.
+* If you're experimenting with WebAssembly threads, the `start` function is
+  executed *once per thread*, not once globally!
+* Note that the `start` function is relatively new, so if you find any bugs with
+  it, please feel free to report an issue!

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -10,6 +10,8 @@ extern crate wasm_bindgen_test_crate_b;
 #[macro_use]
 extern crate serde_derive;
 
+use wasm_bindgen::prelude::*;
+
 pub mod api;
 pub mod char;
 pub mod classes;
@@ -36,3 +38,9 @@ pub mod u64;
 pub mod validate_prt;
 pub mod variadic;
 pub mod vendor_prefix;
+
+// should not be executed
+#[wasm_bindgen(start)]
+pub fn start() {
+    panic!();
+}


### PR DESCRIPTION
This commit adds a new attribute to `#[wasm_bindgen]`: `start`. The
`start` attribute can be used to indicate that a function should be
executed when the module is loaded, configuring the `start` function of
the wasm executable. While this doesn't necessarily literally configure
the `start` section, it does its best!

Only one crate in a crate graph may indicate `#[wasm_bindgen(start)]`,
so it's not recommended to be used in libraries but only end-user
applications. Currently this still must be used with the `crate-type =
["cdylib"]` annotation in `Cargo.toml`.

The implementation here is somewhat tricky because of the circular
dependency between our generated JS and the wasm file that we emit. This
circular dependency makes running initialization routines (like the
`start` shim) particularly fraught with complications because one may
need to run before the other but bundlers may not necessarily respect
it. Workarounds have been implemented for various emission strategies,
for example calling the start function directly after exports are wired
up with `--no-modules` and otherwise working around what appears to be
a Webpack bug with initializers running in a different order than we'd
like. In any case, this in theory doesn't show up to the end user!

Closes #74