### PR TITLE
Update to walrus 0.10.0

### DIFF
--- a/crates/anyref-xform/Cargo.toml
+++ b/crates/anyref-xform/Cargo.toml
@@ -13,4 +13,4 @@ edition = '2018'
 
 [dependencies]
 failure = "0.1"
-walrus = "0.9.0"
+walrus = "0.10.0"

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -18,9 +18,9 @@ log = "0.4"
 rustc-demangle = "0.1.13"
 serde_json = "1.0"
 tempfile = "3.0"
-walrus = "0.9.0"
+walrus = "0.10.0"
 wasm-bindgen-anyref-xform = { path = '../anyref-xform', version = '=0.2.48' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.48' }
 wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.48' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.48' }
-wasm-webidl-bindings = "0.2.0"
+wasm-webidl-bindings = "0.3.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ rouille = { version = "3.0.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
-walrus = "0.9.0"
+walrus = { version = "0.10.0", features = ['parallel'] }
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.48" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.48" }
 

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-walrus = "0.9.0"
+walrus = "0.10.0"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -14,7 +14,7 @@ edition = '2018'
 [dependencies]
 failure = "0.1"
 log = "0.4"
-walrus = "0.9.0"
+walrus = "0.10.0"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Ensure that we enable the new `parallel` feature in the CLI so our tools all use
parallelized parsing, but none of our specific crates need it for usage.