### PR TITLE
Removed unnecessary dereference in Store::find

### DIFF
--- a/examples/todomvc/src/store.rs
+++ b/examples/todomvc/src/store.rs
@@ -85,7 +85,7 @@ impl Store {
         Some(
             self.data
                 .iter()
-                .filter(|todo| query.matches(*todo))
+                .filter(|todo| query.matches(todo))
                 .collect(),
         )
     }


### PR DESCRIPTION
Prefer no dereference when it is not needed.
`todo` has type `&&Item`. Argument needs to be `&Item`, but this is already converted via deref coercion.