### PR TITLE
browser-support: warn about the performance hit of the polyfill

### DIFF
--- a/guide/src/reference/browser-support.md
+++ b/guide/src/reference/browser-support.md
@@ -44,6 +44,10 @@ also like to be aware of it!
      };
      ```
 
+     **Warning:** doing this implies the polyfill will always be used,
+     even if native APIs are available. This has a very significant
+     performance impact (the polyfill was measured to be 100x slower in Chromium)!
+
   2. If you're not using a bundler you can also include support manually by
      adding a `<script>` tag which defines the `TextEncoder` and `TextDecoder`
      globals. [This StackOverflow question][soq] has some example usage and MDN


### PR DESCRIPTION
Fixes #1205, kind of.

furthermore:

* perhaps this warning should be more visible and also added as a comment to the config itself; users who are taking examples from the crate as a basis need to know this
* I still intend on fixing this completely, but other than just forking text-encoding, idk what else can be done; perhaps creating a wrapper to text-encoding called text-encoding-browser/text-encoding/fallthrough which checks if the native APIs are available first 