### PR TITLE
Allow using include_str! in typescript_custom_section consts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = ["spans", "std"]
 spans = ["wasm-bindgen-macro/spans"]
 std = []
 serde-serialize = ["serde", "serde_json", "std"]
-nightly = []
+nightly = ["wasm-bindgen-macro/nightly"]
 
 # Whether or not the `#[wasm_bindgen]` macro is strict and generates an error on
 # all unused attributes

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -18,6 +18,6 @@ strict-macro = []
 [dependencies]
 syn = { version = '0.15.0', features = ['visit'] }
 quote = '0.6'
-proc-macro2 = "0.4.9"
+proc-macro2 = { version = "0.4.9", features = ["nightly"] }
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.29" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.29" }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -14,10 +14,11 @@ The part of the implementation of the `#[wasm_bindgen]` attribute that is not in
 spans = ["wasm-bindgen-backend/spans"]
 extra-traits = ["syn/extra-traits"]
 strict-macro = []
+nightly = ["proc-macro2/nightly"]
 
 [dependencies]
 syn = { version = '0.15.0', features = ['visit'] }
 quote = '0.6'
-proc-macro2 = { version = "0.4.9", features = ["nightly"] }
+proc-macro2 = { version = "0.4.9" }
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.29" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.29" }

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate contains the part of the implementation of the `#[wasm_bindgen]` optsibute that is
 //! not in the shared backend crate.
 
-#![feature(proc_macro_span)]
+#![cfg_attr(feature = "nightly", feature(proc_macro_span))]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro-support/0.2")]
 
 extern crate proc_macro2;

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate contains the part of the implementation of the `#[wasm_bindgen]` optsibute that is
 //! not in the shared backend crate.
 
+#![feature(proc_macro_span)]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro-support/0.2")]
 
 extern crate proc_macro2;

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 spans = ["wasm-bindgen-macro-support/spans"]
 xxx_debug_only_print_generated_code = []
 strict-macro = ["wasm-bindgen-macro-support/strict-macro"]
+nightly = ["wasm-bindgen-macro-support/nightly"]
 
 [dependencies]
 wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.29" }

--- a/crates/macro/ui-tests/invalid-items.stderr
+++ b/crates/macro/ui-tests/invalid-items.stderr
@@ -58,7 +58,7 @@ error: can't #[wasm_bindgen] functions with lifetime or type parameters
 33 | pub fn foo6<'a, T>() {}
    |            ^^^^^^^
 
-error: #[wasm_bindgen] can only be applied to a function, struct, enum, impl, or extern block
+error: #[wasm_bindgen] can only be applied to a function, struct, enum, impl, extern block, or typescript_custom_section const
   --> $DIR/invalid-items.rs:36:1
    |
 36 | trait X {}


### PR DESCRIPTION
As it says in the title. This would be useful for separating type definitions from the code, and you would be able to get syntax highlighting for the typescript in your editor as well.