### PR TITLE
Make `env_logger` an optional dependency

### DIFF
--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 test = false
 
 [build-dependencies]
-env_logger = "0.6.0"
+env_logger = { version = "0.6.0", optional = true }
 failure = "0.1.2"
 wasm-bindgen-webidl = { path = "../webidl", version = "=0.2.45" }
 sourcefile = "0.1"

--- a/crates/web-sys/build.rs
+++ b/crates/web-sys/build.rs
@@ -8,6 +8,7 @@ use std::path::{self, PathBuf};
 use std::process::{self, Command};
 
 fn main() {
+    #[cfg(feature = "env_logger")]
     env_logger::init();
 
     if let Err(e) = try_main() {


### PR DESCRIPTION
Only used during development no need to pull in its set of features when
typically compiled as a dependency of other crates!

Closes #1580