### PR TITLE
Update .gitignore to ignore cargo-timing*.html

### DIFF
--- a/examples/raytrace-parallel/.gitignore
+++ b/examples/raytrace-parallel/.gitignore
@@ -1,2 +1,3 @@
+cargo-timing*.html
 raytrace_parallel.js
 raytrace_parallel_bg.wasm


### PR DESCRIPTION
This PR updates the `.gitignore` to ignore the `cargo-timing*.html` files that are generated after building and running the example.