### PR TITLE
Add a "nightly only" warning to documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ links = "wasm_bindgen"
 readme = "README.md"
 categories = ["wasm"]
 repository = "https://github.com/rustwasm/wasm-bindgen"
-homepage = "https://rustwasm.github.io/wasm-bindgen/"
+homepage = "https://rustwasm.github.io/"
 documentation = "https://docs.rs/wasm-bindgen"
 description = """
 Easy support for interacting between JS and Rust.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,16 @@ greet("World!");
 
 ## Guide
 
-[**📚 Read the `wasm-bindgen` guide here! 📚**](https://rustwasm.github.io/wasm-bindgen)
+[**📚 Read the `wasm-bindgen` guide here! 📚**](https://rustwasm.github.io/docs/wasm-bindgen/)
+
+You can find general documentation about Rust and WebAssembly
+[here](https://rustwasm.github.io/docs).
 
 ## API Docs
 
-- [wasm-bindgen](https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/)
-- [js-sys](https://rustwasm.github.io/wasm-bindgen/api/js_sys/)
-- [web-sys](https://rustwasm.github.io/wasm-bindgen/api/web_sys/)
+- [wasm-bindgen](https://docs.rs/wasm-bindgen)
+- [js-sys](https://docs.rs/js-sys)
+- [web-sys](https://docs.rs/web-sys)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ You can find general documentation about Rust and WebAssembly
 - [wasm-bindgen](https://docs.rs/wasm-bindgen)
 - [js-sys](https://docs.rs/js-sys)
 - [web-sys](https://docs.rs/web-sys)
+- [wasm-bindgen-futures](https://docs.rs/wasm-bindgen-futures)
 
 ## License
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -236,7 +236,7 @@ jobs:
           curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.2.1/mdbook-v0.2.1-x86_64-unknown-linux-musl.tar.gz | tar xzf - -C $HOME/mdbook
           echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/mdbook"
         displayName: "Install mdbook"
-      - script: (cd guide && mdbook build)
+      - script: (cd guide && mv _theme theme && mdbook build)
       - task: PublishPipelineArtifact@0
         inputs:
           artifactName: doc_book

--- a/guide/_theme/header.hbs
+++ b/guide/_theme/header.hbs
@@ -1,0 +1,44 @@
+<style>
+  header.warning {
+    background-color: rgb(242, 222, 222);
+    border-bottom-color: rgb(238, 211, 215);
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom-style: solid;
+    border-bottom-width: 0.666667px;
+    border-image-outset: 0 0 0 0;
+    border-image-repeat: stretch stretch;
+    border-image-slice: 100% 100% 100% 100%;
+    border-image-source: none;
+    border-image-width: 1 1 1 1;
+    border-left-color: rgb(238, 211, 215);
+    border-left-style: solid;
+    border-left-width: 0.666667px;
+    border-right-color: rgb(238, 211, 215);
+    border-right-style: solid;
+    border-right-width: 0.666667px;
+    border-top-color: rgb(238, 211, 215);
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-top-style: solid;
+    border-top-width: 0.666667px;
+    color: rgb(185, 74, 72);
+    margin-bottom: 0px;
+    margin-left: 0px;
+    margin-right: 0px;
+    margin-top: 30px;
+    padding-bottom: 8px;
+    padding-left: 14px;
+    padding-right: 35px;
+    padding-top: 8px;
+    text-align: center;
+  }
+</style>
+<header class='warning'>
+  This is the <strong>unpublished</strong> documentation of
+  <code>wasm-bindgen</code>, the published documentation is available
+  <a href="https://rustwasm.github.io/docs/wasm-bindgen/">
+    on the main Rust and WebAssembly documentation site
+  </a>. Features documented here may not be available in released versions of
+  <code>wasm-bindgen</code>.
+</header>

--- a/guide/src/contributing/index.md
+++ b/guide/src/contributing/index.md
@@ -8,7 +8,7 @@ development. You may want to browse the [unpublished guide documentation] for
 
 ## Prerequisites
 
-1. Rust.[Install Rust]. Once Rust is installed, run
+1. Rust. [Install Rust]. Once Rust is installed, run
 
     ```shell
     rustup target add wasm32-unknown-unknown

--- a/guide/src/contributing/index.md
+++ b/guide/src/contributing/index.md
@@ -1,14 +1,16 @@
 # Contributing to `wasm-bindgen`
 
 This section contains instructions on how to get this project up and running for
-development.
+development. You may want to browse the [unpublished guide documentation] for
+`wasm-bindgen` as well as it may have more up-to-date information.
+
+[unpublished documentation]: https://rustwasm.github.io/wasm-bindgen/
 
 ## Prerequisites
 
-1. Rust Nightly. [Install Rust]. Once Rust is installed, run
+1. Rust.[Install Rust]. Once Rust is installed, run
 
     ```shell
-    rustup default nightly
     rustup target add wasm32-unknown-unknown
     ```
 

--- a/guide/src/contributing/js-sys/index.md
+++ b/guide/src/contributing/js-sys/index.md
@@ -6,8 +6,8 @@ and its source lives at [`wasm-bindgen/crates/js-sys`][src].  With the `js-sys`
 crate, we can work with `Object`s, `Array`s, `Function`s, `Map`s, `Set`s,
 etc... without writing the `#[wasm_bindgen]` imports by hand.
 
-Documentation for this crate will eventually be available on [docs.rs][docsrs]
-but temporarily you can also check out the [master branch
+Documentation for the published version of this crate is available on
+[docs.rs][docsrs] but you can also check out the [master branch
 documentation][masterdoc] for the crate.
 
 [docsrs]: https://docs.rs/js-sys

--- a/guide/src/contributing/web-sys/index.md
+++ b/guide/src/contributing/web-sys/index.md
@@ -8,3 +8,10 @@ using `wasm-bindgen`'s WebIDL frontend and the WebIDL interface definitions for
 Web APIs. This means that `web-sys` isn't always the most ergonomic crate to
 use, but it's intended to provide verified and correct bindings to the web
 platform, and then better interfaces can be iterated on crates.io!
+
+Documentation for the published version of this crate is available on
+[docs.rs][docsrs] but you can also check out the [master branch
+documentation][masterdoc] for the crate.
+
+[docsrs]: https://docs.rs/web-sys
+[masterdoc]: https://rustwasm.github.io/wasm-bindgen/api/js_sys/


### PR DESCRIPTION
Official documentation is now available at
https://rustwasm.github.io/docs/wasm-bindgen/, so let's leave this git
repository's documentation purely for our own previewing purposes.