### PR TITLE
Fix order of export/gc

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -457,6 +457,7 @@ impl<'a> Context<'a> {
             }
         }
 
+        self.export_table();
         self.gc();
 
         // Note that it's important `throw` comes last *after* we gc. The
@@ -627,9 +628,6 @@ impl<'a> Context<'a> {
                 footer = self.footer,
             )
         };
-
-        self.export_table();
-        self.gc();
 
         while js.contains("\n\n\n") {
             js = js.replace("\n\n\n", "\n\n");


### PR DESCRIPTION
We might gc a table away so if we need to export it be sure to do so
before we gc! Additionally remove an extraneous gc that snuck in at some
point, no need to do more than one.

Closes #1130