### PR TITLE
Be sure to GC our imports as well as the module

### DIFF
--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -136,3 +136,18 @@ fn works_on_empty_project() {
 }
 
 mod npm;
+
+#[test]
+fn one_export_works() {
+    let (mut cmd, _out_dir) = Project::new("one_export_works")
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+                #[wasm_bindgen]
+                pub fn foo() {}
+            "#,
+        )
+        .wasm_bindgen("");
+    cmd.assert().success();
+}


### PR DESCRIPTION
After a module goes through its primary GC pass we need to look over the
set of remaining imports and use that to prune the set of imports that
we're binding.

Closes #1613