### PR TITLE
Remove reliance on `wat2wasm` in interpreter tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,8 @@ jobs:
         displayName: "wasm-bindgen-anyref-xform tests"
       - script: cargo test -p wasm-bindgen-multi-value-xform
         displayName: "wasm-bindgen-multi-value-xform tests"
+      - script: cargo test -p wasm-bindgen-wasm-interpreter
+        displayName: "wasm-bindgen-wasm-interpreter tests"
 
   - job: test_web_sys
     displayName: "Run web-sys crate tests"
@@ -157,23 +159,6 @@ jobs:
       # Temporarily disable sccache because it is failing on CI.
       # - template: ci/azure-install-sccache.yml
       - script: cargo test -p wasm-bindgen-macro
-
-  - job: test_wasm_interpreter
-    displayName: "Run wasm-bindgen-wasm-interpreter tests"
-    steps:
-      - template: ci/azure-install-rust.yml
-      # Temporarily disable sccache because it is failing on CI.
-      # - template: ci/azure-install-sccache.yml
-      - script: |
-          git clone https://github.com/WebAssembly/wabt
-          mkdir -p wabt/build
-          cd wabt/build
-          # Temporarily disable sccache because it is failing on CI.
-          # cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=off -DCMAKE_CXX_COMPILER_LAUNCHER=$RUSTC_WRAPPER
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=off
-          cmake --build . -- -j$(nproc)
-          echo "##vso[task.prependpath]$PWD"
-      - script: cargo test -p wasm-bindgen-wasm-interpreter
 
   - job: test_typescript_output
     displayName: "Test TypeScript output of wasm-bindgen"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -18,3 +18,4 @@ walrus = "0.14.0"
 
 [dev-dependencies]
 tempfile = "3"
+wat = "1.0"

--- a/crates/wasm-interpreter/tests/smoke.rs
+++ b/crates/wasm-interpreter/tests/smoke.rs
@@ -1,21 +1,8 @@
-use std::fs;
-use std::process::Command;
-
 use wasm_bindgen_wasm_interpreter::Interpreter;
 
 fn interpret(wat: &str, name: &str, result: Option<&[u32]>) {
-    let input = tempfile::NamedTempFile::new().unwrap();
-    let output = tempfile::NamedTempFile::new().unwrap();
-    fs::write(input.path(), wat).unwrap();
-    let status = Command::new("wat2wasm")
-        .arg(input.path())
-        .arg("-o")
-        .arg(output.path())
-        .status()
-        .unwrap();
-    println!("status: {}", status);
-    assert!(status.success());
-    let module = walrus::Module::from_file(output.path()).unwrap();
+    let wasm = wat::parse_str(wat).unwrap();
+    let module = walrus::Module::from_buffer(&wasm).unwrap();
     let mut i = Interpreter::new(&module).unwrap();
     let id = module
         .exports


### PR DESCRIPTION
Move usage to the `wat` crate instead.