### PR TITLE
Generate bindings for indexed struct properties

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -227,7 +227,7 @@ pub struct Struct {
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 #[derive(Clone)]
 pub struct StructField {
-    pub name: Ident,
+    pub name: syn::Member,
     pub struct_name: Ident,
     pub readonly: bool,
     pub ty: syn::Type,

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -332,7 +332,10 @@ fn shared_struct<'a>(s: &'a ast::Struct, intern: &'a Interner) -> Struct<'a> {
 
 fn shared_struct_field<'a>(s: &'a ast::StructField, intern: &'a Interner) -> StructField<'a> {
     StructField {
-        name: intern.intern(&s.name),
+        name: match &s.name {
+            syn::Member::Named(ident) => intern.intern(ident),
+            syn::Member::Unnamed(index) => intern.intern_str(&index.index.to_string()),
+        },
         readonly: s.readonly,
         comments: s.comments.iter().map(|s| &**s).collect(),
     }

--- a/examples/guide-supported-types-examples/exported_types.js
+++ b/examples/guide-supported-types-examples/exported_types.js
@@ -1,14 +1,22 @@
 import {
-  ExportedRustType,
-  exported_type_by_value,
-  exported_type_by_shared_ref,
-  exported_type_by_exclusive_ref,
-  return_exported_type,
+  ExportedNamedStruct,
+  named_struct_by_value,
+  named_struct_by_shared_ref,
+  named_struct_by_exclusive_ref,
+  return_named_struct,
+
+  ExportedTupleStruct,
+  return_tuple_struct
 } from './guide_supported_types_examples';
 
-let rustThing = return_exported_type();
-console.log(rustThing instanceof ExportedRustType); // true
+let namedStruct = return_named_struct(42);
+console.log(namedStruct instanceof ExportedNamedStruct); // true
+console.log(namedStruct.inner); // 42
 
-exported_type_by_value(rustThing);
-exported_type_by_shared_ref(rustThing);
-exported_type_by_exclusive_ref(rustThing);
+named_struct_by_value(namedStruct);
+named_struct_by_shared_ref(namedStruct);
+named_struct_by_exclusive_ref(namedStruct);
+
+let tupleStruct = return_tuple_struct(10, 20);
+console.log(tupleStruct instanceof ExportedTupleStruct); // true
+console.log(tupleStruct[0], tupleStruct[1]); // 10, 20

--- a/examples/guide-supported-types-examples/src/exported_types.rs
+++ b/examples/guide-supported-types-examples/src/exported_types.rs
@@ -1,20 +1,28 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct ExportedRustType {
-    inner: u32,
+pub struct ExportedNamedStruct {
+    pub inner: u32,
 }
 
 #[wasm_bindgen]
-pub fn exported_type_by_value(x: ExportedRustType) {}
+pub fn named_struct_by_value(x: ExportedNamedStruct) {}
 
 #[wasm_bindgen]
-pub fn exported_type_by_shared_ref(x: &ExportedRustType) {}
+pub fn named_struct_by_shared_ref(x: &ExportedNamedStruct) {}
 
 #[wasm_bindgen]
-pub fn exported_type_by_exclusive_ref(x: &mut ExportedRustType) {}
+pub fn named_struct_by_exclusive_ref(x: &mut ExportedNamedStruct) {}
 
 #[wasm_bindgen]
-pub fn return_exported_type() -> ExportedRustType {
-    unimplemented!()
+pub fn return_named_struct(inner: u32) -> ExportedNamedStruct {
+    ExportedNamedStruct { inner }
+}
+
+#[wasm_bindgen]
+pub struct ExportedTupleStruct(pub u32, pub u32);
+
+#[wasm_bindgen]
+pub fn return_tuple_struct(x: u32, y: u32) -> ExportedTupleStruct {
+    ExportedTupleStruct(x, y)
 }

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -137,6 +137,7 @@ exports.js_js_rename = () => {
 
 exports.js_access_fields = () => {
     assert.ok((new wasm.AccessFieldFoo()).bar instanceof wasm.AccessFieldBar);
+    assert.ok((new wasm.AccessField0())[0] instanceof wasm.AccessFieldBar);
 };
 
 exports.js_renamed_export = () => {

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -370,6 +370,9 @@ pub struct AccessFieldFoo {
 }
 
 #[wasm_bindgen]
+pub struct AccessField0(pub AccessFieldBar);
+
+#[wasm_bindgen]
 #[derive(Copy, Clone)]
 pub struct AccessFieldBar {
     _value: u32,
@@ -382,6 +385,14 @@ impl AccessFieldFoo {
         AccessFieldFoo {
             bar: AccessFieldBar { _value: 2 },
         }
+    }
+}
+
+#[wasm_bindgen]
+impl AccessField0 {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> AccessField0 {
+        AccessField0(AccessFieldBar { _value: 2 })
     }
 }
 


### PR DESCRIPTION
This allows to export fields of tuple-like structs as indexed JS properties.

While we could rename it to `_0`, `$0` or something else, this feels like the most natural mapping of "indexed" properties to JavaScript concepts, and just works out of the box with current JS and TypeScript codegens.