### PR TITLE
Use basic-http-server from crates.io.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,7 +168,7 @@ jobs:
           echo "##vso[task.setvariable variable=PATH;]$PATH:$PWD"
         displayName: "install xargo"
       - script: |
-          sed -i 's/python/#python/' examples/raytrace-parallel/build.sh
+          sed -i 's/basic-http-server/#basic-http-server/' examples/raytrace-parallel/build.sh
           (cd examples/raytrace-parallel && ./build.sh)
           cp examples/raytrace-parallel/*.{js,html,wasm} $BUILD_ARTIFACTSTAGINGDIRECTORY
         displayName: "build example"

--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -22,4 +22,5 @@ WASM_BINDGEN_THREADS=1 \
     ../../target/wasm32-unknown-unknown/release/raytrace_parallel.wasm --out-dir . \
     --no-modules
 
-python3 -m http.server
+# `cargo install basic-http-server`
+basic-http-server

--- a/examples/without-a-bundler/build.sh
+++ b/examples/without-a-bundler/build.sh
@@ -12,4 +12,5 @@ cargo run --manifest-path ../../crates/cli/Cargo.toml \
     ../../target/wasm32-unknown-unknown/release/without_a_bundler.wasm --out-dir pkg \
     --web
 
-python3 -m http.server
+# `cargo install basic-http-server`
+basic-http-server


### PR DESCRIPTION
Avoids `python3` as dependency in some examples by using [basic-http-server](https://crates.io/crates/basic-http-server).