### PR TITLE
Improve worker.js reliability

### DIFF
--- a/examples/raytrace-parallel/worker.js
+++ b/examples/raytrace-parallel/worker.js
@@ -1,36 +1,25 @@
 // synchronously, using the browser, import out shim JS scripts
 importScripts('raytrace_parallel.js');
 
-let booted = false;
-let lastPtr = null;
-
 // Wait for the main thread to send us the shared module/memory. Once we've got
 // it, initialize it all with the `wasm_bindgen` global we imported via
 // `importScripts`.
 //
 // After our first message all subsequent messages are an entry point to run,
 // so we just do that.
-self.onmessage = function(args) {
-  self.onmessage = event => run(event.data);
-  const [module, memory] = args.data;
-  wasm_bindgen(module, memory)
-    .then(() => {
-      booted = true;
-      if (lastPtr)
-        run(lastPtr);
-    })
-    .catch(e => setTimeout(() => { throw e; })); // propagate to main `onerror`
-};
+self.onmessage = event => {
+  let initialised = wasm_bindgen(...event.data).catch(err => {
+    // Propagate to main `onerror`:
+    setTimeout(() => {
+      throw err;
+    });
+    // Rethrow to keep promise rejected and prevent execution of further commands:
+    throw err;
+  });
 
-function run(ptr) {
-  if (!booted) {
-    lastPtr = ptr;
-    return;
-  }
-  lastPtr = null;
-  try {
-    wasm_bindgen.child_entry_point(ptr);
-  } catch (e) {
-    throw new Error(e.message + "\n\n" + e.stack);
-  }
-}
+  self.onmessage = async event => {
+    // This will queue further commands up until the module is fully initialised:
+    await initialised;
+    wasm_bindgen.child_entry_point(event.data);
+  };
+};


### PR DESCRIPTION
While it doesn't happen right now in this particular example, `lastPtr` can be potentially overridden several times before the module is fully initialised.

Rather than having a boolean and a storage for one last argument, `await` a promise returned from `wasm_bindgen` itself in the new `onmessage` handler before executing actual command.

This way all the potential tasks will queue up naturally, wait for the initialisation, and then execute in a correct order.