### PR TITLE
Simplify instructions for CI testing of wasm code

### DIFF
--- a/guide/src/wasm-bindgen-test/continuous-integration.md
+++ b/guide/src/wasm-bindgen-test/continuous-integration.md
@@ -29,22 +29,6 @@ script:
   - wasm-pack test --chrome  --headless
 ```
 
-Note that the wasm-pack installer will ask for confirmation before overwriting the wasm-pack binary. So if you use caching you can make sure it's not caching wasm-pack by adding this to your `travis.yml`:
-```yml
-# Need to cache the whole `.cargo` directory to keep .crates.toml for cargo-update to work
-#
-cache:
-  directories:
-    - /home/travis/.cargo
-
-# But don't cache the cargo registry
-# and remove wasm-pack binary to avoid the installer asking confirmation for overwriting it.
-#
-before_cache:
-  - rm -rf /home/travis/.cargo/registry
-  - rm -rf /home/travis/.cargo/bin/wasm-pack
-```
-
 ## AppVeyor
 
 ```yaml

--- a/guide/src/wasm-bindgen-test/continuous-integration.md
+++ b/guide/src/wasm-bindgen-test/continuous-integration.md
@@ -10,37 +10,39 @@ request!](https://github.com/rustwasm/wasm-bindgen)
 
 ```yaml
 language: rust
-rust: nightly
+rust    : nightly
 
 addons:
   firefox: latest
-  chrome: stable
+  chrome : stable
 
 install:
-  - rustup target add wasm32-unknown-unknown
-  # Downloads a `wasm-bindgen` release binary from https://github.com/rustwasm/wasm-bindgen/releases.
-  # Alternatively, use `wasm-pack` to manage `wasm-bindgen` binaries for you
-  - curl -OL https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.21/wasm-bindgen-0.2.21-x86_64-unknown-linux-musl.tar.gz
-  - tar xf wasm-bindgen-0.2.21-x86_64-unknown-linux-musl.tar.gz
-  - chmod +x wasm-bindgen-0.2.21-x86_64-unknown-linux-musl/wasm-bindgen
-  # Moves the binaries to a directory that is in your PATH
-  - mv wasm-bindgen-0.2.21-x86_64-unknown-linux-musl/wasm-bindgen* ~/.cargo/bin 
-  # Install node.js with nvm.
-  - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
-  - source ~/.nvm/nvm.sh
-  - nvm install v10.5
-  # Install chromedriver.
-  - curl --retry 5 -LO https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
-  - unzip chromedriver_linux64.zip
-  # Install geckodriver.
-  - curl --retry 5 -LO https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
-  - tar xf geckodriver-v0.21.0-linux64.tar.gz
+  - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
 script:
-  # Test in Chrome.
-  - CHROMEDRIVER=$(pwd)/chromedriver cargo test --target wasm32-unknown-unknown
-  # Test in Firefox.
-  - GECKODRIVER=$(pwd)/geckodriver cargo test --target wasm32-unknown-unknown
+
+  # this will test the non wasm targets if your crate has those, otherwise remove this line.
+  #
+  - cargo test
+
+  - wasm-pack test --firefox --headless
+  - wasm-pack test --chrome  --headless
+```
+
+Note that the wasm-pack installer will ask for confirmation before overwriting the wasm-pack binary. So if you use caching you can make sure it's not caching wasm-pack by adding this to your `travis.yml`:
+```yml
+# Need to cache the whole `.cargo` directory to keep .crates.toml for cargo-update to work
+#
+cache:
+  directories:
+    - /home/travis/.cargo
+
+# But don't cache the cargo registry
+# and remove wasm-pack binary to avoid the installer asking confirmation for overwriting it.
+#
+before_cache:
+  - rm -rf /home/travis/.cargo/registry
+  - rm -rf /home/travis/.cargo/bin/wasm-pack
 ```
 
 ## AppVeyor


### PR DESCRIPTION
After discussion on #1611, this replaces the complicated setup with the automated install of wasm-pack.

I have added a note on caching, which I think would be useful to users, since the installer is really stuborn about not wanting to be automated. eg. `yes | installer` won't work. You have to remove all wasm-pack binaries before running it in order for it to be automated.

Closes #1611.