### PR TITLE
fix spawn_local

### DIFF
--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -113,6 +113,7 @@ use std::sync::Arc;
 
 use futures::executor::{self, Notify, Spawn};
 use futures::prelude::*;
+use futures::future;
 use futures::sync::oneshot;
 use js_sys::{Function, Promise};
 use wasm_bindgen::prelude::*;
@@ -393,6 +394,6 @@ where
     future_to_promise(
         future
             .map(|()| JsValue::undefined())
-            .map_err(|()| JsValue::undefined()),
+            .or_else(|()| future::ok::<JsValue, JsValue>(JsValue::undefined())),
     );
 }

--- a/crates/futures/tests/tests.rs
+++ b/crates/futures/tests/tests.rs
@@ -86,3 +86,25 @@ fn spawn_local_runs() -> impl Future<Item = (), Error = JsValue> {
         }
     })
 }
+
+/// check that `spawn_local` does not forward the `future::err` as an unchecked rejection
+#[wasm_bindgen_test(async)]
+fn spawn_local_err_no_exception() -> impl Future<Item = (), Error = JsValue> {
+    let (tx, rx) = oneshot::channel::<u32>();
+    let fn_box = Box::new(move || {
+        tx.send(42).unwrap();
+    });
+    // Promises should run in a deterministic order, so the `err` should be handled during the execution of this test.
+    spawn_local(futures::future::err::<(), ()>(()));
+    spawn_local(futures::future::ok::<(), ()>(()).map(|_| {
+        fn_box();
+    }));
+    rx.then(|val| {
+        if val == Ok(42) {
+            Ok(())
+        } else {
+            Err(JsValue::undefined())
+        }
+    })
+}
+


### PR DESCRIPTION
`spawn_local` caused `uncaught exception: undefined` on firefox when supplied with an error variant. This should now be fixed.

# Examples

```rust
spawn_local(future::err::<(), ()>(()));
```

I don't know if and how I should write a test for this.