### PR TITLE
Support webidl sequence

### DIFF
--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -388,7 +388,7 @@ fn _future_to_promise(future: Box<Future<Item = JsValue, Error = JsValue>>) -> P
 /// This function has the same panic behavior as `future_to_promise`.
 pub fn spawn_local<F>(future: F)
 where
-    F: Future<Item = (), Error = ()> + 'static,
+    F: Future + 'static,
 {
     future_to_promise(
         future

--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -378,7 +378,14 @@ fn _future_to_promise(future: Box<Future<Item = JsValue, Error = JsValue>>) -> P
     }
 }
 
-/// Spawns a future.
+/// Converts a Rust `Future` on a local task queue.
+///
+/// The `future` provided must adhere to `'static` because it'll be scheduled
+/// to run in the background and cannot contain any stack references.
+///
+/// # Panics
+///
+/// This function has the same panic behavior as `future_to_promise`.
 pub fn spawn_local<F>(future: F)
 where
     F: Future<Item = (), Error = ()> + 'static,

--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -377,3 +377,15 @@ fn _future_to_promise(future: Box<Future<Item = JsValue, Error = JsValue>>) -> P
         }
     }
 }
+
+/// Spawns a future.
+pub fn spawn_local<F>(future: F)
+where
+    F: Future<Item = (), Error = ()> + 'static,
+{
+    future_to_promise(
+        future
+            .map(|_| JsValue::undefined())
+            .map_err(|_| JsValue::undefined()),
+    );
+}

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -542,7 +542,7 @@ impl<'a> IdlType<'a> {
                 Some(option_ty(inner))
             }
             IdlType::FrozenArray(_idl_type) => None,
-            IdlType::Sequence(_idl_type) => None,
+            IdlType::Sequence(_idl_type) => js_sys("Array"),
             IdlType::Promise(_idl_type) => js_sys("Promise"),
             IdlType::Record(_idl_type_from, _idl_type_to) => None,
             IdlType::Union(idl_types) => {


### PR DESCRIPTION
Use `js_sys::Array` for parameters and return types of webidl type `sequence<_>`.