### PR TITLE
Update toolchain for raytrace example

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,7 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2019-09-26
+          toolchain: nightly-2019-10-04
       # Temporarily disable sccache because it is failing on CI.
       # - template: ci/azure-install-sccache.yml
       - script: rustup component add rust-src


### PR DESCRIPTION
Pulls in an LLVM tweak which emits far fewer `memory.copy`, drastrically
improving performance on Firefox!