### PR TITLE
 Added out-name flag to the cli, offering an alternative over the crate name

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -25,6 +25,7 @@ pub mod wasm2es6js;
 
 pub struct Bindgen {
     path: Option<PathBuf>,
+    out_name: Option<String>,
     nodejs: bool,
     nodejs_experimental_modules: bool,
     browser: bool,
@@ -40,6 +41,7 @@ impl Bindgen {
     pub fn new() -> Bindgen {
         Bindgen {
             path: None,
+            out_name: None,
             nodejs: false,
             nodejs_experimental_modules: false,
             browser: false,
@@ -54,6 +56,11 @@ impl Bindgen {
 
     pub fn input_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Bindgen {
         self.path = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    pub fn out_name(&mut self, name: &str) -> &mut Bindgen {
+        self.out_name = Some(name.to_string());
         self
     }
 
@@ -111,7 +118,10 @@ impl Bindgen {
             Some(ref path) => path,
             None => bail!("must have a path input for now"),
         };
-        let stem = input.file_stem().unwrap().to_str().unwrap();
+        let stem = match &self.out_name {
+            Some(name) => name,
+            None => input.file_stem().unwrap().to_str().unwrap(),
+        };
         let mut contents = Vec::new();
         File::open(&input)
             .and_then(|mut f| f.read_to_end(&mut contents))

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -24,6 +24,7 @@ Usage:
 Options:
     -h --help                Show this screen.
     --out-dir DIR            Output directory
+    --out-name VAR               Name of output files (Default is the crate's name) 
     --nodejs                 Generate output that only works in node.js
     --browser                Generate output that only works in a browser
     --no-modules             Generate output that only works in a browser (without modules)
@@ -44,6 +45,7 @@ struct Args {
     flag_typescript: bool,
     flag_no_typescript: bool,
     flag_out_dir: Option<PathBuf>,
+    flag_out_name: Option<String>,
     flag_debug: bool,
     flag_version: bool,
     flag_no_demangle: bool,
@@ -91,6 +93,9 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .typescript(typescript);
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name);
+    }
+    if let Some(ref name) = args.flag_out_name {
+        b.out_name(name);
     }
 
     let out_dir = match args.flag_out_dir {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [What Else Can We Do?](./what-else-can-we-do.md)
 - [Closures](./closures.md)
 - [No ES Modules](./no-esm.md)
+- [Passing Arbitrary data](./passing-data.md)
 - [Feature Reference](./feature-reference.md)
 - [CLI Reference](./cli-reference.md)
 - [Type Reference](./reference.md)

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -1,12 +1,12 @@
 # Passing arbitrary data to JS
 
 It's possible to pass data from Rust to JS not explicitly supported
-in the [Feature Reference]: ./feature-reference by serializing vis [Serde]: https://github.com/serde-rs/serde
+in the [Feature Reference](./feature-reference.md) by serializing vis [Serde] (https://github.com/serde-rs/serde).
 
-Wasm_bindgen includes the JsValue type, which handles serializing and
-deserializing smoothly.
+Wasm_bindgen includes the JsValue type, which streamlines serializing and deserializing.
+This page describes how to use it.
 
-In order to make this work, you must include the serde and serde_derive
+In order accomplish this, we must include the serde and serde_derive
 crates in Cargo.toml, and configure wasm_bindgen to work with this feature:
 
 Cargo.toml
@@ -20,14 +20,14 @@ version = "^0.2"
 features = ["serde-serialize"]
 ```
 
-In our top-level Rust file (eg lib.rs or main.rs), we must enable the Serialize
+In our top-level Rust file (eg lib.rs or main.rs), weenable the Serialize
 macro: 
 ```rust
 #[macro_use]
 extern crate serde_derive;
 ```
 
-The data you pass must be supported by serde, or be a struct or enum that
+The data we pass at all nesting levels must be supported by serde, or be a struct or enum that
 derives the Serialize trait. For example, let's say we'd like to pass this
 struct to JS; doing so is not possible in bindgen directly due to the use
 of public fields, HashMaps, arrays, and nested Vecs. Note that we do not
@@ -58,7 +58,7 @@ pub fn pass_example() -> JsValue {
 }
 ```
 
-When calling this function from JS, its result will automatically be deserialized.
+When calling this function from JS, its output will automatically be deserialized.
 In this example, fied1 will be a JS object (Not a JS Map), field2 will be a 
 2d JS array, and field3 will be a 1d JS array. Example calling code:
 

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -1,7 +1,7 @@
 # Passing arbitrary data to JS
 
 It's possible to pass data from Rust to JS not explicitly supported
-in the [Feature Reference](./feature-reference.md) by serializing vis [Serde] (https://github.com/serde-rs/serde).
+in the [Feature Reference](./feature-reference.md) by serializing via [Serde](https://github.com/serde-rs/serde).
 
 Wasm_bindgen includes the JsValue type, which streamlines serializing and deserializing.
 This page describes how to use it.

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -4,7 +4,6 @@ It's possible to pass data from Rust to JS not explicitly supported
 in the [Feature Reference](./feature-reference.md) by serializing via [Serde](https://github.com/serde-rs/serde).
 
 `wasm-bindgen` includes the `JsValue` type, which streamlines serializing and deserializing.
-This page describes how to use it.
 
 In order accomplish this, we must include the serde and serde_derive
 crates in `Cargo.toml`, and configure `wasm-bindgen` to work with this feature:

--- a/guide/src/passing-data.md
+++ b/guide/src/passing-data.md
@@ -3,11 +3,11 @@
 It's possible to pass data from Rust to JS not explicitly supported
 in the [Feature Reference](./feature-reference.md) by serializing via [Serde](https://github.com/serde-rs/serde).
 
-Wasm_bindgen includes the JsValue type, which streamlines serializing and deserializing.
+`wasm-bindgen` includes the `JsValue` type, which streamlines serializing and deserializing.
 This page describes how to use it.
 
 In order accomplish this, we must include the serde and serde_derive
-crates in Cargo.toml, and configure wasm_bindgen to work with this feature:
+crates in `Cargo.toml`, and configure `wasm-bindgen` to work with this feature:
 
 Cargo.toml
 ```toml
@@ -20,18 +20,18 @@ version = "^0.2"
 features = ["serde-serialize"]
 ```
 
-In our top-level Rust file (eg lib.rs or main.rs), weenable the Serialize
+In our top-level Rust file (eg `lib.rs` or `main.rs`), we enable the `Serialize`
 macro: 
 ```rust
 #[macro_use]
 extern crate serde_derive;
 ```
 
-The data we pass at all nesting levels must be supported by serde, or be a struct or enum that
+The data we pass at all nesting levels must be supported by serde, or be a `struct` or `enum` that
 derives the Serialize trait. For example, let's say we'd like to pass this
 struct to JS; doing so is not possible in bindgen directly due to the use
-of public fields, HashMaps, arrays, and nested Vecs. Note that we do not
-need to use the #[wasm_bindgen] macro.
+of public fields, `HashMap`s, arrays, and nested `Vec`s. Note that we do not
+need to use the `#[wasm_bindgen]` macro.
 
 ```rust
 #[derive(Serialize)]
@@ -42,7 +42,7 @@ pub struct Example {
 }
 ```
 
-Here's a function that will pass an instance of this struct to JS:
+Here's a function that will pass an instance of this `struct` to JS:
 ```rust
 #[wasm_bindgen]
 pub fn pass_example() -> JsValue {
@@ -59,8 +59,8 @@ pub fn pass_example() -> JsValue {
 ```
 
 When calling this function from JS, its output will automatically be deserialized.
-In this example, fied1 will be a JS object (Not a JS Map), field2 will be a 
-2d JS array, and field3 will be a 1d JS array. Example calling code:
+In this example, `fied1` will be a JS `object` (Not a JS `Map`), `field2` will be a 
+2d JS `array`, and `field3` will be a 1d JS `array`. Example calling code:
 
 ```typescript
 const rust = import("./from_rust");


### PR DESCRIPTION
Untested! Builds, but unable to test due to this error: 
```
it looks like the Rust project used to create this wasm file was linked against
a different version of wasm-bindgen than this binary:

  rust wasm file: 0.2.29
     this binary: 0.2.12 (d37d4ae81)
```