### PR TITLE
Spawn local

### DIFF
--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -378,7 +378,14 @@ fn _future_to_promise(future: Box<Future<Item = JsValue, Error = JsValue>>) -> P
     }
 }
 
-/// Spawns a future.
+/// Converts a Rust `Future` on a local task queue.
+///
+/// The `future` provided must adhere to `'static` because it'll be scheduled
+/// to run in the background and cannot contain any stack references.
+///
+/// # Panics
+///
+/// This function has the same panic behavior as `future_to_promise`.
 pub fn spawn_local<F>(future: F)
 where
     F: Future<Item = (), Error = ()> + 'static,

--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -377,3 +377,15 @@ fn _future_to_promise(future: Box<Future<Item = JsValue, Error = JsValue>>) -> P
         }
     }
 }
+
+/// Spawns a future.
+pub fn spawn_local<F>(future: F)
+where
+    F: Future<Item = (), Error = ()> + 'static,
+{
+    future_to_promise(
+        future
+            .map(|_| JsValue::undefined())
+            .map_err(|_| JsValue::undefined()),
+    );
+}


### PR DESCRIPTION
This is a very simple implementation of `spawn_local`, a function that spawns a rust future using the javascript promise infrastructure as the executor.