### PR TITLE
Fix optional arguments in TypeScript

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2963,7 +2963,7 @@ impl<'a, 'b> SubContext<'a, 'b> {
                     "\n  {}{}: {};",
                     if field.readonly { "readonly " } else { "" },
                     field.name,
-                    &cx.js_arguments[0].1
+                    &cx.js_arguments[0].type_
                 ));
                 cx.finish("", &format!("wasm.{}", wasm_setter), setter).0
             };

--- a/crates/typescript-tests/src/opt_args_and_ret.rs
+++ b/crates/typescript-tests/src/opt_args_and_ret.rs
@@ -1,6 +1,14 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn opt_fn(_a: Option<i32>) -> Option<i32> {
+/// Optional parameters followed by non-optional parameters.
+/// Only the parameter _c may be marked as omittable.
+pub fn opt_fn_mixed(_a: Option<i32>, _b: i32, _c: Option<i32>) -> Option<i32> {
+    None
+}
+
+#[wasm_bindgen]
+/// Only optional parameters. All of them may be marked as omittable.
+pub fn opt_fn_only(_a: Option<i32>, _b: Option<i32>, _c: Option<i32>) -> Option<i32> {
     None
 }

--- a/crates/typescript-tests/src/opt_args_and_ret.ts
+++ b/crates/typescript-tests/src/opt_args_and_ret.ts
@@ -1,3 +1,3 @@
 import * as wbg from '../pkg/typescript_tests';
 
-const opt_fn: (a: number | undefined) => number | undefined = wbg.opt_fn;
+const opt_fn: (a?: number) => number | undefined = wbg.opt_fn;

--- a/crates/typescript-tests/src/opt_args_and_ret.ts
+++ b/crates/typescript-tests/src/opt_args_and_ret.ts
@@ -1,3 +1,4 @@
 import * as wbg from '../pkg/typescript_tests';
 
-const opt_fn: (a?: number) => number | undefined = wbg.opt_fn;
+const opt_fn_mixed: (a: number | undefined, b: number, c?: number) => number | undefined = wbg.opt_fn_mixed;
+const opt_fn_only: (a?: number, b?: number, c?: number) => number | undefined = wbg.opt_fn_only;


### PR DESCRIPTION
For a function like this:

```rust
#[wasm_bindgen]
pub fn opt_fn(_a: Option<i32>) -> Option<i32> {
    None
}
```

...the currently generated typescript looks like this:

```typescript
/**
* @param {number | undefined} _a
* @returns {number | undefined}
*/
export function opt_fn(_a: number | undefined): number | undefined;
```

Support for `undefined` in the parameter type was added in #1201. However, while type `number | undefined` is technically optional at runtime, typechecking tools will still consider the parameter to be required. (CC @rhysd, please correct me if this information is actually incorrect.)

Instead, the TypeScript should look like this, with a `?` appended to the parameter name:

```typescript
/**
* @param {number | undefined} _a
* @returns {number | undefined}
*/
export function opt_fn(_a?: number): number | undefined;
```

Reference: https://www.typescriptlang.org/docs/handbook/functions.html#optional-and-default-parameters

This PR should actually fix #1129.

Some notes: I also adjusted `crates/typescript-tests/src/opt_args_and_ret.ts`, but I could not find out whether and where this file is actually used. I think it's dead code, but I might be wrong.