### PR TITLE
Ensure our JS heap is a dense array

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -907,6 +907,7 @@ impl<'a> Context<'a> {
             return;
         }
         self.global(&format!("const heap = new Array({});", INITIAL_HEAP_OFFSET));
+        self.global("heap.fill(undefined);");
         self.global(&format!("heap.push({});", INITIAL_HEAP_VALUES.join(", ")));
     }
 


### PR DESCRIPTION
Turns out `heap.fill(undefined)` is required to ensure it's a dense
array, otherwise we'll accidentally be a sparse array and much slower
than necessary!