### PR TITLE
Fix an assert while deleting table elements

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -14,6 +14,7 @@ edition = '2018'
 [dependencies]
 base64 = "0.9"
 failure = "0.1.2"
+log = "0.4"
 rustc-demangle = "0.1.13"
 tempfile = "3.0"
 walrus = "0.2.1"

--- a/crates/wasm-interpreter/src/lib.rs
+++ b/crates/wasm-interpreter/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![deny(missing_docs)]
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use walrus::ir::ExprId;
 use walrus::{FunctionId, LocalFunction, LocalId, Module, TableId};
 
@@ -168,7 +168,7 @@ impl Interpreter {
         &mut self,
         id: FunctionId,
         module: &Module,
-        entry_removal_list: &mut Vec<usize>,
+        entry_removal_list: &mut HashSet<usize>,
     ) -> Option<&[u32]> {
         // Call the `id` function. This is an internal `#[inline(never)]`
         // whose code is completely controlled by the `wasm-bindgen` crate, so
@@ -213,7 +213,7 @@ impl Interpreter {
 
         // This is used later to actually remove the entry from the table, but
         // we don't do the removal just yet
-        entry_removal_list.push(descriptor_table_idx);
+        entry_removal_list.insert(descriptor_table_idx);
 
         // And now execute the descriptor!
         self.interpret_descriptor_id(descriptor_id, module)


### PR DESCRIPTION
LLVM's mergefunc pass may mean that the same descriptor function is used
for different closure invocation sites even when the closure itself is
different. This typically only happens with LTO but in theory could
happen at any time!

The assert was tripping when we tried to delete the same function table
entry twice, so instead of a `Vec<usize>` of entries to delete this
commit switches to a `HashSet<usize>` which should do the deduplication
for us and enusre that we delete each descriptor only once.

Closes #1264