### PR TITLE
Fix build error in nightly version

### DIFF
--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -4,6 +4,7 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro-support/0.2")]
 
 extern crate proc_macro2;
+#[macro_use]
 extern crate quote;
 #[macro_use]
 extern crate syn;


### PR DESCRIPTION
Build in rust nightly:

```
warning: ignoring -C extra-filename flag due to -o flag

error: cannot find macro `quote_spanned!` in this scope
   --> /Users/---/.cargo/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-macro-support-0.2.36/src/parser.rs:898:18
    |
898 |             tts: quote::quote! { (#class = #js_class) }.into(),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: aborting due to previous error

error: Could not compile `wasm-bindgen-macro-support`.
warning: build failed, waiting for other jobs to finish...
error: build failed

```

this PR can fix this.