### PR TITLE
Fix or suppress {primitive}::new warnings in tests

### DIFF
--- a/crates/js-sys/tests/wasm/Boolean.rs
+++ b/crates/js-sys/tests/wasm/Boolean.rs
@@ -3,16 +3,19 @@ use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
+#[allow(deprecated)]
 #[wasm_bindgen_test]
 fn new_undefined() {
     assert_eq!(Boolean::new(&JsValue::undefined()).value_of(), false);
 }
 
+#[allow(deprecated)]
 #[wasm_bindgen_test]
 fn new_truely() {
     assert_eq!(Boolean::new(&JsValue::from("foo")).value_of(), true);
 }
 
+#[allow(deprecated)]
 #[wasm_bindgen_test]
 fn boolean_inheritance() {
     let b = Boolean::new(&JsValue::from(true));

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -39,9 +39,7 @@ fn parse_object() {
     assert_eq!(y.as_bool(), Some(true));
 
     let x = values.pop();
-    assert!(Number::is_integer(&x));
-    let x_num = Number::new(&x);
-    assert_eq!(x_num.value_of(), 5.0);
+    assert_eq!(x.as_f64().unwrap(), 5.0);
 }
 
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/Number.rs
+++ b/crates/js-sys/tests/wasm/Number.rs
@@ -52,6 +52,7 @@ fn is_safe_integer() {
     assert_eq!(Number::is_safe_integer(&INFINITY.into()), false);
 }
 
+#[allow(deprecated)]
 #[wasm_bindgen_test]
 fn new() {
     let n = Number::new(&JsValue::from(42));
@@ -72,7 +73,7 @@ fn parse_int_float() {
 
 #[wasm_bindgen_test]
 fn to_locale_string() {
-    let number = Number::new(&1234.45.into());
+    let number = Number::from(1234.45);
     assert_eq!(number.to_locale_string("en-US"), "1,234.45");
     // TODO: these tests seems to be system dependent, disable for now
     // assert_eq!(wasm.to_locale_string(number, "de-DE"), "1,234.45");
@@ -81,37 +82,35 @@ fn to_locale_string() {
 
 #[wasm_bindgen_test]
 fn to_precision() {
-    assert_eq!(Number::new(&0.1.into()).to_precision(3).unwrap(), "0.100");
-    assert!(Number::new(&10.into()).to_precision(101).is_err());
+    assert_eq!(Number::from(0.1).to_precision(3).unwrap(), "0.100");
+    assert!(Number::from(10).to_precision(101).is_err());
 }
 
 #[wasm_bindgen_test]
 fn to_string() {
-    assert_eq!(Number::new(&42.into()).to_string(10).unwrap(), "42");
-    assert_eq!(Number::new(&233.into()).to_string(16).unwrap(), "e9");
-    assert!(Number::new(&100.into()).to_string(100).is_err());
+    assert_eq!(Number::from(42).to_string(10).unwrap(), "42");
+    assert_eq!(Number::from(233).to_string(16).unwrap(), "e9");
+    assert!(Number::from(100).to_string(100).is_err());
 }
 
 #[wasm_bindgen_test]
 fn value_of() {
-    assert_eq!(Number::new(&42.into()).value_of(), 42.);
+    assert_eq!(Number::from(42).value_of(), 42.);
 }
 
 #[wasm_bindgen_test]
 fn to_fixed() {
-    assert_eq!(Number::new(&123.456.into()).to_fixed(2).unwrap(), "123.46");
-    assert!(Number::new(&10.into()).to_fixed(101).is_err());
+    assert_eq!(Number::from(123.456).to_fixed(2).unwrap(), "123.46");
+    assert!(Number::from(10).to_fixed(101).is_err());
 }
 
 #[wasm_bindgen_test]
 fn to_exponential() {
-    assert_eq!(
-        Number::new(&123456.into()).to_exponential(2).unwrap(),
-        "1.23e+5"
-    );
-    assert!(Number::new(&10.into()).to_exponential(101).is_err());
+    assert_eq!(Number::from(123456).to_exponential(2).unwrap(), "1.23e+5");
+    assert!(Number::from(10).to_exponential(101).is_err());
 }
 
+#[allow(deprecated)]
 #[wasm_bindgen_test]
 fn number_inheritance() {
     let n = Number::new(&JsValue::from(42));

--- a/crates/js-sys/tests/wasm/Reflect.rs
+++ b/crates/js-sys/tests/wasm/Reflect.rs
@@ -1,5 +1,5 @@
 use js_sys::*;
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/Reflect.js")]


### PR DESCRIPTION
Constructing boxed primitives was deprecated in #1447.

Some tests have been still using these methods, so this PR either updates them to use newly added {primitive}::from implementations or adds `#[allow(deprecated)]` where necessary.

r? @alexcrichton 