### PR TITLE
Touch up documentation about futures

### DIFF
--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -13,3 +13,12 @@ Learn more:
 
 [crate]: https://crates.io/crates/wasm-bindgen-futures
 [docs]: https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen_futures/
+
+## Compatibility with versions of `Future`
+
+The current crate on crates.io, `wasm-bindgen-futures 0.4.*`, supports
+`std::future::Future` and `async`/`await` in Rust. This typically requires Rust
+1.39.0+ (as of this writing on 2019-09-05 it's the nightly channel of Rust).
+
+If you're using the `Future` trait from the `futures` `0.1.*` crate then you'll
+want to use the `0.3.*` track of `wasm-bindgen-futures` on crates.io.

--- a/guide/src/wasm-bindgen-test/usage.md
+++ b/guide/src/wasm-bindgen-test/usage.md
@@ -2,13 +2,14 @@
 
 ### Add `wasm-bindgen-test` to Your `Cargo.toml`'s `[dev-dependencies]`
 
-Make sure to replace "X.Y.Z" with the same version of `wasm-bindgen` that you
-have in the `[dependencies]` section!
-
 ```toml
 [dev-dependencies]
-wasm-bindgen-test = "X.Y.Z"
+wasm-bindgen-test = "0.3.0"
 ```
+
+Note that the `0.3.0` track of `wasm-bindgen-test` supports Rust 1.39.0+, which
+is currently the nightly channel (as of 2019-09-05). If you want support for
+older compilers use the `0.2.*` track of `wasm-bindgen-test`.
 
 ## Write Some Tests
 


### PR DESCRIPTION
This commit updates our guide documentation with the current status of futures/promises/etc with the recent changes to default to async/await