### PR TITLE
Add 'ignore' attribute to wasm_bindgen

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -48,6 +48,7 @@ macro_rules! attrgen {
             (variadic, Variadic(Span)),
             (typescript_custom_section, TypescriptCustomSection(Span)),
             (start, Start(Span)),
+            (ignore, Ignore(Span)),
         }
     };
 }
@@ -302,6 +303,12 @@ impl<'a> ConvertToAst<BindgenAttrs> for &'a mut syn::ItemStruct {
             .unwrap_or(self.ident.to_string());
         if let syn::Fields::Named(names) = &mut self.fields {
             for field in names.named.iter_mut() {
+                let attrs = BindgenAttrs::find(&mut field.attrs)?;
+                let ignored = attrs.ignore().is_some();
+                attrs.check_used()?;
+                if ignored {
+                    continue;
+                }
                 match field.vis {
                     syn::Visibility::Public(..) => {}
                     _ => continue,


### PR DESCRIPTION
This PR adds `ignore` as an attribute for `#[wasm_bindgen]`. This makes it not generate getters/setters for a pub field marked with `#[wasm_bindgen(ignore)]`.

I'm not sure I did this 100% correct, but it is able to convert!

I'll make any changes/fixes necessary.

Thanks!

Fixes #1284 