### PR TITLE
Fix a nondeterministic bug in the JS wrapper emitted

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2,7 +2,7 @@ use crate::decode;
 use crate::descriptor::{Descriptor, VectorKind};
 use crate::{Bindgen, EncodeInto, OutputMode};
 use failure::{bail, Error, ResultExt};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, BTreeMap};
 use std::env;
 use walrus::{MemoryId, Module};
 use wasm_bindgen_wasm_interpreter::Interpreter;
@@ -49,7 +49,7 @@ pub struct Context<'a> {
     /// wasm-bindgen emits.
     pub direct_imports: HashMap<&'a str, (&'a str, &'a str)>,
 
-    pub exported_classes: Option<HashMap<String, ExportedClass>>,
+    pub exported_classes: Option<BTreeMap<String, ExportedClass>>,
     pub function_table_needed: bool,
     pub interpreter: &'a mut Interpreter,
     pub memory: MemoryId,


### PR DESCRIPTION
We've always wanted this to be the deterministic, but usage of `HashMap`
for example can accidentally lead to non-determinism. Looks like one was
forgotten and the bindings were nondeterministic by accident as a
result!