### PR TITLE
Fix typo: point master branch documention link to web_sys instead of js_sys

### DIFF
--- a/guide/src/contributing/web-sys/index.md
+++ b/guide/src/contributing/web-sys/index.md
@@ -14,4 +14,4 @@ Documentation for the published version of this crate is available on
 documentation][masterdoc] for the crate.
 
 [docsrs]: https://docs.rs/web-sys
-[masterdoc]: https://rustwasm.github.io/wasm-bindgen/api/js_sys/
+[masterdoc]: https://rustwasm.github.io/wasm-bindgen/api/web_sys/


### PR DESCRIPTION
The web_sys master branch documentation link was pointing to js_sys 🙂 