### PR TITLE
Update browser support for `BigInt`

### DIFF
--- a/guide/src/reference/browser-support.md
+++ b/guide/src/reference/browser-support.md
@@ -58,9 +58,9 @@ also like to be aware of it!
   forbids the usage of 64-bit integers (Rust types `i64` and `u64`) in
   exported/imported functions. When using `wasm-bindgen`, however, `u64` is
   allowed! The reason for this is that it's translated to the `BigInt` type in
-  JS. The `BigInt` class, however, is only currently supported in Chrome (as of
-  the time of this writing) and isn't supported in Firefox or Edge, for
-  example.
+  JS. The `BigInt` class, however, is only currently supported in Chrome 67+ and
+  Firefox 68+ (as of the time of this writing) and isn't supported in Edge or
+  Safari, for example.
 
 If you find other incompatibilities please report them to us! We'd love to
 either keep this list up-to-date or fix the underlying bugs :)

--- a/guide/src/reference/browser-support.md
+++ b/guide/src/reference/browser-support.md
@@ -60,7 +60,8 @@ also like to be aware of it!
   allowed! The reason for this is that it's translated to the `BigInt` type in
   JS. The `BigInt` class, however, is only currently supported in Chrome 67+ and
   Firefox 68+ (as of the time of this writing) and isn't supported in Edge or
-  Safari, for example.
+  Safari, for example. For more, up-to-date details, see [`BigInt` on Can I
+  use...][ciu_bigint].
 
 If you find other incompatibilities please report them to us! We'd love to
 either keep this list up-to-date or fix the underlying bugs :)
@@ -71,3 +72,4 @@ either keep this list up-to-date or fix the underlying bugs :)
 [`text-encoding`]: https://www.npmjs.com/package/text-encoding
 [soq]: https://stackoverflow.com/questions/40662142/polyfill-for-textdecoder/46549188#46549188
 [mdntepi]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#Polyfill
+[ciu_bigint]: https://caniuse.com/#feat=bigint


### PR DESCRIPTION
`BigInt` is supported in Firefox as of Firefox 68!

Edge doesn't support it for now but it will when EdgeHTML will be replaced with Chromium.
I replaced Firefox with Safari as a second example of an unsupported browser (I still swapped them because "Edge or Safari" sounds better than "Safari or Edge" to me :p).

As a further improvement (not included here), we could add a link to the `Can I use...` support table for `BigInt`.