### PR TITLE
Create --out_dir (usually "pkg") if it does not exist

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -350,6 +350,7 @@ impl Bindgen {
         } else {
             "js"
         };
+        fs::create_dir_all(out_dir)?;
         let js_path = out_dir.join(stem).with_extension(extension);
         fs::write(&js_path, reset_indentation(&js))
             .with_context(|_| format!("failed to write `{}`", js_path.display()))?;


### PR DESCRIPTION
Fixes #1324 .