### PR TITLE
Format web-sys bindings by default

### DIFF
--- a/crates/web-sys/build.rs
+++ b/crates/web-sys/build.rs
@@ -113,13 +113,13 @@ fn try_main() -> Result<(), failure::Error> {
 
     // run rustfmt on the generated file - really handy for debugging
     println!("cargo:rerun-if-env-changed=WEBIDL_RUSTFMT_BINDINGS");
-    if env::var("WEBIDL_RUSTFMT_BINDINGS").is_ok() {
+    if env::var("WEBIDL_RUSTFMT_BINDINGS").ok() != Some("0".to_string()) {
         let status = Command::new("rustfmt")
             .arg(&out_file_path)
             .status()
             .context("running rustfmt")?;
         if !status.success() {
-            bail!("rustfmt failed: {}", status)
+            println!("cargo:warning=rustfmt failed: {}", status)
         }
     }
 


### PR DESCRIPTION
This commit switches to executing `rustfmt` by default on
`web-sys`-generated bindings. This improves situations like "view
source" in Rustdoc as well as the IDE interactive debugging experience.

This was initially disabled by default because `rustfmt` took so long to
execute, but nowadays `web-sys` is by default much smaller so there's
much less need to avoid running `rustfmt` in fear of it taking too
long.

Closes #1457