### PR TITLE
Add in (unsafe and incorrect) impls of Send/Sync that are now required.

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -130,8 +130,7 @@ impl<'a, 'b> Builder<'a, 'b> {
             // returning data through.
             if binding.return_via_outptr.is_some() {
                 drop(webidl_params.next());
-                self.args_prelude
-                    .push_str("const retptr = 8;\n");
+                self.args_prelude.push_str("const retptr = 8;\n");
                 arg_names.push("retptr".to_string());
             }
 

--- a/crates/futures/src/futures_0_3.rs
+++ b/crates/futures/src/futures_0_3.rs
@@ -26,8 +26,8 @@ use wasm_bindgen::prelude::*;
 pub struct JsFuture {
     resolved: oneshot::Receiver<JsValue>,
     rejected: oneshot::Receiver<JsValue>,
-    _cb_resolve: Closure<FnMut(JsValue)>,
-    _cb_reject: Closure<FnMut(JsValue)>,
+    _cb_resolve: Closure<dyn FnMut(JsValue)>,
+    _cb_reject: Closure<dyn FnMut(JsValue)>,
 }
 
 impl fmt::Debug for JsFuture {
@@ -142,6 +142,10 @@ where
         // This is used to ensure that the Task will only be queued once
         is_queued: Cell<bool>,
     }
+
+    // TODO This is only safe because JS is currently single-threaded
+    unsafe impl Send for Task {}
+    unsafe impl Sync for Task {}
 
     impl Task {
         #[inline]

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1079,7 +1079,6 @@ extern "C" {
     #[wasm_bindgen(method, js_name = bind)]
     pub fn bind(this: &Function, context: &JsValue) -> Function;
 
-
     /// The bind() method creates a new function that, when called, has its this keyword set to the provided value,
     /// with a given sequence of arguments preceding any provided when the new function is called.
     ///
@@ -1092,23 +1091,14 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
     #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind1(
-        this: &Function,
-        context: &JsValue,
-        arg1: &JsValue,
-    ) -> Function;
+    pub fn bind1(this: &Function, context: &JsValue, arg1: &JsValue) -> Function;
 
     /// The bind() method creates a new function that, when called, has its this keyword set to the provided value,
     /// with a given sequence of arguments preceding any provided when the new function is called.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind)
     #[wasm_bindgen(method, js_name = bind)]
-    pub fn bind2(
-        this: &Function,
-        context: &JsValue,
-        arg1: &JsValue,
-        arg2: &JsValue,
-    ) -> Function;
+    pub fn bind2(this: &Function, context: &JsValue, arg1: &JsValue, arg2: &JsValue) -> Function;
 
     /// The bind() method creates a new function that, when called, has its this keyword set to the provided value,
     /// with a given sequence of arguments preceding any provided when the new function is called.

--- a/crates/js-sys/tests/wasm/Function.rs
+++ b/crates/js-sys/tests/wasm/Function.rs
@@ -90,7 +90,12 @@ fn bind2() {
 #[wasm_bindgen_test]
 fn bind3() {
     let a_list = list();
-    let prepended_list = a_list.bind3(&JsValue::NULL, &JsValue::from(2), &JsValue::from(3), &JsValue::from(4));
+    let prepended_list = a_list.bind3(
+        &JsValue::NULL,
+        &JsValue::from(2),
+        &JsValue::from(3),
+        &JsValue::from(4),
+    );
 
     let arr = Array::from(&call_function(&prepended_list));
 

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -4,8 +4,8 @@ use std::prelude::v1::*;
 use core::slice;
 use core::str;
 
-use crate::convert::{FromWasmAbi, IntoWasmAbi, RefFromWasmAbi, RefMutFromWasmAbi, WasmAbi};
 use crate::convert::OptionIntoWasmAbi;
+use crate::convert::{FromWasmAbi, IntoWasmAbi, RefFromWasmAbi, RefMutFromWasmAbi, WasmAbi};
 
 if_std! {
     use core::mem;


### PR DESCRIPTION
To fix a soundness hole in futures, extra Send/Sync bounds were added to `ArcWake`. Since we already assume we are single-threaded, (see `crates/futures/src/futures_0_3.rs L224`), this patch impls `Send` and `Sync` so the futures 0.3 feature compiles again. This means we can continue to experiment while a full thread-safe solution is developed.