### PR TITLE
Make HTMLHyperlinkElementUtils a mixin, not a NoInterfaceObject

### DIFF
--- a/crates/web-sys/webidls/enabled/HTMLHyperlinkElementUtils.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLHyperlinkElementUtils.webidl
@@ -10,8 +10,7 @@
  * and create derivative works of this document.
  */
 
-[NoInterfaceObject]
-interface HTMLHyperlinkElementUtils {
+interface mixin HTMLHyperlinkElementUtils {
   // Bug 824857: no support for stringifier attributes yet.
   //  stringifier attribute USVString href;
 


### PR DESCRIPTION
Fixes #1315.