### PR TITLE
Add JsString <-> char conversions

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3679,12 +3679,6 @@ impl PartialEq<str> for JsString {
     }
 }
 
-impl PartialEq<char> for JsString {
-    fn eq(&self, other: &char) -> bool {
-        self.as_char() == Some(*other)
-    }
-}
-
 impl<'a> PartialEq<&'a str> for JsString {
     fn eq(&self, other: &&'a str) -> bool {
         <JsString as PartialEq<str>>::eq(self, other)

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -553,3 +553,14 @@ fn is_valid_utf16() {
     assert!(!JsString::from_char_code1(0xd800).is_valid_utf16());
     assert!(!JsString::from_char_code1(0xdc00).is_valid_utf16());
 }
+
+#[wasm_bindgen_test]
+fn as_char() {
+    assert_eq!(JsString::from('a').as_char(), Some('a'));
+    assert_eq!(JsString::from('🥑').as_char(), Some('🥑'));
+    assert_eq!(JsString::from("").as_char(), None);
+    assert_eq!(JsString::from("ab").as_char(), None);
+    assert_eq!(JsString::from_char_code1(0xd800).as_char(), None);
+    assert_eq!(JsString::from_char_code1(0xdc00).as_char(), None);
+    assert_eq!(JsString::from_char_code1(0xdfff).as_char(), None);
+}


### PR DESCRIPTION
These are pretty common and already supported via ABI conversions, yet pretty easy to get wrong when converting them manually.

Fixes #1363.