### PR TITLE
Format .d.ts file

### DIFF
--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -743,7 +743,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             ts.push_str(": ");
             ts.push_str(&self.ret_ty);
         }
-        ts.push_str(";\n");
+        ts.push(';');
         (js, ts, self.js_doc_comments())
     }
 }

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -734,7 +734,11 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
             .map(|s| format!("{}: {}", s.0, s.1))
             .collect::<Vec<_>>()
             .join(", ");
-        let mut ts = format!("{} {}({})", prefix, self.js_name, ts_args);
+        let mut ts = if prefix.is_empty() {
+            format!("{}({})", self.js_name, ts_args)
+        } else {
+            format!("{} {}({})", prefix, self.js_name, ts_args)
+        };
         if self.constructor.is_none() {
             ts.push_str(": ");
             ts.push_str(&self.ret_ty);

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -845,7 +845,7 @@ impl<'a> Context<'a> {
             ",
             name,
         ));
-        ts_dst.push_str("free(): void;\n");
+        ts_dst.push_str("  free(): void;\n");
         dst.push_str(&class.contents);
         ts_dst.push_str(&class.typescript);
         dst.push_str("}\n");
@@ -2399,6 +2399,8 @@ impl<'a, 'b> SubContext<'a, 'b> {
             .contents
             .push_str(&format_doc_comments(&export.comments, Some(js_doc)));
 
+        class.typescript.push_str("  "); // Indentation
+
         if export.is_constructor {
             if class.has_constructor {
                 bail!("found duplicate constructor `{}`", export.function.name);
@@ -2596,7 +2598,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                     .argument(&descriptor)?
                     .ret(&Descriptor::Unit)?;
                 ts_dst.push_str(&format!(
-                    "{}{}: {};\n",
+                    "  {}{}: {};\n",
                     if field.readonly { "readonly " } else { "" },
                     field.name,
                     &cx.js_arguments[0].1

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2573,12 +2573,12 @@ impl<'a, 'b> SubContext<'a, 'b> {
             .typescript
             .push_str(&format!("export enum {} {{", enum_.name));
 
-        variants.clear();
         for variant in enum_.variants.iter() {
-            variants.push_str(&format!("{},", variant.name));
+            self.cx
+                .typescript
+                .push_str(&format!("\n  {},", variant.name));
         }
-        self.cx.typescript.push_str(&variants);
-        self.cx.typescript.push_str("}\n");
+        self.cx.typescript.push_str("\n}\n");
     }
 
     fn generate_struct(&mut self, struct_: &decode::Struct) -> Result<(), Error> {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -845,7 +845,7 @@ impl<'a> Context<'a> {
             ",
             name,
         ));
-        ts_dst.push_str("  free(): void;\n");
+        ts_dst.push_str("  free(): void;");
         dst.push_str(&class.contents);
         ts_dst.push_str(&class.typescript);
         dst.push_str("}\n");
@@ -2598,7 +2598,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                     .argument(&descriptor)?
                     .ret(&Descriptor::Unit)?;
                 ts_dst.push_str(&format!(
-                    "  {}{}: {};\n",
+                    "\n  {}{}: {};",
                     if field.readonly { "readonly " } else { "" },
                     field.name,
                     &cx.js_arguments[0].1


### PR DESCRIPTION
TypeScript description file is useful not only for TypeScript compiler but also for programmers to know the API. However, current `.d.ts` file generated by `wasm-bindgen` is not fully formatted.

This patch improves readability of generated `.d.ts` file by fixing some formats

- Give each class member 2 spaces indentation
- Remove unnecessary space before function name
- Remove unnecessary blank lines
- Give 2 space indentations to each enum variant

I applied my patched `wasm-bindgen` to [my project](https://github.com/rhysd/world-map-gen). Here is the result.

### Before applying this patch:

```typescript
/* tslint:disable */
export enum Resolution {Low,Middle,High,}
export enum LandKind {Sea,Mountain,Forest,Plain,Town,Top,Highland,DeepSea,Path,}
export class Cell {
free(): void;
kind: number;
altitude: number;

 color_code(): string;

 rgb_color(): number | undefined;

 legend(): string;

}
export class Generator {
free(): void;

static  new(): Generator;

 gen_auto(arg0: number, arg1: number): Board;

 gen(arg0: number, arg1: number, arg2: number): Board;

}
export class Board {
free(): void;

 width(): number;

 height(): number;

 at(arg0: number, arg1: number): Cell;

 as_json(): string;

}
```

### After applying this patch

```typescript
/* tslint:disable */
export enum LandKind {
  Sea,
  Mountain,
  Forest,
  Plain,
  Town,
  Top,
  Highland,
  DeepSea,
  Path,
}
export enum Resolution {
  Low,
  Middle,
  High,
}
export class Board {
  free(): void;
  width(): number;
  height(): number;
  at(arg0: number, arg1: number): Cell;
  as_json(): string;
}
export class Cell {
  free(): void;
  kind: number;
  altitude: number;
  color_code(): string;
  rgb_color(): number | undefined;
  legend(): string;
}
export class Generator {
  free(): void;
  static new(): Generator;
  gen_auto(arg0: number, arg1: number): Board;
  gen(arg0: number, arg1: number, arg2: number): Board;
}
```