### PR TITLE
re-enable UTF-8 BOM tests

### DIFF
--- a/tests/headless/strings.js
+++ b/tests/headless/strings.js
@@ -13,8 +13,7 @@ export function test_string_roundtrip(f) {
   test('a longer string');
   test('a longer 💖 string');
 
-  // TODO re-enable this when Firefox 70 is released
-  //test('\uFEFFbar');
+  test('\uFEFFbar');
 }
 
 export function identity(s) {

--- a/tests/headless/strings.rs
+++ b/tests/headless/strings.rs
@@ -12,6 +12,5 @@ extern "C" {
 fn string_roundtrip() {
     test_string_roundtrip(&Closure::wrap(Box::new(|s| s)));
 
-    // TODO re-enable this when Firefox 70 is released
-    //assert_eq!("\u{feff}bar", &identity("\u{feff}bar"));
+    assert_eq!("\u{feff}bar", &identity("\u{feff}bar"));
 }


### PR DESCRIPTION
~~Firefox 70 has been released.~~ I'm sorry, Firefox 70 will be released tomorrow, I was baited by the fact that [Arch already packaged it](https://www.archlinux.org/packages/extra/x86_64/firefox/)...