### PR TITLE
Use idiomatic syntax of Rc::clone()

### DIFF
--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -45,7 +45,7 @@ fn app(name: &str) {
         None => return,
     };
     let controller = Controller::new(store, Rc::downgrade(&sched));
-    if let Some(mut view) = View::new(sched.clone()) {
+    if let Some(mut view) = View::new(Rc::clone(&sched)) {
         let sch: &Rc<Scheduler> = &sched;
         view.init();
         sch.set_view(view);


### PR DESCRIPTION
This syntax makes it easier to see that this code is creating a new reference rather than copying the whole content of `sched`.