### PR TITLE
Port `julia_set`, `no_modules`, `paint` and `performance` to Rust 2018

### DIFF
--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -2,6 +2,7 @@
 name = "julia_set"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/julia_set/src/lib.rs
+++ b/examples/julia_set/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use std::ops::Add;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::Clamped;

--- a/examples/no_modules/Cargo.toml
+++ b/examples/no_modules/Cargo.toml
@@ -2,6 +2,7 @@
 name = "no_modules"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/no_modules/src/lib.rs
+++ b/examples/no_modules/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use wasm_bindgen::prelude::*;
 
 // Called by our JS entry point to run the example

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-bindgen-paint"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate js_sys;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
 use std::cell::Cell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
@@ -30,7 +26,7 @@ pub fn start() -> Result<(), JsValue> {
             context.begin_path();
             context.move_to(event.offset_x() as f64, event.offset_y() as f64);
             pressed.set(true);
-        }) as Box<FnMut(_)>);
+        }) as Box<dyn FnMut(_)>);
         canvas.add_event_listener_with_callback("mousedown", closure.as_ref().unchecked_ref())?;
         closure.forget();
     }
@@ -44,7 +40,7 @@ pub fn start() -> Result<(), JsValue> {
                 context.begin_path();
                 context.move_to(event.offset_x() as f64, event.offset_y() as f64);
             }
-        }) as Box<FnMut(_)>);
+        }) as Box<dyn FnMut(_)>);
         canvas.add_event_listener_with_callback("mousemove", closure.as_ref().unchecked_ref())?;
         closure.forget();
     }
@@ -55,7 +51,7 @@ pub fn start() -> Result<(), JsValue> {
             pressed.set(false);
             context.line_to(event.offset_x() as f64, event.offset_y() as f64);
             context.stroke();
-        }) as Box<FnMut(_)>);
+        }) as Box<dyn FnMut(_)>);
         canvas.add_event_listener_with_callback("mouseup", closure.as_ref().unchecked_ref())?;
         closure.forget();
     }

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -2,6 +2,7 @@
 name = "performance"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -1,7 +1,4 @@
-extern crate humantime;
-extern crate wasm_bindgen;
-extern crate web_sys;
-
+use humantime;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wasm_bindgen::prelude::*;

--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -1,4 +1,3 @@
-use humantime;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Closes #1099 with the last set of examples 😊 