### PR TITLE
Add one more webkit-specific whitelist in web-sys 

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -465,10 +465,12 @@ impl<'a> Context<'a> {
         };
 
         let default_module_path = match self.config.mode {
-            OutputMode::Web => "\
+            OutputMode::Web => {
+                "\
                     if (typeof module === 'undefined') {
                         module = import.meta.url.replace(/\\.js$/, '_bg.wasm');
-                    }",
+                    }"
+            }
             _ => "",
         };
 

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -206,7 +206,7 @@ fn empty_interface_types() {
             r#"
                 #[no_mangle]
                 pub extern fn foo() {}
-            "#
+            "#,
         )
         .file(
             "Cargo.toml",

--- a/crates/futures/src/task/multithread.rs
+++ b/crates/futures/src/task/multithread.rs
@@ -130,7 +130,7 @@ impl Task {
             // resources associated with the future ASAP.
             Poll::Ready(()) => {
                 *borrow = None;
-            },
+            }
 
             // Unlike `singlethread.rs` we are responsible for ensuring there's
             // a closure to handle the notification that a Future is ready. In

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -568,7 +568,7 @@ impl<'src> FirstPassRecord<'src> {
 
         // whitelist a few names that have known polyfills
         match name {
-            "AudioContext" => {
+            "AudioContext" | "OfflineAudioContext" => {
                 import_type
                     .vendor_prefixes
                     .push(Ident::new("webkit", Span::call_site()));


### PR DESCRIPTION
Adds `OfflineAudioContext` to the list of types that may have the `webkit` prefix, as [mentioned here](https://github.com/rustwasm/wasm-bindgen/issues/897#issuecomment-555481621)