### PR TITLE
Add an accessor for the function table

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -783,6 +783,14 @@ impl<'a> Context<'a> {
             ))
         })?;
 
+        self.bind("__wbindgen_function_table", &|me| {
+            me.function_table_needed = true;
+            Ok(format!(
+                "function() {{ return {}; }}",
+                me.add_heap_object("wasm.__wbg_function_table")
+            ))
+        })?;
+
         self.bind("__wbindgen_rethrow", &|me| {
             Ok(format!(
                 "function(idx) {{ throw {}; }}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -517,6 +517,7 @@ externs! {
 
         fn __wbindgen_memory() -> u32;
         fn __wbindgen_module() -> u32;
+        fn __wbindgen_function_table() -> u32;
     }
 }
 
@@ -734,6 +735,12 @@ pub fn module() -> JsValue {
 /// Returns a handle to this wasm instance's `WebAssembly.Memory`
 pub fn memory() -> JsValue {
     unsafe { JsValue::_new(__wbindgen_memory()) }
+}
+
+/// Returns a handle to this wasm instance's `WebAssembly.Table` which is the
+/// indirect function table used by Rust
+pub fn function_table() -> JsValue {
+    unsafe { JsValue::_new(__wbindgen_function_table()) }
 }
 
 #[doc(hidden)]

--- a/tests/wasm/api.js
+++ b/tests/wasm/api.js
@@ -55,3 +55,9 @@ exports.debug_values = () => ([
     () => (null),
     new Set(),
 ]);
+
+exports.assert_function_table = (x, i) => {
+  const rawWasm = require('wasm-bindgen-test_bg.js');
+  assert.ok(x instanceof WebAssembly.Table);
+  assert.strictEqual(x.get(i), rawWasm.function_table_lookup);
+};

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -9,6 +9,7 @@ extern "C" {
     fn js_eq_works();
     fn assert_null(v: JsValue);
     fn debug_values() -> JsValue;
+    fn assert_function_table(a: JsValue, b: usize);
 }
 
 #[wasm_bindgen_test]
@@ -171,3 +172,14 @@ fn debug_output() {
         assert_eq!(format!("{:?}", test.unwrap()), expected);
     }
 }
+
+#[wasm_bindgen_test]
+fn function_table_is() {
+    assert_function_table(
+        wasm_bindgen::function_table(),
+        function_table_lookup as usize,
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn function_table_lookup() {}


### PR DESCRIPTION
This commit adds an intrinsics to the `wasm_bindgen` crate which
accesses the `WebAssembly.Table` which is the function table of the
module. Eventually the thinking is that a module would import its own
function table via native wasm functionality (via `anyref` and such),
but until that's implemented let's add a binding for it ourselves!

Closes #1427