### PR TITLE
Fix importing `static` values of non-JS types

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1162,6 +1162,14 @@ impl ToTokens for ast::ImportStatic {
             };
         })
         .to_tokens(into);
+
+        Descriptor(
+            &shim_name,
+            quote! {
+                <#ty as WasmDescribe>::describe();
+            },
+        )
+        .to_tokens(into);
     }
 }
 

--- a/crates/cli-support/src/webidl/mod.rs
+++ b/crates/cli-support/src/webidl/mod.rs
@@ -1049,6 +1049,11 @@ impl<'a> Context<'a> {
             None => return Ok(()),
         };
 
+        let descriptor = match self.descriptors.remove(static_.shim) {
+            None => return Ok(()),
+            Some(d) => d,
+        };
+
         // Register the signature of this imported shim
         bindings::register_import(
             self.module,
@@ -1057,7 +1062,7 @@ impl<'a> Context<'a> {
             Function {
                 arguments: Vec::new(),
                 shim_idx: 0,
-                ret: Descriptor::Anyref,
+                ret: descriptor,
             },
             ast::WebidlFunctionKind::Static,
         )?;

--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -105,3 +105,5 @@ exports.assert_dead_import_not_generated = function() {
 exports.import_inside_function_works = function() {};
 exports.import_inside_private_module = function() {};
 exports.should_call_undefined_functions = () => false;
+
+exports.STATIC_STRING = 'x';

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -51,6 +51,9 @@ extern "C" {
     fn unused_import();
     fn assert_dead_import_not_generated();
     fn should_call_undefined_functions() -> bool;
+
+
+    static STATIC_STRING: String;
 }
 
 #[wasm_bindgen]
@@ -231,4 +234,9 @@ fn undefined_function_is_ok() {
     let x = TypeThatIsNotDefined::new();
     x.method();
     x.set_property(x.property());
+}
+
+#[wasm_bindgen_test]
+fn static_string_ok() {
+    assert_eq!(*STATIC_STRING, "x");
 }


### PR DESCRIPTION
This hasn't ever actually worked in `wasm-bindgen` but there's been
enough refactorings since the initial implementation that it's actually
quite trivial to implement now!

Closes #1777