### PR TITLE
Fix local webdriver discovery via PATH

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -264,7 +264,7 @@ impl Driver {
                 Some(p) => p,
                 None => continue,
             };
-            return Ok(ctor(Locate::Local((path.into(), env_args(driver)))));
+            return Ok(ctor(Locate::Local((driver.into(), env_args(driver)))));
         }
 
         // TODO: download an appropriate driver? How to know which one to


### PR DESCRIPTION
Fixes the following bug (minor regression after eeebec07)

**Describe the Bug**

Local webdriver discovery via PATH is not working.

**Steps to Reproduce**

```
$ cd crates/web-sys
$ which geckodriver  # make sure geckodriver is installed and in PATH
/usr/local/bin/geckodriver
$ unset GECKODRIVER_REMOTE  # make sure not remotely using geckodriver via env vars
$ unset GECKODRIVER  # make sure not using geckodriver via env vars
$ cargo test --target wasm32-unknown-unknown --all-features
```

**Expected Behavior**

```
...
Running headless tests in Firefox on `http://127.0.0.1:55305/`
...
test result: ok. 56 passed; 0 failed; 0 ignored
```
**Actual Behavior**

*/usr/local/bin/geckodriver* is incorrectly resolved to *"/user/local/bin"*:
```
...
error: failed to spawn "/usr/local/bin" binary
	caused by: Permission denied (os error 13)
error: test failed, to rerun pass '--test wasm'
```
