### PR TITLE
Fix warning on ATOMIC_USIZE_INIT & ATOMIC_BOOL_INIT

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use proc_macro2::{Ident, Literal, Span, TokenStream};
@@ -79,7 +79,7 @@ impl TryToTokens for ast::Program {
         // of the wasm executable. For now it's just a plain old static, but we'll
         // eventually have it actually in its own section.
 
-        static CNT: AtomicUsize = ATOMIC_USIZE_INIT;
+        static CNT: AtomicUsize = AtomicUsize::new(0);
 
         let generated_static_name = format!(
             "__WASM_BINDGEN_GENERATED_{}",

--- a/crates/backend/src/util.rs
+++ b/crates/backend/src/util.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::iter::FromIterator;
 use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT};
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use std::sync::atomic::{AtomicBool};
+use std::sync::atomic::{AtomicUsize};
 
 use ast;
 use proc_macro2::{self, Ident};
@@ -109,8 +109,8 @@ pub struct ShortHash<T>(pub T);
 
 impl<T: Hash> fmt::Display for ShortHash<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        static HASHED: AtomicBool = ATOMIC_BOOL_INIT;
-        static HASH: AtomicUsize = ATOMIC_USIZE_INIT;
+        static HASHED: AtomicBool = AtomicBool::new(false);
+        static HASH: AtomicUsize = AtomicUsize::new(0);
 
         // Try to amortize the cost of loading env vars a lot as we're gonna be
         // hashing for a lot of symbols.

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -9,7 +9,7 @@ extern crate quote;
 use proc_macro2::*;
 use std::sync::atomic::*;
 
-static CNT: AtomicUsize = ATOMIC_USIZE_INIT;
+static CNT: AtomicUsize = AtomicUsize::new(0);
 
 #[proc_macro_attribute]
 pub fn wasm_bindgen_test(

--- a/examples/raytrace-parallel/src/lib.rs
+++ b/examples/raytrace-parallel/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::cmp;
 use std::rc::Rc;
-use std::sync::atomic::ATOMIC_USIZE_INIT;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -28,7 +27,7 @@ pub struct Scene {
     inner: raytracer::scene::Scene,
 }
 
-static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[wasm_bindgen]
 impl Scene {


### PR DESCRIPTION
This PR fix the following warnings:
![2019-02-15-120137_2213x446_scrot](https://user-images.githubusercontent.com/1716173/52855490-777af100-3119-11e9-98b8-8b31a1d0e6cb.png)
![2019-02-15-120217_2115x358_scrot](https://user-images.githubusercontent.com/1716173/52855522-9083a200-3119-11e9-9954-520f867cc363.png)
