### PR TITLE
Adding in Reflect::get_f64, Reflect::get_u32, Reflect::set_f64, and Reflect::set_u32

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2654,6 +2654,14 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Reflect, catch)]
     pub fn get(target: &JsValue, key: &JsValue) -> Result<JsValue, JsValue>;
 
+    /// The same as [`Reflect::get`](#method.get) except the key is an `f64`, which is slightly faster.
+    #[wasm_bindgen(static_method_of = Reflect, js_name = "get", catch)]
+    pub fn get_f64(target: &JsValue, key: f64) -> Result<JsValue, JsValue>;
+
+    /// The same as [`Reflect::get`](#method.get) except the key is a `u32`, which is slightly faster.
+    #[wasm_bindgen(static_method_of = Reflect, js_name = "get", catch)]
+    pub fn get_u32(target: &JsValue, key: u32) -> Result<JsValue, JsValue>;
+
     /// The static `Reflect.getOwnPropertyDescriptor()` method is similar to
     /// `Object.getOwnPropertyDescriptor()`. It returns a property descriptor
     /// of the given property if it exists on the object, `undefined` otherwise.
@@ -2711,6 +2719,14 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set)
     #[wasm_bindgen(static_method_of = Reflect, catch)]
     pub fn set(target: &JsValue, property_key: &JsValue, value: &JsValue) -> Result<bool, JsValue>;
+
+    /// The same as [`Reflect::set`](#method.set) except the key is an `f64`, which is slightly faster.
+    #[wasm_bindgen(static_method_of = Reflect, js_name = "set", catch)]
+    pub fn set_f64(target: &JsValue, property_key: f64, value: &JsValue) -> Result<bool, JsValue>;
+
+    /// The same as [`Reflect::set`](#method.set) except the key is a `u32`, which is slightly faster.
+    #[wasm_bindgen(static_method_of = Reflect, js_name = "set", catch)]
+    pub fn set_u32(target: &JsValue, property_key: u32, value: &JsValue) -> Result<bool, JsValue>;
 
     /// The static `Reflect.set()` method works like setting a
     /// property on an object.

--- a/crates/js-sys/tests/wasm/Reflect.rs
+++ b/crates/js-sys/tests/wasm/Reflect.rs
@@ -106,6 +106,22 @@ fn get() {
 }
 
 #[wasm_bindgen_test]
+fn get_f64() {
+    let a = Array::new();
+    assert_eq!(Reflect::get_f64(&a, 0.0).unwrap(), JsValue::UNDEFINED);
+    assert_eq!(a.push(&JsValue::from_str("Hi!")), 1);
+    assert_eq!(Reflect::get_f64(&a, 0.0).unwrap(), JsValue::from_str("Hi!"));
+}
+
+#[wasm_bindgen_test]
+fn get_u32() {
+    let a = Array::new();
+    assert_eq!(Reflect::get_u32(&a, 0).unwrap(), JsValue::UNDEFINED);
+    assert_eq!(a.push(&JsValue::from_str("Hi!")), 1);
+    assert_eq!(Reflect::get_u32(&a, 0).unwrap(), JsValue::from_str("Hi!"));
+}
+
+#[wasm_bindgen_test]
 fn get_own_property_descriptor() {
     let r = Rectangle::new();
     r.set_x(10);
@@ -167,6 +183,30 @@ fn set() {
 }
 
 #[wasm_bindgen_test]
+fn set_f64() {
+    let a = Array::new();
+    a.push(&JsValue::from_str("Hi!"));
+
+    assert_eq!(Reflect::get_f64(&a, 0.0).unwrap(), JsValue::from_str("Hi!"));
+
+    Reflect::set_f64(&a, 0.0, &JsValue::from_str("Bye!")).unwrap();
+
+    assert_eq!(Reflect::get_f64(&a, 0.0).unwrap(), JsValue::from_str("Bye!"));
+}
+
+#[wasm_bindgen_test]
+fn set_u32() {
+    let a = Array::new();
+    a.push(&JsValue::from_str("Hi!"));
+
+    assert_eq!(Reflect::get_u32(&a, 0).unwrap(), JsValue::from_str("Hi!"));
+
+    Reflect::set_u32(&a, 0, &JsValue::from_str("Bye!")).unwrap();
+
+    assert_eq!(Reflect::get_u32(&a, 0).unwrap(), JsValue::from_str("Bye!"));
+}
+
+#[wasm_bindgen_test]
 fn set_with_receiver() {
     let obj1 = JsValue::from(Object::new());
     let obj2 = JsValue::from(Object::new());
@@ -209,6 +249,8 @@ fn reflect_bindings_handle_proxies_that_just_throw_for_everything() {
     assert!(Reflect::delete_property(&p, &"a".into()).is_err());
 
     assert!(Reflect::get(p.as_ref(), &"a".into()).is_err());
+    assert!(Reflect::get_f64(p.as_ref(), 0.0).is_err());
+    assert!(Reflect::get_u32(p.as_ref(), 0).is_err());
 
     assert!(Reflect::get_own_property_descriptor(&p, &"a".into()).is_err());
 
@@ -223,6 +265,8 @@ fn reflect_bindings_handle_proxies_that_just_throw_for_everything() {
     assert!(Reflect::prevent_extensions(&p).is_err());
 
     assert!(Reflect::set(p.as_ref(), &"a".into(), &1.into()).is_err());
+    assert!(Reflect::set_f64(p.as_ref(), 0.0, &1.into()).is_err());
+    assert!(Reflect::set_u32(p.as_ref(), 0, &1.into()).is_err());
 
     assert!(Reflect::set_prototype_of(&p, Object::new().as_ref()).is_err());
 }


### PR DESCRIPTION
It is quite common to want to get/set numeric properties (e.g. on Arrays, TypedArrays, etc.)

These methods are both more convenient and faster than `Reflect::get` and `Reflect::set`.

It might also be worth it to add methods directly to some of the types (e.g. Array and the TypedArrays), but that has some implementation difficulties which we should discuss first.