### PR TITLE
Fix getter and setter for TS

### DIFF
--- a/crates/typescript-tests/src/getters_setters.rs
+++ b/crates/typescript-tests/src/getters_setters.rs
@@ -1,0 +1,57 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct ColorWithGetter { r: f64, _g: f64, _b: f64, _a: u8 }
+
+#[wasm_bindgen]
+impl ColorWithGetter {
+  #[wasm_bindgen(getter)]
+  pub fn r(&self) -> f64 {
+    self.r
+  }
+}
+
+#[wasm_bindgen]
+pub struct ColorWithSetter { r: f64, _g: f64, _b: f64, a: u8 }
+
+#[wasm_bindgen]
+impl ColorWithSetter {
+  #[wasm_bindgen(setter)]
+  pub fn set_r(&mut self, r: f64) {
+    self.r = r;
+    self.a = if self.r > 1.0 {
+      255
+    }
+    else if self.r < 0.0 {
+      0
+    }
+    else {
+      (self.r * 255.0) as u8
+    };
+  }
+}
+
+#[wasm_bindgen]
+pub struct ColorWithGetterAndSetter { r: f64, _g: f64, _b: f64, a: u8 }
+
+#[wasm_bindgen]
+impl ColorWithGetterAndSetter {
+  #[wasm_bindgen(getter)]
+  pub fn r(&self) -> f64 {
+    self.r
+  }
+
+  #[wasm_bindgen(setter)]
+  pub fn set_r(&mut self, r: f64) {
+    self.r = r;
+    self.a = if self.r > 1.0 {
+      255
+    }
+    else if self.r < 0.0 {
+      0
+    }
+    else {
+      (self.r * 255.0) as u8
+    };
+  }
+}

--- a/crates/typescript-tests/src/getters_setters.ts
+++ b/crates/typescript-tests/src/getters_setters.ts
@@ -1,0 +1,11 @@
+import * as wbg from '../pkg/typescript_tests';
+
+const colorWithGetter: wbg.ColorWithGetter = new wbg.ColorWithGetter;
+const _a = colorWithGetter.r;
+
+const colorWithSetter: wbg.ColorWithSetter = new wbg.ColorWithSetter;
+colorWithSetter.r = 1;
+
+const colorWithGetterAndSetter: wbg.ColorWithGetterAndSetter = new wbg.ColorWithGetterAndSetter;
+colorWithGetterAndSetter.r = 1;
+const _b = colorWithGetterAndSetter.r;

--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -1,4 +1,5 @@
 mod custom_section;
+mod getters_setters;
 mod opt_args_and_ret;
 mod simple_fn;
 mod simple_struct;


### PR DESCRIPTION
Some setters were being included without types and this PR also fix some formatting.
I modified the code based on the fact that a getter (`get foo()`) **must** have a return and a setter (`set foo(a)`) **must** have one argument, at least for TS.