### PR TITLE
Fix imported usage of `wasm_bindgen` macro

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -896,7 +896,7 @@ fn prepare_for_impl_recursion(
             pound_token: Default::default(),
             style: syn::AttrStyle::Outer,
             bracket_token: Default::default(),
-            path: syn::Ident::new("__wasm_bindgen_class_marker", Span::call_site()).into(),
+            path: syn::parse_quote! { wasm_bindgen::prelude::__wasm_bindgen_class_marker },
             tts: quote::quote! { (#class = #js_class) }.into(),
         },
     );

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -459,3 +459,21 @@ pub fn option_class_assert_none(x: Option<OptionClass>) {
 pub fn option_class_assert_some(x: Option<OptionClass>) {
     assert_eq!(x.unwrap().0, 3);
 }
+
+mod works_in_module {
+    use wasm_bindgen::prelude::wasm_bindgen;
+
+    #[wasm_bindgen]
+    pub struct WorksInModule(u32);
+
+    #[wasm_bindgen]
+    impl WorksInModule {
+        #[wasm_bindgen(constructor)]
+        pub fn new() -> WorksInModule {
+            WorksInModule(1)
+        }
+
+        pub fn foo(&self) {
+        }
+    }
+}


### PR DESCRIPTION
Make sure it refers to `__wasm_bindgen_class_marker` via an absolute
path!

Closes #1422