### PR TITLE
wasm2es6js: Fix handling of start function

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -68,8 +68,10 @@ pub fn spawn(
     let output = Config::new()
         .fetch(Some(format!("/{}", wasm_name)))
         .generate(&wasm)?;
-    let js = output.js()?;
+    let (js, wasm) = output.js_and_wasm()?;
+    let wasm = wasm.unwrap();
     fs::write(tmpdir.join(format!("{}_bg.js", module)), js).context("failed to write JS file")?;
+    fs::write(tmpdir.join(format!("{}_bg.wasm", module)), wasm).context("failed to write wasm file")?;
 
     // For now, always run forever on this port. We may update this later!
     let tmpdir = tmpdir.to_path_buf();


### PR DESCRIPTION
This is split out from #1002 and is intended to fix the tool's handling
of the `start` function. For the most accurate emulation of the wasm ESM
spec I believe we need to defer execution of the start function until
all our exports are wired up which should allow valid cyclical
references during instantiation.

The fix here is to remove the start function, if one is present, and
inject an invocation of it at the end of initialization (after our
exports are wired up). This fixes tests on #1002, but doesn't have any
direct analogue for tests here just yet.

Along the way because multiple files now come out of `wasm2es6js` by
default I've added an `--out-dir` argument as well as `-o` to ensure
that a folder for all outputs can be specified.