### PR TITLE
Added explicit extension for imported .wasm file for --target bundler

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -284,7 +284,7 @@ impl<'a> Context<'a> {
             | OutputMode::Node {
                 experimental_modules: true,
             } => {
-                imports.push_str(&format!("import * as wasm from './{}_bg';\n", module_name));
+                imports.push_str(&format!("import * as wasm from './{}_bg.wasm';\n", module_name));
                 for (id, js) in sorted_iter(&self.wasm_import_definitions) {
                     let import = self.module.imports.get_mut(*id);
                     import.module = format!("./{}.js", module_name);


### PR DESCRIPTION
Closes #1441 

This update is more in line with esm-module integration. At the moment there's a comment near this code:
```
// With Bundlers and modern ES6 support in Node we can simply import
// the wasm file as if it were an ES module and let the
// bundler/runtime take care of it.
```
If I get it right, without extension this will not work in node.js