### PR TITLE
Port dom, fetch, guide-supported-types-examples, import_js examples to Rust 2018 edition

### DIFF
--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dom"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -1,4 +1,3 @@
-
 use wasm_bindgen::prelude::*;
 
 // Called by our JS entry point to run the example

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -1,6 +1,4 @@
 
-use web_sys;
-
 use wasm_bindgen::prelude::*;
 
 // Called by our JS entry point to run the example

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -1,5 +1,5 @@
-extern crate wasm_bindgen;
-extern crate web_sys;
+
+use web_sys;
 
 use wasm_bindgen::prelude::*;
 

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.1.20"
 wasm-bindgen = { version = "0.2.29", features = ["serde-serialize"]  }
 js-sys = "0.3.6"
 wasm-bindgen-futures = "0.3.6"
-serde = "^1.0.59"
+serde = { version = "1.0.80", features = ["derive"] }
 serde_derive = "^1.0.59"
 
 [dependencies.web-sys]

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fetch"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,8 +1,8 @@
-extern crate futures;
-extern crate js_sys;
-extern crate wasm_bindgen;
-extern crate wasm_bindgen_futures;
-extern crate web_sys;
+
+
+
+
+use web_sys;
 #[macro_use]
 extern crate serde_derive;
 

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate serde_derive;
-
 use futures::{future, Future};
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
@@ -8,6 +5,7 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response};
+use serde::{Deserialize, Serialize};
 
 /// A struct to hold some data from the github Branch API.
 ///

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,8 +1,3 @@
-
-
-
-
-use web_sys;
 #[macro_use]
 extern crate serde_derive;
 

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -2,6 +2,7 @@
 name = "guide-supported-types-examples"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guide-supported-types-examples/src/lib.rs
+++ b/examples/guide-supported-types-examples/src/lib.rs
@@ -1,7 +1,5 @@
 #![allow(unused_variables, dead_code)]
 
-use wasm_bindgen;
-
 pub mod bool;
 pub mod boxed_js_value_slice;
 pub mod boxed_number_slices;

--- a/examples/guide-supported-types-examples/src/lib.rs
+++ b/examples/guide-supported-types-examples/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables, dead_code)]
 
-extern crate wasm_bindgen;
+use wasm_bindgen;
 
 pub mod bool;
 pub mod boxed_js_value_slice;

--- a/examples/import_js/Cargo.toml
+++ b/examples/import_js/Cargo.toml
@@ -2,6 +2,7 @@
 name = "import_js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/import_js/src/lib.rs
+++ b/examples/import_js/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(module = "./defined-in-js")]


### PR DESCRIPTION
This PR ports the following examples: 
- [ ] dom
- [ ] fetch
- [ ] guide-supported-types-examples
- [ ] import_js

I run these command.
```
cargo fix --edition
cargo check --target wasm32-unknown-unknown
cargo fix --edition-idioms
```
Relates to #1099.

### 🐞 bug report 
When I run `$ cargo fix --edition-idioms` in `import_js`, I got an error message.
full output: 
```
import_js $ cargo fix --edition-idioms
    Checking import_js v0.1.0 (/Users/misakimakino/Works/clones/fork-wasm-bindgen/wasm-bindgen/examples/import_js)
warning: failed to automatically apply fixes suggested by rustc to crate `import_js`

after fixes were automatically applied the compiler reported errors within these files:

  * examples/import_js/src/lib.rs

This likely indicates a bug in either rustc or cargo itself,
and we would appreciate a bug report! You're likely to see
a number of compiler warnings after this message which cargo
attempted to fix but failed. If you could open an issue at
https://github.com/rust-lang/cargo/issues
quoting the full output of this command we'd be very appreciative!

warning: `extern crate` is not idiomatic in the new edition
 --> examples/import_js/src/lib.rs:1:1
  |
1 | extern crate wasm_bindgen;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert it to a `use`
  |
  = note: `-W unused-extern-crates` implied by `-W rust-2018-idioms`

warning: `extern crate` is not idiomatic in the new edition
 --> examples/import_js/src/lib.rs:1:1
  |
1 | extern crate wasm_bindgen;
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert it to a `use`
  |
  = note: `-W unused-extern-crates` implied by `-W rust-2018-idioms`

    Finished dev [unoptimized + debuginfo] target(s) in 1.05s
import_js $
```
