### PR TITLE
Skip generating JS import shims when unnecessary

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -122,6 +122,7 @@ pub struct ImportFunction {
     pub catch: bool,
     pub variadic: bool,
     pub structural: bool,
+    pub assert_no_shim: bool,
     pub kind: ImportFunctionKind,
     pub shim: Ident,
     pub doc_comment: Option<String>,

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -272,6 +272,7 @@ fn shared_import_function<'a>(
         shim: intern.intern(&i.shim),
         catch: i.catch,
         method,
+        assert_no_shim: i.assert_no_shim,
         structural: i.structural,
         function: shared_function(&i.function, intern),
         variadic: i.variadic,

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -23,4 +23,4 @@ wasm-bindgen-anyref-xform = { path = '../anyref-xform', version = '=0.2.48' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.48' }
 wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.48' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.48' }
-wasm-webidl-bindings = "0.1.0"
+wasm-webidl-bindings = "0.1.1"

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -23,4 +23,4 @@ wasm-bindgen-anyref-xform = { path = '../anyref-xform', version = '=0.2.48' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.48' }
 wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.48' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.48' }
-wasm-webidl-bindings = "0.1.1"
+wasm-webidl-bindings = "0.1.2"

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2001,7 +2001,11 @@ impl<'a> Context<'a> {
                 if assert_no_shim {
                     panic!(
                         "imported function was annotated with `#[wasm_bindgen(assert_no_shim)]` \
-                         but we need to generate a JS shim for it"
+                         but we need to generate a JS shim for it:\n\n\
+                         \timport = {:?}\n\n\
+                         \tbinding = {:?}\n\n\
+                         \twebidl = {:?}",
+                        import, binding, webidl,
                     );
                 }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1917,7 +1917,7 @@ impl<'a> Context<'a> {
         let js_doc = builder.js_doc_comments();
         let docs = format_doc_comments(&export.comments, Some(js_doc));
 
-        // Once we've got all the JS then put it in the right location dependin
+        // Once we've got all the JS then put it in the right location depending
         // on what's being exported.
         match &export.kind {
             AuxExportKind::Function(name) => {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -285,7 +285,10 @@ impl<'a> Context<'a> {
             | OutputMode::Node {
                 experimental_modules: true,
             } => {
-                imports.push_str(&format!("import * as wasm from './{}_bg.wasm';\n", module_name));
+                imports.push_str(&format!(
+                    "import * as wasm from './{}_bg.wasm';\n",
+                    module_name
+                ));
                 for (id, js) in sorted_iter(&self.wasm_import_definitions) {
                     let import = self.module.imports.get_mut(*id);
                     import.module = format!("./{}.js", module_name);

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2060,7 +2060,7 @@ impl<'a> Context<'a> {
                 ast::WebidlFunctionKind::Static => {
                     let js = match val {
                         AuxValue::Bare(js) => self.import_name(js)?,
-                        _ => bail!("invalid import set for constructor"),
+                        _ => bail!("invalid import set for free function"),
                     };
                     Ok(format!("{}({})", js, variadic_args(&args)?))
                 }

--- a/crates/cli-support/src/webidl/mod.rs
+++ b/crates/cli-support/src/webidl/mod.rs
@@ -163,6 +163,7 @@ pub struct WasmBindgenAux {
     /// Small bits of metadata about imports.
     pub imports_with_catch: HashSet<ImportId>,
     pub imports_with_variadic: HashSet<ImportId>,
+    pub imports_with_assert_no_shim: HashSet<ImportId>,
 
     /// Auxiliary information to go into JS/TypeScript bindings describing the
     /// exported enums from Rust.
@@ -793,6 +794,7 @@ impl<'a> Context<'a> {
             method,
             structural,
             function,
+            assert_no_shim,
         } = function;
         let (import_id, _id) = match self.function_imports.get(*shim) {
             Some(pair) => *pair,
@@ -810,6 +812,9 @@ impl<'a> Context<'a> {
         }
         if *catch {
             self.aux.imports_with_catch.insert(import_id);
+        }
+        if *assert_no_shim {
+            self.aux.imports_with_assert_no_shim.insert(import_id);
         }
 
         // Perform two functions here. First we're saving off our WebIDL

--- a/crates/cli-support/src/webidl/outgoing.rs
+++ b/crates/cli-support/src/webidl/outgoing.rs
@@ -200,8 +200,12 @@ impl OutgoingBuilder<'_> {
             Descriptor::U16 => self.standard_as(ValType::I32, ast::WebidlScalarType::UnsignedShort),
             Descriptor::I32 => self.standard_as(ValType::I32, ast::WebidlScalarType::Long),
             Descriptor::U32 => self.standard_as(ValType::I32, ast::WebidlScalarType::UnsignedLong),
-            Descriptor::F32 => self.standard_as(ValType::F32, ast::WebidlScalarType::Float),
-            Descriptor::F64 => self.standard_as(ValType::F64, ast::WebidlScalarType::Double),
+            Descriptor::F32 => {
+                self.standard_as(ValType::F32, ast::WebidlScalarType::UnrestrictedFloat)
+            }
+            Descriptor::F64 => {
+                self.standard_as(ValType::F64, ast::WebidlScalarType::UnrestrictedDouble)
+            }
             Descriptor::Enum { .. } => self.standard_as(ValType::I32, ast::WebidlScalarType::Long),
 
             Descriptor::Char => {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -52,6 +52,9 @@ macro_rules! attrgen {
             (typescript_custom_section, TypescriptCustomSection(Span)),
             (start, Start(Span)),
             (skip, Skip(Span)),
+
+            // For testing purposes only.
+            (assert_no_shim, AssertNoShim(Span)),
         }
     };
 }
@@ -496,8 +499,10 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 return Err(Diagnostic::span_error(*span, msg));
             }
         }
+        let assert_no_shim = opts.assert_no_shim().is_some();
         let ret = ast::ImportKind::Function(ast::ImportFunction {
             function: wasm,
+            assert_no_shim,
             kind,
             js_ret,
             catch,

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -44,6 +44,7 @@ macro_rules! shared_api {
             shim: &'a str,
             catch: bool,
             variadic: bool,
+            assert_no_shim: bool,
             method: Option<MethodData<'a>>,
             structural: bool,
             function: Function<'a>,

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -314,6 +314,7 @@ impl<'src> FirstPassRecord<'src> {
             variadic,
             catch,
             structural,
+            assert_no_shim: false,
             shim: {
                 let ns = match kind {
                     ast::ImportFunctionKind::Normal => "",

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -29,6 +29,7 @@ pub mod imports;
 pub mod js_objects;
 pub mod jscast;
 pub mod math;
+pub mod no_shims;
 pub mod node;
 pub mod option;
 pub mod optional_primitives;

--- a/tests/wasm/math.rs
+++ b/tests/wasm/math.rs
@@ -10,15 +10,15 @@ extern "C" {
     // return value is always `f64` to faithfully capture what was sent to JS
     // (what we're interested in) because all JS numbers fit in `f64` anyway.
     // This is testing what happens when we pass numbers to JS and what it sees.
-    #[wasm_bindgen(js_name = roundtrip)]
+    #[wasm_bindgen(assert_no_shim, js_name = roundtrip)]
     fn roundtrip_i8(a: i8) -> f64;
-    #[wasm_bindgen(js_name = roundtrip)]
+    #[wasm_bindgen(assert_no_shim, js_name = roundtrip)]
     fn roundtrip_i16(a: i16) -> f64;
-    #[wasm_bindgen(js_name = roundtrip)]
+    #[wasm_bindgen(assert_no_shim, js_name = roundtrip)]
     fn roundtrip_i32(a: i32) -> f64;
-    #[wasm_bindgen(js_name = roundtrip)]
+    #[wasm_bindgen(assert_no_shim, js_name = roundtrip)]
     fn roundtrip_u8(a: u8) -> f64;
-    #[wasm_bindgen(js_name = roundtrip)]
+    #[wasm_bindgen(assert_no_shim, js_name = roundtrip)]
     fn roundtrip_u16(a: u16) -> f64;
     #[wasm_bindgen(js_name = roundtrip)]
     fn roundtrip_u32(a: u32) -> f64;

--- a/tests/wasm/no_shims.rs
+++ b/tests/wasm/no_shims.rs
@@ -14,10 +14,20 @@ use wasm_bindgen_test::*;
 
     module.exports.trivial = function () {};
 
+    module.exports.incoming_bool = function () { return true; };
+    module.exports.incoming_u8 = function () { return 255; };
+    module.exports.incoming_i8 = function () { return -127; };
+    module.exports.incoming_u16 = function () { return 65535; };
+    module.exports.incoming_i16 = function () { return 32767; };
+    module.exports.incoming_u32 = function () { return 4294967295; };
     module.exports.incoming_i32 = function () { return 0; };
     module.exports.incoming_f32 = function () { return 1.5; };
     module.exports.incoming_f64 = function () { return 13.37; };
 
+    module.exports.outgoing_u8 = function (k) { assert_eq(k, 255); };
+    module.exports.outgoing_i8 = function (i) { assert_eq(i, -127); };
+    module.exports.outgoing_u16 = function (l) { assert_eq(l, 65535); };
+    module.exports.outgoing_i16 = function (j) { assert_eq(j, 32767); };
     module.exports.outgoing_i32 = function (x) { assert_eq(x, 0); };
     module.exports.outgoing_f32 = function (y) { assert_eq(y, 1.5); };
     module.exports.outgoing_f64 = function (z) { assert_eq(z, 13.37); };
@@ -33,11 +43,27 @@ use wasm_bindgen_test::*;
         assert_eq(v, 'hello');
         return v;
     };
+
+    module.exports.MyNamespace = {};
+    module.exports.MyNamespace.incoming_namespaced = function () { return 3.14; };
+    module.exports.MyNamespace.outgoing_namespaced = function (pi) { assert_eq(3.14, pi); };
 ")]
 extern "C" {
     #[wasm_bindgen(assert_no_shim)]
     fn trivial();
 
+    #[wasm_bindgen(assert_no_shim)]
+    fn incoming_bool() -> bool;
+    #[wasm_bindgen(assert_no_shim)]
+    fn incoming_u8() -> u8;
+    #[wasm_bindgen(assert_no_shim)]
+    fn incoming_i8() -> i8;
+    #[wasm_bindgen(assert_no_shim)]
+    fn incoming_u16() -> u16;
+    #[wasm_bindgen(assert_no_shim)]
+    fn incoming_i16() -> i16;
+    #[wasm_bindgen(assert_no_shim)]
+    fn incoming_u32() -> u32;
     #[wasm_bindgen(assert_no_shim)]
     fn incoming_i32() -> i32;
     #[wasm_bindgen(assert_no_shim)]
@@ -45,6 +71,14 @@ extern "C" {
     #[wasm_bindgen(assert_no_shim)]
     fn incoming_f64() -> f64;
 
+    #[wasm_bindgen(assert_no_shim)]
+    fn outgoing_u8(k: u8);
+    #[wasm_bindgen(assert_no_shim)]
+    fn outgoing_i8(i: i8);
+    #[wasm_bindgen(assert_no_shim)]
+    fn outgoing_u16(l: u16);
+    #[wasm_bindgen(assert_no_shim)]
+    fn outgoing_i16(j: i16);
     #[wasm_bindgen(assert_no_shim)]
     fn outgoing_i32(x: i32);
     #[wasm_bindgen(assert_no_shim)]
@@ -54,6 +88,11 @@ extern "C" {
 
     #[wasm_bindgen(assert_no_shim)]
     fn many(x: i32, y: f32, z: f64) -> i32;
+
+    #[wasm_bindgen(assert_no_shim, js_namespace = MyNamespace)]
+    fn incoming_namespaced() -> f64;
+    #[wasm_bindgen(assert_no_shim, js_namespace = MyNamespace)]
+    fn outgoing_namespaced(x: f64);
 
     // Note that this should only skip the JS shim if we have anyref support
     // enabled.
@@ -66,19 +105,46 @@ extern "C" {
 fn no_shims() {
     trivial();
 
+    let k = incoming_u8();
+    assert_eq!(k, 255);
+    outgoing_u8(k);
+
+    let l = incoming_u16();
+    assert_eq!(l, 65535);
+    outgoing_u16(l);
+
+    let m = incoming_u32();
+    assert_eq!(m, 4294967295);
+
+    let i = incoming_i8();
+    assert_eq!(i, -127);
+    outgoing_i8(i);
+
+    let j = incoming_i16();
+    assert_eq!(j, 32767);
+    outgoing_i16(j);
+
     let x = incoming_i32();
     assert_eq!(x, 0);
+    outgoing_i32(x);
+
     let y = incoming_f32();
     assert_eq!(y, 1.5);
+    outgoing_f32(y);
+
     let z = incoming_f64();
     assert_eq!(z, 13.37);
-
-    outgoing_i32(x);
-    outgoing_f32(y);
     outgoing_f64(z);
 
     let w = many(x, y, z);
     assert_eq!(w, 42);
+
+    let pi = incoming_namespaced();
+    assert_eq!(pi, 3.14);
+    outgoing_namespaced(pi);
+
+    let b = incoming_bool();
+    assert!(b);
 
     let v = JsValue::from("hello");
     let vv = works_when_anyref_support_is_enabled(v.clone());

--- a/tests/wasm/no_shims.rs
+++ b/tests/wasm/no_shims.rs
@@ -1,0 +1,76 @@
+//! A collection of tests to exercise imports where we don't need to generate a
+//! JS shim to convert arguments/returns even when Web IDL bindings is not
+//! implemented.
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(inline_js = "
+    function assert_eq(a, b) {
+        if (a !== b) {
+            throw new Error(`assert_eq failed: ${a} != ${b}`);
+        }
+    }
+
+    module.exports.trivial = function () {};
+
+    module.exports.incoming_i32 = function () { return 0; };
+    module.exports.incoming_f32 = function () { return 1.5; };
+    module.exports.incoming_f64 = function () { return 13.37; };
+
+    module.exports.outgoing_i32 = function (x) { assert_eq(x, 0); };
+    module.exports.outgoing_f32 = function (y) { assert_eq(y, 1.5); };
+    module.exports.outgoing_f64 = function (z) { assert_eq(z, 13.37); };
+
+    module.exports.many = function (x, y, z) {
+        assert_eq(x, 0);
+        assert_eq(y, 1.5);
+        assert_eq(z, 13.37);
+        return 42;
+    };
+
+    module.exports.works_when_anyref_support_is_enabled = function (v) {
+        assert_eq(v, 'hello');
+        return v;
+    };
+")]
+extern "C" {
+    fn trivial();
+
+    fn incoming_i32() -> i32;
+    fn incoming_f32() -> f32;
+    fn incoming_f64() -> f64;
+
+    fn outgoing_i32(x: i32);
+    fn outgoing_f32(y: f32);
+    fn outgoing_f64(z: f64);
+
+    fn many(x: i32, y: f32, z: f64) -> i32;
+
+    // Note that this should only skip the JS shim if we have anyref support
+    // enabled.
+    fn works_when_anyref_support_is_enabled(v: JsValue) -> JsValue;
+}
+
+#[wasm_bindgen_test]
+fn no_shims() {
+    trivial();
+
+    let x = incoming_i32();
+    assert_eq!(x, 0);
+    let y = incoming_f32();
+    assert_eq!(y, 1.5);
+    let z = incoming_f64();
+    assert_eq!(z, 13.37);
+
+    outgoing_i32(x);
+    outgoing_f32(y);
+    outgoing_f64(z);
+
+    let w = many(x, y, z);
+    assert_eq!(w, 42);
+
+    let v = JsValue::from("hello");
+    let vv = works_when_anyref_support_is_enabled(v.clone());
+    assert_eq!(v, vv);
+}

--- a/tests/wasm/no_shims.rs
+++ b/tests/wasm/no_shims.rs
@@ -35,20 +35,30 @@ use wasm_bindgen_test::*;
     };
 ")]
 extern "C" {
+    #[wasm_bindgen(assert_no_shim)]
     fn trivial();
 
+    #[wasm_bindgen(assert_no_shim)]
     fn incoming_i32() -> i32;
+    #[wasm_bindgen(assert_no_shim)]
     fn incoming_f32() -> f32;
+    #[wasm_bindgen(assert_no_shim)]
     fn incoming_f64() -> f64;
 
+    #[wasm_bindgen(assert_no_shim)]
     fn outgoing_i32(x: i32);
+    #[wasm_bindgen(assert_no_shim)]
     fn outgoing_f32(y: f32);
+    #[wasm_bindgen(assert_no_shim)]
     fn outgoing_f64(z: f64);
 
+    #[wasm_bindgen(assert_no_shim)]
     fn many(x: i32, y: f32, z: f64) -> i32;
 
     // Note that this should only skip the JS shim if we have anyref support
     // enabled.
+    //
+    // #[wasm_bindgen(assert_no_shim)]
     fn works_when_anyref_support_is_enabled(v: JsValue) -> JsValue;
 }
 


### PR DESCRIPTION
After this change, any import that only takes and returns ABI-safe numbers (signed integers less than 64 bits and unrestricted floating point numbers) will be a direct import, and will not have a little JS shim in the middle.

We don't have a great mechanism for testing the generated bindings' contents -- as opposed to its behavior -- but I manually verified that everything here does the Right Thing and doesn't have a JS shim:

```rust
#[wasm_bindgen]
extern "C" {
    fn trivial();

    fn incoming_i32() -> i32;
    fn incoming_f32() -> f32;
    fn incoming_f64() -> f64;

    fn outgoing_i32(x: i32);
    fn outgoing_f32(y: f32);
    fn outgoing_f64(z: f64);

    fn many(x: i32, y: f32, z: f64) -> i32;
}
```

Furthermore, I verified that when our support for emitting native `anyref` is enabled, then we do not have a JS shim for the following import, but if it is disabled, then we do have a JS shim:

```rust
#[wasm_bindgen]
extern "C" {
    fn works_when_anyref_support_is_enabled(v: JsValue) -> JsValue;
}
```

Fixes #1636.
