### PR TITLE
Update to work with futures-preview 0.3.0-alpha.18

### DIFF
--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -15,8 +15,8 @@ cfg-if = "0.1.9"
 futures = "0.1.20"
 js-sys = { path = "../js-sys", version = '0.3.25' }
 wasm-bindgen = { path = "../..", version = '0.2.48' }
-futures-util-preview = { version = "0.3.0-alpha.15", optional = true }
-futures-channel-preview = { version = "0.3.0-alpha.15", optional = true }
+futures-util-preview = { version = "0.3.0-alpha.18", optional = true }
+futures-channel-preview = { version = "0.3.0-alpha.18", optional = true }
 lazy_static = { version = "1.3.0", optional = true }
 
 [target.'cfg(target_feature = "atomics")'.dependencies.web-sys]

--- a/crates/futures/src/futures_0_3.rs
+++ b/crates/futures/src/futures_0_3.rs
@@ -248,7 +248,7 @@ where
                                     drop(lock);
 
                                     // TODO is there some way of saving these so they don't need to be recreated all the time ?
-                                    let waker = ArcWake::into_waker(task.clone());
+                                    let waker = futures_util::task::waker(task.clone());
                                     let cx = &mut Context::from_waker(&waker);
                                     Pin::new(future).poll(cx)
                                 };


### PR DESCRIPTION
This release of futures-preview has a breaking change: `ArcWaker::into_waker` has been moved to `task::waker()`