### PR TITLE
Add From impl for TypedArrays

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4593,11 +4593,6 @@ macro_rules! arrays {
         impl<'a> From<&'a [$ty]> for $name {
             #[inline]
             fn from(slice: &'a [$ty]) -> $name {
-                // TODO if this was written in JS it could avoid passing the `view` TypedArray to Rust,
-                //      which would be more efficient
-
-                // TODO measure if it's faster to use `slice` instead of `new`
-
                 // This is safe because the `new` function makes a copy if its argument is a TypedArray
                 unsafe { $name::new(&$name::view(slice)) }
             }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4589,6 +4589,17 @@ macro_rules! arrays {
                 all_wasm_memory.set(self, offset as u32);
             }
         }
+
+        impl<'a> From<&'a [$ty]> for $name {
+            #[inline]
+            fn from(slice: &'a [$ty]) -> $name {
+                // TODO if this was written in JS it could avoid passing the `view` TypedArray to Rust,
+                //      which would be more efficient
+
+                // This is safe because the `new` function makes a copy if its argument is a TypedArray
+                unsafe { $name::new(&$name::view(slice)) }
+            }
+        }
     )*);
 }
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4596,6 +4596,8 @@ macro_rules! arrays {
                 // TODO if this was written in JS it could avoid passing the `view` TypedArray to Rust,
                 //      which would be more efficient
 
+                // TODO measure if it's faster to use `slice` instead of `new`
+
                 // This is safe because the `new` function makes a copy if its argument is a TypedArray
                 unsafe { $name::new(&$name::view(slice)) }
             }

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -112,6 +112,16 @@ fn view() {
 }
 
 #[wasm_bindgen_test]
+fn from() {
+    let x: Vec<i32> = vec![1, 2, 3];
+    let array = Int32Array::from(x.as_slice());
+    assert_eq!(array.length(), 3);
+    array.for_each(&mut |x, i, _| {
+        assert_eq!(x, (i + 1) as i32);
+    });
+}
+
+#[wasm_bindgen_test]
 fn copy_to() {
     let mut x = [0; 10];
     let array = Int32Array::new(&10.into());

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -19,18 +19,19 @@ const WASM: &[u8] = include_bytes!("add.wasm");
 pub fn run() -> Result<(), JsValue> {
     console_log!("instantiating a new wasm module directly");
 
-    // Note that `Uint8Array::view` this is somewhat dangerous (hence the
+    // Note that `Uint8Array::view` is somewhat dangerous (hence the
     // `unsafe`!). This is creating a raw view into our module's
     // `WebAssembly.Memory` buffer, but if we allocate more pages for ourself
     // (aka do a memory allocation in Rust) it'll cause the buffer to change,
     // causing the `Uint8Array` to be invalid.
     //
     // As a result, after `Uint8Array::view` we have to be very careful not to
-    // do any memory allocations before it's next used.
+    // do any memory allocations before it's dropped.
     let a = unsafe {
         let array = Uint8Array::view(WASM);
         WebAssembly::Module::new(array.as_ref())?
     };
+
     let b = WebAssembly::Instance::new(&a, &Object::new())?;
     let c = b.exports();
 

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -39,12 +39,25 @@ pub fn start() -> Result<(), JsValue> {
 
     let buffer = context.create_buffer().ok_or("failed to create buffer")?;
     context.bind_buffer(WebGlRenderingContext::ARRAY_BUFFER, Some(&buffer));
-    let vert_array = unsafe { js_sys::Float32Array::view(&vertices) };
-    context.buffer_data_with_array_buffer_view(
-        WebGlRenderingContext::ARRAY_BUFFER,
-        &vert_array,
-        WebGlRenderingContext::STATIC_DRAW,
-    );
+
+    // Note that `Float32Array::view` is somewhat dangerous (hence the
+    // `unsafe`!). This is creating a raw view into our module's
+    // `WebAssembly.Memory` buffer, but if we allocate more pages for ourself
+    // (aka do a memory allocation in Rust) it'll cause the buffer to change,
+    // causing the `Float32Array` to be invalid.
+    //
+    // As a result, after `Float32Array::view` we have to be very careful not to
+    // do any memory allocations before it's dropped.
+    unsafe {
+        let vert_array = js_sys::Float32Array::view(&vertices);
+
+        context.buffer_data_with_array_buffer_view(
+            WebGlRenderingContext::ARRAY_BUFFER,
+            &vert_array,
+            WebGlRenderingContext::STATIC_DRAW,
+        );
+    }
+
     context.vertex_attrib_pointer_with_i32(0, 3, WebGlRenderingContext::FLOAT, false, 0, 0);
     context.enable_vertex_attrib_array(0);
 


### PR DESCRIPTION
There's been quite a few issues ([1](https://github.com/rustwasm/wasm-bindgen/issues/1134), [2](https://github.com/rustwasm/wasm-bindgen/issues/1206), [3](https://github.com/rustwasm/wasm-bindgen/issues/1619)) about TypedArrays and Rust slices.

Right now the only way to convert a Rust slice into a TypedArray is to use the unsafe `view` function. But it's common for people to make mistakes when using it, and those mistakes are quite bad (since it's `unsafe`).

So this PR adds in safe `From` impls for all of the TypedArrays, allowing for easy, safe, and fast conversion from Rust slices.