### PR TITLE
Update all non-mutable slices into Rust to use `AllocCopy`

### DIFF
--- a/crates/cli-support/src/js/incoming.rs
+++ b/crates/cli-support/src/js/incoming.rs
@@ -153,7 +153,7 @@ impl<'a, 'b> Incoming<'a, 'b> {
 
             // Similar to `AllocCopy`, except that we deallocate in a finally
             // block.
-            NonstandardIncoming::Slice { kind, val, mutable } => {
+            NonstandardIncoming::MutableSlice { kind, val } => {
                 let (expr, ty) = self.standard_typed(val)?;
                 assert_eq!(ty, ast::WebidlScalarType::Any.into());
                 let func = self.cx.pass_to_wasm_function(*kind)?;
@@ -162,7 +162,7 @@ impl<'a, 'b> Incoming<'a, 'b> {
                     .prelude(&format!("const ptr{} = {}({});", i, func, expr));
                 self.js
                     .prelude(&format!("const len{} = WASM_VECTOR_LEN;", i));
-                self.finally_free_slice(&expr, i, *kind, *mutable)?;
+                self.finally_free_slice(&expr, i, *kind, true)?;
                 self.js.typescript_required(kind.js_ty());
                 return Ok(vec![format!("ptr{}", i), format!("len{}", i)]);
             }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -94,14 +94,11 @@ macro_rules! vectors {
 
         impl RefFromWasmAbi for [$t] {
             type Abi = WasmSlice;
-            type Anchor = &'static [$t];
+            type Anchor = Box<[$t]>;
 
             #[inline]
-            unsafe fn ref_from_abi(js: WasmSlice) -> &'static [$t] {
-                slice::from_raw_parts(
-                    <*const $t>::from_abi(js.ptr),
-                    js.len as usize,
-                )
+            unsafe fn ref_from_abi(js: WasmSlice) -> Box<[$t]> {
+                <Box<[$t]>>::from_abi(js)
             }
         }
 
@@ -195,11 +192,11 @@ impl<'a> OptionIntoWasmAbi for &'a str {
 
 impl RefFromWasmAbi for str {
     type Abi = <[u8] as RefFromWasmAbi>::Abi;
-    type Anchor = &'static str;
+    type Anchor = Box<str>;
 
     #[inline]
     unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
-        str::from_utf8_unchecked(<[u8]>::ref_from_abi(js))
+        mem::transmute::<Box<[u8]>, Box<str>>(<Box<[u8]>>::from_abi(js))
     }
 }
 


### PR DESCRIPTION
This commit migrates all non-mutable slices incoming into Rust to use
the standard `AllocCopy` binding instead of using a custom `Slice`
binding defined by `wasm-bindgen`. This is done by freeing the memory
from Rust rather than freeing the memory from JS. We can't do this for
mutable slices yet but otherwise this should be working well!