### PR TITLE
Port WebGL, webaudio, wasm-in-wasm, and todomvc examples to Rust 2018 edition

### DIFF
--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/src/element.rs
+++ b/examples/todomvc/src/element.rs
@@ -1,4 +1,3 @@
-extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::EventTarget;
@@ -62,7 +61,7 @@ impl Element {
     where
         T: 'static + FnMut(web_sys::Event),
     {
-        let cb = Closure::wrap(Box::new(handler) as Box<FnMut(_)>);
+        let cb = Closure::wrap(Box::new(handler) as Box<dyn FnMut(_)>);
         if let Some(el) = self.el.take() {
             let el_et: EventTarget = el.into();
             el_et
@@ -117,7 +116,7 @@ impl Element {
                                 }
                             }
                         }
-                    }) as Box<FnMut(_)>);
+                    }) as Box<dyn FnMut(_)>);
 
                     dyn_el
                         .add_event_listener_with_callback_and_bool(

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -2,15 +2,9 @@
 //!
 //! A [TODO MVC](https://todomvc.com/) implementation written using [web-sys](https://rustwasm.github.io/wasm-bindgen/web-sys/overview.html)
 
-extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
-extern crate js_sys;
-extern crate web_sys;
 use std::rc::Rc;
-
-extern crate askama;
-extern crate console_error_panic_hook;
 
 /// Controller of the program
 pub mod controller;

--- a/examples/todomvc/src/store.rs
+++ b/examples/todomvc/src/store.rs
@@ -43,7 +43,7 @@ impl Store {
                 let title = item_array.shift().as_string()?;
                 let completed = item_array.shift().as_bool()?;
                 let id = item_array.shift().as_string()?;
-                let mut temp_item = Item {
+                let temp_item = Item {
                     title,
                     completed,
                     id,
@@ -59,7 +59,7 @@ impl Store {
     fn sync_local_storage(&mut self) {
         let array = js_sys::Array::new();
         for item in self.data.iter() {
-            let mut child = js_sys::Array::new();
+            let child = js_sys::Array::new();
             let s = item.title.clone();
             child.push(&JsValue::from(&s));
             child.push(&JsValue::from(item.completed));
@@ -82,7 +82,7 @@ impl Store {
     ///  let data = db.find(ItemQuery::Completed {completed: true});
     ///	 // data will contain items whose completed properties are true
     /// ```
-    pub fn find(&mut self, query: ItemQuery) -> Option<ItemListSlice> {
+    pub fn find(&mut self, query: ItemQuery) -> Option<ItemListSlice<'_>> {
         Some(
             self.data
                 .iter()
@@ -160,7 +160,7 @@ pub trait ItemListTrait<T> {
     fn get(&self, i: usize) -> Option<&T>;
     fn length(&self) -> usize;
     fn push(&mut self, item: T);
-    fn iter(&self) -> std::slice::Iter<T>;
+    fn iter(&self) -> std::slice::Iter<'_, T>;
 }
 
 pub struct ItemList {
@@ -173,7 +173,7 @@ impl ItemList {
     {
         self.list.retain(f);
     }
-    fn iter_mut(&mut self) -> std::slice::IterMut<Item> {
+    fn iter_mut(&mut self) -> std::slice::IterMut<'_, Item> {
         self.list.iter_mut()
     }
 }
@@ -190,7 +190,7 @@ impl ItemListTrait<Item> for ItemList {
     fn push(&mut self, item: Item) {
         self.list.push(item)
     }
-    fn iter(&self) -> std::slice::Iter<Item> {
+    fn iter(&self) -> std::slice::Iter<'_, Item> {
         self.list.iter()
     }
 }
@@ -224,7 +224,7 @@ impl<'a> ItemListTrait<&'a Item> for ItemListSlice<'a> {
     fn push(&mut self, item: &'a Item) {
         self.list.push(item)
     }
-    fn iter(&self) -> std::slice::Iter<&'a Item> {
+    fn iter(&self) -> std::slice::Iter<'_, &'a Item> {
         self.list.iter()
     }
 }

--- a/examples/todomvc/src/template.rs
+++ b/examples/todomvc/src/template.rs
@@ -1,5 +1,5 @@
 use askama::Template as AskamaTemplate;
-use store::{ItemList, ItemListTrait};
+use crate::store::{ItemList, ItemListTrait};
 
 #[derive(AskamaTemplate)]
 #[template(path = "row.html")]

--- a/examples/todomvc/src/view.rs
+++ b/examples/todomvc/src/view.rs
@@ -12,7 +12,6 @@ use crate::template::Template;
 const ENTER_KEY: u32 = 13;
 const ESCAPE_KEY: u32 = 27;
 
-extern crate wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 /// Messages that represent the methods to be called on the View
@@ -53,7 +52,7 @@ pub struct View {
     main: Element,
     toggle_all: Element,
     new_todo: Element,
-    callbacks: Vec<(web_sys::EventTarget, String, Closure<FnMut()>)>,
+    callbacks: Vec<(web_sys::EventTarget, String, Closure<dyn FnMut()>)>,
 }
 
 impl View {
@@ -95,7 +94,7 @@ impl View {
                     }
                 }
             }
-        }) as Box<FnMut()>);
+        }) as Box<dyn FnMut()>);
 
         let window_et: web_sys::EventTarget = window.into();
         window_et
@@ -422,7 +421,7 @@ impl View {
 impl Drop for View {
     fn drop(&mut self) {
         exit("calling drop on view");
-        let callbacks: Vec<(web_sys::EventTarget, String, Closure<FnMut()>)> =
+        let callbacks: Vec<(web_sys::EventTarget, String, Closure<dyn FnMut()>)> =
             self.callbacks.drain(..).collect();
         for callback in callbacks {
             callback

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-in-wasm"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate js_sys;
-extern crate wasm_bindgen;
-
 use js_sys::{Function, Object, Reflect, Uint8Array, WebAssembly};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -2,6 +2,7 @@
 name = "webaudio"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webaudio/src/lib.rs
+++ b/examples/webaudio/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use wasm_bindgen::prelude::*;
 use web_sys::{AudioContext, OscillatorType};
 

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "webgl"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate js_sys;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use js_sys::WebAssembly;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;


### PR DESCRIPTION
This PR ports the following examples: WebGL, webaudio, wasm-in-wasm, and todomvc using the following commands:
```
  cargo fix --edition
  cargo fix --edition-idioms
  cargo check --target wasm32-unknown-unknown
```

Also tested each example via the .build.sh script. 

Relates to #1099.