### PR TITLE
Remove the `Clamped` descriptor type

### DIFF
--- a/crates/cli-support/src/anyref.rs
+++ b/crates/cli-support/src/anyref.rs
@@ -82,7 +82,6 @@ fn process_closure_arguments(cfg: &mut Context, function: &mut Function) {
             | Descriptor::RefMut(d)
             | Descriptor::Option(d)
             | Descriptor::Slice(d)
-            | Descriptor::Clamped(d)
             | Descriptor::Vector(d) => process_descriptor(cfg, d),
             Descriptor::Closure(c) => process_closure(cfg, c),
             Descriptor::Function(c) => process_function(cfg, c),

--- a/crates/cli-support/src/js/js2rust.rs
+++ b/crates/cli-support/src/js/js2rust.rs
@@ -204,7 +204,7 @@ impl<'a, 'b> Js2Rust<'a, 'b> {
                 i = i,
                 val = val,
             ));
-            if arg.is_by_ref() || arg.is_clamped_by_ref() {
+            if arg.is_by_ref() {
                 if optional {
                     bail!("optional slices aren't currently supported");
                 }

--- a/crates/cli-support/src/js/rust2js.rs
+++ b/crates/cli-support/src/js/rust2js.rs
@@ -165,7 +165,7 @@ impl<'a, 'b> Rust2Js<'a, 'b> {
                 },
             ));
 
-            if !arg.is_by_ref() && !arg.is_clamped_by_ref() {
+            if !arg.is_by_ref() {
                 self.prelude(&format!(
                     "\
                      {start}


### PR DESCRIPTION
This is just a bit too general to work with and is pretty funky. Instead
just tweak `Clamped<&[u8]>` to naturally generate a descriptor for
`Ref(Slice(ClampedU8))`, requiring fewer gymnastics when interpreting
descriptors.