### PR TITLE
Fix a bug using `encodeInto` truncating strings

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1364,11 +1364,11 @@ impl<'a> Context<'a> {
                 while (true) {{
                     const view = getUint8Memory().subarray(ptr + writeOffset, ptr + size);
                     const {{ read, written }} = cachedTextEncoder.encodeInto(arg, view);
+                    writeOffset += written;
                     if (read === arg.length) {{
                         break;
                     }}
                     arg = arg.substring(read);
-                    writeOffset += written;
                     ptr = wasm.__wbindgen_realloc(ptr, size, size += arg.length * 3);
                 }}
                 WASM_VECTOR_LEN = writeOffset;


### PR DESCRIPTION
The last write accidentally wasn't accounted for in the returned length
of the string and we unfortunately don't have any test coverage of
`encodeInto` since it requires Firefox nightly right now (and doesn't
work in Node yet).

Closes #1436