### PR TITLE
Update to walrus 0.9.0

### DIFF
--- a/crates/anyref-xform/Cargo.toml
+++ b/crates/anyref-xform/Cargo.toml
@@ -13,4 +13,4 @@ edition = '2018'
 
 [dependencies]
 failure = "0.1"
-walrus = "0.8.0"
+walrus = "0.9.0"

--- a/crates/anyref-xform/src/lib.rs
+++ b/crates/anyref-xform/src/lib.rs
@@ -676,7 +676,7 @@ impl Transform<'_> {
     // initialized correctly.
     fn inject_initialization(&mut self, module: &mut Module) {
         let ty = module.types.add(&[], &[]);
-        let import = module.add_import_func(
+        let (import, _) = module.add_import_func(
             "__wbindgen_placeholder__",
             "__wbindgen_init_anyref_table",
             ty,

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -18,9 +18,9 @@ log = "0.4"
 rustc-demangle = "0.1.13"
 serde_json = "1.0"
 tempfile = "3.0"
-walrus = "0.8.0"
+walrus = "0.9.0"
 wasm-bindgen-anyref-xform = { path = '../anyref-xform', version = '=0.2.48' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.48' }
 wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.48' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.48' }
-wasm-webidl-bindings = "0.1.2"
+wasm-webidl-bindings = "0.2.0"

--- a/crates/cli-support/src/descriptors.rs
+++ b/crates/cli-support/src/descriptors.rs
@@ -152,13 +152,8 @@ impl WasmBindgenDescriptorsSection {
         let ty = module.funcs.get(wbindgen_describe_closure).ty();
         for (func, (call_instr, descriptor)) in func_to_descriptor {
             let import_name = format!("__wbindgen_closure_wrapper{}", func.index());
-            let id = module.add_import_func("__wbindgen_placeholder__", &import_name, ty);
-            let import_id = module
-                .imports
-                .iter()
-                .find(|i| i.name == import_name)
-                .unwrap()
-                .id();
+            let (id, import_id) =
+                module.add_import_func("__wbindgen_placeholder__", &import_name, ty);
             module.funcs.get_mut(id).name = Some(import_name);
 
             let local = match &mut module.funcs.get_mut(func).kind {

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ rouille = { version = "3.0.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
-walrus = "0.8.0"
+walrus = "0.9.0"
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.48" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.48" }
 

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-walrus = "0.8.0"
+walrus = "0.9.0"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -14,7 +14,7 @@ edition = '2018'
 [dependencies]
 failure = "0.1"
 log = "0.4"
-walrus = "0.8.0"
+walrus = "0.9.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
This commit updates the `walrus` dependency with recent upstream API
changes in `walrus` itself, namely updates to passive segements and how
memory data segments are handled