### PR TITLE
Handle `JSON.stringify(undefined)`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2606,7 +2606,11 @@ impl<'a> Context<'a> {
 
             Intrinsic::JsonSerialize => {
                 assert_eq!(args.len(), 1);
-                format!("JSON.stringify({})", args[0])
+                // Turns out `JSON.stringify(undefined) === undefined`, so if
+                // we're passed `undefined` reinterpret it as `null` for JSON
+                // purposes.
+                prelude.push_str(&format!("const obj = {};\n", args[0]));
+                "JSON.stringify(obj === undefined ? null : obj)".to_string()
             }
 
             Intrinsic::AnyrefHeapLiveCount => {

--- a/tests/wasm/js_objects.rs
+++ b/tests/wasm/js_objects.rs
@@ -144,4 +144,5 @@ fn serde() {
     assert_eq!(foo.d.a, 4);
 
     assert_eq!(JsValue::from("bar").into_serde::<String>().unwrap(), "bar");
+    assert_eq!(JsValue::undefined().into_serde::<i32>().ok(), None);
 }


### PR DESCRIPTION
Turns out that `JSON.stringify(undefined)` doesn't actually return a
string, it returns `undefined`! If we're requested to serialize
`undefined` into JSON instead just interpret it as `null` which should
have the expected semantics of serving as a placeholder for `None`.

Closes #1778