### PR TITLE
Switch from heap/stack to just a heap

### DIFF
--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -392,7 +392,11 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
         if arg.is_ref_anyref() {
             self.js_arguments.push((name.clone(), "any".to_string()));
             self.cx.expose_borrowed_objects();
-            self.finally("stack.pop();");
+            self.cx.expose_global_stack_pointer();
+            // the "stack-ful" nature means that we're always popping from the
+            // stack, and make sure that we actually clear our reference to
+            // allow stale values to get GC'd
+            self.finally("heap[stack_pointer++] = undefined;");
             self.rust_arguments
                 .push(format!("addBorrowedObject({})", name));
             return Ok(self);


### PR DESCRIPTION
This commit switches strategies for storing `JsValue` from a heap/stack
to just one heap. This mirrors the new strategy for `JsValue` storage
in #1002 and should make multiplexing those strategies at
`wasm-bindgen`-time much easier.

Instead of having one array which acts as a stack for borrowed values
and one array for a heap of borrowed values, only one JS array is used
for storage of JS values now. This makes `getObject` far simpler by
simply being an array access, but it means that cloning an object now
reserves a new slot instead of reference counting it. If the old
reference counting behavior is needed it's thought that `Rc<JsValue>`
can be used in Rust.

The new "heap" has an initial stack pointer which grows downwards, and a
heap which grows upwards. The heap is a singly-linked-list which is
allocated/deallocated from. The stack grows downwards to zero and
presumably starts generating errors once it underflows. An initial stack
size of 32 is chosen as that should encompass all use cases today, but
we can eventually probably add configuration for this!

Note that the heap is initialized to all `null` for the stack and then
the initial JS values (`undefined`, `null`, `true`, `false`) are pushed
onto the heap in reserved locations.