### PR TITLE
ci: build docs on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -223,7 +223,7 @@ matrix:
       if: branch = master
 
     # Build API documentation
-    - rust: nightly
+    - rust: stable
       name: "doc: API documentation"
       install: *INSTALL_AWS
       script:


### PR DESCRIPTION
This avoids https://github.com/rust-lang/rust/issues/57628 and also generally makes sense since wasm-bindgen buils on stable.