### PR TITLE
Add an unsafe method view_mut_raw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn.lock
 *.d.ts
 /publish
 /publish.exe
+.vscode

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4792,6 +4792,21 @@ macro_rules! arrays {
                 )
             }
 
+            /// Creates a JS typed array which is a view into wasm's linear
+            /// memory at the slice specified.
+            ///
+            /// This function returns a new typed array which is a view into
+            /// wasm's memory. This view does not copy the underlying data.
+            ///
+            /// # Unsafety
+            ///
+            /// Views into WebAssembly memory are only valid so long as the
+            /// backing buffer isn't resized in JS. Once this function is called
+            /// any future calls to `Box::new` (or malloc of any form) may cause
+            /// the returned value here to be invalidated. Use with caution!
+            ///
+            /// Additionally the returned object can be safely mutated,
+            /// the changes are guranteed to be reflected in the input array.
             pub unsafe fn view_mut_raw(ptr: *mut $ty, length: usize) -> $name {
                 let buf = wasm_bindgen::memory();
                 let mem = buf.unchecked_ref::<WebAssembly::Memory>();

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4793,7 +4793,7 @@ macro_rules! arrays {
             }
 
             /// Creates a JS typed array which is a view into wasm's linear
-            /// memory at the slice specified.
+            /// memory at the specified pointer with specified length.
             ///
             /// This function returns a new typed array which is a view into
             /// wasm's memory. This view does not copy the underlying data.

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4792,6 +4792,16 @@ macro_rules! arrays {
                 )
             }
 
+            pub unsafe fn view_mut_raw(ptr: *mut $ty, length: usize) -> $name {
+                let buf = wasm_bindgen::memory();
+                let mem = buf.unchecked_ref::<WebAssembly::Memory>();
+                $name::new_with_byte_offset_and_length(
+                    &mem.buffer(),
+                    ptr as u32,
+                    length as u32
+                )
+            }
+
             fn raw_copy_to(&self, dst: &mut [$ty]) {
                 let buf = wasm_bindgen::memory();
                 let mem = buf.unchecked_ref::<WebAssembly::Memory>();

--- a/crates/js-sys/tests/wasm/Array.js
+++ b/crates/js-sys/tests/wasm/Array.js
@@ -1,0 +1,6 @@
+// Used for `Array.rs` tests
+exports.populate_array =  function(arr, len) {
+  for (i = 0; i < len; i++) {
+    arr[i] = i;
+  }
+};

--- a/crates/js-sys/tests/wasm/Array.js
+++ b/crates/js-sys/tests/wasm/Array.js
@@ -1,6 +1,6 @@
 // Used for `Array.rs` tests
-exports.populate_array =  function(arr, len) {
+exports.populate_array =  function(arr, start, len) {
   for (i = 0; i < len; i++) {
-    arr[i] = i;
+    arr[i] = start + i;
   }
 };

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -1,5 +1,6 @@
 use js_sys::*;
 use std::iter::FromIterator;
+use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
@@ -467,7 +468,21 @@ fn array_inheritance() {
     let _: &Object = array.as_ref();
 }
 
+#[wasm_bindgen(module = "tests/wasm/Array.js")]
+extern "C" {
+    fn populate_array(arr: JsValue, len: JsValue) -> JsValue;
+}
+
 #[wasm_bindgen_test]
 fn uint8_view_mut_raw() {
-    assert!(1 == 2);
+    let len: usize = 32;
+    let mut buffer: Vec<u8> = Vec::new();
+    buffer.reserve(len);
+    unsafe {
+        let array = js_sys::Uint8Array::view_mut_raw(buffer.as_mut_ptr(), len);
+        populate_array(JsValue::from(array), JsValue::from(len as u32));
+        buffer.set_len(len);
+    }
+    let expected: Vec<u8> = (0..(len as u8)).collect();
+    assert_eq!(buffer, expected)
 }

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -474,7 +474,7 @@ extern "C" {
 }
 
 #[wasm_bindgen_test]
-fn uint8array_view_mut_raw() {
+fn Uint8Array_view_mut_raw_no_macro() {
     let start: u8 = 10;
     let len: usize = 32;
     let end: u8 = start + len as u8;
@@ -493,22 +493,78 @@ fn uint8array_view_mut_raw() {
     assert_eq!(buffer, expected)
 }
 
+macro_rules! test_view_mut_raw {
+    ($($name:ident $ty:ident)?) => ($(
+        let start: $ty = 10 as $ty;
+        let len: usize = 32;
+        let end: $ty = start + len as $ty;
+        let mut buffer: Vec<$ty> = Vec::new();
+        buffer.reserve(len);
+        unsafe {
+            let array = js_sys::$name::view_mut_raw(buffer.as_mut_ptr(), len);
+            populate_array(
+                JsValue::from(array),
+                JsValue::from(start),
+                JsValue::from(len as u32),
+            );
+            buffer.set_len(len);
+        }
+        let expected: Vec<$ty> = (start..end).collect();
+        assert_eq!(buffer, expected)
+    )?);
+}
+
 #[wasm_bindgen_test]
-fn uint32array_view_mut_raw() {
-    let start: u32 = 10;
+fn Int8Array_view_mut_raw() {
+    test_view_mut_raw! { Int8Array i8 }
+}
+
+#[wasm_bindgen_test]
+fn Int16Array_view_mut_raw() {
+    test_view_mut_raw! { Int16Array i16 }
+}
+
+#[wasm_bindgen_test]
+fn Int32Array_view_mut_raw() {
+    test_view_mut_raw! { Int32Array i32 }
+}
+
+#[wasm_bindgen_test]
+fn Uint8Array_view_mut_raw() {
+    test_view_mut_raw! { Uint8Array u8 }
+}
+
+#[wasm_bindgen_test]
+fn Uint8ClampedArray_view_mut_raw() {
+    test_view_mut_raw! { Uint8ClampedArray u8 }
+}
+
+#[wasm_bindgen_test]
+fn Uint16Array_view_mut_raw() {
+    test_view_mut_raw! { Uint16Array u16 }
+}
+
+#[wasm_bindgen_test]
+fn Uint32Array_view_mut_raw() {
+    test_view_mut_raw! { Uint32Array u32 }
+}
+
+#[wasm_bindgen_test]
+fn Float64Array_view_mut_raw() {
+    let start: u8 = 10;
     let len: usize = 32;
-    let end: u32 = start + len as u32;
-    let mut buffer: Vec<u32> = Vec::new();
+    let end: u8 = start + len as u8;
+    let mut buffer: Vec<f64> = Vec::new();
     buffer.reserve(len);
     unsafe {
-        let array = js_sys::Uint32Array::view_mut_raw(buffer.as_mut_ptr(), len);
+        let array = js_sys::Float64Array::view_mut_raw(buffer.as_mut_ptr(), len);
         populate_array(
             JsValue::from(array),
-            JsValue::from(start),
+            JsValue::from(f64::from(start)),
             JsValue::from(len as u32),
         );
         buffer.set_len(len);
     }
-    let expected: Vec<u32> = (start..end).collect();
+    let expected: Vec<f64> = (start..end).map(f64::from).collect();
     assert_eq!(buffer, expected)
 }

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -470,19 +470,45 @@ fn array_inheritance() {
 
 #[wasm_bindgen(module = "tests/wasm/Array.js")]
 extern "C" {
-    fn populate_array(arr: JsValue, len: JsValue) -> JsValue;
+    fn populate_array(arr: JsValue, start: JsValue, len: JsValue) -> JsValue;
 }
 
 #[wasm_bindgen_test]
-fn uint8_view_mut_raw() {
+fn uint8array_view_mut_raw() {
+    let start: u8 = 10;
     let len: usize = 32;
+    let end: u8 = start + len as u8;
     let mut buffer: Vec<u8> = Vec::new();
     buffer.reserve(len);
     unsafe {
         let array = js_sys::Uint8Array::view_mut_raw(buffer.as_mut_ptr(), len);
-        populate_array(JsValue::from(array), JsValue::from(len as u32));
+        populate_array(
+            JsValue::from(array),
+            JsValue::from(start),
+            JsValue::from(len as u32),
+        );
         buffer.set_len(len);
     }
-    let expected: Vec<u8> = (0..(len as u8)).collect();
+    let expected: Vec<u8> = (start..end).collect();
+    assert_eq!(buffer, expected)
+}
+
+#[wasm_bindgen_test]
+fn uint32array_view_mut_raw() {
+    let start: u32 = 10;
+    let len: usize = 32;
+    let end: u32 = start + len as u32;
+    let mut buffer: Vec<u32> = Vec::new();
+    buffer.reserve(len);
+    unsafe {
+        let array = js_sys::Uint32Array::view_mut_raw(buffer.as_mut_ptr(), len);
+        populate_array(
+            JsValue::from(array),
+            JsValue::from(start),
+            JsValue::from(len as u32),
+        );
+        buffer.set_len(len);
+    }
+    let expected: Vec<u32> = (start..end).collect();
     assert_eq!(buffer, expected)
 }

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -466,3 +466,8 @@ fn array_inheritance() {
     assert!(array.is_instance_of::<Object>());
     let _: &Object = array.as_ref();
 }
+
+#[wasm_bindgen_test]
+fn uint8_view_mut_raw() {
+    assert!(1 == 2);
+}


### PR DESCRIPTION
See #1643
### TODO:
- [x] add `Uint8Array::view_mut_raw` test
- [x] add `Int16Array::view_mut_raw` test
- [x] add `Uint32Array::view_mut_raw` test
- [x] add `Float64Array::view_mut_raw` test