### PR TITLE
Switch to Cargo's `-Zbuild-std` for building libstd

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,13 +211,11 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2019-08-27
+          toolchain: nightly-2019-09-26
       # Temporarily disable sccache because it is failing on CI.
       # - template: ci/azure-install-sccache.yml
       - script: rustup component add rust-src
         displayName: "install rust-src"
-      - script: cargo install xargo
-        displayName: "install xargo"
       - script: |
           set -e
           sed -i 's/python/#python/' examples/raytrace-parallel/build.sh

--- a/examples/raytrace-parallel/Xargo.toml
+++ b/examples/raytrace-parallel/Xargo.toml
@@ -1,2 +1,0 @@
-[dependencies.std]
-stage = 0


### PR DESCRIPTION
This commit switches away from `xargo` to using `-Zbuild-std` to
building the standard library for the raytrace-parallel example (which
needs to rebuild std with new target features).