### PR TITLE
CanvasRenderingContext2d.get_image_data argument is float

### DIFF
--- a/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
@@ -251,7 +251,7 @@ interface mixin CanvasImageData {
   [NewObject, Throws]
   ImageData createImageData(ImageData imagedata);
   [NewObject, Throws, NeedsSubjectPrincipal]
-  ImageData getImageData(double sx, double sy, double sw, double sh);
+  ImageData getImageData(long sx, long sy, long sw, long sh);
   [Throws]
   void putImageData(ImageData imagedata, double dx, double dy);
   [Throws]

--- a/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
@@ -253,9 +253,9 @@ interface mixin CanvasImageData {
   [NewObject, Throws, NeedsSubjectPrincipal]
   ImageData getImageData(long sx, long sy, long sw, long sh);
   [Throws]
-  void putImageData(ImageData imagedata, double dx, double dy);
+  void putImageData(ImageData imagedata, long dx, long dy);
   [Throws]
-  void putImageData(ImageData imagedata, double dx, double dy, double dirtyX, double dirtyY, double dirtyWidth, double dirtyHeight);
+  void putImageData(ImageData imagedata, long dx, long dy, long dirtyX, long dirtyY, long dirtyWidth, long dirtyHeight);
 };
 
 interface mixin CanvasPathDrawingStyles {


### PR DESCRIPTION
issue #1917

according to the [spec](https://html.spec.whatwg.org/multipage/canvas.html#2dcontext:dom-context-2d-getimagedata) it should be `i32` .

```
 ImageData getImageData(long sx, long sy, long sw, long sh);
```
It also fix putImageData, createImageData