### PR TITLE
Remove repetitive branching on value drop

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -854,7 +854,7 @@ impl<'a> Context<'a> {
         // remove usages of this.
         self.bind("__wbindgen_object_drop_ref", &|me| {
             me.expose_drop_ref();
-            Ok(String::from("function(i) { dropObject(i); }"))
+            Ok(String::from("dropObject"))
         })?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,13 +551,7 @@ impl Drop for JsValue {
         unsafe {
             // We definitely should never drop anything in the stack area
             debug_assert!(self.idx >= JSIDX_OFFSET);
-
-            // Otherwise if we're not dropping one of our reserved values,
-            // actually call the intrinsic. See #1054 for eventually removing
-            // this branch.
-            if self.idx >= JSIDX_RESERVED {
-                __wbindgen_object_drop_ref(self.idx);
-            }
+            __wbindgen_object_drop_ref(self.idx);
         }
     }
 }


### PR DESCRIPTION
This was unnecessarily checking that the value is not reserved twice (on both sides).