### PR TITLE
Rename test `Context` in JS

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
@@ -44,7 +44,7 @@ pub fn execute(
             const support = require("./{0}");
             const wasm = require("./{0}_bg");
 
-            cx = new support.Context();
+            cx = new support.WasmBindgenTestContext();
             handlers.on_console_debug = support.__wbgtest_console_debug;
             handlers.on_console_log = support.__wbgtest_console_log;
             handlers.on_console_info = support.__wbgtest_console_info;

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -18,7 +18,7 @@ pub fn spawn(
     let mut js_to_execute = format!(
         r#"
         import {{
-            Context,
+            WasmBindgenTestContext as Context,
             __wbgtest_console_debug,
             __wbgtest_console_log,
             __wbgtest_console_info,

--- a/crates/test/src/rt/mod.rs
+++ b/crates/test/src/rt/mod.rs
@@ -114,7 +114,7 @@ pub mod node;
 ///
 /// The node.js entry script instantiates a `Context` here which is used to
 /// drive test execution.
-#[wasm_bindgen]
+#[wasm_bindgen(js_name = WasmBindgenTestContext)]
 pub struct Context {
     state: Rc<State>,
 }
@@ -199,7 +199,7 @@ pub fn log(args: &fmt::Arguments) {
     js_console_log(&args.to_string());
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_class = WasmBindgenTestContext)]
 impl Context {
     /// Creates a new context ready to run tests.
     ///


### PR DESCRIPTION
This will hopefully help avoid symbol collisions with other projects
that have a struct named `Context`