### PR TITLE
js-sys: add Object.fromEntries

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2176,6 +2176,13 @@ extern "C" {
     #[wasm_bindgen(static_method_of = Object)]
     pub fn freeze(value: &Object) -> Object;
 
+    /// The Object.fromEntries() method transforms a list of key-value pairs
+    /// into an object.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries)
+    #[wasm_bindgen(static_method_of = Object, catch, js_name = fromEntries)]
+    pub fn from_entries(iterable: &JsValue) -> Result<Object, JsValue>;
+
     /// The Object.getOwnPropertyDescriptor() method returns a
     /// property descriptor for an own property (that is, one directly
     /// present on an object and not in the object's prototype chain)

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -132,6 +132,8 @@ fn from_entries() {
     entry_one.push(&"bar".into());
     entry_two.push(&"baz".into());
     entry_two.push(&42.into());
+    array.push(&entry_one);
+    array.push(&entry_two);
     let object = Object::from_entries(&array).unwrap();
 
     assert_eq!(Reflect::get(object.as_ref(), &"foo".into()).unwrap(), "bar");

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -124,6 +124,25 @@ fn entries() {
 }
 
 #[wasm_bindgen_test]
+fn from_entries() {
+    let array = Array::new();
+    let entry_one = Array::new();
+    let entry_two = Array::new();
+    entry_one.push(&"foo".into());
+    entry_one.push(&"bar".into());
+    entry_two.push(&"baz".into());
+    entry_two.push(&42.into());
+    let object = Object::from_entries(&array).unwrap();
+
+    assert_eq!(Reflect::get(object.as_ref(), &"foo".into()).unwrap(), "bar");
+    assert_eq!(Reflect::get(object.as_ref(), &"baz".into()).unwrap(), 42);
+
+    let not_iterable = Object::new();
+    let error = Object::from_entries(&not_iterable).unwrap_err();
+    assert!(error.is_instance_of::<TypeError>());
+}
+
+#[wasm_bindgen_test]
 fn get_own_property_descriptor() {
     let foo = foo_42();
     let desc = Object::get_own_property_descriptor(&foo, &"foo".into());


### PR DESCRIPTION
Fixes #1453.

I couldn't actually get tests to pass, possibly because Node does not yet support this function.