### PR TITLE
Fix return type of WebIDL indexing getters

### DIFF
--- a/crates/web-sys/tests/wasm/html_element.rs
+++ b/crates/web-sys/tests/wasm/html_element.rs
@@ -33,6 +33,21 @@ fn test_html_element() {
     element.set_hidden(true);
     assert!(element.hidden(), "Should be hidden");
 
+    assert_eq!(element.class_list().get(0), None, "Shouldn't have class at index 0");
+    element.class_list().add_2("a", "b").unwrap();
+    assert_eq!(element.class_list().get(0).unwrap(), "a", "Should have class at index 0");
+    assert_eq!(element.class_list().get(1).unwrap(), "b", "Should have class at index 1");
+    assert_eq!(element.class_list().get(2), None, "Shouldn't have class at index 2");
+
+    assert_eq!(element.dataset().get("id"), None, "Shouldn't have data-id");
+    element.dataset().set("id", "123").unwrap();
+    assert_eq!(element.dataset().get("id").unwrap(), "123", "Should have data-id");
+
+    assert_eq!(element.style().get(0), None, "Shouldn't have style property name at index 0");
+    element.style().set_property("background-color", "red").unwrap();
+    assert_eq!(element.style().get(0).unwrap(), "background-color", "Should have style property at index 0");
+    assert_eq!(element.style().get_property_value("background-color").unwrap(), "red", "Should have style property");
+
     // TODO add a click handler here
     element.click();
 

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -86,11 +86,11 @@ fn global_method() {
 #[wasm_bindgen_test]
 fn indexing() {
     let f = Indexing::new().unwrap();
-    assert_eq!(f.get(123), -1);
+    assert_eq!(f.get(123).unwrap(), -1);
     f.set(123, 456);
-    assert_eq!(f.get(123), 456);
+    assert_eq!(f.get(123).unwrap(), 456);
     f.delete(123);
-    assert_eq!(f.get(123), -1);
+    assert_eq!(f.get(123).unwrap(), -1);
 }
 
 #[wasm_bindgen_test]

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -580,6 +580,20 @@ impl<'src> FirstPassRecord<'src> {
             let structural =
                 force_structural || is_structural(signature.orig.attrs.as_ref(), container_attrs);
             let catch = force_throws || throws(&signature.orig.attrs);
+            let ret_ty = if id == &OperationId::IndexingGetter {
+                // All indexing getters should return optional values (or
+                // otherwise be marked with catch).
+                match ret_ty {
+                    IdlType::Nullable(_) => ret_ty,
+                    ref ty @ _ => if catch {
+                        ret_ty
+                    } else {
+                        IdlType::Nullable(Box::new(ty.clone()))
+                    },
+                }
+            } else {
+                ret_ty
+            };
             let variadic = signature.args.len() == signature.orig.args.len()
                 && signature
                     .orig

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -297,23 +297,9 @@ impl<'src> FirstPassRecord<'src> {
             },
         };
 
-        // Some WebIDL indexing getters (e.g. __widl_f_get_DOMStringMap) return
-        // `undefined` although the WebIDL specification does not explicitly
-        // state so, which causes uncaught runtime exceptions
-        // (rustwasm/wasm-bindgen#1756). To fix this, we check the return
-        // types of the generated Rust bindings for indexing getters, and
-        // ensure that they are wrapped as either `Result<T, JsValue>` or
-        // `Option<T>`. For indexing getters with an unwrapped return type, we
-        // convert their return types to `Option<T>`.
-        //
-        // Here we compute the `is_indexing_getter_to_fix` flag that tells us
-        // whether the binding function we are generating is for an indexing
-        // getter and its return type is not originally wrapped (i.e. neither
-        // `Result<T, JsValue>` nor `Option<T>`) thus needing the conversion
-        // to `Option<T>`.
-        let is_indexing_getter_to_fix = is_indexing_getter && // exclude non indexing getters
-            !catch && // exclude indexing getters that return `Result<T, JsValue>`
-            if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`
+        let is_indexing_getter_to_fix = is_indexing_getter && // exclude non index getters.
+            !catch && // exclude indexing getters that return `Result<T, JsValue>`.
+            if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`.
                 !format!("{}", quote! { #ty })
                     .replace(" ", "")
                     .starts_with("Option<")

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -298,7 +298,7 @@ impl<'src> FirstPassRecord<'src> {
         };
 
         let is_indexing_getter_to_fix = is_indexing_getter && // exclude non index getters.
-            !catch && // exclude indexing getters that return `Result<T, JsValue>`.
+            !catch && // exclude indexing getters that return `Result<T>`.
             if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`.
                 !format!("{}", quote! { #ty })
                     .replace(" ", "")

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -298,7 +298,7 @@ impl<'src> FirstPassRecord<'src> {
         };
 
         let is_indexing_getter_to_fix = is_indexing_getter && // exclude non index getters.
-            !catch && // exclude indexing getters that return `Result<T>`.
+            !catch && // exclude indexing getters that return `Result<T, JsValue>`.
             if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`.
                 !format!("{}", quote! { #ty })
                     .replace(" ", "")

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -297,9 +297,23 @@ impl<'src> FirstPassRecord<'src> {
             },
         };
 
-        let is_indexing_getter_to_fix = is_indexing_getter && // exclude non index getters.
-            !catch && // exclude indexing getters that return `Result<T, JsValue>`.
-            if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`.
+        // Some WebIDL indexing getters (e.g. __widl_f_get_DOMStringMap) return
+        // `undefined` although the WebIDL specification does not explicitly
+        // state so, which causes uncaught runtime exceptions
+        // (rustwasm/wasm-bindgen#1756). To fix this, we check the return
+        // types of the generated Rust bindings for indexing getters, and
+        // ensure that they are wrapped as either `Result<T, JsValue>` or
+        // `Option<T>`. For indexing getters with an unwrapped return type, we
+        // convert their return types to `Option<T>`.
+        //
+        // Here we compute the `is_indexing_getter_to_fix` flag that tells us
+        // whether the binding function we are generating is for an indexing
+        // getter and its return type is not originally wrapped (i.e. neither
+        // `Result<T, JsValue>` nor `Option<T>`) thus needing the conversion
+        // to `Option<T>`.
+        let is_indexing_getter_to_fix = is_indexing_getter && // exclude non indexing getters
+            !catch && // exclude indexing getters that return `Result<T, JsValue>`
+            if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`
                 !format!("{}", quote! { #ty })
                     .replace(" ", "")
                     .starts_with("Option<")

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -3,6 +3,7 @@ use std::ptr;
 
 use heck::{CamelCase, ShoutySnakeCase, SnakeCase};
 use proc_macro2::{Ident, Span};
+use quote::quote;
 use syn;
 use wasm_bindgen_backend::ast;
 use wasm_bindgen_backend::util::{ident_ty, leading_colon_path_ty, raw_ident, rust_ident};
@@ -227,6 +228,7 @@ impl<'src> FirstPassRecord<'src> {
         idl_arguments: impl Iterator<Item = (&'a str, &'a IdlType<'src>)>,
         ret: &IdlType<'src>,
         kind: ast::ImportFunctionKind,
+        is_indexing_getter: bool,
         structural: bool,
         catch: bool,
         variadic: bool,
@@ -294,9 +296,24 @@ impl<'src> FirstPassRecord<'src> {
                 }
             },
         };
-        let js_ret = ret.clone();
+
+        let is_indexing_getter_to_fix = is_indexing_getter && // exclude non index getters.
+            !catch && // exclude indexing getters that return `Result<T>`.
+            if let Some(ref ty) = ret { // exclude indexing getters that return `Option<T>`.
+                !format!("{}", quote! { #ty })
+                    .replace(" ", "")
+                    .starts_with("Option<")
+            } else {
+                false
+            };
+
+        let mut js_ret = ret.clone();
         let ret = if catch {
             Some(ret.map_or_else(|| result_ty(unit_ty()), result_ty))
+        } else if is_indexing_getter_to_fix {
+            let ret = Some(ret.map_or_else(|| option_ty(unit_ty()), option_ty));
+            js_ret = ret.clone();
+            ret
         } else {
             ret
         };
@@ -349,6 +366,7 @@ impl<'src> FirstPassRecord<'src> {
             None.into_iter(),
             &ret,
             kind,
+            false,
             is_structural(attrs.as_ref(), container_attrs),
             throws(attrs),
             false,
@@ -379,6 +397,7 @@ impl<'src> FirstPassRecord<'src> {
             Some((name, &field_ty)).into_iter(),
             &IdlType::Void,
             kind,
+            false,
             is_structural(attrs.as_ref(), container_attrs),
             throws(attrs),
             false,
@@ -516,6 +535,8 @@ impl<'src> FirstPassRecord<'src> {
             OperationId::IndexingDeleter => ("delete", true, false),
         };
 
+        let is_indexing_getter = id == &OperationId::IndexingGetter;
+
         let mut ret = Vec::new();
         for signature in actual_signatures.iter() {
             // Ignore signatures with invalid return types
@@ -598,6 +619,7 @@ impl<'src> FirstPassRecord<'src> {
                         .map(|(idl_type, orig_arg)| (orig_arg.name, idl_type)),
                     &ret_ty,
                     kind.clone(),
+                    is_indexing_getter,
                     structural,
                     catch,
                     variadic,
@@ -624,6 +646,7 @@ impl<'src> FirstPassRecord<'src> {
                             .map(|(name, idl_type)| (&name[..], idl_type.clone())),
                         &ret_ty,
                         kind.clone(),
+                        is_indexing_getter,
                         structural,
                         catch,
                         false,

--- a/examples/todomvc/src/element.rs
+++ b/examples/todomvc/src/element.rs
@@ -294,7 +294,9 @@ impl Element {
         if let Some(el) = self.el.take() {
             {
                 if let Some(el) = wasm_bindgen::JsCast::dyn_ref::<web_sys::HtmlElement>(&el) {
-                    text = el.dataset().get(key);
+                    if let Some(value) = el.dataset().get(key) {
+                        text = value;
+                    }
                 }
             }
             self.el = Some(el);


### PR DESCRIPTION
This PR is to update the return signatures of WebIDL indexing getters.  All indexing getters will return optional values unless marked by `[Throws]` in their WebIDL definitions.

I summarize the impact of this change in the list below.  As a result, 14 indexing getters with originally unwrapped return type `T` (non-highlighted in 3rd column) will return `Option<T>` instead.

![table-before-after-change-clean](https://user-images.githubusercontent.com/38098238/65814081-a86ee880-e207-11e9-9a6a-21ec015c5325.png)

Since this is a breaking change, I am including some commits that deal with affected examples as well.  It turned out that I found only the `todomvc` example (50fbb5c).

**Motivation**

In #1756,  we have observed the situations where indexing getters (such as `__widl_f_get_DOMStringMap` and `__widl_f_get_CSSStyleDeclaration`) can return `undefined` that breaks our assumptions based on their WebIDL definitions,  leading to unrecoverable runtime exceptions.  Following @Pauan 's [advice](https://github.com/rustwasm/wasm-bindgen/issues/1756#issuecomment-529680334), this PR is aimed at fixing the problem by updating the return signatures of indexing getters.
