### PR TITLE
Fix importing and exporting the same name

### DIFF
--- a/crates/cli-support/src/js/closures.rs
+++ b/crates/cli-support/src/js/closures.rs
@@ -234,7 +234,7 @@ impl ClosureDescriptors {
                 js,
                 input.add_heap_object("real"),
             );
-            input.export(&import_name, &body, None);
+            input.export(&import_name, &body, None)?;
 
             let module = "__wbindgen_placeholder__";
             let id = input.module.add_import_func(module, &import_name, ty);

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -328,7 +328,7 @@ impl Bindgen {
                 exposed_globals: Some(Default::default()),
                 required_internal_exports: Default::default(),
                 imported_names: Default::default(),
-                imported_identifiers: Default::default(),
+                defined_identifiers: Default::default(),
                 exported_classes: Some(Default::default()),
                 config: &self,
                 module: &mut module,

--- a/tests/headless/main.js
+++ b/tests/headless/main.js
@@ -1,0 +1,2 @@
+export function import_export_same_name() {
+}

--- a/tests/headless/main.rs
+++ b/tests/headless/main.rs
@@ -38,5 +38,14 @@ fn can_log_html_strings() {
     log("<script>alert('lol')</script>");
 }
 
+#[wasm_bindgen]
+pub fn import_export_same_name() {
+    #[wasm_bindgen(module = "/tests/headless/main.js")]
+    extern "C" {
+        fn import_export_same_name();
+    }
+    import_export_same_name();
+}
+
 pub mod snippets;
 pub mod modules;

--- a/tests/wasm/js_objects.rs
+++ b/tests/wasm/js_objects.rs
@@ -111,15 +111,15 @@ fn another_vector_return() {
 #[wasm_bindgen_test]
 fn serde() {
     #[derive(Deserialize, Serialize)]
-    pub struct Foo {
+    pub struct SerdeFoo {
         a: u32,
         b: String,
-        c: Option<Bar>,
-        d: Bar,
+        c: Option<SerdeBar>,
+        d: SerdeBar,
     }
 
     #[derive(Deserialize, Serialize)]
-    pub struct Bar {
+    pub struct SerdeBar {
         a: u32,
     }
 
@@ -127,16 +127,16 @@ fn serde() {
     assert_eq!(js.as_string(), Some("foo".to_string()));
 
     let ret = verify_serde(
-        JsValue::from_serde(&Foo {
+        JsValue::from_serde(&SerdeFoo {
             a: 0,
             b: "foo".to_string(),
             c: None,
-            d: Bar { a: 1 },
+            d: SerdeBar { a: 1 },
         })
         .unwrap(),
     );
 
-    let foo = ret.into_serde::<Foo>().unwrap();
+    let foo = ret.into_serde::<SerdeFoo>().unwrap();
     assert_eq!(foo.a, 2);
     assert_eq!(foo.b, "bar");
     assert!(foo.c.is_some());

--- a/tests/wasm/simple.js
+++ b/tests/wasm/simple.js
@@ -90,3 +90,5 @@ exports.test_rust_optional = function() {
 
 exports.RenamedInRust = class {};
 exports.new_renamed = () => new exports.RenamedInRust;
+
+exports.import_export_same_name = () => {};

--- a/tests/wasm/simple.rs
+++ b/tests/wasm/simple.rs
@@ -21,6 +21,8 @@ extern "C" {
     fn return_string_none() -> Option<String>;
     fn return_string_some() -> Option<String>;
     fn test_rust_optional();
+    #[wasm_bindgen(js_name = import_export_same_name)]
+    fn js_import_export_same_name();
 
     #[wasm_bindgen(js_name = RenamedInRust)]
     type Renamed;
@@ -193,4 +195,9 @@ fn renaming_imports_and_instanceof() {
 
     let renamed: JsValue = new_renamed().into();
     assert!(renamed.is_instance_of::<Renamed>());
+}
+
+#[wasm_bindgen]
+pub fn import_export_same_name() {
+    js_import_export_same_name();
 }

--- a/tests/wasm/structural.rs
+++ b/tests/wasm/structural.rs
@@ -8,18 +8,18 @@ extern "C" {
 
 #[wasm_bindgen]
 extern "C" {
-    pub type Foo;
+    pub type StructuralFoo;
 
     #[wasm_bindgen(method, structural)]
-    fn bar(this: &Foo);
+    fn bar(this: &StructuralFoo);
     #[wasm_bindgen(method, getter, structural)]
-    fn baz(this: &Foo) -> u32;
+    fn baz(this: &StructuralFoo) -> u32;
     #[wasm_bindgen(method, setter, structural)]
-    fn set_baz(this: &Foo, val: u32);
+    fn set_baz(this: &StructuralFoo, val: u32);
 }
 
 #[wasm_bindgen]
-pub fn run(a: &Foo) {
+pub fn run(a: &StructuralFoo) {
     a.bar();
     assert_eq!(a.baz(), 1);
     a.set_baz(2);


### PR DESCRIPTION
Run exports through the same identifier generation as imports to ensure
that everything gets a unique identifier and then just make sure all the
appropriate wires are hooked up when dealing with exports and imports.

Closes #1496