### PR TITLE
Move `links` annotation to `wasm-bindgen-shared`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ name = "wasm-bindgen"
 version = "0.2.39"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
-# Because only a single `wasm_bindgen` version can be used in a dependency
-# graph, pretend we link a native library so that `cargo` will provide better
-# error messages than the esoteric linker errors we would otherwise trigger.
-links = "wasm_bindgen"
 readme = "README.md"
 categories = ["wasm"]
 repository = "https://github.com/rustwasm/wasm-bindgen"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -10,3 +10,8 @@ description = """
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
 dependency.
 """
+
+# Because only a single `wasm_bindgen` version can be used in a dependency
+# graph, pretend we link a native library so that `cargo` will provide better
+# error messages than the esoteric linker errors we would otherwise trigger.
+links = "wasm_bindgen"


### PR DESCRIPTION
This commit moves our `links` annotation in the `wasm-bindgen` crate to
the `wasm-bindgen-shared` crate. The `links` annotation is used to
ensure that there's only one version of `wasm-bindgen` in a crate graph
because if there are multiple versions then a CLI surely cannot actually
process the wasm binary (as the multiple versions likely have different
formats in their custom sections).

Discovered in #1373 it looks like the usage in `wasm-bindgen` isn't
quite sufficient to cause this deduplication. It turns out that
`wasm-bindgen-shared`, a very core dependency, is actually the most
critical to be deduplicated since its the one that defines the format of
the custom section. In #1373 a case came up where `wasm-bindgen` was
deduplciated but there were two versions of `wasm-bindgen-shared` in the
crate graph, meaning that a `[patch]` for only `wasm-bindgen` wasn't
sufficient, but rather `web-sys` and/or `js-sys` also needed a `[patch]`
annotation to ensure everyone used the right dependencies.

This commit won't actually fix #1373 to the point where it "just works",
but what it does do is present a better error message than an internal
panic of `wasm-bindgen`. The hope is that by moving the `links`
annotation we can catch more errors of this crate graph duplication,
leading to more `[patch]` annotations locally.

Closes #1373