### PR TITLE
Temporarily unconditionally remove producers section

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -58,7 +58,7 @@ impl Bindgen {
             demangle: true,
             keep_debug: false,
             remove_name_section: false,
-            remove_producers_section: false,
+            remove_producers_section: true,
             emit_start: true,
             weak_refs: env::var("WASM_BINDGEN_WEAKREF").is_ok(),
             threads: threads_config(),


### PR DESCRIPTION
We've had a lot of bug reports with upstream webpack currently and while
webpack has a fix it may take a moment to deploy. Let's try and fix
wasm-bindgen in the meantime!

Once webpack is updated we can go back to emitting a producers section
by default and publish a new version of wasm-bindgen.