### PR TITLE
Update alert message regarding Firefox version

### DIFF
--- a/examples/raytrace-parallel/index.js
+++ b/examples/raytrace-parallel/index.js
@@ -12,7 +12,7 @@ concurrency.disabled = true;
 
 // First up, but try to do feature detection to provide better error messages
 function loadWasm() {
-  let msg = 'This demo currently requires Firefox Nightly (64.0) with\n'
+  let msg = 'This demo requires a current version of Firefox (e.g., 70.0) with\n'
   msg += 'the `javascript.options.shared_memory` option enabled in `about:config`';
   if (typeof SharedArrayBuffer !== 'function') {
     alert('this browser does not have SharedArrayBuffer support enabled' + '\n\n' + msg);


### PR DESCRIPTION
This PR updates the alert message regarding the required Firefox version for running the demo. As far as I can tell, the demo doesn't actually work with the current Firefox nightly. It does work with the current stable release though.

(It seems like it should also work with Chrome since I think the required features are supported there now too [but also must be enabled]. However, when I tried with Chrome it didn't work; just gets stuck at "loading wasm" on the button or something.)