### PR TITLE
Add first-class support for binary crates

### DIFF
--- a/crates/cli-support/src/webidl/mod.rs
+++ b/crates/cli-support/src/webidl/mod.rs
@@ -645,7 +645,8 @@ impl<'a> Context<'a> {
             }
             let mut wrapper = walrus::FunctionBuilder::new(&mut self.module.types, &[], &[]);
             const NAME: &str = "__wasm_bindgen_autodiscoveredmain_wrapper";
-            wrapper.func_body()
+            wrapper
+                .func_body()
                 .i32_const(0)
                 .i32_const(0)
                 .call(main_id)
@@ -653,38 +654,31 @@ impl<'a> Context<'a> {
                 .return_();
             let wrapper = wrapper.finish(vec![], &mut self.module.funcs);
             let export = self.module.exports.add(NAME, wrapper);
-            self.function_exports.insert(NAME.to_string(), (export, wrapper));
+            self.function_exports
+                .insert(NAME.to_string(), (export, wrapper));
             let descriptor = Descriptor::Function(Box::new(Function {
                 arguments: vec![],
                 shim_idx: 0, // TODO is this bad
                 ret: Descriptor::Unit,
             }));
             self.descriptors.insert(NAME.to_string(), descriptor);
-            let program = decode::Program {
-                exports: vec![decode::Export {
-                    class: None,
-                    comments: vec![],
-                    consumed: false,
-                    function: decode::Function {
-                        arg_names: vec![],
-                        name: NAME,
-                    },
-                    method_kind: decode::MethodKind::Operation(decode::Operation {
-                        is_static: true,
-                        kind: decode::OperationKind::Regular,
-                    }),
-                    start: true,
-                }],
-                enums: vec![],
-                imports: vec![],
-                structs: vec![],
-                typescript_custom_sections: vec![],
-                local_modules: vec![],
-                inline_js: vec![],
-                unique_crate_identifier: NAME,
-                package_json: None,
+
+            let export = decode::Export {
+                class: None,
+                comments: vec![],
+                consumed: false,
+                function: decode::Function {
+                    arg_names: vec![],
+                    name: NAME,
+                },
+                method_kind: decode::MethodKind::Operation(decode::Operation {
+                    is_static: true,
+                    kind: decode::OperationKind::Regular,
+                }),
+                start: true,
             };
-            self.program(program)?;
+
+            self.export(export)?;
         }
 
         Ok(())

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -151,3 +151,49 @@ fn one_export_works() {
         .wasm_bindgen("");
     cmd.assert().success();
 }
+
+#[test]
+fn bin_crate_works() {
+    let (mut cmd, out_dir) = Project::new("bin_crate_works")
+        .file(
+            "src/main.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+                #[wasm_bindgen]
+                extern "C" {
+                    #[wasm_bindgen(js_namespace = console)]
+                    fn log(data: &str);
+                }
+
+                fn main() {
+                    log("hello, world");
+                }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            &format!(
+                "
+                    [package]
+                    name = \"bin_crate_works\"
+                    authors = []
+                    version = \"1.0.0\"
+                    edition = '2018'
+
+                    [dependencies]
+                    wasm-bindgen = {{ path = '{}' }}
+
+                    [workspace]
+                ",
+                repo_root().display(),
+            ),
+        )
+        .wasm_bindgen("--target nodejs");
+    cmd.assert().success();
+    Command::new("node")
+        .arg("bin_crate_works.js")
+        .current_dir(out_dir)
+        .assert()
+        .success()
+        .stdout("hello, world\n");
+}


### PR DESCRIPTION
fixes #1630 

Essentially, "if nothing was tagged `#[wasm_bindgen(start)]` and there is an exported `fn main(i32, i32) -> i32` then process it as though it were tagged that way."

open questions before i'm confident this implementation is ready:
- [ ] should it refuse to autodiscover a `main` that is already tagged for `wasm_bindgen` in some other way?
- [x] can the `shim_idx` field on the function descriptor be safely set to 0?
- [x] can the arg names be justifiably set to `argc` and `argv`?
- [x] should there be an automated test for this behavior somewhere? if so, how and where should that test be written?