### PR TITLE
expose forget to wasm

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -249,7 +249,7 @@ impl<'a> Context<'a> {
                     format!("{}{}\n", export, contents)
                 } else {
                     assert_eq!(export_name, definition_name);
-                    format!("{}const {} = {};\n", export, export_name, contents)
+                    format!("{}const {name} = {};\n__exports.{name} = {name};", export, contents, name = export_name)
                 }
             }
         };

--- a/tests/headless/main.rs
+++ b/tests/headless/main.rs
@@ -51,3 +51,11 @@ pub mod snippets;
 pub mod modules;
 pub mod anyref_heap_live_count;
 pub mod strings;
+
+#[wasm_bindgen_test]
+fn closures_work() {
+    let x = Closure::wrap(Box::new(|| {}) as Box<FnMut()>);
+    drop(x);
+    let x = Closure::wrap(Box::new(|| {}) as Box<FnMut()>);
+    x.forget();
+}


### PR DESCRIPTION
Closes #1543 

I made some research on the issue

`forget` is exposed here:
https://github.com/rustwasm/wasm-bindgen/blob/master/crates/cli-support/src/js/mod.rs#L792

Then there is a line `if contents.starts_with("function") {` here
https://github.com/rustwasm/wasm-bindgen/blob/master/crates/cli-support/src/js/mod.rs#L229

Well, it's not a class and not a function, that's why we go here:
https://github.com/rustwasm/wasm-bindgen/blob/master/crates/cli-support/src/js/mod.rs#L252

Probably, exposing to wasm every exported const is not the best idea, but it depends on the usage. If only function aliases are bound in such way, it's fine enough.