### PR TITLE
Add a flag to remove producers section

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.9"
 failure = "0.1.2"
 rustc-demangle = "0.1.13"
 tempfile = "3.0"
-walrus = "0.2"
+walrus = "0.2.1"
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.36' }
 wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.36' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.36' }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -27,6 +27,7 @@ pub struct Bindgen {
     demangle: bool,
     keep_debug: bool,
     remove_name_section: bool,
+    remove_producers_section: bool,
     emit_start: bool,
     // Experimental support for `WeakRefGroup`, an upcoming ECMAScript feature.
     // Currently only enable-able through an env var.
@@ -57,6 +58,7 @@ impl Bindgen {
             demangle: true,
             keep_debug: false,
             remove_name_section: false,
+            remove_producers_section: false,
             emit_start: true,
             weak_refs: env::var("WASM_BINDGEN_WEAKREF").is_ok(),
             threads: threads_config(),
@@ -130,6 +132,11 @@ impl Bindgen {
         self
     }
 
+    pub fn remove_producers_section(&mut self, remove: bool) -> &mut Bindgen {
+        self.remove_producers_section = remove;
+        self
+    }
+
     pub fn emit_start(&mut self, emit: bool) -> &mut Bindgen {
         self.emit_start = emit;
         self
@@ -159,6 +166,7 @@ impl Bindgen {
                     .strict_validate(false)
                     .generate_dwarf(self.keep_debug)
                     .generate_name_section(!self.remove_name_section)
+                    .generate_producers_section(!self.remove_producers_section)
                     .parse(&contents)
                     .context("failed to parse input file as wasm")?;
                 let stem = match &self.out_name {

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -18,20 +18,21 @@ Usage:
     wasm-bindgen -V | --version
 
 Options:
-    -h --help                Show this screen.
-    --out-dir DIR            Output directory
-    --out-name VAR           Set a custom output filename (Without extension. Defaults to crate name)
-    --nodejs                 Generate output that only works in node.js
-    --browser                Generate output that only works in a browser
-    --no-modules             Generate output that only works in a browser (without modules)
-    --no-modules-global VAR  Name of the global variable to initialize
-    --typescript             Output a TypeScript definition file (on by default)
-    --no-typescript          Don't emit a *.d.ts file
-    --debug                  Include otherwise-extraneous debug checks in output
-    --no-demangle            Don't demangle Rust symbol names
-    --keep-debug             Keep debug sections in wasm files
-    --remove-name-section    Remove the debugging `name` section of the file
-    -V --version             Print the version number of wasm-bindgen
+    -h --help                    Show this screen.
+    --out-dir DIR                Output directory
+    --out-name VAR               Set a custom output filename (Without extension. Defaults to crate name)
+    --nodejs                     Generate output that only works in node.js
+    --browser                    Generate output that only works in a browser
+    --no-modules                 Generate output that only works in a browser (without modules)
+    --no-modules-global VAR      Name of the global variable to initialize
+    --typescript                 Output a TypeScript definition file (on by default)
+    --no-typescript              Don't emit a *.d.ts file
+    --debug                      Include otherwise-extraneous debug checks in output
+    --no-demangle                Don't demangle Rust symbol names
+    --keep-debug                 Keep debug sections in wasm files
+    --remove-name-section        Remove the debugging `name` section of the file
+    --remove-producers-section   Remove the telemetry `producers` section
+    -V --version                 Print the version number of wasm-bindgen
 ";
 
 #[derive(Debug, Deserialize)]
@@ -48,6 +49,7 @@ struct Args {
     flag_no_demangle: bool,
     flag_no_modules_global: Option<String>,
     flag_remove_name_section: bool,
+    flag_remove_producers_section: bool,
     flag_keep_debug: bool,
     arg_input: Option<PathBuf>,
 }
@@ -90,6 +92,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .demangle(!args.flag_no_demangle)
         .keep_debug(args.flag_keep_debug)
         .remove_name_section(args.flag_remove_name_section)
+        .remove_producers_section(args.flag_remove_producers_section)
         .typescript(typescript);
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name);


### PR DESCRIPTION
This should help handle instances like the recent Webpack bug and is
also a useful flag in its own right. For now it's set to `false`, but if
the Webpack bug persists through to tomorrow we likely want to publish a
version of `wasm-bindgen` with it default set to `true`.