### PR TITLE
Simplify macro for arrays

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4657,7 +4657,7 @@ pub fn global() -> Object {
 }
 
 macro_rules! arrays {
-    ($(#[doc = $ctor:literal] #[doc = $mdn:literal] $name:ident: $ty:ident => $zero:literal,)*) => ($(
+    ($(#[doc = $ctor:literal] #[doc = $mdn:literal] $name:ident: $ty:ident,)*) => ($(
         #[wasm_bindgen]
         extern "C" {
             #[wasm_bindgen(extends = Object)]
@@ -4843,7 +4843,7 @@ macro_rules! arrays {
 
             /// Efficiently copies the contents of this JS typed array into a new Vec.
             pub fn to_vec(&self) -> Vec<$ty> {
-                let mut output = vec![$zero; self.length() as usize];
+                let mut output = vec![$ty::default(); self.length() as usize];
                 self.raw_copy_to(&mut output);
                 output
             }
@@ -4862,37 +4862,37 @@ macro_rules! arrays {
 arrays! {
     /// `Int8Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int8Array
-    Int8Array: i8 => 0,
+    Int8Array: i8,
 
     /// `Int16Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int16Array
-    Int16Array: i16 => 0,
+    Int16Array: i16,
 
     /// `Int32Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Int32Array
-    Int32Array: i32 => 0,
+    Int32Array: i32,
 
     /// `Uint8Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array
-    Uint8Array: u8 => 0,
+    Uint8Array: u8,
 
     /// `Uint8ClampedArray()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray
-    Uint8ClampedArray: u8 => 0,
+    Uint8ClampedArray: u8,
 
     /// `Uint16Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array
-    Uint16Array: u16 => 0,
+    Uint16Array: u16,
 
     /// `Uint32Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array
-    Uint32Array: u32 => 0,
+    Uint32Array: u32,
 
     /// `Float32Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array
-    Float32Array: f32 => 0.0,
+    Float32Array: f32,
 
     /// `Float64Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float64Array
-    Float64Array: f64 => 0.0,
+    Float64Array: f64,
 }

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -5,7 +5,7 @@ use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
 fn parse_array() {
-    let js_array = JSON::parse("[1, 2, 3]").unwrap();;
+    let js_array = JSON::parse("[1, 2, 3]").unwrap();
     assert!(Array::is_array(&js_array));
 
     let array = Array::from(&js_array);


### PR DESCRIPTION
I think we can benefit from `$ty::default()` here