### PR TITLE
Support 1-reference argument closures

### DIFF
--- a/tests/wasm/closures.js
+++ b/tests/wasm/closures.js
@@ -113,3 +113,9 @@ exports.calling_it_throws = a => {
 };
 
 exports.call_val = f => f();
+
+exports.pass_reference_first_arg_twice = (a, b, c) => {
+  b(a);
+  c(a);
+  a.free();
+};


### PR DESCRIPTION
This is work towards #1399, although it's just for one-argument closures
where the first argument is a reference. No other closures with
references in argument position are supported yet