### PR TITLE
Initialize imports on bind

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -289,9 +289,7 @@ impl<'a> Context<'a> {
                 for (id, js) in sorted_iter(&self.wasm_import_definitions) {
                     let import = self.module.imports.get_mut(*id);
                     import.module = format!("./{}.js", module_name);
-                    footer.push_str("\nexport const ");
-                    footer.push_str(&import.name);
-                    footer.push_str(" = ");
+                    footer.push_str("\nexport ");
                     footer.push_str(js.trim());
                     footer.push_str(";\n");
                 }
@@ -2074,7 +2072,7 @@ impl<'a> Context<'a> {
                     },
                 )?;
                 self.wasm_import_definitions
-                    .insert(id, format!("function{}", js));
+                    .insert(id, format!("function {} {}", &self.module.imports.get(id).name, js));
                 Ok(())
             }
         }


### PR DESCRIPTION
We use binaryen to compile wasm to js so our glue code after wasm-bindgen looks like so:

```
import * as wasm from './index_bg.wasm';

/**
* @param {string} data
* @returns {any}
*/
export function parseBasic(data) {
    const ret = wasm.parseBasic(passStringToWasm(data), WASM_VECTOR_LEN);
    return takeObject(ret);
}

export const __wbg_from_c2752402b9a4442b = function (arg0, arg1, arg2, arg3) {
    const v0 = getArrayU8FromWasm(arg0, arg1).slice();
    wasm.__wbindgen_free(arg0, arg1 * 1);
    const ret = Buffer.from(v0, getStringFromWasm(arg2, arg3));
    return addHeapObject(ret);
};
```

Here we are importing node's `Buffer` into wasm and the generated output uses `export const`. This is fine when we use native webassembly but when webassembly file is compiled to js with binaryen the import on top of the file suggests that it should start loading immediately not waiting for the `export const` function expression to execute so `export const __wbg_from_c2752402b9a4442b = undefined` while wasm js file is imported so function pointers are not initialised properly.

This PR proposes to:

Initialize import functions as soon as they are bound on module load to avoid issues for the cases where wasm imports want to use them and to enable proper behaviour when wasm is compiled to js.

It also looks more consistent with all export statements which use `export function` syntax.