### PR TITLE
Add missing variadic bindings for string methods

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -3400,6 +3400,14 @@ extern "C" {
     ///
     /// There are a few bindings to `from_char_code` in `js-sys`: `from_char_code1`, `from_char_code2`, etc...
     /// with different arities.
+    ///
+    /// Additionally, this function accepts `u16` for character codes, but
+    /// fixing others requires a breaking change release
+    /// (see https://github.com/rustwasm/wasm-bindgen/issues/1460 for details).
+    #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode, variadic)]
+    pub fn from_char_code(char_codes: &[u16]) -> JsString;
+
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode)
     #[wasm_bindgen(static_method_of = JsString, js_class = "String", js_name = fromCharCode)]
     pub fn from_char_code1(a: u32) -> JsString;
 
@@ -3432,6 +3440,10 @@ extern "C" {
     ///
     /// There are a few bindings to `from_code_point` in `js-sys`: `from_code_point1`, `from_code_point2`, etc...
     /// with different arities.
+    #[wasm_bindgen(catch, static_method_of = JsString, js_class = "String", js_name = fromCodePoint, variadic)]
+    pub fn from_code_point(code_points: &[u32]) -> Result<JsString, JsValue>;
+
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint)
     #[wasm_bindgen(catch, static_method_of = JsString, js_class = "String", js_name = fromCodePoint)]
     pub fn from_code_point1(a: u32) -> Result<JsString, JsValue>;
 

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -91,6 +91,16 @@ fn from_char_code() {
         JsString::from_char_code4(codes[0], codes[1], codes[2], codes[3]),
         "½+¾="
     );
+
+    let codes_u16: Vec<u16> = codes.into_iter().map(|code| {
+        assert!(code <= u32::from(u16::max_value()));
+        code as u16
+    }).collect();
+
+    assert_eq!(
+        JsString::from_char_code(&codes_u16),
+        "½+¾="
+    );
 }
 
 #[wasm_bindgen_test]
@@ -109,6 +119,10 @@ fn from_code_point() {
     );
     assert_eq!(
         JsString::from_code_point4(codes[0], codes[1], codes[2], codes[3]).unwrap(),
+        "☃★♲你"
+    );
+    assert_eq!(
+        JsString::from_code_point(&codes).unwrap(),
         "☃★♲你"
     );
 


### PR DESCRIPTION
 - `JsString::from_code_point` - allows to create JS strings using slice of codes in WASM memory.
 - `JsString::from_char_code` - same as above, but also uses updated signature with `u16` instead of `u32` (partially helps with #1460 at least for the new binding).