### PR TITLE
Add support for `FnOnce` to `Closure<T>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ features = ['serde-serialize']
 
 [lib]
 test = false
-doctest = false
 
 [features]
 default = ["spans", "std"]

--- a/ci/azure-install-node.yml
+++ b/ci/azure-install-node.yml
@@ -3,4 +3,4 @@ steps:
     displayName: "Add WebAssembly target via rustup"
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+      versionSpec: '>=10.11'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,9 @@ pub fn throw_val(s: JsValue) -> ! {
 ///
 /// # Example
 ///
-/// ```no_run
+/// ```
+/// use wasm_bindgen::prelude::*;
+///
 /// // If the value is `Option::Some` or `Result::Ok`, then we just get the
 /// // contained `T` value.
 /// let x = Some(42);

--- a/tests/wasm/closures.js
+++ b/tests/wasm/closures.js
@@ -102,3 +102,14 @@ exports.drop_during_call_call = () => DROP_DURING_CALL();
 exports.js_test_closure_returner = () => {
   wasm.closure_returner().someKey();
 };
+
+exports.calling_it_throws = a => {
+  try {
+    a();
+    return false;
+  } catch(_) {
+    return true;
+  }
+};
+
+exports.call_val = f => f();


### PR DESCRIPTION
Sort of. By turning them into `FnMut` and doing a dynamic check that they are only ever called once.

I initially tried to get `Closure<FnOnce(...) -> R>` working, but that proved too difficult.