### PR TITLE
Update init() typings

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -922,7 +922,7 @@ impl<'a> Context<'a> {
             *\n\
             * @returns {{Promise<any>}}\n\
             */\n\
-            export function init \
+            export default function init \
                 (module_or_path: RequestInfo | BufferSource | WebAssembly.Module{}): Promise<any>;
         ",
             memory_doc, memory_param

--- a/crates/typescript-tests/src/web/init.ts
+++ b/crates/typescript-tests/src/web/init.ts
@@ -1,3 +1,3 @@
-import * as wbg from '../../pkg/web/typescript_tests';
+import initialize from "../../pkg/web/typescript_tests";
 
-const init: Promise<any> = wbg.init('.');
+const init: Promise<any> = initialize(".");


### PR DESCRIPTION
The JavaScript output emits a 'init' function that is the default export. This PR updates the TypeScript output so that it marks init as the default export instead of a named export.

Fixes #1517
Fixes rustwasm/wasm-pack/issues/644