### PR TITLE
Use official node releases for anyref test suite

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,11 +36,9 @@ jobs:
         displayName: "multi-value xform tests on native"
       - script: |
           set -e
-          curl https://nodejs.org/download/nightly/v13.0.0-nightly2019081215b2d13310/node-v13.0.0-nightly2019081215b2d13310-linux-x64.tar.xz | tar xJf -
-          echo "##vso[task.prependpath]$PWD/node-v13.0.0-nightly2019081215b2d13310-linux-x64/bin"
-          echo "##vso[task.setvariable variable=NODE_ARGS]--experimental-wasm-anyref,--experimental-wasm-bulk_memory"
+          echo "##vso[task.setvariable variable=NODE_ARGS]--experimental-wasm-anyref"
           echo "##vso[task.setvariable variable=WASM_BINDGEN_ANYREF]1"
-        displayName: "Install a custom node.js and configure anyref"
+        displayName: "Configure anyref passes"
       - script: cargo test --target wasm32-unknown-unknown --test wasm
         displayName: "(anyref) Crate test suite"
       - script: WASM_BINDGEN_NO_DEBUG=1 cargo test --target wasm32-unknown-unknown --test wasm

--- a/ci/azure-install-node.yml
+++ b/ci/azure-install-node.yml
@@ -3,4 +3,4 @@ steps:
     displayName: "Add WebAssembly target via rustup"
   - task: NodeTool@0
     inputs:
-      versionSpec: '>=12.0'
+      versionSpec: '>=12.11'


### PR DESCRIPTION
Looks like 12.11.0 has all the support we need!