### PR TITLE
Recommend to use dyn_ref on funcs and strings

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1078,6 +1078,7 @@ impl Function {
     ///
     /// If this JS value is not an instance of a function then this returns
     /// `None`.
+    #[deprecated(note = "recommended to use dyn_ref instead which is now equivalent")]
     pub fn try_from(val: &JsValue) -> Option<&Function> {
         val.dyn_ref()
     }
@@ -3796,6 +3797,7 @@ impl JsString {
     ///
     /// If this JS value is not an instance of a string then this returns
     /// `None`.
+    #[deprecated(note = "recommended to use dyn_ref instead which is now equivalent")]
     pub fn try_from(val: &JsValue) -> Option<&JsString> {
         val.dyn_ref()
     }


### PR DESCRIPTION
Now that functions and strings work properly with custom typechecks, these custom methods seem obsolete, so I'd recommend to use standard dyn_ref instead.