### PR TITLE
Make the slice argument of texImage2D and related functions immutable

### DIFF
--- a/crates/web-sys/tests/wasm/element.js
+++ b/crates/web-sys/tests/wasm/element.js
@@ -156,6 +156,11 @@ export function new_webgl_rendering_context() {
   return canvas.getContext('webgl');
 }
 
+export function new_webgl2_rendering_context() {
+  const canvas = document.createElement('canvas');
+  return canvas.getContext('webgl2');
+}
+
 export function new_xpath_result() {
     let xmlDoc = new DOMParser().parseFromString("<root><value>tomato</value></root>", "application/xml");
     let xpathResult = xmlDoc.evaluate("/root//value", xmlDoc, null, XPathResult.ANY_TYPE, null);

--- a/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
+++ b/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
@@ -12,11 +12,12 @@
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
-use web_sys::WebGlRenderingContext;
+use web_sys::{WebGlRenderingContext, WebGl2RenderingContext};
 
 #[wasm_bindgen(module = "/tests/wasm/element.js")]
 extern "C" {
     fn new_webgl_rendering_context() -> WebGlRenderingContext;
+    fn new_webgl2_rendering_context() -> WebGl2RenderingContext;
 // TODO: Add a function to create another type to test here.
 // These functions come from element.js
 }
@@ -49,8 +50,41 @@ extern "C" {
 //    gl.uniform_matrix2fv_with_f32_array(None, false, &[1.]);
 //    gl.uniform_matrix3fv_with_f32_array(None, false, &[1.]);
 //    gl.uniform_matrix4fv_with_f32_array(None, false, &[1.]);
-//}
+//
+//    gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        Some(&[1]),
+//    );
+//    gl.tex_sub_image_2d_with_i32_and_i32_and_u32_and_type_and_opt_u8_array(
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        0,
+//        Some(&[1]),
+//    );
+//    gl.compressed_tex_image_2d_with_u8_array(0, 0, 0, 0, 0, 0, &[1]);
+// }
+//
+//#[wasm_bindgen_test]
+//fn test_webgl2_rendering_context_immutable_slices() {
+//    let gl = new_webgl2_rendering_context();
 
+//    gl.tex_image_3d_with_opt_u8_array(0, 0, 0, 0, 0, 0, 0, 0, 0, Some(&[1]));
+//    gl.tex_sub_image_3d_with_opt_u8_array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, Some(&[1]));
+//    gl.compressed_tex_image_3d_with_u8_array(0, 0, 0, 0, 0, 0, 0, &[1]);
+//}
+//
 // TODO:
 //#[wasm_bindgen_test]
 //fn test_another_types_immutable_slices_here() {

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -37,7 +37,7 @@ pub(crate) struct FirstPassRecord<'src> {
     pub(crate) dictionaries: BTreeMap<&'src str, DictionaryData<'src>>,
     pub(crate) callbacks: BTreeSet<&'src str>,
     pub(crate) callback_interfaces: BTreeMap<&'src str, CallbackInterfaceData<'src>>,
-    pub(crate) immutable_f32_whitelist: BTreeSet<&'static str>,
+    pub(crate) immutable_slice_whitelist: BTreeSet<&'static str>,
 }
 
 /// We need to collect interface data during the first pass, to be used later.

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -82,7 +82,7 @@ fn parse(webidl_source: &str, allowed_types: Option<&[&str]>) -> Result<Program>
 
     let mut first_pass_record: FirstPassRecord = Default::default();
     first_pass_record.builtin_idents = builtin_idents();
-    first_pass_record.immutable_f32_whitelist = immutable_f32_whitelist();
+    first_pass_record.immutable_slice_whitelist = immutable_slice_whitelist();
 
     definitions.first_pass(&mut first_pass_record, ())?;
     let mut program = Default::default();
@@ -181,9 +181,9 @@ fn builtin_idents() -> BTreeSet<Ident> {
     )
 }
 
-fn immutable_f32_whitelist() -> BTreeSet<&'static str> {
+fn immutable_slice_whitelist() -> BTreeSet<&'static str> {
     BTreeSet::from_iter(vec![
-        // WebGlRenderingContext
+        // WebGlRenderingContext, WebGl2RenderingContext
         "uniform1fv",
         "uniform2fv",
         "uniform3fv",
@@ -195,6 +195,14 @@ fn immutable_f32_whitelist() -> BTreeSet<&'static str> {
         "vertexAttrib2fv",
         "vertexAttrib3fv",
         "vertexAttrib4fv",
+        "bufferData",
+        "texImage2D",
+        "texSubImage2D",
+        "compressedTexImage2D",
+        // WebGl2RenderingContext
+        "texImage3D",
+        "texSubImage3D",
+        "compressedTexImage3D",
         // TODO: Add another type's functions here. Leave a comment header with the type name
     ])
 }

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -647,11 +647,9 @@ impl<'src> FirstPassRecord<'src> {
             _ => return idl_type,
         };
 
-        if self.immutable_f32_whitelist.contains(op) {
+        if self.immutable_slice_whitelist.contains(op) {
             flag_slices_immutable(&mut idl_type)
         }
-
-        // TODO: Add other whitelisted slices here, such as F64 or u8..
 
         idl_type
     }
@@ -737,7 +735,10 @@ pub fn public() -> syn::Visibility {
 
 fn flag_slices_immutable(ty: &mut IdlType) {
     match ty {
+        IdlType::Uint8Array { immutable } => *immutable = true,
         IdlType::Float32Array { immutable } => *immutable = true,
+        IdlType::ArrayBufferView { immutable } => *immutable = true,
+        IdlType::BufferSource { immutable } => *immutable = true,
         IdlType::Nullable(item) => flag_slices_immutable(item),
         IdlType::FrozenArray(item) => flag_slices_immutable(item),
         IdlType::Sequence(item) => flag_slices_immutable(item),


### PR DESCRIPTION
This also adds immutable slice whitelisting for Uint8Array, ArrayBufferView, and BufferSource, and removes Uint8ArrayMut.