### PR TITLE
Add doc comments export for typescript

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -122,6 +122,7 @@ impl<'a> Context<'a> {
         let contents = contents.trim();
         if let Some(ref c) = comments {
             self.globals.push_str(c);
+            self.typescript.push_str(c);
         }
         let global = if self.use_node_require() {
             if contents.starts_with("class") {


### PR DESCRIPTION
This PR adds exporting Rust doc comments to TypeScript defs.

This is just pushing the comment string to the `typescript` variable on `Context` right after pushing it to `globals` for JS.

I'm not sure if there are any significant differences between JS Doc and TypeScript docs, so I didn't add in any additional formatting. I'd be happy to try and add that if there are any.

This is my first code contribution, so please let me know if there are additional things needed for this PR.

Thanks!

Fixes #1276 