### PR TITLE
Add Uint16 to `buffer_data`

### DIFF
--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -637,7 +637,7 @@ impl<'a> IdlType<'a> {
                 .iter()
                 .flat_map(|idl_type| idl_type.flatten())
                 .collect(),
-            IdlType::ArrayBufferView => vec![IdlType::ArrayBufferView, IdlType::Uint8ArrayMut],
+            IdlType::ArrayBufferView => vec![IdlType::ArrayBufferView, IdlType::Uint8ArrayMut, IdlType::Uint16Array],
             IdlType::BufferSource => vec![IdlType::BufferSource, IdlType::Uint8ArrayMut],
             IdlType::LongLong => vec![IdlType::Long, IdlType::Double],
             IdlType::UnsignedLongLong => vec![IdlType::UnsignedLong, IdlType::Double],


### PR DESCRIPTION
Closes #1089

---

There was no `IdlType::Uint16ArrayMut` so I went with `Uint16Array`. Is this an issue?