### PR TITLE
Update `webidl_ty` field in multi-value transform  

### DIFF
--- a/crates/cli-support/src/webidl/standard.rs
+++ b/crates/cli-support/src/webidl/standard.rs
@@ -54,22 +54,23 @@ pub fn add_multi_value(
     // Finally, unset `return_via_outptr`, fix up its incoming bindings'
     // argument numberings, and update its function type.
     for (id, binding) in &mut bindings.exports {
-        if binding.return_via_outptr.take().is_some() {
-            if binding.incoming.is_empty() {
-                bail!("missing incoming binding expression for return pointer parameter");
-            }
-            if !is_ret_ptr_bindings(binding.incoming.remove(0)) {
-                bail!("unexpected incoming binding expression for return pointer parameter");
-            }
-
-            fixup_binding_argument_gets(&mut binding.incoming)?;
-
-            let func = match module.exports.get(*id).item {
-                walrus::ExportItem::Function(f) => f,
-                _ => unreachable!(),
-            };
-            binding.wasm_ty = module.funcs.get(func).ty();
+        if binding.return_via_outptr.take().is_none() {
+            continue;
         }
+        if binding.incoming.is_empty() {
+            bail!("missing incoming binding expression for return pointer parameter");
+        }
+        if !is_ret_ptr_bindings(binding.incoming.remove(0)) {
+            bail!("unexpected incoming binding expression for return pointer parameter");
+        }
+
+        fixup_binding_argument_gets(&mut binding.incoming)?;
+
+        let func = match module.exports.get(*id).item {
+            walrus::ExportItem::Function(f) => f,
+            _ => unreachable!(),
+        };
+        binding.wasm_ty = module.funcs.get(func).ty();
     }
 
     Ok(())

--- a/crates/cli-support/src/webidl/standard.rs
+++ b/crates/cli-support/src/webidl/standard.rs
@@ -71,6 +71,15 @@ pub fn add_multi_value(
             _ => unreachable!(),
         };
         binding.wasm_ty = module.funcs.get(func).ty();
+
+        // Be sure to delete the out-param pointer from the WebIDL type as well.
+        let webidl_ty = bindings
+            .types
+            .get::<ast::WebidlFunction>(binding.webidl_ty)
+            .unwrap();
+        let mut new_ty = webidl_ty.clone();
+        new_ty.params.remove(0);
+        binding.webidl_ty = bindings.types.insert(new_ty);
     }
 
     Ok(())


### PR DESCRIPTION


When we're emitting a bindings section we need to be sure to update the
listed type of the binding in addition to the actual binding
expressions. This should help remove the stray return pointer being
listed there by accident!

