### PR TITLE
Adding in async support for start

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -452,11 +452,7 @@ impl TryToTokens for ast::Export {
                     quote! { () },
                     quote! {
                         wasm_bindgen_futures::spawn_local(async move {
-                            let val = <#syn_ret as wasm_bindgen::__rt::StartReturn>::into_null_result(#ret.await);
-
-                            if let std::result::Result::Err(val) = val {
-                                wasm_bindgen::throw_val(val);
-                            }
+                            <#syn_ret as wasm_bindgen::__rt::Start>::start(#ret.await);
                         })
                     },
                 )
@@ -474,8 +470,8 @@ impl TryToTokens for ast::Export {
 
         } else if self.start {
             (
-                quote! { std::result::Result<(), wasm_bindgen::JsValue> },
-                quote! { <#syn_ret as wasm_bindgen::__rt::StartReturn>::into_null_result(#ret) },
+                quote! { () },
+                quote! { <#syn_ret as wasm_bindgen::__rt::Start>::start(#ret) },
             )
 
         } else {

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -447,17 +447,41 @@ impl TryToTokens for ast::Export {
         // since we're returning a promise to JS, and this will implicitly
         // require that the function returns a `Future<Output = Result<...>>`
         let (ret_ty, ret_expr) = if self.function.r#async {
+            if self.start {
+                (
+                    quote! { () },
+                    quote! {
+                        wasm_bindgen_futures::spawn_local(async move {
+                            let val = <#syn_ret as wasm_bindgen::__rt::StartReturn>::into_null_result(#ret.await);
+
+                            if let std::result::Result::Err(val) = val {
+                                wasm_bindgen::throw_val(val);
+                            }
+                        })
+                    },
+                )
+
+            } else {
+                (
+                    quote! { wasm_bindgen::JsValue },
+                    quote! {
+                        wasm_bindgen_futures::future_to_promise(async move {
+                            <#syn_ret as wasm_bindgen::__rt::IntoJsResult>::into_js_result(#ret.await)
+                        }).into()
+                    },
+                )
+            }
+
+        } else if self.start {
             (
-                quote! { wasm_bindgen::JsValue },
-                quote! {
-                    wasm_bindgen_futures::future_to_promise(async {
-                        wasm_bindgen::__rt::IntoJsResult::into_js_result(#ret.await)
-                    }).into()
-                },
+                quote! { std::result::Result<(), wasm_bindgen::JsValue> },
+                quote! { <#syn_ret as wasm_bindgen::__rt::StartReturn>::into_null_result(#ret) },
             )
+
         } else {
             (quote! { #syn_ret }, quote! { #ret })
         };
+
         let projection = quote! { <#ret_ty as wasm_bindgen::convert::ReturnWasmAbi> };
         let convert_ret = quote! { #projection::return_abi(#ret_expr) };
         let describe_ret = quote! {

--- a/crates/macro/ui-tests/start-function.rs
+++ b/crates/macro/ui-tests/start-function.rs
@@ -9,4 +9,22 @@ pub fn foo2(x: u32) {}
 #[wasm_bindgen(start)]
 pub fn foo3<T>() {}
 
+#[wasm_bindgen(start)]
+pub fn foo4() -> Result<(), JsValue> { Ok(()) }
+
+#[wasm_bindgen(start)]
+pub fn foo5() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+
+#[wasm_bindgen(start)]
+pub async fn foo_async1() {}
+
+#[wasm_bindgen(start)]
+pub async fn foo_async2() -> Result<(), JsValue> { Ok(()) }
+
+#[wasm_bindgen(start)]
+pub async fn foo_async3() -> Result<JsValue, ()> { Err(()) }
+
+#[wasm_bindgen(start)]
+pub async fn foo_async4() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+
 fn main() {}

--- a/crates/macro/ui-tests/start-function.rs
+++ b/crates/macro/ui-tests/start-function.rs
@@ -13,7 +13,10 @@ pub fn foo3<T>() {}
 pub fn foo4() -> Result<(), JsValue> { Ok(()) }
 
 #[wasm_bindgen(start)]
-pub fn foo5() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+pub fn foo5() -> Result<JsValue, ()> { Err(()) }
+
+#[wasm_bindgen(start)]
+pub fn foo6() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
 
 #[wasm_bindgen(start)]
 pub async fn foo_async1() {}

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -11,9 +11,9 @@ error: the start function cannot have generics
    |            ^^^
 
 error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::StartReturn` is not satisfied
-  --> $DIR/start-function.rs:24:1
+  --> $DIR/start-function.rs:27:1
    |
-24 | #[wasm_bindgen(start)]
+27 | #[wasm_bindgen(start)]
    | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::StartReturn` is not implemented for `std::result::Result<wasm_bindgen::JsValue, ()>`
    |
    = help: the following implementations were found:
@@ -21,9 +21,9 @@ error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, ()>: w
    = note: required by `wasm_bindgen::__rt::StartReturn::into_null_result`
 
 error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::StartReturn` is not satisfied
-  --> $DIR/start-function.rs:27:1
+  --> $DIR/start-function.rs:30:1
    |
-27 | #[wasm_bindgen(start)]
+30 | #[wasm_bindgen(start)]
    | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::StartReturn` is not implemented for `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
    |
    = help: the following implementations were found:

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -10,22 +10,22 @@ error: the start function cannot have generics
 10 | pub fn foo3<T>() {}
    |            ^^^
 
-error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::StartReturn` is not satisfied
+error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
   --> $DIR/start-function.rs:27:1
    |
 27 | #[wasm_bindgen(start)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::StartReturn` is not implemented for `std::result::Result<wasm_bindgen::JsValue, ()>`
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `std::result::Result<wasm_bindgen::JsValue, ()>`
    |
    = help: the following implementations were found:
-             <std::result::Result<(), E> as wasm_bindgen::__rt::StartReturn>
-   = note: required by `wasm_bindgen::__rt::StartReturn::into_null_result`
+             <std::result::Result<(), E> as wasm_bindgen::__rt::Start>
+   = note: required by `wasm_bindgen::__rt::Start::start`
 
-error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::StartReturn` is not satisfied
+error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
   --> $DIR/start-function.rs:30:1
    |
 30 | #[wasm_bindgen(start)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::StartReturn` is not implemented for `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
    |
    = help: the following implementations were found:
-             <std::result::Result<(), E> as wasm_bindgen::__rt::StartReturn>
-   = note: required by `wasm_bindgen::__rt::StartReturn::into_null_result`
+             <std::result::Result<(), E> as wasm_bindgen::__rt::Start>
+   = note: required by `wasm_bindgen::__rt::Start::start`

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -9,3 +9,23 @@ error: the start function cannot have generics
    |
 10 | pub fn foo3<T>() {}
    |            ^^^
+
+error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::StartReturn` is not satisfied
+  --> $DIR/start-function.rs:24:1
+   |
+24 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::StartReturn` is not implemented for `std::result::Result<wasm_bindgen::JsValue, ()>`
+   |
+   = help: the following implementations were found:
+             <std::result::Result<(), E> as wasm_bindgen::__rt::StartReturn>
+   = note: required by `wasm_bindgen::__rt::StartReturn::into_null_result`
+
+error[E0277]: the trait bound `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::StartReturn` is not satisfied
+  --> $DIR/start-function.rs:27:1
+   |
+27 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::StartReturn` is not implemented for `std::result::Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+   |
+   = help: the following implementations were found:
+             <std::result::Result<(), E> as wasm_bindgen::__rt::StartReturn>
+   = note: required by `wasm_bindgen::__rt::StartReturn::into_null_result`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1116,6 +1116,28 @@ pub mod __rt {
             }
         }
     }
+
+
+    /// An internal helper trait for usage in `#[wasm_bindgen(start)]`
+    /// functions to convert the return value of the function to
+    /// `Result<(), JsValue>` which is what we'll return to JS.
+    pub trait StartReturn {
+        fn into_null_result(self) -> Result<(), JsValue>;
+    }
+
+    impl StartReturn for () {
+        #[inline]
+        fn into_null_result(self) -> Result<(), JsValue> {
+            Ok(self)
+        }
+    }
+
+    impl<E: Into<JsValue>> StartReturn for Result<(), E> {
+        #[inline]
+        fn into_null_result(self) -> Result<(), JsValue> {
+            self.map_err(|e| e.into())
+        }
+    }
 }
 
 /// A wrapper type around slices and vectors for binding the `Uint8ClampedArray`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1119,23 +1119,22 @@ pub mod __rt {
 
 
     /// An internal helper trait for usage in `#[wasm_bindgen(start)]`
-    /// functions to convert the return value of the function to
-    /// `Result<(), JsValue>` which is what we'll return to JS.
-    pub trait StartReturn {
-        fn into_null_result(self) -> Result<(), JsValue>;
+    /// functions to throw the error (if it is `Err`).
+    pub trait Start {
+        fn start(self);
     }
 
-    impl StartReturn for () {
+    impl Start for () {
         #[inline]
-        fn into_null_result(self) -> Result<(), JsValue> {
-            Ok(self)
-        }
+        fn start(self) {}
     }
 
-    impl<E: Into<JsValue>> StartReturn for Result<(), E> {
+    impl<E: Into<JsValue>> Start for Result<(), E> {
         #[inline]
-        fn into_null_result(self) -> Result<(), JsValue> {
-            self.map_err(|e| e.into())
+        fn start(self) {
+            if let Err(e) = self {
+                crate::throw_val(e.into());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1904

One issue with this PR is that the `start-function` UI test is *supposed* to error for `foo5`/`foo6` (like how it does for `foo_async3`/`foo_async4`) but it doesn't error. I tried for several hours, but I couldn't figure out why.