### PR TITLE
Fix raytrace example by using an older nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -170,15 +170,17 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly
+          toolchain: nightly-2019-04-01
       - template: ci/azure-install-sccache.yml
       - script: rustup component add rust-src
         displayName: "install rust-src"
       - script: |
+          set -e
           curl -L https://github.com/japaric/xargo/releases/download/v0.3.13/xargo-v0.3.13-x86_64-unknown-linux-musl.tar.gz | tar xzf -
           echo "##vso[task.setvariable variable=PATH;]$PATH:$PWD"
         displayName: "install xargo"
       - script: |
+          set -e
           sed -i 's/python/#python/' examples/raytrace-parallel/build.sh
           (cd examples/raytrace-parallel && ./build.sh)
           cp examples/raytrace-parallel/*.{js,html,wasm} $BUILD_ARTIFACTSTAGINGDIRECTORY

--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -11,7 +11,7 @@ set -ex
 # * Next we need to compile everything with the `atomics` feature enabled,
 #   ensuring that LLVM will generate atomic instructions and such.
 RUSTFLAGS='-C target-feature=+atomics' \
-  rustup run nightly xargo build --target wasm32-unknown-unknown --release
+  xargo build --target wasm32-unknown-unknown --release
 
 # Threading support is disabled by default in wasm-bindgen, so use an env var
 # here to turn it on for our bindings generation. Also note that webpack isn't


### PR DESCRIPTION
Unfortunately xargo is currently broken against master Rust, so let's
pin to an older nightly while that's sorted out