### PR TITLE
Support multi-value JS engines

### DIFF
--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -85,7 +85,7 @@ pub fn typescript(module: &Module) -> Result<String, Error> {
             ret = match ty.results().len() {
                 0 => "void",
                 1 => "number",
-                _ => bail!("cannot support multi-return yet"),
+                _ => "Array",
             },
         ));
     }


### PR DESCRIPTION
This commit adds support to wasm-bindgen to run over interface
types-enabled modules that use multi-value returns and returns are
loaded from the returned array rather than from memory.