### PR TITLE
Add support for customising `instanceof` behaviour

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -183,6 +183,7 @@ pub struct ImportType {
     pub attrs: Vec<syn::Attribute>,
     pub doc_comment: Option<String>,
     pub instanceof_shim: String,
+    pub is_type_of: Option<syn::Expr>,
     pub extends: Vec<syn::Path>,
     pub vendor_prefixes: Vec<Ident>,
 }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -588,6 +588,13 @@ impl ToTokens for ast::ImportType {
             }
         };
 
+        let is_type_of = self.is_type_of.as_ref().map(|is_type_of| quote! {
+            fn is_type_of(val: &JsValue) -> bool {
+                let is_type_of: fn(&JsValue) -> bool = #is_type_of;
+                is_type_of(val)
+            }
+        });
+
         (quote! {
             #[allow(bad_style)]
             #(#attrs)*
@@ -719,6 +726,8 @@ impl ToTokens for ast::ImportType {
                         drop(val);
                         panic!("cannot check instanceof on non-wasm targets");
                     }
+
+                    #is_type_of
 
                     #[inline]
                     fn unchecked_from_js(val: JsValue) -> Self {

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -126,7 +126,7 @@ extern "C" {
 // Array
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object)]
+    #[wasm_bindgen(extends = Object, is_type_of = Array::is_array)]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type Array;
 
@@ -466,7 +466,7 @@ extern "C" {
 // Boolean
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object)]
+    #[wasm_bindgen(extends = Object, is_type_of = |v| v.as_bool().is_some())]
     #[derive(Clone, PartialEq, Eq)]
     pub type Boolean;
 
@@ -801,7 +801,7 @@ extern "C" {
 // Function
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object)]
+    #[wasm_bindgen(extends = Object, is_type_of = JsValue::is_function)]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type Function;
 
@@ -897,11 +897,7 @@ impl Function {
     /// If this JS value is not an instance of a function then this returns
     /// `None`.
     pub fn try_from(val: &JsValue) -> Option<&Function> {
-        if val.is_function() {
-            Some(val.unchecked_ref())
-        } else {
-            None
-        }
+        val.dyn_ref()
     }
 }
 
@@ -1141,7 +1137,10 @@ pub fn try_iter(val: &JsValue) -> Result<Option<IntoIter>, JsValue> {
         return Ok(None);
     }
 
-    let iter_fn: Function = iter_fn.unchecked_into();
+    let iter_fn: Function = match iter_fn.dyn_into() {
+        Ok(iter_fn) => iter_fn,
+        Err(_) => return Ok(None)
+    };
     let it = iter_fn.call0(val)?;
     if !it.is_object() {
         return Ok(None);
@@ -1434,7 +1433,7 @@ extern "C" {
 // Number.
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(extends = Object)]
+    #[wasm_bindgen(extends = Object, is_type_of = |v| v.as_f64().is_some())]
     #[derive(Clone)]
     pub type Number;
 
@@ -3127,7 +3126,7 @@ extern "C" {
 // JsString
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_name = String, extends = Object)]
+    #[wasm_bindgen(js_name = String, extends = Object, is_type_of = JsValue::is_string)]
     #[derive(Clone, PartialEq, Eq)]
     pub type JsString;
 
@@ -3587,11 +3586,7 @@ impl JsString {
     /// If this JS value is not an instance of a string then this returns
     /// `None`.
     pub fn try_from(val: &JsValue) -> Option<&JsString> {
-        if val.is_string() {
-            Some(val.unchecked_ref())
-        } else {
-            None
-        }
+        val.dyn_ref()
     }
 
     /// Returns whether this string is a valid UTF-16 string.
@@ -3683,6 +3678,7 @@ impl fmt::Debug for JsString {
 // Symbol
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(is_type_of = JsValue::is_symbol)]
     #[derive(Clone, Debug)]
     pub type Symbol;
 

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -45,6 +45,7 @@ macro_rules! attrgen {
             (readonly, Readonly(Span)),
             (js_name, JsName(Span, String, Span)),
             (js_class, JsClass(Span, String, Span)),
+            (is_type_of, IsTypeOf(Span, syn::Expr)),
             (extends, Extends(Span, syn::Path)),
             (vendor_prefix, VendorPrefix(Span, Ident)),
             (variadic, Variadic(Span)),
@@ -236,6 +237,11 @@ impl Parse for BindgenAttr {
             });
 
             (@parser $variant:ident(Span, syn::Path)) => ({
+                input.parse::<Token![=]>()?;
+                return Ok(BindgenAttr::$variant(attr_span, input.parse()?));
+            });
+
+            (@parser $variant:ident(Span, syn::Expr)) => ({
                 input.parse::<Token![=]>()?;
                 return Ok(BindgenAttr::$variant(attr_span, input.parse()?));
             });
@@ -515,6 +521,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ForeignItemType {
             .js_name()
             .map(|s| s.0)
             .map_or_else(|| self.ident.to_string(), |s| s.to_string());
+        let is_type_of = attrs.is_type_of().cloned();
         let shim = format!("__wbg_instanceof_{}_{}", self.ident, ShortHash(&self.ident));
         let mut extends = Vec::new();
         let mut vendor_prefixes = Vec::new();
@@ -537,6 +544,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ForeignItemType {
             attrs: self.attrs,
             doc_comment: None,
             instanceof_shim: shim,
+            is_type_of,
             rust_name: self.ident,
             js_name,
             extends,

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -514,6 +514,7 @@ impl<'src> FirstPassRecord<'src> {
             attrs,
             doc_comment: None,
             instanceof_shim: format!("__widl_instanceof_{}", name),
+            is_type_of: None,
             extends: Vec::new(),
             vendor_prefixes: Vec::new(),
         };

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -20,6 +20,9 @@ where
     ///
     /// This method performs a dynamic check (at runtime) using the JS
     /// `instanceof` operator. This method returns `self instanceof T`.
+    ///
+    /// Note that `instanceof` does not work with primitive values or across
+    /// different realms (e.g. iframes). Prefer using `has_type` instead.
     fn is_instance_of<T>(&self) -> bool
     where
         T: JsCast,
@@ -27,17 +30,28 @@ where
         T::instanceof(self.as_ref())
     }
 
+    /// Test whether this JS value has a type `T`.
+    ///
+    /// Unlike `is_instance_of`, the type can override this to a specialised
+    /// check that works reliably with primitives and across realms.
+    fn has_type<T>(&self) -> bool
+    where
+        T: JsCast,
+    {
+        T::is_type_of(self.as_ref())
+    }
+
     /// Performs a dynamic cast (checked at runtime) of this value into the
     /// target type `T`.
     ///
-    /// This method will return `Err(self)` if `T::is_type_of(self)`
+    /// This method will return `Err(self)` if `self.has_type::<T>()`
     /// returns `false`, and otherwise it will return `Ok(T)` manufactured with
     /// an unchecked cast (verified correct via the `instanceof` operation).
     fn dyn_into<T>(self) -> Result<T, Self>
     where
         T: JsCast,
     {
-        if T::is_type_of(self.as_ref()) {
+        if self.has_type::<T>() {
             Ok(self.unchecked_into())
         } else {
             Err(self)
@@ -47,14 +61,14 @@ where
     /// Performs a dynamic cast (checked at runtime) of this value into the
     /// target type `T`.
     ///
-    /// This method will return `None` if `T::is_type_of(self)`
+    /// This method will return `None` if `self.has_type::<T>()`
     /// returns `false`, and otherwise it will return `Some(&T)` manufactured
     /// with an unchecked cast (verified correct via the `instanceof` operation).
     fn dyn_ref<T>(&self) -> Option<&T>
     where
         T: JsCast,
     {
-        if T::is_type_of(self.as_ref()) {
+        if self.has_type::<T>() {
             Some(self.unchecked_ref())
         } else {
             None
@@ -103,7 +117,12 @@ where
     /// Performs a dynamic check to see whether the `JsValue` provided
     /// is a value of this type.
     ///
-    /// Unlike `instanceof`, this can be specialised to use a custom check.
+    /// Unlike `instanceof`, this can be specialised to use a custom check by
+    /// adding a `#[wasm_bindgen(is_type_of = callback)]` attribute to the
+    /// type import declaration.
+    ///
+    /// Other than that, this is intended to be an internal implementation
+    /// detail of `has_type` and you likely won't need to call this.
     fn is_type_of(val: &JsValue) -> bool {
         Self::instanceof(val)
     }

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -30,14 +30,14 @@ where
     /// Performs a dynamic cast (checked at runtime) of this value into the
     /// target type `T`.
     ///
-    /// This method will return `Err(self)` if `self.is_instance_of::<T>()`
+    /// This method will return `Err(self)` if `T::is_type_of(self)`
     /// returns `false`, and otherwise it will return `Ok(T)` manufactured with
     /// an unchecked cast (verified correct via the `instanceof` operation).
     fn dyn_into<T>(self) -> Result<T, Self>
     where
         T: JsCast,
     {
-        if self.is_instance_of::<T>() {
+        if T::is_type_of(self.as_ref()) {
             Ok(self.unchecked_into())
         } else {
             Err(self)
@@ -47,14 +47,14 @@ where
     /// Performs a dynamic cast (checked at runtime) of this value into the
     /// target type `T`.
     ///
-    /// This method will return `None` if `self.is_instance_of::<T>()`
+    /// This method will return `None` if `T::is_type_of(self)`
     /// returns `false`, and otherwise it will return `Some(&T)` manufactured
     /// with an unchecked cast (verified correct via the `instanceof` operation).
     fn dyn_ref<T>(&self) -> Option<&T>
     where
         T: JsCast,
     {
-        if self.is_instance_of::<T>() {
+        if T::is_type_of(self.as_ref()) {
             Some(self.unchecked_ref())
         } else {
             None
@@ -99,6 +99,14 @@ where
     /// This is intended to be an internal implementation detail, you likely
     /// won't need to call this.
     fn instanceof(val: &JsValue) -> bool;
+
+    /// Performs a dynamic check to see whether the `JsValue` provided
+    /// is a value of this type.
+    ///
+    /// Unlike `instanceof`, this can be specialised to use a custom check.
+    fn is_type_of(val: &JsValue) -> bool {
+        Self::instanceof(val)
+    }
 
     /// Performs a zero-cost unchecked conversion from a `JsValue` into an
     /// instance of `Self`


### PR DESCRIPTION
This allows types to define custom Rust code as an override for `JsCast::instanceof`.

 - Fixes #1367 for types that have built-in cross-realm checks, allowing `dyn_ref` and `dyn_into` to accept values from other realms. In particular:
   - `.instanceof::<Array>()` will now automatically use `Array::is_array` instead of actual `... instanceof Array`.
   - `.instanceof::<Function>()` will use `JsValue::is_function`. This also simplifies `Function::try_from` to being an alias for `dyn_ref::<Function>()`.
   - `.dyn_into::<JsString>()`, `.dyn_into::<Number>()`, `.dyn_into::<Boolean>()` will also now use corresponding checks from `JsValue`.
     In theory, these 3 can break checks if someone has been using boxed primitives (`new String(...)`, `new Number(...)`, `new Boolean(...)`), but these are extremely rare in real-world JS code and are already not support by `JsValue` methods. If we do want to support them, I believe it should be done at the `JsValue` level in `as_f64`, `as_bool`, `as_string` too.
 - Fixes #1370 - `.instanceof::<Symbol>()` will now use `JsValue::is_symbol` - previously it would return `false` for any value, even actual `Symbol`s, making it impossible to use `.dyn_ref::<Symbol>()` and `.dyn_into::<Symbol>()`.

cc @alexcrichton @fitzgen 