### PR TITLE
Fix small issues around web-sys dictionaries

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -293,6 +293,8 @@ pub struct Dictionary {
     pub name: Ident,
     pub fields: Vec<DictionaryField>,
     pub ctor: bool,
+    pub doc_comment: Option<String>,
+    pub ctor_doc_comment: Option<String>,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -302,6 +304,7 @@ pub struct DictionaryField {
     pub js_name: String,
     pub required: bool,
     pub ty: syn::Type,
+    pub doc_comment: Option<String>,
 }
 
 impl Export {

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -292,6 +292,7 @@ pub enum ConstValue {
 pub struct Dictionary {
     pub name: Ident,
     pub fields: Vec<DictionaryField>,
+    pub ctor: bool,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1282,6 +1282,18 @@ impl ToTokens for ast::Dictionary {
         let required_names2 = required_names;
         let required_names3 = required_names;
 
+        let ctor = if self.ctor {
+            quote! {
+                pub fn new(#(#required_names: #required_types),*) -> #name {
+                    let mut _ret = #name { obj: ::js_sys::Object::new() };
+                    #(_ret.#required_names2(#required_names3);)*
+                    return _ret
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         let const_name = Ident::new(&format!("_CONST_{}", name), Span::call_site());
         (quote! {
             #[derive(Clone, Debug)]
@@ -1293,12 +1305,7 @@ impl ToTokens for ast::Dictionary {
 
             #[allow(clippy::all)]
             impl #name {
-                pub fn new(#(#required_names: #required_types),*) -> #name {
-                    let mut _ret = #name { obj: ::js_sys::Object::new() };
-                    #(_ret.#required_names2(#required_names3);)*
-                    return _ret
-                }
-
+                #ctor
                 #methods
             }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1281,9 +1281,18 @@ impl ToTokens for ast::Dictionary {
             .collect::<Vec<_>>();
         let required_names2 = required_names;
         let required_names3 = required_names;
+        let doc_comment = match &self.doc_comment {
+            None => "",
+            Some(doc_string) => doc_string,
+        };
 
         let ctor = if self.ctor {
+            let doc_comment = match &self.ctor_doc_comment {
+                None => "",
+                Some(doc_string) => doc_string,
+            };
             quote! {
+                #[doc = #doc_comment]
                 pub fn new(#(#required_names: #required_types),*) -> #name {
                     let mut _ret = #name { obj: ::js_sys::Object::new() };
                     #(_ret.#required_names2(#required_names3);)*
@@ -1299,6 +1308,7 @@ impl ToTokens for ast::Dictionary {
             #[derive(Clone, Debug)]
             #[repr(transparent)]
             #[allow(clippy::all)]
+            #[doc = #doc_comment]
             pub struct #name {
                 obj: ::js_sys::Object,
             }
@@ -1414,8 +1424,13 @@ impl ToTokens for ast::DictionaryField {
         let rust_name = &self.rust_name;
         let js_name = &self.js_name;
         let ty = &self.ty;
+        let doc_comment = match &self.doc_comment {
+            None => "",
+            Some(doc_string) => doc_string,
+        };
         (quote! {
             #[allow(clippy::all)]
+            #[doc = #doc_comment]
             pub fn #rust_name(&mut self, val: #ty) -> &mut Self {
                 use wasm_bindgen::JsValue;
                 let r = ::js_sys::Reflect::set(

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -317,6 +317,7 @@ impl<'src> FirstPassRecord<'src> {
         program.dictionaries.push(ast::Dictionary {
             name: rust_ident(&camel_case_ident(def.identifier.0)),
             fields,
+            ctor: true,
         });
     }
 
@@ -784,6 +785,7 @@ impl<'src> FirstPassRecord<'src> {
         program.dictionaries.push(ast::Dictionary {
             name: rust_ident(&camel_case_ident(item.definition.identifier.0)),
             fields,
+            ctor: true,
         });
     }
 }


### PR DESCRIPTION
* Generate dictionary types even if some of their required fields are filtered out. They're not too useful, but they'll at least exist, get things compiling, and make the existing docs accurate.
* Generate documentation for dictionaries and dictionary fields, ensuring they're listed with what features are necessary to activate the API

Closes #1569