### PR TITLE
Remove `__wbindgen_global_argument_ptr` intrinsic

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1558,25 +1558,6 @@ impl<'a> Context<'a> {
         })
     }
 
-    fn expose_global_argument_ptr(&mut self) -> Result<(), Error> {
-        if !self.should_write_global("global_argument_ptr") {
-            return Ok(());
-        }
-        self.require_internal_export("__wbindgen_global_argument_ptr")?;
-        self.global(
-            "
-            let cachedGlobalArgumentPtr = null;
-            function globalArgumentPtr() {
-                if (cachedGlobalArgumentPtr === null) {
-                    cachedGlobalArgumentPtr = wasm.__wbindgen_global_argument_ptr();
-                }
-                return cachedGlobalArgumentPtr;
-            }
-            ",
-        );
-        Ok(())
-    }
-
     fn expose_get_inherited_descriptor(&mut self) {
         if !self.should_write_global("get_inherited_descriptor") {
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1017,20 +1017,6 @@ pub mod __rt {
         }
     }
 
-    pub const GLOBAL_STACK_CAP: usize = 16;
-
-    // Increase the alignment to 8 here because this can be used as a
-    // BigUint64Array pointer base which requires alignment 8
-    #[repr(align(8))]
-    struct GlobalData([u32; GLOBAL_STACK_CAP]);
-
-    static mut GLOBAL_STACK: GlobalData = GlobalData([0; GLOBAL_STACK_CAP]);
-
-    #[no_mangle]
-    pub unsafe extern "C" fn __wbindgen_global_argument_ptr() -> *mut u32 {
-        GLOBAL_STACK.0.as_mut_ptr()
-    }
-
     /// This is a curious function necessary to get wasm-bindgen working today,
     /// and it's a bit of an unfortunate hack.
     ///


### PR DESCRIPTION
We don't actually need this since we can simply pass in a number like 8
for the return pointer all the time. There's no need to allocate more
space in static data for a return pointer tha may not even get used!