### PR TITLE
Fix use-after-free with closures in JS bindings

### DIFF
--- a/crates/cli-support/src/js/closures.rs
+++ b/crates/cli-support/src/js/closures.rs
@@ -198,7 +198,7 @@ impl ClosureDescriptors {
                         .prelude("this.a = 0;")
                         .rust_argument("a")
                         .rust_argument("b")
-                        .finally("if (this.cnt-- == 1) d(a, b);")
+                        .finally("if (--this.cnt === 0) d(a, b);")
                         .finally("else this.a = a;");
                 } else {
                     // For shared closures they can be invoked recursively so we

--- a/crates/cli-support/src/js/closures.rs
+++ b/crates/cli-support/src/js/closures.rs
@@ -209,7 +209,7 @@ impl ClosureDescriptors {
                     builder
                         .rust_argument("this.a")
                         .rust_argument("b")
-                        .finally("if (this.cnt-- == 1) { d(this.a, b); this.a = 0; }");
+                        .finally("if (--this.cnt === 0) { d(this.a, b); this.a = 0; }");
                 }
                 builder.process(&closure.function, None)?.finish(
                     "function",


### PR DESCRIPTION
This commit fixes an erroneous use-after-free which can happen in
erroneous situations in JS. It's intended that if you invoke a closure
after its environment has been destroyed that you'll immediately get an
error from Rust saying so. The JS binding generation for mutable
closures, however, accidentally did not protect against this.

Each closure has an internal reference count which is incremented while
being invoked and decremented when the invocation finishes and also when
the `Closure` in Rust is dropped. That means there's two branches where
the reference count reaches zero and the internal pointer stored in JS
needs to be set to zero. Only one, however, actually set the pointer to
zero!

This means that if a closure was destroyed while it was being invoked it
would not correctly set its internal pointer to zero. A further
invocation of the closure would then pass as seemingly valid pointer
into Rust, causing a use-after-free.

A test isn't included here specifically for this because our CI has
started failing left-and-right over this test, so this commit will
hopefully just make our CI green!