### PR TITLE
Use static accessors if possible to get global object

### DIFF
--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -69,7 +69,7 @@ exports.return_three = function() { return 3; };
 
 exports.underscore = function(x) {};
 
-exports.self = function() { return 2; };
+exports.pub = function() { return 2; };
 
 exports.bar = { foo: 3 };
 

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -30,7 +30,7 @@ extern "C" {
 
     fn underscore(_: u8);
 
-    #[wasm_bindgen(js_name = self)]
+    #[wasm_bindgen(js_name = pub)]
     fn js_function_named_rust_keyword() -> u32;
 
     type bar;


### PR DESCRIPTION
Previously we always used `Function('return this')` but this triggers
CSP errors since it's basically `eval`. Instead this adds a few
preflight checks to look for objects like `globalThis`, `self`, etc.
Currently we don't have a `#[wasm_bindgen]` function annotation to
import a bare global field like `self`, but we test accesses with
`self.self` and `globalThis.globalThis`, catching errors to handle any
issues.

Closes #1641