### PR TITLE
Add support for `TextEncoder#encodeInto`

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -36,12 +36,19 @@ pub struct Bindgen {
     // module to be "ready to be instantiated on any thread"
     threads: Option<wasm_bindgen_threads_xform::Config>,
     anyref: bool,
+    encode_into: EncodeInto,
 }
 
 enum Input {
     Path(PathBuf),
     Module(Module, String),
     None,
+}
+
+pub enum EncodeInto {
+    Test,
+    Always,
+    Never,
 }
 
 impl Bindgen {
@@ -64,6 +71,7 @@ impl Bindgen {
             weak_refs: env::var("WASM_BINDGEN_WEAKREF").is_ok(),
             threads: threads_config(),
             anyref: env::var("WASM_BINDGEN_ANYREF").is_ok(),
+            encode_into: EncodeInto::Test,
         }
     }
 
@@ -141,6 +149,11 @@ impl Bindgen {
 
     pub fn emit_start(&mut self, emit: bool) -> &mut Bindgen {
         self.emit_start = emit;
+        self
+    }
+
+    pub fn encode_into(&mut self, mode: EncodeInto) -> &mut Bindgen {
+        self.encode_into = mode;
         self
     }
 


### PR DESCRIPTION
This commit adds support for the recently implemented standard of
[`TextEncoder#encodeInto`][standard]. This new function is a "bring your
own buffer" style function where we can avoid an intermediate allocation
and copy by encoding strings directly into wasm's memory.

Currently we feature-detect whether `encodeInto` exists as it is only
implemented in recent browsers and not in all browsers. Additionally
this commit emits the binding using `encodeInto` by default, but this
requires `realloc` functionality to be exposed by the wasm module.
Measured locally an empty binary which takes `&str` previously took
7.6k, but after this commit takes 8.7k due to the extra code needed for
`realloc`.

[standard]: https://encoding.spec.whatwg.org/#dom-textencoder-encodeinto

Closes #1172