### PR TITLE
A couple small improvements

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -612,7 +612,17 @@ impl<'a> Context<'a> {
             memory = __exports.memory = {init_memory};
             const response = fetch(module_or_path);
             if (typeof WebAssembly.instantiateStreaming === 'function') {{
-                result = WebAssembly.instantiateStreaming(response, imports);
+                result = WebAssembly.instantiateStreaming(response, imports)
+                    .catch(e => {{
+                        console.warn(\"`WebAssembly.instantiateStreaming` failed. Assuming this is \
+                                        because your server does not serve wasm with \
+                                        `application/wasm` MIME type. Falling back to \
+                                        `WebAssembly.instantiate` which is slower. Original \
+                                        error:\\n\", e);
+                        return response
+                            .then(r => r.arrayBuffer())
+                            .then(bytes => WebAssembly.instantiate(bytes, imports));
+                    }});
             }} else {{
                 result = response
                     .then(r => r.arrayBuffer())

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4339,7 +4339,7 @@ impl From<String> for JsString {
 
 impl<'a> From<&'a JsString> for String {
     fn from(s: &'a JsString) -> Self {
-        s.obj.as_string().unwrap()
+        s.obj.as_string().unwrap_throw()
     }
 }
 


### PR DESCRIPTION
* Use `unwrap_throw` instead of normal `unwrap` for JsString -> String conversion
* Don't give up when servers don't set the application/wasm MIME type