### PR TITLE
Installing and running the linkcheck mdbook backend

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,15 +232,14 @@ jobs:
     displayName: "Doc - build the book"
     steps:
       - script: |
-          mkdir $HOME/mdbook
-          curl -L https://github.com/rust-lang-nursery/mdBook/releases/download/v0.2.1/mdbook-v0.2.1-x86_64-unknown-linux-musl.tar.gz | tar xzf - -C $HOME/mdbook
-          echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/mdbook"
+          which mdbook || cargo install mdbook
+          which mdbook-linkcheck || cargo install mdbook-linkcheck
         displayName: "Install mdbook"
       - script: (cd guide && mv _theme theme && mdbook build)
       - task: PublishPipelineArtifact@0
         inputs:
           artifactName: doc_book
-          targetPath: guide/book
+          targetPath: guide/book/html
 
   - job: doc_api
     displayName: "Doc - build the API documentation"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,6 +231,7 @@ jobs:
   - job: doc_book
     displayName: "Doc - build the book"
     steps:
+      - template: ci/azure-install-rust.yml
       - script: |
           which mdbook || cargo install mdbook
           which mdbook-linkcheck || cargo install mdbook-linkcheck

--- a/guide/book.toml
+++ b/guide/book.toml
@@ -3,3 +3,6 @@ authors = ["Nick Fitzgerald"]
 multilingual = false
 src = "src"
 title = "The `wasm-bindgen` Guide"
+
+[output.html]
+[output.linkcheck]


### PR DESCRIPTION
Installs and runs the "mdbook-linkcheck" backend on the guide, to test for broken links. This installs mdbook with cargo instead of downloading a binary because I can't work out a way to install mdbook-linkcheck in a compatible way.

Reincarnation of https://github.com/rustwasm/wasm-bindgen/pull/1240.