### PR TITLE
Check for use-after-move in JS glue when `--debug` is enabled again

### DIFF
--- a/tests/wasm/validate_prt.rs
+++ b/tests/wasm/validate_prt.rs
@@ -21,6 +21,10 @@ impl Fruit {
     pub fn new(name: String) -> Self {
         Fruit { name }
     }
+
+    pub fn rot(self) {
+        drop(self);
+    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Fixes #1669