### PR TITLE
Fix name of "current thread ID" intrinsic

### DIFF
--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -388,9 +388,9 @@ fn implement_thread_intrinsics(module: &mut Module, globals: &Globals) -> Result
         let ty = module.types.get(function.ty());
 
         match &import.name[..] {
-            "__wbindgen_thread_id" => {
+            "__wbindgen_current_id" => {
                 if !ty.params().is_empty() || ty.results() != &[ValType::I32] {
-                    bail!("`__wbindgen_thread_id` intrinsic has the wrong signature");
+                    bail!("`__wbindgen_current_id` intrinsic has the wrong signature");
                 }
                 map.insert(function.id(), Intrinsic::GetThreadId);
             }


### PR DESCRIPTION
This was accidentally renamed in the transition to `walrus`, but
upstream rust-lang/rust still uses the old name so let's switch back to
that.