### PR TITLE
Use textContent instead of innerHTML for extracting logs from headless browser tests

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
@@ -13,7 +13,7 @@
      const orig = id => (...args) => {
          const logs = document.getElementById(id);
          for (let msg of args) {
-             logs.innerHTML += `${msg}\n`;
+             logs.textContent += `${msg}\n`;
          }
      };
 

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -30,7 +30,7 @@ pub fn spawn(
         // Now that we've gotten to the point where JS is executing, update our
         // status text as at this point we should be asynchronously fetching the
         // wasm module.
-        document.getElementById('output').innerHTML = "Loading wasm module...";
+        document.getElementById('output').textContent = "Loading wasm module...";
 
         async function main(test) {{
             // this is a facet of using wasm2es6js, a hack until browsers have

--- a/crates/test/src/rt/browser.rs
+++ b/crates/test/src/rt/browser.rs
@@ -22,10 +22,10 @@ extern "C" {
     fn getElementById(this: &HTMLDocument, id: &str) -> Element;
 
     type Element;
-    #[wasm_bindgen(method, getter = innerHTML, structural)]
-    fn inner_html(this: &Element) -> String;
-    #[wasm_bindgen(method, setter = innerHTML, structural)]
-    fn set_inner_html(this: &Element, html: &str);
+    #[wasm_bindgen(method, getter = textContent, structural)]
+    fn text_content(this: &Element) -> String;
+    #[wasm_bindgen(method, setter = textContent, structural)]
+    fn set_text_content(this: &Element, text: &str);
 
     type BrowserError;
     #[wasm_bindgen(method, getter, structural)]
@@ -37,24 +37,16 @@ impl Browser {
     /// (requires `Node::new()` to have return `None` first).
     pub fn new() -> Browser {
         let pre = document.getElementById("output");
-        pre.set_inner_html("");
+        pre.set_text_content("");
         Browser { pre }
     }
 }
 
 impl super::Formatter for Browser {
     fn writeln(&self, line: &str) {
-        let mut html = self.pre.inner_html();
-        for c in line.chars() {
-            match c {
-                '<' => html.push_str("&lt;"),
-                '>' => html.push_str("&gt;"),
-                '&' => html.push_str("&amp;"),
-                c => html.push(c),
-            }
-        }
-        html.push_str("\n");
-        self.pre.set_inner_html(&html);
+        let mut html = self.pre.text_content();
+        html.extend(line.chars().chain(Some('\n')));
+        self.pre.set_text_content(&html);
     }
 
     fn log_test(&self, name: &str, result: &Result<(), JsValue>) {

--- a/tests/headless.rs
+++ b/tests/headless.rs
@@ -26,3 +26,14 @@ impl ConsumeRetString {
 fn works() {
     ConsumeRetString.consume();
 }
+
+#[wasm_bindgen]
+extern {
+    #[wasm_bindgen(js_namespace = console)]
+    pub fn log(s: &str);
+}
+
+#[wasm_bindgen_test]
+fn can_log_html_strings() {
+    log("<script>alert('lol')</script>");
+}


### PR DESCRIPTION
Easier to maintain fidelity and less likely to be sabotaged by XSS and `<script>` tags.

Fixes #1232