### PR TITLE
Add support for importing reserved JS words

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,11 @@ matrix:
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync ~/$TRAVIS_BUILD_NUMBER s3://wasm-bindgen-ci/$TRAVIS_BUILD_NUMBER; fi
       if: branch = master
 
+    # The `cli-support` crate's tests pass
+    - name: "test cli-support crate"
+      script: cargo test -p wasm-bindgen-cli-support
+      if: branch = master
+
     # The `web-sys` crate's tests pass
     - name: "test web-sys crate"
       install:

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -13,6 +13,7 @@ Shared support for the wasm-bindgen-cli package, an internal dependency
 [dependencies]
 base64 = "0.9"
 failure = "0.1.2"
+lazy_static = "1.0.0"
 parity-wasm = "0.35"
 tempfile = "3.0"
 wasm-bindgen-gc = { path = '../gc', version = '=0.2.29' }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -119,54 +119,59 @@ const INITIAL_HEAP_VALUES: &[&str] = &["undefined", "null", "true", "false"];
 const INITIAL_HEAP_OFFSET: usize = 32;
 
 lazy_static! {
-    static ref JS_KEYWORDS: HashSet<&'static str> = {
-        let mut keywords = HashSet::new();
-        keywords.insert("await");
-        keywords.insert("break");
-        keywords.insert("case");
-        keywords.insert("catch");
-        keywords.insert("class");
-        keywords.insert("const");
-        keywords.insert("continue");
-        keywords.insert("debugger");
-        keywords.insert("default");
-        keywords.insert("delete");
-        keywords.insert("do");
-        keywords.insert("else");
-        keywords.insert("enum");
-        keywords.insert("export");
-        keywords.insert("extends");
-        keywords.insert("false");
-        keywords.insert("finally");
-        keywords.insert("for");
-        keywords.insert("function");
-        keywords.insert("if");
-        keywords.insert("implements");
-        keywords.insert("import");
-        keywords.insert("in");
-        keywords.insert("instanceof");
-        keywords.insert("interface");
-        keywords.insert("new");
-        keywords.insert("null");
-        keywords.insert("package");
-        keywords.insert("private");
-        keywords.insert("protected");
-        keywords.insert("public");
-        keywords.insert("return");
-        keywords.insert("super");
-        keywords.insert("switch");
-        keywords.insert("this");
-        keywords.insert("throw");
-        keywords.insert("true");
-        keywords.insert("try");
-        keywords.insert("typeof");
-        keywords.insert("undefined");
-        keywords.insert("var");
-        keywords.insert("void");
-        keywords.insert("while");
-        keywords.insert("with");
-        keywords.insert("yield");
-        keywords
+    static ref JS_RESERVED_WORDS: HashSet<&'static str> = {
+        let mut words = HashSet::with_capacity(49);
+        words.insert("Infinity");
+        words.insert("NaN");
+        words.insert("arguments");
+        words.insert("await");
+        words.insert("break");
+        words.insert("case");
+        words.insert("catch");
+        words.insert("class");
+        words.insert("const");
+        words.insert("continue");
+        words.insert("debugger");
+        words.insert("default");
+        words.insert("delete");
+        words.insert("do");
+        words.insert("else");
+        words.insert("enum");
+        words.insert("export");
+        words.insert("extends");
+        words.insert("false");
+        words.insert("finally");
+        words.insert("for");
+        words.insert("function");
+        words.insert("if");
+        words.insert("implements");
+        words.insert("import");
+        words.insert("in");
+        words.insert("instanceof");
+        words.insert("interface");
+        words.insert("let");
+        words.insert("new");
+        words.insert("null");
+        words.insert("package");
+        words.insert("private");
+        words.insert("protected");
+        words.insert("public");
+        words.insert("require");
+        words.insert("return");
+        words.insert("super");
+        words.insert("switch");
+        words.insert("this");
+        words.insert("throw");
+        words.insert("true");
+        words.insert("try");
+        words.insert("typeof");
+        words.insert("undefined");
+        words.insert("var");
+        words.insert("void");
+        words.insert("while");
+        words.insert("with");
+        words.insert("yield");
+        words
     };
 }
 
@@ -2701,7 +2706,7 @@ impl<'a> Import<'a> {
 fn generate_identifier(name: &str, used_names: &mut HashMap<String, usize>) -> String {
     let cnt = used_names.entry(name.to_string()).or_insert(0);
     *cnt += 1;
-    if *cnt == 1 && !JS_KEYWORDS.contains(name) {
+    if *cnt == 1 && !JS_RESERVED_WORDS.contains(name) {
         name.to_string()
     } else {
         format!("{}{}", name, cnt)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -120,9 +120,7 @@ const INITIAL_HEAP_OFFSET: usize = 32;
 
 lazy_static! {
     static ref JS_RESERVED_WORDS: HashSet<&'static str> = {
-        let mut words = HashSet::with_capacity(49);
-        words.insert("Infinity");
-        words.insert("NaN");
+        let mut words = HashSet::with_capacity(47);
         words.insert("arguments");
         words.insert("await");
         words.insert("break");
@@ -137,6 +135,7 @@ lazy_static! {
         words.insert("do");
         words.insert("else");
         words.insert("enum");
+        words.insert("eval");
         words.insert("export");
         words.insert("extends");
         words.insert("false");
@@ -156,7 +155,6 @@ lazy_static! {
         words.insert("private");
         words.insert("protected");
         words.insert("public");
-        words.insert("require");
         words.insert("return");
         words.insert("super");
         words.insert("switch");
@@ -165,7 +163,6 @@ lazy_static! {
         words.insert("true");
         words.insert("try");
         words.insert("typeof");
-        words.insert("undefined");
         words.insert("var");
         words.insert("void");
         words.insert("while");

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-cli-support/0.2")]
 
+#[macro_use]
+extern crate lazy_static;
 extern crate parity_wasm;
 #[macro_use]
 extern crate wasm_bindgen_shared as shared;

--- a/tests/wasm/import_class.js
+++ b/tests/wasm/import_class.js
@@ -30,7 +30,7 @@ class Construct {
 Construct.internal_string = '';
 exports.Construct = Construct;
 
-exports.NewConstructors = class {
+class NewConstructor {
   constructor(field) {
     this.field = field;
   }
@@ -38,7 +38,10 @@ exports.NewConstructors = class {
   get() {
     return this.field + 1;
   }
-};
+}
+
+exports.NewConstructors = NewConstructor;
+exports.default = NewConstructor;
 
 let switch_called = false;
 class SwitchMethods {

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -29,6 +29,13 @@ extern "C" {
     #[wasm_bindgen(method)]
     fn get(this: &NewConstructors) -> i32;
 
+    #[wasm_bindgen(js_name = default)]
+    type RenamedTypes;
+    #[wasm_bindgen(constructor)]
+    fn new(arg: i32) -> RenamedTypes;
+    #[wasm_bindgen(method)]
+    fn get(this: &RenamedTypes) -> i32;
+
     fn switch_methods_a();
     fn switch_methods_b();
     type SwitchMethods;
@@ -122,6 +129,12 @@ fn construct() {
 #[wasm_bindgen_test]
 fn new_constructors() {
     let f = NewConstructors::new(1);
+    assert_eq!(f.get(), 2);
+}
+
+#[wasm_bindgen_test]
+fn rename_type() {
+    let f = RenamedTypes::new(1);
     assert_eq!(f.get(), 2);
 }
 

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -31,9 +31,9 @@ extern "C" {
 
     #[wasm_bindgen(js_name = default)]
     type RenamedTypes;
-    #[wasm_bindgen(constructor)]
+    #[wasm_bindgen(constructor, js_class = default)]
     fn new(arg: i32) -> RenamedTypes;
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_class = default)]
     fn get(this: &RenamedTypes) -> i32;
 
     fn switch_methods_a();


### PR DESCRIPTION
This should fix #1006

Implemented the idea explained in https://github.com/rustwasm/wasm-bindgen/issues/1006#issuecomment-442621024.

Now
```rust
#[wasm_bindgen(module = "./SomeModule")]
extern "C" {
    #[wasm_bindgen(js_name = default)]
    type SomeType;
}
```

should be glued with
```js
import { default as default1 } from './SomeModule';
```

I tested this behaviour on my local example project and it seems to be OK, though I couldn't get it working for the tests and `import_js` example. For some reason `js_name` attribute for types is just ignored there.
