### PR TITLE
Better output from `impl Debug for JsValue`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ INSTALL_NODE_VIA_NVM: &INSTALL_NODE_VIA_NVM
     rustup target add wasm32-unknown-unknown
     curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
     source ~/.nvm/nvm.sh
-    nvm install v10.5
+    nvm install v10.9
 
 INSTALL_GECKODRIVER: &INSTALL_GECKODRIVER
   |

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -377,7 +377,7 @@ impl<'a> Context<'a> {
                         }
                         if (type == 'function') {
                             const name = val.name;
-                            if (typeof name == 'string') {
+                            if (typeof name == 'string' && name.length > 0) {
                                 return `Function(${name})`;
                             } else {
                                 return 'Function';
@@ -391,16 +391,16 @@ impl<'a> Context<'a> {
                                 debug += debug_str(val[0]);
                             }
                             for(let i = 1; i < length; i++) {
-                                debug += debug_str(val[i]) + ', ';
+                                debug += ', ' + debug_str(val[i]);
                             }
                             debug += ']';
                             return debug;
                         }
                         // Test for built-in
-                        const builtInMatches = /\\[object ([^])+\\]/.exec(toString.call(val));
+                        const builtInMatches = /\\[object ([^\\]]+)\\]/.exec(toString.call(val));
                         let className;
-                        if (builtInMatches.len > 0) {
-                            className = builtInMatches[0];
+                        if (builtInMatches.length > 1) {
+                            className = builtInMatches[1];
                         } else {
                             // Failed to match the standard '[object ClassName]'
                             return toString.call(val);
@@ -414,6 +414,7 @@ impl<'a> Context<'a> {
                             } catch (_) {
                                 return 'Object';
                             }
+                        // TODO we could test for more things here, like `Set`s and `Map`s.
                         } else {
                             return className;
                         }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -369,7 +369,7 @@ impl<'a> Context<'a> {
                         if (type == 'symbol') {
                             const description = val.description;
                             if (description == null) {
-                                return 'Symbol()';
+                                return 'Symbol';
                             } else {
                                 return 'Symbol(' + description + ')';
                             }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -350,6 +350,23 @@ impl<'a> Context<'a> {
             ))
         })?;
 
+        self.bind("__wbindgen_to_string", &|me| {
+            me.expose_pass_string_to_wasm()?;
+            me.expose_get_object();
+            me.expose_uint32_memory();
+            Ok(String::from(
+                "
+                function(i, len_ptr) {
+                    let toString = getObject(i).toString();
+                    if (typeof(toString) !== 'string') return 0;
+                    const ptr = passStringToWasm(toString);
+                    getUint32Memory()[len_ptr / 4] = WASM_VECTOR_LEN;
+                    return ptr;
+                }
+                ",
+            ))
+        })?;
+
         self.bind("__wbindgen_cb_drop", &|me| {
             me.expose_drop_ref();
             Ok(String::from(

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -417,7 +417,7 @@ impl<'a> Context<'a> {
                         }
                         // errors
                         if (val instanceof Error) {
-                            return `${className}: ${val.message}\n${val.stack}`;
+                            return `${val.name}: ${val.message}\n${val.stack}`;
                         }
                         // TODO we could test for more things here, like `Set`s and `Map`s.
                         return className;

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -299,18 +299,6 @@ impl<'a> Context<'a> {
             ))
         })?;
 
-        self.bind("__wbindgen_is_array", &|me| {
-            me.expose_get_object();
-            Ok(String::from(
-                "
-                function(i) {
-                    const val = getObject(i);
-                    return Array.isArray(val) ? 1 : 0;
-                }
-                ",
-            ))
-        })?;
-
         self.bind("__wbindgen_is_function", &|me| {
             me.expose_get_object();
             Ok(String::from(

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -414,10 +414,13 @@ impl<'a> Context<'a> {
                             } catch (_) {
                                 return 'Object';
                             }
-                        // TODO we could test for more things here, like `Set`s and `Map`s.
-                        } else {
-                            return className;
                         }
+                        // errors
+                        if (val instanceof Error) {
+                            return `${className}: ${val.message}\n${val.stack}`;
+                        }
+                        // TODO we could test for more things here, like `Set`s and `Map`s.
+                        return className;
                     };
                     const val = getObject(i);
                     const debug = debug_str(val);

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -299,6 +299,18 @@ impl<'a> Context<'a> {
             ))
         })?;
 
+        self.bind("__wbindgen_is_array", &|me| {
+            me.expose_get_object();
+            Ok(String::from(
+                "
+                function(i) {
+                    const val = getObject(i);
+                    return Array.isArray(val) ? 1 : 0;
+                }
+                ",
+            ))
+        })?;
+
         self.bind("__wbindgen_is_function", &|me| {
             me.expose_get_object();
             Ok(String::from(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -536,9 +536,7 @@ impl fmt::Debug for JsValue {
 #[cfg(not(feature = "std"))]
 impl fmt::Debug for JsValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // TODO before merge - this is less info than before - is this OK? Can we do the above
-        // without using allocation (no_std)?
-        f.write_str("JsValue(..)")
+        f.write_str("JsValue")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,7 +489,6 @@ externs! {
     fn __wbindgen_symbol_new(ptr: *const u8, len: usize) -> u32;
     fn __wbindgen_is_symbol(idx: u32) -> u32;
     fn __wbindgen_is_object(idx: u32) -> u32;
-    fn __wbindgen_is_array(idx: u32) -> u32;
     fn __wbindgen_is_function(idx: u32) -> u32;
     fn __wbindgen_is_string(idx: u32) -> u32;
     fn __wbindgen_string_get(idx: u32, len: *mut usize) -> *mut u8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,8 @@ impl Clone for JsValue {
 #[cfg(feature = "std")]
 impl fmt::Debug for JsValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.as_debug_string())
+        use std::fmt::Write;
+        write!(f, "JsValue({})", self.as_debug_string())
     }
 }
 
@@ -538,7 +539,7 @@ impl fmt::Debug for JsValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO before merge - this is less info than before - is this OK? Can we do the above
         // without using allocation (no_std)?
-        f.write_str("[object]")
+        f.write_str("JsValue(..)")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,12 +298,6 @@ impl JsValue {
         unsafe { __wbindgen_is_object(self.idx) == 1 }
     }
 
-    /// Tests whether `Array.isArray(self)`.
-    #[inline]
-    pub fn is_array(&self) -> bool {
-        unsafe { __wbindgen_is_array(self.idx) == 1 }
-    }
-
     /// Tests whether the type of this JS value is `function`.
     #[inline]
     pub fn is_function(&self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,6 +313,21 @@ impl JsValue {
             String::from_utf8_unchecked(s)
         }
     }
+
+    /// Get the string value of self using the JS `toString` method.
+    #[cfg(feature = "std")]
+    fn js_to_string(&self) -> String {
+        unsafe {
+            let mut len = 0;
+            let ptr = __wbindgen_to_string(self.idx, &mut len);
+            if ptr.is_null() {
+                unreachable!("Object.toString must return a valid string")
+            } else {
+                let data = Vec::from_raw_parts(ptr, len, len);
+                String::from_utf8_unchecked(data)
+            }
+        }
+    }
 }
 
 impl PartialEq for JsValue {
@@ -488,6 +503,7 @@ externs! {
     fn __wbindgen_is_function(idx: u32) -> u32;
     fn __wbindgen_is_string(idx: u32) -> u32;
     fn __wbindgen_string_get(idx: u32, len: *mut usize) -> *mut u8;
+    fn __wbindgen_to_string(idx: u32, len: *mut usize) -> *mut u8;
     fn __wbindgen_throw(a: *const u8, b: usize) -> !;
     fn __wbindgen_rethrow(a: u32) -> !;
 
@@ -539,7 +555,7 @@ impl fmt::Debug for JsValue {
         }
         let json = self.as_json();
         if json == "{}" {
-            f.write_str("[object]")
+            f.write_str(&self.js_to_string())
         } else {
             f.write_str(&json)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,6 @@ impl Clone for JsValue {
 #[cfg(feature = "std")]
 impl fmt::Debug for JsValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::fmt::Write;
         write!(f, "JsValue({})", self.as_debug_string())
     }
 }

--- a/tests/wasm/api.js
+++ b/tests/wasm/api.js
@@ -41,3 +41,17 @@ exports.js_eq_works = () => {
     assert.strictEqual(wasm.eq_test(x, x), true);
     assert.strictEqual(wasm.eq_test1(x), true);
 };
+
+exports.debug_values = () => ([
+    null,
+    undefined,
+    0,
+    1.0,
+    true,
+    [1,2,3],
+    "string",
+    {test: "object"},
+    [1.0, [2.0, 3.0]],
+    () => (null),
+    new Set(),
+]);

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -71,7 +71,7 @@ pub fn api_get_false() -> JsValue {
 #[wasm_bindgen]
 pub fn api_test_bool(a: &JsValue, b: &JsValue, c: &JsValue) {
     assert_eq!(a.as_bool(), Some(true));
-    assert_eq!(format!("{:?}", a), "true");
+    assert_eq!(format!("{:?}", a), "JsValue(true)");
     assert_eq!(b.as_bool(), Some(false));
     assert_eq!(c.as_bool(), None);
 }
@@ -80,7 +80,7 @@ pub fn api_test_bool(a: &JsValue, b: &JsValue, c: &JsValue) {
 pub fn api_mk_symbol() -> JsValue {
     let a = JsValue::symbol(None);
     assert!(a.is_symbol());
-    assert_eq!(format!("{:?}", a), "Symbol()");
+    assert_eq!(format!("{:?}", a), "JsValue(Symbol)");
     return a;
 }
 
@@ -100,7 +100,7 @@ pub fn api_assert_symbols(a: &JsValue, b: &JsValue) {
 #[wasm_bindgen]
 pub fn api_acquire_string(a: &JsValue, b: &JsValue) {
     assert_eq!(a.as_string().unwrap(), "foo");
-    assert_eq!(format!("{:?}", a), "\"foo\"");
+    assert_eq!(format!("{:?}", a), "JsValue(\"foo\")");
     assert_eq!(b.as_string(), None);
 }
 

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -80,7 +80,7 @@ pub fn api_test_bool(a: &JsValue, b: &JsValue, c: &JsValue) {
 pub fn api_mk_symbol() -> JsValue {
     let a = JsValue::symbol(None);
     assert!(a.is_symbol());
-    assert_eq!(format!("{:?}", a), "Symbol(..)");
+    assert_eq!(format!("{:?}", a), "Symbol()");
     return a;
 }
 

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -8,6 +8,7 @@ extern "C" {
     fn js_works();
     fn js_eq_works();
     fn assert_null(v: JsValue);
+    fn debug_values() -> JsValue;
 }
 
 #[wasm_bindgen_test]
@@ -144,4 +145,25 @@ fn memory_accessor_appears_to_work() {
         .subarray(ptr, ptr + 4)
         .for_each(&mut |val, _, _| v.push(val));
     assert_eq!(v, [3, 0, 0, 0]);
+}
+
+#[wasm_bindgen_test]
+fn debug_output() {
+    let test_iter = debug_values().dyn_into::<js_sys::Array>().unwrap().values().into_iter();
+    let expecteds = vec![
+        "JsValue(null)",
+        "JsValue(undefined)",
+        "JsValue(0)",
+        "JsValue(1)",
+        "JsValue(true)",
+        "JsValue([1, 2, 3])",
+        "JsValue(\"string\")",
+        "JsValue(Object({\"test\":\"object\"}))",
+        "JsValue([1, [2, 3]])",
+        "JsValue(Function)",
+        "JsValue(Set)",
+    ];
+    for (test, expected) in test_iter.zip(expecteds) {
+        assert_eq!(format!("{:?}", test.unwrap()), expected);
+    }
 }


### PR DESCRIPTION
We can use `JSON.stringify` to get a better debug representation of a value. It's slow, but I think there's an acceptance that Debug (unlike maybe Display) is allowed to be slow to write better strings, given that it's used mostly before deployment.

There's also a new method for testing whether something is an array in javascript. I can remove this if you don't think it's useful.