### PR TITLE
Fix missing semicolons at generated struct fields in .d.ts

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2514,7 +2514,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                     .argument(&descriptor)?
                     .ret(&Descriptor::Unit)?;
                 ts_dst.push_str(&format!(
-                    "{}{}: {}\n",
+                    "{}{}: {};\n",
                     if field.readonly { "readonly " } else { "" },
                     field.name,
                     &cx.js_arguments[0].1


### PR DESCRIPTION
I had [Rust+Wasm tutorial](https://rustwasm.github.io/book/game-of-life/introduction.html) (Thank you for nice tutorial BTW!) and found that generated TypeScript type definition was wrong.

Rust:

```rust
#[wasm_bindgen]
pub struct Universe {
    pub width: u32,
    pub height: u32,
    // ...
}
```

Generated `.d.ts`

```typescript
export class Universe {
free(): void;
width: number
height: number

// ...
}
```

TypeScript class property requires semicolon at the end. https://www.typescriptlang.org/docs/handbook/classes.html

So I expected

```typescript
export class Universe {
free(): void;
width: number;
height: number;

// ...
}
```

I fixed the issue by this PR.

I confirmed it fixes the issue by manually building `wasm-bindgen` cli and running it in my local project. But I did not add any test for this change because I could not find any tests for TypeScript `.d.ts` generation.