### PR TITLE
Protect against segfaults calling destroyed closures

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -576,7 +576,14 @@ macro_rules! doit {
                     a: usize,
                     b: usize,
                 ) {
-                    debug_assert!(a != 0, "should never destroy a Fn whose pointer is 0");
+                    // This can be called by the JS glue in erroneous situations
+                    // such as when the closure has already been destroyed. If
+                    // that's the case let's not make things worse by
+                    // segfaulting and/or asserting, so just ignore null
+                    // pointers.
+                    if a == 0 {
+                        return;
+                    }
                     drop(Box::from_raw(FatPtr::<Fn($($var,)*) -> R> {
                         fields: (a, b)
                     }.ptr));
@@ -623,7 +630,10 @@ macro_rules! doit {
                     a: usize,
                     b: usize,
                 ) {
-                    debug_assert!(a != 0, "should never destroy a FnMut whose pointer is 0");
+                    // See `Fn()` above for why we simply return
+                    if a == 0 {
+                        return;
+                    }
                     drop(Box::from_raw(FatPtr::<FnMut($($var,)*) -> R> {
                         fields: (a, b)
                     }.ptr));
@@ -736,7 +746,10 @@ unsafe impl<A, R> WasmClosure for Fn(&A) -> R
             a: usize,
             b: usize,
         ) {
-            debug_assert!(a != 0, "should never destroy a Fn whose pointer is 0");
+            // See `Fn()` above for why we simply return
+            if a == 0 {
+                return;
+            }
             drop(Box::from_raw(FatPtr::<Fn(&A) -> R> {
                 fields: (a, b)
             }.ptr));
@@ -781,7 +794,10 @@ unsafe impl<A, R> WasmClosure for FnMut(&A) -> R
             a: usize,
             b: usize,
         ) {
-            debug_assert!(a != 0, "should never destroy a FnMut whose pointer is 0");
+            // See `Fn()` above for why we simply return
+            if a == 0 {
+                return;
+            }
             drop(Box::from_raw(FatPtr::<FnMut(&A) -> R> {
                 fields: (a, b)
             }.ptr));

--- a/tests/wasm/closures.js
+++ b/tests/wasm/closures.js
@@ -119,3 +119,7 @@ exports.pass_reference_first_arg_twice = (a, b, c) => {
   c(a);
   a.free();
 };
+
+exports.call_destroyed = f => {
+  assert.throws(f, /invoked recursively or destroyed/);
+};


### PR DESCRIPTION
This commit updates the drop glue generated for closures to simply
ignore null pointers. The drop glue can be called in erroneous
situations such as when a closure is invoked after it's been destroyed.
In these cases we don't want to segfault and/or corrupt memory but
instead let the normal error message from the invoke glue continue to
get propagated.

Closes #1526