### PR TITLE
Remove unsafe from #[wasm_bindgen_test] output

### DIFF
--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -65,12 +65,9 @@ pub fn wasm_bindgen_test(
     tokens.extend(
         (quote! {
             #[no_mangle]
-            pub extern "C" fn #name(cx: *const ::wasm_bindgen_test::__rt::Context) {
-                unsafe {
-                    let cx = &*cx;
-                    let test_name = concat!(module_path!(), "::", stringify!(#ident));
-                    #test_body
-                }
+            pub extern "C" fn #name(cx: &::wasm_bindgen_test::__rt::Context) {
+                let test_name = concat!(module_path!(), "::", stringify!(#ident));
+                #test_body
             }
         })
         .into_iter(),


### PR DESCRIPTION
This is not necessary because references are FFI-safe and compatible with corresponding pointers, so we can just use them directly as an input.

Fixes #1540.