### PR TITLE
Workaround an upstream `nom` bug

### DIFF
--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -68,10 +68,17 @@ fn parse(webidl_source: &str, allowed_types: Option<&[&str]>) -> Result<Program>
                     .context(ErrorKind::ParsingWebIDLSource)
                     .into(),
                 weedle::Err::Error(cx) | weedle::Err::Failure(cx) => {
+                    // Note that #[allow] here is a workaround for Geal/nom#843
+                    // because the `Context` type here comes from `nom` and if
+                    // something else in our crate graph enables the
+                    // `verbose-errors` feature then we need to still compiled
+                    // against the changed enum definition.
+                    #[allow(unreachable_patterns)]
                     let remaining = match cx {
-                        weedle::Context::Code(remaining, _) => remaining,
+                        weedle::Context::Code(remaining, _) => remaining.len(),
+                        _ => 0,
                     };
-                    let pos = webidl_source.len() - remaining.len();
+                    let pos = webidl_source.len() - remaining;
                     format_err!("failed to parse WebIDL")
                         .context(ErrorKind::ParsingWebIDLSourcePos(pos))
                         .into()


### PR DESCRIPTION
This commit works around Geal/nom#843 where the API of the `nom` crate
changes based on feature selection, meaning we need to be compatible
even if another crate in the crate graph enables a feature.

Ideally this'd be fixed in upstream `nom`, and it looks like it will in
the next major version! For now a local catch-all directive should help
out.