### PR TITLE
Hotfix for double encodeInto call

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1501,7 +1501,7 @@ impl<'a> Context<'a> {
                     const view = getUint8Memory().subarray(ptr + offset, ptr + size);
                     const ret = cachedTextEncoder.encodeInto(arg, view);
                     {}
-                    offset += cachedTextEncoder.encodeInto(arg, view).written;
+                    offset += ret.written;
                 }}
                 WASM_VECTOR_LEN = offset;
                 return ptr;


### PR DESCRIPTION
This was a regression introduced in the last commit of https://github.com/rustwasm/wasm-bindgen/pull/1470, which might make Unicode strings 2x slower to pass.

r? @alexcrichton 