### PR TITLE
Improve leniency of `--no-modules` output

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -502,7 +502,7 @@ impl<'a> Context<'a> {
                     let result;
                     const imports = {{}};
                     {imports_init}
-                    if (module instanceof URL || typeof module === 'string' || module instanceof Request) {{
+                    if ((typeof URL === 'function' && module instanceof URL) || typeof module === 'string' || (typeof Request === 'function' && module instanceof Request)) {{
                         {init_memory2}
                         const response = fetch(module);
                         if (typeof WebAssembly.instantiateStreaming === 'function') {{


### PR DESCRIPTION
Instead of assuming names like `URL` and `Request` are defined, instead
check to see if they exist first and otherwise skip the checks that
reference them.