### PR TITLE
Support outputting wasm as inline base64

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -573,7 +573,6 @@ impl<'a> Context<'a> {
                 function init(module{init_memory_arg}) {{
                     {default_module_path}
                     let result;
-                    const imports = {{}};
                     {imports_init}
                     if ((typeof URL === 'function' && module instanceof URL) || typeof module === 'string' || (typeof Request === 'function' && module instanceof Request)) {{
                         {init_memory2}

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -57,7 +57,7 @@ pub struct Output {
 
 #[derive(Clone)]
 enum OutputMode {
-    Bundler { browser_only: bool },
+    Bundler { browser_only: bool, inline: bool },
     Web,
     NoModules { global: String },
     Node { experimental_modules: bool },
@@ -85,6 +85,7 @@ impl Bindgen {
             out_name: None,
             mode: OutputMode::Bundler {
                 browser_only: false,
+                inline: false,
             },
             debug: false,
             typescript: false,
@@ -154,10 +155,21 @@ impl Bindgen {
         Ok(self)
     }
 
+    pub fn inline(&mut self, inline: bool) -> Result<&mut Bindgen, Error> {
+        if inline {
+            match &mut self.mode {
+                OutputMode::Bundler { inline, .. } => *inline = true,
+                _ => bail!("cannot specify `--inline` with other output types"),
+            }
+        }
+        Ok(self)
+    }
+
     pub fn bundler(&mut self, bundler: bool) -> Result<&mut Bindgen, Error> {
         if bundler {
             self.switch_mode(
                 OutputMode::Bundler {
+                    inline: false,
                     browser_only: false,
                 },
                 "--target bundler",
@@ -188,7 +200,7 @@ impl Bindgen {
     pub fn browser(&mut self, browser: bool) -> Result<&mut Bindgen, Error> {
         if browser {
             match &mut self.mode {
-                OutputMode::Bundler { browser_only } => *browser_only = true,
+                OutputMode::Bundler { browser_only, .. } => *browser_only = true,
                 _ => bail!("cannot specify `--browser` with other output types"),
             }
         }
@@ -517,7 +529,7 @@ impl OutputMode {
         match self {
             OutputMode::Web => true,
             OutputMode::NoModules { .. } => true,
-            OutputMode::Bundler { browser_only } => *browser_only,
+            OutputMode::Bundler { browser_only, .. } => *browser_only,
             _ => false,
         }
     }


### PR DESCRIPTION
It's difficult to use `wasm-bindgen` in libraries meant to be consumed across a variety of bundler setups.

Given an application using `pkg-a -> pkg-wasm`, you'd need to ship separate builds for both `pkg-wasm` and `pkg-a`. This will be fixed when `.wasm` imports become mainstream.

In the meantime, this PR adds support for an `inline` option that outputs the wasm as Base64, in the JS file.

This alleviates the need for separate builds, at the cost of a slightly larger bundle / no async streaming compiler.


<details>
<summary>Expected JS output</summary>

```js
const wasm = (() => {
    const imports = {};
    imports.wbg = {};
    imports.wbg._abc = ...

    const raw = atob('...')
    const rawLength = raw.length
    const buf = new Uint8Array(new ArrayBuffer(rawLength))
    for(var i = 0; i < rawLength; i++) {
    buf[i] = raw.charCodeAt(i)
    }

    const mod = new WebAssembly.Module(buf)
    return new WebAssembly.Instance(mod, imports).exports
})()

export function greet() {
    wasm.greet();
}

let cachedTextDecoder = new TextDecoder('utf-8', { ignoreBOM: true, fatal: true });

cachedTextDecoder.decode();

let cachegetUint8Memory = null;
function getUint8Memory() {
    if (cachegetUint8Memory === null || cachegetUint8Memory.buffer !== wasm.memory.buffer) {
        cachegetUint8Memory = new Uint8Array(wasm.memory.buffer);
    }
    return cachegetUint8Memory;
}

function getStringFromWasm(ptr, len) {
    return cachedTextDecoder.decode(getUint8Memory().subarray(ptr, ptr + len));
}
```

</details>