### PR TITLE
Changing wasm-in-wasm example to be async

### DIFF
--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2.55"
 js-sys = "0.3.32"
+wasm-bindgen-futures = "0.4.5"


### PR DESCRIPTION
This has three big benefits:

1. It removes an `unsafe` usage.

2. It uses the idiomatic async APIs rather than the soft deprecated sync APIs.

2. The old code would error with a `.wasm` module which is bigger than 4KB. But the new code works no matter how big the `.wasm` file is.