### PR TITLE
Fully update threading support for LLVM 9

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,7 +166,7 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2019-06-13
+          toolchain: nightly-2019-07-30
       - template: ci/azure-install-sccache.yml
       - script: rustup component add rust-src
         displayName: "install rust-src"

--- a/examples/raytrace-parallel/Xargo.toml
+++ b/examples/raytrace-parallel/Xargo.toml
@@ -1,3 +1,2 @@
 [dependencies.std]
 stage = 0
-features = ['wasm-bindgen-threads']

--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -10,16 +10,15 @@ set -ex
 #
 # * Next we need to compile everything with the `atomics` feature enabled,
 #   ensuring that LLVM will generate atomic instructions and such.
-RUSTFLAGS='-C target-feature=+atomics' \
+RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' \
   xargo build --target wasm32-unknown-unknown --release
 
-# Threading support is disabled by default in wasm-bindgen, so use an env var
-# here to turn it on for our bindings generation. Also note that webpack isn't
-# currently compatible with atomics, so we go with the --no-modules output.
-WASM_BINDGEN_THREADS=1 \
-  cargo run --manifest-path ../../crates/cli/Cargo.toml \
-    --bin wasm-bindgen -- \
-    ../../target/wasm32-unknown-unknown/release/raytrace_parallel.wasm --out-dir . \
-    --no-modules
+# Note the usage of `--no-modules` here which is used to create an output which
+# is usable from Web Workers. We notably can't use `--target bundler` since
+# Webpack doesn't have support for atomics yet.
+cargo run --manifest-path ../../crates/cli/Cargo.toml \
+  --bin wasm-bindgen -- \
+  ../../target/wasm32-unknown-unknown/release/raytrace_parallel.wasm --out-dir . \
+  --no-modules
 
 python3 -m http.server


### PR DESCRIPTION
Support has landed in rust-lang/rust for full support for LLVM 9's
interpretation of WebAssembly threads. This commit updates our thread
transformation pass to take all this into account, namely:

* The threading pass now runs by default and is keyed on whether memory
  is shared, not off an env var.
* TLS is initialized in addition to memory on each thread.
* Stack pointer finding is tweaked to account for the TLS base also
  being a mutable global.
* The build of the parallel raytrace example was updated to use today's
  nightly.