### PR TITLE
Add support for importing default exports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,11 @@ matrix:
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync ~/$TRAVIS_BUILD_NUMBER s3://wasm-bindgen-ci/$TRAVIS_BUILD_NUMBER; fi
       if: branch = master
 
+    # The `cli-support` crate's tests pass
+    - name: "test cli-support crate"
+      script: cargo test -p wasm-bindgen-cli-support
+      if: branch = master
+
     # The `web-sys` crate's tests pass
     - name: "test web-sys crate"
       install:

--- a/tests/wasm/import_class.js
+++ b/tests/wasm/import_class.js
@@ -30,7 +30,7 @@ class Construct {
 Construct.internal_string = '';
 exports.Construct = Construct;
 
-exports.NewConstructors = class {
+class NewConstructor {
   constructor(field) {
     this.field = field;
   }
@@ -38,7 +38,10 @@ exports.NewConstructors = class {
   get() {
     return this.field + 1;
   }
-};
+}
+
+exports.NewConstructors = NewConstructor;
+exports.default = NewConstructor;
 
 let switch_called = false;
 class SwitchMethods {

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -29,6 +29,13 @@ extern "C" {
     #[wasm_bindgen(method)]
     fn get(this: &NewConstructors) -> i32;
 
+    #[wasm_bindgen(js_name = default)]
+    type RenamedTypes;
+    #[wasm_bindgen(constructor, js_class = default)]
+    fn new(arg: i32) -> RenamedTypes;
+    #[wasm_bindgen(method, js_class = default)]
+    fn get(this: &RenamedTypes) -> i32;
+
     fn switch_methods_a();
     fn switch_methods_b();
     type SwitchMethods;
@@ -122,6 +129,12 @@ fn construct() {
 #[wasm_bindgen_test]
 fn new_constructors() {
     let f = NewConstructors::new(1);
+    assert_eq!(f.get(), 2);
+}
+
+#[wasm_bindgen_test]
+fn rename_type() {
+    let f = RenamedTypes::new(1);
     assert_eq!(f.get(), 2);
 }
 


### PR DESCRIPTION
This should fix #1006

This PR doesn't mangle reserved JS words, only `default`. This is an alternative to #1091