### PR TITLE
docs: update docs link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,4 @@ This directory contains a number of Cargo projects that are all examples of how
 to use `wasm-bindgen` in various contexts. More documentation can be [found
 online][dox]
 
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/index.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/index.html

--- a/examples/add/README.md
+++ b/examples/add/README.md
@@ -3,7 +3,7 @@
 [View documentation for this example online][dox] or [View compiled example
 online][compiled]
 
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/add.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/add.html
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/add/
 
 You can build the example locally with:

--- a/examples/canvas/README.md
+++ b/examples/canvas/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/canvas/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/2d-canvas.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/2d-canvas.html
 
 You can build the example locally with:
 

--- a/examples/char/README.md
+++ b/examples/char/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/char/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/char.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/char.html
 
 You can build the example locally with:
 

--- a/examples/closures/README.md
+++ b/examples/closures/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/closures/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/closures.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/closures.html
 
 You can build the example locally with:
 

--- a/examples/console_log/README.md
+++ b/examples/console_log/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/console_log/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/console-log.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/console-log.html
 
 You can build the example locally with:
 

--- a/examples/dom/README.md
+++ b/examples/dom/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/dom/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/dom.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/dom.html
 
 You can build the example locally with:
 

--- a/examples/fetch/README.md
+++ b/examples/fetch/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/fetch/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/fetch.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/fetch.html
 
 You can build the example locally with:
 

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/hello_world/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/hello-world.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/hello-world.html
 
 You can build the example locally with:
 

--- a/examples/import_js/README.md
+++ b/examples/import_js/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/import_js/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/import-js.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/import-js.html
 
 You can build the example locally with:
 

--- a/examples/julia_set/README.md
+++ b/examples/julia_set/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/julia_set/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/julia.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/julia.html
 
 You can build the example locally with:
 

--- a/examples/paint/README.md
+++ b/examples/paint/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/paint/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/paint.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/paint.html
 
 You can build the example locally with:
 

--- a/examples/performance/README.md
+++ b/examples/performance/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/performance/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/performance.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/performance.html
 
 You can build the example locally with:
 

--- a/examples/raytrace-parallel/README.md
+++ b/examples/raytrace-parallel/README.md
@@ -3,7 +3,7 @@
 [View documentation for this example online][dox] or [View compiled example
 online][compiled]
 
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/raytrace.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/raytrace.html
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/raytrace-parallel/
 
 You can build the example locally with:

--- a/examples/request-animation-frame/README.md
+++ b/examples/request-animation-frame/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/request-animation-frame/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/request-animation-frame.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/request-animation-frame.html
 
 You can build the example locally with:
 

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/todomvc/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/todomvc.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/todomvc.html
 
 You can build the example locally with:
 

--- a/examples/wasm-in-wasm/README.md
+++ b/examples/wasm-in-wasm/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/wasm-in-wasm/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/wasm-in-wasm.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/wasm-in-wasm.html
 
 You can build the example locally with:
 

--- a/examples/wasm2js/README.md
+++ b/examples/wasm2js/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/wasm2js/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/wasm2js.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/wasm2js.html
 
 You can build the example locally with:
 

--- a/examples/webaudio/README.md
+++ b/examples/webaudio/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/web-audio/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/web-audio.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/web-audio.html
 
 You can build the example locally with:
 

--- a/examples/webgl/README.md
+++ b/examples/webgl/README.md
@@ -4,7 +4,7 @@
 online][compiled]
 
 [compiled]: https://rustwasm.github.io/wasm-bindgen/exbuild/webgl/
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/webgl.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/webgl.html
 
 You can build the example locally with:
 

--- a/examples/without-a-bundler-no-modules/README.md
+++ b/examples/without-a-bundler-no-modules/README.md
@@ -2,7 +2,7 @@
 
 [View documentation for this example online][dox]
 
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/without-a-bundler.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
 
 You can build the example locally with:
 

--- a/examples/without-a-bundler/README.md
+++ b/examples/without-a-bundler/README.md
@@ -2,7 +2,7 @@
 
 [View documentation for this example online][dox]
 
-[dox]: https://rustwasm.github.io/wasm-bindgen/examples/without-a-bundler.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
 
 You can build the example locally with:
 

--- a/guide/src/reference/optimize-size.md
+++ b/guide/src/reference/optimize-size.md
@@ -46,4 +46,4 @@ file for adding two numbers.
 [gol]: https://rustwasm.github.io/book/game-of-life/introduction.html
 [size]: https://rustwasm.github.io/book/game-of-life/code-size.html
 [issue]: https://github.com/rustwasm/wasm-bindgen/issues/new
-[example]: https://rustwasm.github.io/wasm-bindgen/examples/add.html
+[example]: https://rustwasm.github.io/docs/wasm-bindgen/examples/add.html


### PR DESCRIPTION
**Summary**
This PR update docs link as the following:
- `rustwasm.github.io/wasm-bindgen` -> `rustwasm.github.io/docs/wasm-bindgen`.
which leads the published documentation.

**Background**
With the old URL, people will encounter the following warning:
<img width="1193" alt="Screen Shot 2019-05-26 at 4 44 00 PM" src="https://user-images.githubusercontent.com/25740248/58378846-ca482c80-7fd5-11e9-9d44-48961117c484.png">

🦀🕸