### PR TITLE
Update tests after nightly fix

### DIFF
--- a/crates/macro/ui-tests/invalid-items.rs
+++ b/crates/macro/ui-tests/invalid-items.rs
@@ -20,9 +20,7 @@ struct Foo<T>(T);
 extern "C" {
     static mut FOO: u32;
 
-    // FIXME(rust-lang/rust#58853) recent regression needs fixing before
-    // re-enabling.
-    // pub fn foo3(x: i32, ...);
+    pub fn foo3(x: i32, ...);
 }
 
 #[wasm_bindgen]

--- a/crates/macro/ui-tests/invalid-items.stderr
+++ b/crates/macro/ui-tests/invalid-items.stderr
@@ -28,35 +28,41 @@ error: cannot import mutable globals yet
 21 |     static mut FOO: u32;
    |            ^^^
 
-error: only foreign mods with the `C` ABI are allowed
-  --> $DIR/invalid-items.rs:29:8
+error: can't #[wasm_bindgen] variadic functions
+  --> $DIR/invalid-items.rs:23:25
    |
-29 | extern "system" {
+23 |     pub fn foo3(x: i32, ...);
+   |                         ^^^
+
+error: only foreign mods with the `C` ABI are allowed
+  --> $DIR/invalid-items.rs:27:8
+   |
+27 | extern "system" {
    |        ^^^^^^^^
+
+error: can't #[wasm_bindgen] functions with lifetime or type parameters
+  --> $DIR/invalid-items.rs:31:12
+   |
+31 | pub fn foo4<T>() {}
+   |            ^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
   --> $DIR/invalid-items.rs:33:12
    |
-33 | pub fn foo4<T>() {}
-   |            ^^^
+33 | pub fn foo5<'a>() {}
+   |            ^^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
   --> $DIR/invalid-items.rs:35:12
    |
-35 | pub fn foo5<'a>() {}
-   |            ^^^^
-
-error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:37:12
-   |
-37 | pub fn foo6<'a, T>() {}
+35 | pub fn foo6<'a, T>() {}
    |            ^^^^^^^
 
 error: #[wasm_bindgen] can only be applied to a function, struct, enum, impl, or extern block
-  --> $DIR/invalid-items.rs:40:1
+  --> $DIR/invalid-items.rs:38:1
    |
-40 | trait X {}
+38 | trait X {}
    | ^^^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 


### PR DESCRIPTION
Re-add `wasm_bindgen` macro test for C-variadics now that
https://github.com/rust-lang/rust/pull/58865 has been merged.