### PR TITLE
Port raytrace-parallel and wasm2js to rust 2018 edition

### DIFF
--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "raytrace-parallel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/raytrace-parallel/src/lib.rs
+++ b/examples/raytrace-parallel/src/lib.rs
@@ -1,9 +1,3 @@
-extern crate futures;
-extern crate js_sys;
-extern crate raytracer;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use std::cell::RefCell;
 use std::cmp;
 use std::rc::Rc;
@@ -88,7 +82,7 @@ impl Scene {
                 }
             }
             Ok(())
-        }) as Box<FnMut(_) -> Result<(), JsValue>>);
+        }) as Box<dyn FnMut(_) -> Result<(), JsValue>>);
 
         for worker in &pool.workers[..concurrency] {
             let ptr_to_send = Arc::into_raw(r.shared.clone()) as u32;
@@ -112,7 +106,7 @@ impl Scene {
 #[wasm_bindgen]
 pub struct WorkerPool {
     workers: Vec<Worker>,
-    callback: Closure<FnMut(Event)>,
+    callback: Closure<dyn FnMut(Event)>,
 }
 
 #[wasm_bindgen]
@@ -193,7 +187,7 @@ impl RenderingScene {
 }
 
 struct Render {
-    callback: Option<Closure<FnMut(Event) -> Result<(), JsValue>>>,
+    callback: Option<Closure<dyn FnMut(Event) -> Result<(), JsValue>>>,
     tx: Option<oneshot::Sender<()>>,
     shared: Arc<Shared>,
     ctx: CanvasRenderingContext2d,
@@ -326,7 +320,7 @@ impl Shared {
     fn update_image(
         &self,
         done: bool,
-        data: MutexGuard<Vec<u8>>,
+        data: MutexGuard<'_,Vec<u8>>,
         global: &DedicatedWorkerGlobalScope,
     ) -> Result<(), JsValue> {
         // This is pretty icky. We can't create an `ImageData` backed by

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm2js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm2js/src/lib.rs
+++ b/examples/wasm2js/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 
 // lifted from the `console_log` example


### PR DESCRIPTION
Update the following examples:

raytrace-parallel and wasm2js to rust 2018 edition (running cargo fix --edition and --edition-idioms)