### PR TITLE
Port examples: add, canvas, char and hello_world to rust 2018 edition examples

### DIFF
--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -2,6 +2,7 @@
 name = "add"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/add/src/lib.rs
+++ b/examples/add/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -2,6 +2,7 @@
 name = "canvas"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -1,7 +1,6 @@
 use std::f64;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys;
 
 #[wasm_bindgen(start)]
 pub fn start() {

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -1,10 +1,7 @@
-extern crate js_sys;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use std::f64;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
+use web_sys;
 
 #[wasm_bindgen(start)]
 pub fn start() {

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -2,6 +2,7 @@
 name = "char"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/char/src/lib.rs
+++ b/examples/char/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 
 // lifted from the `console_log` example

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hello_world"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]


### PR DESCRIPTION
As part of issue #1099

This PR ports the following examples:
- add
- canvas
- char
- hello_world

also ran `cargo fix --edition-idioms`