### PR TITLE
Update webpack.config.js

### DIFF
--- a/examples/closures/webpack.config.js
+++ b/examples/closures/webpack.config.js
@@ -10,7 +10,9 @@ module.exports = {
         filename: 'index.js',
     },
     plugins: [
-        new HtmlWebpackPlugin(),
+        new HtmlWebpackPlugin({
+            template: './index.html'
+        }),
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),


### PR DESCRIPTION
Fixes https://github.com/rustwasm/wasm-bindgen/issues/1501

The `#loading` element is not found in the page, which is triggering the `expect()`, the panic is not clear tho.

I didn't check the other example.