### PR TITLE
Remove an unused crate from wasm-bindgen-webidl

### DIFF
--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -13,7 +13,6 @@ Support for parsing WebIDL specific to wasm-bindgen
 
 [dependencies]
 failure = "0.1.2"
-failure_derive = "0.1.2"
 heck = "0.3"
 log = "0.4.1"
 proc-macro2 = "0.4.8"

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -11,8 +11,6 @@ emitted for the types and methods described in the WebIDL.
 
 #[macro_use]
 extern crate failure;
-#[macro_use]
-extern crate failure_derive;
 extern crate heck;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
Apparently this is no longer needed according to rustc!