### PR TITLE
Simplifying the error handling code

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1546,6 +1546,23 @@ impl<'a> Context<'a> {
         ));
     }
 
+    fn expose_handle_error(&mut self) {
+        if !self.should_write_global("handle_error") {
+            return;
+        }
+        self.expose_uint32_memory();
+        self.expose_add_heap_object();
+        self.global(
+            "
+            function handleError(exnptr, e) {
+                const view = getUint32Memory();
+                view[exnptr / 4] = 1;
+                view[exnptr / 4 + 1] = addHeapObject(e);
+            }
+            ",
+        );
+    }
+
     fn wasm_import_needed(&self, name: &str) -> bool {
         let imports = match self.module.import_section() {
             Some(s) => s,

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -643,23 +643,16 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         };
 
         if self.catch {
-            self.cx.expose_uint32_memory();
-            self.cx.expose_add_heap_object();
-            let catch = "\
-                         const view = getUint32Memory();\n\
-                         view[exnptr / 4] = 1;\n\
-                         view[exnptr / 4 + 1] = addHeapObject(e);\n\
-                         ";
-
+            self.cx.expose_handle_error();
             invoc = format!(
                 "\
                 try {{\n\
                     {}
                 }} catch (e) {{\n\
-                    {}
+                    handleError(exnptr, e);\n\
                 }}\
                 ",
-                &invoc, catch
+                &invoc
             );
         } else if self.catch_and_rethrow {
             invoc = format!(


### PR DESCRIPTION
A lot of methods use `catch`, and thus generate error handling code.

This error handling code is identical for all methods, and it takes up a lot of space (bloating up the file size).

This PR fixes that, by moving the error handling code into a top-level `handleError` function.