### PR TITLE
Update mod.rs

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -950,7 +950,7 @@ impl<'a> Context<'a> {
             debug,
             encode_as_ascii,
             if self.config.debug {
-                "if (ret.read != arg.length) throw new Error('failed to pass whole string');"
+                "if (ret.read !== arg.length) throw new Error('failed to pass whole string');"
             } else {
                 ""
             },


### PR DESCRIPTION
Using Typescript I have this warning:
`./pkg/index.js
  Line 52:22:  Expected '!==' and instead saw '!='  eqeqeq

Search for the keywords to learn more about each warning.
To ignore, add // eslint-disable-next-line to the line before.
`

I guess this should solve the warning.

Thank you for all the work.