### PR TITLE
Add '| undefined' to optional types in generated .d.ts

### DIFF
--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -208,7 +208,8 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
         if optional {
             if arg.is_wasm_native() {
                 self.cx.expose_is_like_none();
-                self.js_arguments.push((name.clone(), "number".to_string()));
+                self.js_arguments
+                    .push((name.clone(), "number | undefined".to_string()));
 
                 if self.cx.config.debug {
                     self.cx.expose_assert_num();
@@ -230,7 +231,8 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
 
             if arg.is_abi_as_u32() {
                 self.cx.expose_is_like_none();
-                self.js_arguments.push((name.clone(), "number".to_string()));
+                self.js_arguments
+                    .push((name.clone(), "number | undefined".to_string()));
 
                 if self.cx.config.debug {
                     self.cx.expose_assert_num();
@@ -256,7 +258,8 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                     self.cx.expose_uint64_cvt_shim()
                 };
                 self.cx.expose_uint32_memory();
-                self.js_arguments.push((name.clone(), "BigInt".to_string()));
+                self.js_arguments
+                    .push((name.clone(), "BigInt | undefined".to_string()));
                 self.prelude(&format!(
                     "
                         {f}[0] = isLikeNone({name}) ? BigInt(0) : {name};
@@ -278,7 +281,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 Descriptor::Boolean => {
                     self.cx.expose_is_like_none();
                     self.js_arguments
-                        .push((name.clone(), "boolean".to_string()));
+                        .push((name.clone(), "boolean | undefined".to_string()));
                     if self.cx.config.debug {
                         self.cx.expose_assert_bool();
                         self.prelude(&format!(
@@ -296,7 +299,8 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 }
                 Descriptor::Char => {
                     self.cx.expose_is_like_none();
-                    self.js_arguments.push((name.clone(), "string".to_string()));
+                    self.js_arguments
+                        .push((name.clone(), "string | undefined".to_string()));
                     self.rust_arguments.push(format!("!isLikeNone({0})", name));
                     self.rust_arguments
                         .push(format!("isLikeNone({0}) ? 0 : {0}.codePointAt(0)", name));


### PR DESCRIPTION
Hi,

```rust
#[wasm_bindgen]
struct X {
    pub foo: Option<i32>,
}

#[wasm_bindgen]
impl X {
    pub fn f(x: Option<i32>) -> Option<u32> {
        x.map(|i| i as u32)
    }
}
```

These option values generate TS type definition in `.d.ts` file as follows

```typescript
export class X {
free(): void;
foo: number;

static  f(arg0: number): number | undefined;

}
```

However, by this type definition, `foo` and `arg0`  cannot accept `undefined` though the original values are `Option` when using `strictNullChecks` compiler flag of `tsc`. Passing `undefined` to the `arg0` causes TypeScript compilation error. And the compiler thinks accessing to `foo` always returns non-`undefined` value so compiler cannot check the case where `foo` is `undefined`.

Expected type definition is:

```typescript
export class X {
free(): void;
foo: number | undefined;

static  f(arg0: number | undefined): number | undefined;

}
```

`number | undefined` means a value which is `number` or `undefined`. It should make `tsc` happy.

This patch modifies TS type definition file generation to generate the types `T | undefind` for `Option<T>` values.