### PR TITLE
Add versions to crates.io patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ members = [
 exclude = ['crates/typescript']
 
 [patch.crates-io]
-wasm-bindgen = { path = '.' }
-wasm-bindgen-futures = { path = 'crates/futures' }
-js-sys = { path = 'crates/js-sys' }
-web-sys = { path = 'crates/web-sys' }
+wasm-bindgen = { path = '.', version = '0.2.40' }
+wasm-bindgen-futures = { path = 'crates/futures', version = '0.3.17' }
+js-sys = { path = 'crates/js-sys', version = '0.3.17' }
+web-sys = { path = 'crates/web-sys', version = '0.3.17' }


### PR DESCRIPTION
Without this running `cargo build` in the top-level directory on nightly
produced an error for me:

```
error: failed to resolve patches for `https://github.com/rust-lang/crates.io-index`

Caused by:
  patch for `wasm-bindgen-futures` in `https://github.com/rust-lang/crates.io-index` did not resolve to any crates. If this is unexpected, you may wish to consult: https://github.com/rust-lang/cargo/issues/4678
```