### PR TITLE
Add bindings for `new Function(args, body)`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -996,6 +996,17 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
     #[wasm_bindgen(constructor)]
+    pub fn new_with_args(args: &str, body: &str) -> Function;
+
+    /// The `Function` constructor creates a new `Function` object. Calling the
+    /// constructor directly can create functions dynamically, but suffers from
+    /// security and similar (but far less significant) performance issues
+    /// similar to `eval`. However, unlike `eval`, the `Function` constructor
+    /// allows executing code in the global scope, prompting better programming
+    /// habits and allowing for more efficient code minification.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    #[wasm_bindgen(constructor)]
     pub fn new_no_args(body: &str) -> Function;
 
     /// The apply() method calls a function with a given this value, and arguments provided as an array

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -101,7 +101,7 @@ fn stringify_with_replacer() {
     assert_eq!(output1, "{\"hello\":\"world\"}");
 
     let replacer_func =
-        Function::new_no_args("return arguments[0] === 'hello' ? undefined : arguments[1]");
+        Function::new_with_args("key, value", "return key === 'hello' ? undefined : value");
     let output2: String =
         JSON::stringify_with_replacer(&JsValue::from(obj), &JsValue::from(replacer_func))
             .unwrap()
@@ -164,7 +164,7 @@ fn stringify_with_replacer_and_space() {
     assert_eq!(output2, "{\n    \"hello\": \"world\"\n}");
 
     let replacer_func =
-        Function::new_no_args("return arguments[0] === 'hello' ? undefined : arguments[1]");
+        Function::new_with_args("key, value", "return key === 'hello' ? undefined : value");
     let output3: String = JSON::stringify_with_replacer_and_space(
         &JsValue::from(obj),
         &JsValue::from(replacer_func),


### PR DESCRIPTION
We don't support variadic args in front, but, luckily for us, `new Function` accepts comma-separated args as a single string as well (see updated JSON test for an example).