### PR TITLE
Disable eslint in auto-generated type definition files

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -84,7 +84,7 @@ impl<'a> Context<'a> {
         Ok(Context {
             globals: String::new(),
             imports_post: String::new(),
-            typescript: "/* tslint:disable */\n".to_string(),
+            typescript: "/* tslint:disable */\n/* eslint-disable */\n".to_string(),
             exposed_globals: Some(Default::default()),
             imported_names: Default::default(),
             js_imports: Default::default(),

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -45,7 +45,7 @@ impl Config {
 }
 
 pub fn typescript(module: &Module) -> Result<String, Error> {
-    let mut exports = format!("/* tslint:disable */\n");
+    let mut exports = format!("/* tslint:disable */\n/* eslint-disable */\n");
 
     for entry in module.exports.iter() {
         let id = match entry.item {


### PR DESCRIPTION
By default [tslint](https://github.com/palantir/tslint) is disabled in auto-generated type definition files by `/* tslint:disable */`.

However, recently main stream of linter for TypeScript moved to [eslint](https://eslint.org/) in favor of [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint) ecosystem.

This PR adds  [`/* eslint-disable */`](https://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments) magic comment to top of auto-generated type definition files for disabling eslint as well as tslint.