### PR TITLE
Don't offset the number of rayon workers by 1

### DIFF
--- a/examples/raytrace-parallel/src/lib.rs
+++ b/examples/raytrace-parallel/src/lib.rs
@@ -60,7 +60,7 @@ impl Scene {
         // Configure a rayon thread pool which will pull web workers from
         // `pool`.
         let thread_pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(concurrency - 1)
+            .num_threads(concurrency)
             .spawn_handler(|thread| Ok(pool.run(|| thread.run()).unwrap()))
             .build()
             .unwrap();


### PR DESCRIPTION
If we pass rayon 0 workers it still spawns 1, so both 1 and 2 threads
were actually spawning one thread each. Let's remove the off-by-one so
1 and 2 cores should show a significant difference.