### PR TITLE
Add `constructor` property to `Object`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1878,6 +1878,13 @@ extern "C" {
     pub fn assign3(target: &Object, source1: &Object, source2: &Object, source3: &Object)
         -> Object;
 
+    /// The constructor property returns a reference to the Object constructor
+    /// function that created the instance object.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor)
+    #[wasm_bindgen(method, getter)]
+    pub fn constructor(this: &Object) -> Function;
+
     /// The Object.create() method creates a new object, using an existing
     /// object to provide the newly created object's prototype.
     ///


### PR DESCRIPTION
Fixes #1361, although shortly after adding this I realised that to be useful wasm-bindgen also needs to expose a way to get constructor of any type as a `Function`, but not sure what is the best way to expose that yet...

Something like autogenerated `fn as_constructor() { ... }` on any `#[wasm_bindgen]` imported type maybe?

Anyway, that can probably be done in a separate PR.