### PR TITLE
Communicate exceptions through global memory

### DIFF
--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -928,7 +928,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 try {{\n\
                     {}
                 }} catch (e) {{\n\
-                    handleError(exnptr, e);\n\
+                    handleError(e);\n\
                 }}\
                 ",
                 &invoc
@@ -973,12 +973,6 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
         let mut ret = String::new();
         ret.push_str("function(");
         ret.push_str(&self.shim_arguments.join(", "));
-        if self.catch {
-            if self.shim_arguments.len() > 0 {
-                ret.push_str(", ")
-            }
-            ret.push_str("exnptr");
-        }
         ret.push_str(") {\n");
         ret.push_str(&self.prelude);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,6 +1067,28 @@ pub mod __rt {
     pub fn link_mem_intrinsics() {
         crate::anyref::link_intrinsics();
     }
+
+    static mut GLOBAL_EXNDATA: [u32; 2] = [0; 2];
+
+    #[no_mangle]
+    pub unsafe extern "C" fn __wbindgen_exn_store(idx: u32) {
+        assert_eq!(GLOBAL_EXNDATA[0], 0);
+        GLOBAL_EXNDATA[0] = 1;
+        GLOBAL_EXNDATA[1] = idx;
+    }
+
+    pub fn take_last_exception() -> Result<(), super::JsValue> {
+        unsafe {
+            let ret = if GLOBAL_EXNDATA[0] == 1 {
+                Err(super::JsValue:: _new(GLOBAL_EXNDATA[1]))
+            } else {
+                Ok(())
+            };
+            GLOBAL_EXNDATA[0] = 0;
+            GLOBAL_EXNDATA[1] = 0;
+            return ret;
+        }
+    }
 }
 
 /// A wrapper type around slices and vectors for binding the `Uint8ClampedArray`


### PR DESCRIPTION
Instead of allocating space on the stack and returning a pointer we
should be able to use a single global memory location to communicate
this error payload information. This shouldn't run into any reentrancy
issues since it's only stored just before returning to wasm and it's
always read just after returning from wasm.