### PR TITLE
Improve error message for non-copy struct fields

### DIFF
--- a/crates/macro/ui-tests/pub-not-copy.rs
+++ b/crates/macro/ui-tests/pub-not-copy.rs
@@ -1,0 +1,10 @@
+#![crate_type = "rlib"]
+
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct A {
+    pub field: String,
+}

--- a/crates/macro/ui-tests/pub-not-copy.stderr
+++ b/crates/macro/ui-tests/pub-not-copy.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `std::string::String: std::marker::Copy` is not satisfied
+ --> $DIR/pub-not-copy.rs:9:16
+  |
+9 |     pub field: String,
+  |                ^^^^^^ the trait `std::marker::Copy` is not implemented for `std::string::String`
+  |
+note: required by `__wbg_get_a_field::assert_copy`
+ --> $DIR/pub-not-copy.rs:7:1
+  |
+7 | #[wasm_bindgen]
+  | ^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Make sure the error message points to the type in question instead of to
the `#[wasm_bindgen]` macro which can be overly confusing!