### PR TITLE
Added tests for SharedArrayBuffer

### DIFF
--- a/crates/js-sys/tests/wasm/ArrayBuffer.rs
+++ b/crates/js-sys/tests/wasm/ArrayBuffer.rs
@@ -22,14 +22,14 @@ fn is_view() {
     assert!(ArrayBuffer::is_view(&JsValue::from(x)));
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn slice() {
     let buf = ArrayBuffer::new(4);
     let slice = buf.slice(2);
     assert!(JsValue::from(slice).is_object());
 }
 
-#[test]
+#[wasm_bindgen_test]
 fn slice_with_end() {
     let buf = ArrayBuffer::new(4);
     let slice = buf.slice_with_end(1, 2);

--- a/crates/js-sys/tests/wasm/SharedArrayBuffer.js
+++ b/crates/js-sys/tests/wasm/SharedArrayBuffer.js
@@ -1,0 +1,3 @@
+exports.is_shared_array_buffer_supported = function () {
+    return typeof SharedArrayBuffer === 'function';
+};

--- a/crates/js-sys/tests/wasm/SharedArrayBuffer.rs
+++ b/crates/js-sys/tests/wasm/SharedArrayBuffer.rs
@@ -1,0 +1,59 @@
+use js_sys::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/SharedArrayBuffer.js")]
+extern "C" {
+    fn is_shared_array_buffer_supported() -> bool;
+}
+
+#[wasm_bindgen_test]
+fn new() {
+    if !is_shared_array_buffer_supported() {
+        return;
+    }
+    let x = SharedArrayBuffer::new(42);
+    let y: JsValue = x.into();
+    assert!(y.is_object());
+}
+
+#[wasm_bindgen_test]
+fn byte_length() {
+    if !is_shared_array_buffer_supported() {
+        return;
+    }
+    let buf = SharedArrayBuffer::new(42);
+    assert_eq!(buf.byte_length(), 42);
+}
+
+#[wasm_bindgen_test]
+fn slice() {
+    if !is_shared_array_buffer_supported() {
+        return;
+    }
+    let buf = SharedArrayBuffer::new(4);
+    let slice = buf.slice(2);
+    assert!(JsValue::from(slice).is_object());
+}
+
+#[wasm_bindgen_test]
+fn slice_with_end() {
+    if !is_shared_array_buffer_supported() {
+        return;
+    }
+    let buf = SharedArrayBuffer::new(4);
+    let slice = buf.slice_with_end(1, 2);
+    assert!(JsValue::from(slice).is_object());
+}
+
+#[wasm_bindgen_test]
+fn sharedarraybuffer_inheritance() {
+    if !is_shared_array_buffer_supported() {
+        return;
+    }
+    let buf = SharedArrayBuffer::new(4);
+    assert!(buf.is_instance_of::<SharedArrayBuffer>());
+    assert!(buf.is_instance_of::<Object>());
+    let _: &Object = buf.as_ref();
+}

--- a/crates/js-sys/tests/wasm/main.rs
+++ b/crates/js-sys/tests/wasm/main.rs
@@ -34,6 +34,7 @@ pub mod Reflect;
 pub mod RegExp;
 pub mod Set;
 pub mod SetIterator;
+pub mod SharedArrayBuffer;
 pub mod Symbol;
 pub mod SyntaxError;
 pub mod TypeError;


### PR DESCRIPTION
Changes:
- Added tests for `SharedArrayBuffer`
- Fixed wrong usage of `#[test]` in `ArrayBuffer` tests
