### PR TITLE
Fix direct imports in `--target web`

### DIFF
--- a/tests/headless/main.rs
+++ b/tests/headless/main.rs
@@ -39,3 +39,4 @@ fn can_log_html_strings() {
 }
 
 pub mod snippets;
+pub mod modules;

--- a/tests/headless/modules.js
+++ b/tests/headless/modules.js
@@ -1,0 +1,3 @@
+export function get_five() {
+  return 5;
+}

--- a/tests/headless/modules.rs
+++ b/tests/headless/modules.rs
@@ -1,0 +1,12 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(raw_module = "./tests/headless/modules.js")]
+extern "C" {
+    fn get_five() -> u32;
+}
+
+#[wasm_bindgen_test]
+fn test_get_five() {
+    assert_eq!(get_five(), 5);
+}


### PR DESCRIPTION
Currently the import object constructed for the `--target web` output
only ever includes the current module as an one of the modules included.
With `wasm-bindgen`'s optimization to import directly from modules,
however, it's possible to have more modules imported from in the
generated wasm file. This commit ensures that the imports are hooked up
in the `--target web` es6 emulation mode, ensuring there aren't
extraneous errors about import objects.