### PR TITLE
In debug mode log all imported uncaught exceptions

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2410,6 +2410,9 @@ impl<'a, 'b> SubContext<'a, 'b> {
         // Build up our shim's state, and we'll use that to guide whether we
         // actually emit an import here or not.
         let mut shim = Rust2Js::new(self.cx);
+        if shim.cx.config.debug {
+            shim.catch_and_rethrow(true);
+        }
         shim.catch(import.catch)
             .variadic(import.variadic)
             .process(descriptor.unwrap_function())?;


### PR DESCRIPTION
This commit updates the `--debug` output of `wasm-bindgen` from the CLI
to catch all JS exceptions from imported functions, log such, and then
rethrow. It's hoped that this can be used when necessary to learn more
information about thrown exceptions and where an uncaught exception
could be causing issues with Rust code.

Closes #1176