### PR TITLE
Run mdbook-linkcheck on guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 sudo: false
+cache: cargo
 
 INSTALL_NODE_VIA_NVM: &INSTALL_NODE_VIA_NVM
   |
@@ -212,14 +213,13 @@ matrix:
     # Build mdbook documentation
     - name: "doc: Guide documentation"
       install:
-        - mkdir -p $HOME/mdbook
-        - curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.2.1/mdbook-v0.2.1-x86_64-unknown-linux-musl.tar.gz | tar xzf - -C $HOME/mdbook
-        - export PATH=$PATH:$HOME/mdbook
+        - cargo list | grep install-update || cargo install -f cargo-update
+        - cargo install-update -i mdbook mdbook-linkcheck
         - *INSTALL_AWS
       script:
         - (cd guide && mdbook build)
         - rm -rf ~/$TRAVIS_BUILD_NUMBER
-        - mv guide/book ~/$TRAVIS_BUILD_NUMBER
+        - mv guide/book/html ~/$TRAVIS_BUILD_NUMBER
         - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then aws s3 sync --quiet ~/$TRAVIS_BUILD_NUMBER s3://wasm-bindgen-ci/$TRAVIS_BUILD_NUMBER; fi
       if: branch = master
 

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -3,3 +3,6 @@ authors = ["Nick Fitzgerald"]
 multilingual = false
 src = "src"
 title = "The `wasm-bindgen` Guide"
+
+[output.html]
+[output.linkcheck]


### PR DESCRIPTION
This updates the guide manifest to run linkcheck as part of building. A side effect is the html output is now in a subdirectory named "html".  I also updated the travis ci config to install mdbook-linkcheck with cargo. While I was at it, I started installing mdbook with cargo as well , and since this will compile mdbook, I added `cargo: cache` to prevent the need to compile it each time the test runs.

Previously mdbook was installed with curl rather than cargo. Was that to prevent compiling mdbook each time the test ran?