### PR TITLE
Fix `__wbindgen_object_drop_ref` unnecessary bindings

### DIFF
--- a/src/anyref.rs
+++ b/src/anyref.rs
@@ -201,7 +201,7 @@ pub extern fn __wbindgen_anyref_table_dealloc(idx: usize) {
 #[no_mangle]
 pub unsafe extern fn __wbindgen_drop_anyref_slice(ptr: *mut JsValue, len: usize) {
     for slot in slice::from_raw_parts_mut(ptr, len) {
-        ptr::drop_in_place(slot);
+        __wbindgen_anyref_table_dealloc(slot.idx as usize);
     }
 }
 


### PR DESCRIPTION
This commit fixes an issue where bindings for
`__wbindgen_object_drop_ref` are generated even if the function isn't
actually used by the final wasm file. This is currently due to the fact
that we run gc passes pretty late in wasm-bindgen and one of the
intrinsics that ended up getting gc'd referenced the
`__wbindgen_object_drop_ref` intrinsic function.

The fix here is somewhat naive by just updating the intrinsic to not
actually use `__wbindgen_object_drop_ref`. This may not be a long-term
solution but it should be good enough for now at least.

Closes #1498