### PR TITLE
Adding in Array::iter and Array::to_vec

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -428,8 +428,7 @@ extern "C" {
 /// Iterator returned by `Array::iter`
 #[derive(Debug, Clone)]
 pub struct ArrayIter<'a> {
-    start: u32,
-    end: u32,
+    range: std::ops::Range<u32>,
     array: &'a Array,
 }
 
@@ -437,33 +436,20 @@ impl<'a> std::iter::Iterator for ArrayIter<'a> {
     type Item = JsValue;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.start == self.end {
-            None
-
-        } else {
-            let value = self.array.get(self.start);
-            self.start += 1;
-            Some(value)
-        }
+        let index = self.range.next()?;
+        Some(self.array.get(index))
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let diff = (self.end - self.start) as usize;
-        (diff, Some(diff))
+        self.range.size_hint()
     }
 }
 
 impl<'a> std::iter::DoubleEndedIterator for ArrayIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.start == self.end {
-            None
-
-        } else {
-            let value = self.array.get(self.end - 1);
-            self.end -= 1;
-            Some(value)
-        }
+        let index = self.range.next_back()?;
+        Some(self.array.get(index))
     }
 }
 
@@ -475,8 +461,7 @@ impl Array {
     /// Returns an iterator over the values of the JS array.
     pub fn iter(&self) -> ArrayIter<'_> {
         ArrayIter {
-            start: 0,
-            end: self.length(),
+            range: 0..self.length(),
             array: self,
         }
     }

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -82,6 +82,41 @@ fn from_iter() {
 }
 
 #[wasm_bindgen_test]
+fn to_vec() {
+    let array = vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]
+        .into_iter()
+        .collect::<js_sys::Array>();
+
+    assert_eq!(array.to_vec(), vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]);
+}
+
+#[wasm_bindgen_test]
+fn iter() {
+    let array = vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]
+        .into_iter()
+        .collect::<js_sys::Array>();
+
+    let mut iter = array.iter();
+
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.next(), Some(JsValue::from("a")));
+
+    assert_eq!(iter.size_hint(), (2, Some(2)));
+    assert_eq!(iter.next_back(), Some(JsValue::from("c")));
+
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    assert_eq!(iter.next_back(), Some(JsValue::from("b")));
+
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.next(), None);
+
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.next_back(), None);
+
+    assert_eq!(array.iter().collect::<Vec<JsValue>>(), vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]);
+}
+
+#[wasm_bindgen_test]
 fn new_with_length() {
     let array = Array::new_with_length(5);
     assert_eq!(array.length(), 5);

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -96,6 +96,8 @@ fn iter() {
         .into_iter()
         .collect::<js_sys::Array>();
 
+    assert_eq!(array.iter().collect::<Vec<JsValue>>(), vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]);
+
     let mut iter = array.iter();
 
     assert_eq!(iter.size_hint(), (3, Some(3)));
@@ -113,7 +115,33 @@ fn iter() {
     assert_eq!(iter.size_hint(), (0, Some(0)));
     assert_eq!(iter.next_back(), None);
 
-    assert_eq!(array.iter().collect::<Vec<JsValue>>(), vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]);
+    let mut iter = array.iter();
+
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.next(), Some(JsValue::from("a")));
+
+    assert_eq!(iter.size_hint(), (2, Some(2)));
+    assert_eq!(iter.next(), Some(JsValue::from("b")));
+
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    assert_eq!(iter.next(), Some(JsValue::from("c")));
+
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.next(), None);
+
+    let mut iter = array.iter();
+
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.next_back(), Some(JsValue::from("c")));
+
+    assert_eq!(iter.size_hint(), (2, Some(2)));
+    assert_eq!(iter.next_back(), Some(JsValue::from("b")));
+
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    assert_eq!(iter.next_back(), Some(JsValue::from("a")));
+
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+    assert_eq!(iter.next_back(), None);
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
There's a few reasons for this:

* Using `array.to_vec()` is more convenient and more efficient than using `array.values().into_iter().map(|x| x.unwrap_throw()).collect::<Vec<_>>()`

* Using `array.iter()` is much more efficient than using `array.values().into_iter()`

* The iterator returned by `array.iter()` supports `size_hint`, `ExactSizeIterator`, and `DoubleEndedIterator`, all of which *cannot* be supported by `array.values()`