### PR TITLE
Pin the toolchain to nightly to fix build

### DIFF
--- a/examples/raytrace-parallel/rust-toolchain
+++ b/examples/raytrace-parallel/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This PR pins the toolchain to nightly for the `raytrace-parallel` example. Running `build.sh` fails otherwise since it uses compiler options only available on nightly.