### PR TITLE
[HTMLMediaElement] Reintroduce srcObject

### DIFF
--- a/crates/web-sys/webidls/enabled/HTMLMediaElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLMediaElement.webidl
@@ -21,6 +21,8 @@ interface HTMLMediaElement : HTMLElement {
            attribute DOMString src;
   readonly attribute DOMString currentSrc;
 
+  attribute MediaStream? srcObject;
+
   [CEReactions, SetterThrows]
            attribute DOMString? crossOrigin;
   const unsigned short NETWORK_EMPTY = 0;


### PR DESCRIPTION
This was removed when mozilla specific extensions were removed. It is not mozilla specific though and currently the only way to show webcam data in a video element that I am aware of.