### PR TITLE
Making passStringToWasm smaller

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -860,7 +860,7 @@ impl<'a> Context<'a> {
 
         // Another possibility is to use `TextEncoder#encodeInto` which is much
         // newer and isn't implemented everywhere yet. It's more efficient,
-        // however, becaues it allows us to elide an intermediate allocation.]
+        // however, becaues it allows us to elide an intermediate allocation.
         let encode_into = "function (arg, view) {
             return cachedTextEncoder.encodeInto(arg, view);
         }";


### PR DESCRIPTION
The behavior is identical, but the `passStringToWasm` function is now much shorter (742 bytes -> 529 bytes).