### PR TITLE
Enable selectionStart and selectionEnd for HTMLInputElement

### DIFF
--- a/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
@@ -120,12 +120,10 @@ interface HTMLInputElement : HTMLElement {
 
   void select();
 
-/* TODO optional u32 not supported
   [Throws]
            attribute unsigned long? selectionStart;
   [Throws]
            attribute unsigned long? selectionEnd;
-*/
   [Throws]
            attribute DOMString? selectionDirection;
   [Throws]


### PR DESCRIPTION
The same case like https://github.com/rustwasm/wasm-bindgen/issues/1522, but for `HTMLInputElement`.