### PR TITLE
Improve instantiateStreaming fallback

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -536,13 +536,19 @@ impl<'a> Context<'a> {
                         if (typeof WebAssembly.instantiateStreaming === 'function') {{
                             result = WebAssembly.instantiateStreaming(response, imports)
                                 .catch(e => {{
-                                    console.warn(\"`WebAssembly.instantiateStreaming` failed. Assuming this is \
-                                                    because your server does not serve wasm with \
-                                                    `application/wasm` MIME type. Falling back to \
-                                                    `WebAssembly.instantiate` which is slower. Original \
-                                                    error:\\n\", e);
                                     return response
-                                        .then(r => r.arrayBuffer())
+                                        .then(r => {{
+                                            if (r.headers.get('Content-Type') != 'application/wasm') {{
+                                                console.warn(\"`WebAssembly.instantiateStreaming` failed \
+                                                                because your server does not serve wasm with \
+                                                                `application/wasm` MIME type. Falling back to \
+                                                                `WebAssembly.instantiate` which is slower. Original \
+                                                                error:\\n\", e);
+                                                return r.arrayBuffer();
+                                            }} else {{
+                                                throw e;
+                                            }}
+                                        }})
                                         .then(bytes => WebAssembly.instantiate(bytes, imports));
                                 }});
                         }} else {{


### PR DESCRIPTION
This commit improves our `instantiateStreaming` fallback to only
actually trigger the fallback if the headers look wrong. If the headers
look right then we let through the original error which should help
avoid accidentally papering over bugs with different bugs in
misconfigured situations.

Closes #1696