### PR TITLE
Port examples - console-log, closures and duck-typed-interfaces to Rust 2018

### DIFF
--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -2,6 +2,7 @@
 name = "closures"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -1,5 +1,3 @@
-use web_sys;
-
 use js_sys::{Array, Date};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -1,6 +1,4 @@
-extern crate js_sys;
-extern crate wasm_bindgen;
-extern crate web_sys;
+use web_sys;
 
 use js_sys::{Array, Date};
 use wasm_bindgen::prelude::*;
@@ -67,7 +65,7 @@ fn setup_clock(window: &Window, document: &Document) -> Result<(), JsValue> {
         .get_element_by_id("current-time")
         .expect("should have #current-time on the page");
     update_time(&current_time);
-    let a = Closure::wrap(Box::new(move || update_time(&current_time)) as Box<Fn()>);
+    let a = Closure::wrap(Box::new(move || update_time(&current_time)) as Box<dyn Fn()>);
     window
         .set_interval_with_callback_and_timeout_and_arguments_0(a.as_ref().unchecked_ref(), 1000)?;
     fn update_time(current_time: &Element) {
@@ -103,7 +101,7 @@ fn setup_clicker(document: &Document) {
     let a = Closure::wrap(Box::new(move || {
         clicks += 1;
         num_clicks.set_inner_html(&clicks.to_string());
-    }) as Box<FnMut()>);
+    }) as Box<dyn FnMut()>);
     document
         .get_element_by_id("green-square")
         .expect("should have #green-square on the page")

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -2,6 +2,7 @@
 name = "console_log"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/console_log/src/lib.rs
+++ b/examples/console_log/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-duck-typed-interfaces"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/duck-typed-interfaces/src/lib.rs
+++ b/examples/duck-typed-interfaces/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 /// Here is a duck-typed interface for any JavaScript object that has a `quack`
@@ -18,6 +17,6 @@ extern "C" {
 /// Next, we can export a function that takes any object that quacks:
 #[wasm_bindgen]
 pub fn make_em_quack_to_this(duck: &Quacks) {
-    let s = duck.quack();
+    let _s = duck.quack();
     // ...
 }


### PR DESCRIPTION
I've left the `_s` from the fix for duck-typed-interfaces/src/lib.rs, it's not required, but removes the warning for unused variable

Checks `console-log`, `closures` and `duck-typed-interfaces` tasks #1099