### PR TITLE
Implement Debug on Closures

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -4,6 +4,7 @@
 //! closures" from Rust to JS. Some more details can be found on the `Closure`
 //! type itself.
 
+use std::fmt;
 #[cfg(feature = "nightly")]
 use std::marker::Unsize;
 use std::mem::{self, ManuallyDrop};
@@ -487,6 +488,15 @@ fn _check() {
     _assert::<&Closure<FnMut()>>();
     _assert::<&Closure<FnMut(String)>>();
     _assert::<&Closure<FnMut() -> String>>();
+}
+
+impl<T> fmt::Debug for Closure<T>
+where
+    T: ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Closure {{ ... }}")
+    }
 }
 
 impl<T> Drop for Closure<T>

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -108,6 +108,12 @@ fn cannot_reuse() {
 }
 
 #[wasm_bindgen_test]
+fn debug() {
+    let closure = Closure::wrap(Box::new(|| {}) as Box<FnMut()>);
+    assert_eq!(&format!("{:?}", closure), "Closure { ... }");
+}
+
+#[wasm_bindgen_test]
 fn long_lived() {
     let hit = Rc::new(Cell::new(false));
     let hit2 = hit.clone();


### PR DESCRIPTION
As per the discussion in #1387 I kept this one simple, the Debug output for a Closure is simply `Closure { ... }`. I don't think there's currently any more useful information we could provide anyway.

resolves #1387 
