### PR TITLE
Add webassembly-js-api for *_bg.d.ts.

### DIFF
--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -52,7 +52,7 @@ pub fn typescript(module: &Module) -> Result<String, Error> {
             walrus::ExportItem::Function(i) => i,
             walrus::ExportItem::Memory(_) => {
                 exports.push_str(&format!(
-                    "export const {}: WebAssembly.Memory;\n",
+                    "import 'webassembly-js-api';\nexport const {}: WebAssembly.Memory;\n",
                     entry.name,
                 ));
                 continue;


### PR DESCRIPTION
Per #1040, `import 'webassembly-js-api'` is needed for `WebAssembly.Memory`.