### PR TITLE
wasm-bindgen-test: Capture more console logging methods' output

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
@@ -3,41 +3,38 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
-    <pre id='output'>Loading scripts...</pre>
-    <pre id='console_log'></pre>
-    <pre id='console_error'></pre>
+    <pre id="output">Loading scripts...</pre>
+    <pre id="console_debug"></pre>
+    <pre id="console_log"></pre>
+    <pre id="console_info"></pre>
+    <pre id="console_warn"></pre>
+    <pre id="console_error"></pre>
     <script>
-      const orig_console_log = function(...args) {
-        const logs = document.getElementById('console_log');
-        for (let msg of args) {
-          logs.innerHTML += `${msg}\n`;
-        }
-      };
+     const orig = id => (...args) => {
+         const logs = document.getElementById(id);
+         for (let msg of args) {
+             logs.innerHTML += `${msg}\n`;
+         }
+     };
 
-      const orig_console_error = function(...args) {
-        const logs = document.getElementById('console_error');
-        for (let msg of args) {
-          logs.innerHTML += `${msg}\n`;
-        }
-      };
+     const wrap = method => {
+         const og = orig(`console_${method}`);
+         const on_method = `on_console_${method}`;
+         console[method] = function (...args) {
+             if (window[on_method]) {
+                 window[on_method](args);
+             }
+             og.apply(this, args);
+         };
+     };
 
-      console.log = function(...args) {
-        if (window.on_console_log) {
-          window.on_console_log(args);
-        }
+     wrap("debug");
+     wrap("log");
+     wrap("info");
+     wrap("warn");
+     wrap("error");
 
-        orig_console_log.apply(this, args);
-      };
-
-      console.error = function(...args) {
-        if (window.on_console_error) {
-          window.on_console_error(args);
-        }
-
-        orig_console_error.apply(this, args);
-      };
-
-      window.__wbg_test_invoke = f => f();
+     window.__wbg_test_invoke = f => f();
     </script>
     <script src='run.js' type=module></script>
   </body>

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index.html
@@ -5,26 +5,24 @@
   <body>
     <pre id='output'>Loading scripts...</pre>
     <script>
-      const orig_console_log = console.log;
-      const orig_console_error = console.error;
+     const wrap = method => {
+         const og = console[method];
+         const on_method = `on_console_${method}`;
+         console[method] = function (...args) {
+             if (window[on_method]) {
+                 window[on_method](args);
+             }
+             og.apply(this, args);
+         };
+     };
 
-      console.log = function(...args) {
-        if (window.on_console_log) {
-          window.on_console_log(args);
-        }
+     wrap("debug");
+     wrap("log");
+     wrap("info");
+     wrap("warn");
+     wrap("error");
 
-        orig_console_log.apply(this, args);
-      };
-
-      console.error = function(...args) {
-        if (window.on_console_error) {
-          window.on_console_error(args);
-        }
-
-        orig_console_error.apply(this, args);
-      };
-
-      window.__wbg_test_invoke = f => f();
+     window.__wbg_test_invoke = f => f();
     </script>
     <script src='run.js' type=module></script>
   </body>

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
@@ -16,26 +16,27 @@ pub fn execute(
         r#"
         const {{ exit }} = require('process');
 
-        let on_console_log = null;
-        let on_console_error = null;
+        const handlers = {{}};
 
-        // override `console.log` and `console.error` before we import tests to
+        const wrap = method => {{
+            const og = console[method];
+            const on_method = `on_console_${{method}}`;
+            console[method] = function (...args) {{
+                if (handlers[on_method]) {{
+                    handlers[on_method](args);
+                }}
+                og.apply(this, args);
+            }};
+        }};
+
+        // override `console.log` and `console.error` etc... before we import tests to
         // ensure they're bound correctly in wasm. This'll allow us to intercept
         // all these calls and capture the output of tests
-        const prev_log = console.log;
-        console.log = function(...args) {{
-            if (on_console_log)  {{
-                on_console_log(args);
-            }}
-            prev_log.apply(null, args);
-        }};
-        const prev_error = console.error;
-        console.error = function(...args) {{
-            if (on_console_error) {{
-                on_console_error(args);
-            }}
-            prev_error.apply(null, args);
-        }};
+        wrap("debug");
+        wrap("log");
+        wrap("info");
+        wrap("warn");
+        wrap("error");
 
         global.__wbg_test_invoke = f => f();
 
@@ -44,8 +45,11 @@ pub fn execute(
             const wasm = require("./{0}_bg");
 
             cx = new support.Context();
-            on_console_log = support.__wbgtest_console_log;
-            on_console_error = support.__wbgtest_console_error;
+            handlers.on_console_debug = support.__wbgtest_console_debug;
+            handlers.on_console_log = support.__wbgtest_console_log;
+            handlers.on_console_info = support.__wbgtest_console_info;
+            handlers.on_console_warn = support.__wbgtest_console_warn;
+            handlers.on_console_error = support.__wbgtest_console_error;
 
             // Forward runtime arguments. These arguments are also arguments to the
             // `wasm-bindgen-test-runner` which forwards them to node which we

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -17,7 +17,14 @@ pub fn spawn(
 ) -> Result<Server<impl Fn(&Request) -> Response + Send + Sync>, Error> {
     let mut js_to_execute = format!(
         r#"
-        import {{ Context, __wbgtest_console_log, __wbgtest_console_error }} from './{0}';
+        import {{
+            Context,
+            __wbgtest_console_debug,
+            __wbgtest_console_log,
+            __wbgtest_console_info,
+            __wbgtest_console_warn,
+            __wbgtest_console_error
+        }} from './{0}';
         import * as wasm from './{0}_bg';
 
         // Now that we've gotten to the point where JS is executing, update our
@@ -31,7 +38,10 @@ pub fn spawn(
             await wasm.booted;
 
             const cx = new Context();
+            window.on_console_debug = __wbgtest_console_debug;
             window.on_console_log = __wbgtest_console_log;
+            window.on_console_info = __wbgtest_console_info;
+            window.on_console_warn = __wbgtest_console_warn;
             window.on_console_error = __wbgtest_console_error;
 
             // Forward runtime arguments. These arguments are also arguments to the


### PR DESCRIPTION
Fixes #1183