### PR TITLE
Add conversions between typed arrays and Rust

### DIFF
--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -100,3 +100,24 @@ macro_rules! test_slice {
 fn new_slice() {
     each!(test_slice);
 }
+
+#[wasm_bindgen_test]
+fn view() {
+    let x = [1, 2, 3];
+    let array = unsafe { Int32Array::view(&x) };
+    assert_eq!(array.length(), 3);
+    array.for_each(&mut |x, i, _| {
+        assert_eq!(x, (i + 1) as i32);
+    });
+}
+
+#[wasm_bindgen_test]
+fn copy_to() {
+    let mut x = [0; 10];
+    let array = Int32Array::new(&10.into());
+    array.fill(5, 0, 10);
+    array.copy_to(&mut x);
+    for i in x.iter() {
+        assert_eq!(*i, 5);
+    }
+}


### PR DESCRIPTION
For all typed arrays, this commit adds:

* `TypedArray::view(src: &[Type])`
* `TypedArray::copy_to(&self, dst: &mut [Type])`

The `view` function is unsafe because it doesn't provide any guarantees
about lifetimes or mutability. The `copy_to` function is, however, safe.

Closes #811