### PR TITLE
Don't put anything before ES module imports

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -42,6 +42,19 @@ enum OutputMode {
     Node { experimental_modules: bool },
 }
 
+impl OutputMode {
+    fn uses_es_modules(&self) -> bool {
+        match self {
+            OutputMode::Bundler { .. }
+            | OutputMode::Web
+            | OutputMode::Node {
+                experimental_modules: true,
+            } => true,
+            _ => false,
+        }
+    }
+}
+
 enum Input {
     Path(PathBuf),
     Module(Module, String),


### PR DESCRIPTION
Because of some incorrect use of `js.push_str(..)`, we could sometimes emit code
before the ES modules imports, which is syntactically invalid:

    const __exports = {};
    import { Thing } from '...'; // Syntax error!

This has been fixed by making sure that the correct `imports` or `imports_post`
string is built up. We now also assert that the `js` string is empty at the
location where we add imports if we're using ES modules.