### PR TITLE
Add inspectable attribute to guide

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -80,6 +80,7 @@
       - [`start`](./reference/attributes/on-rust-exports/start.md)
       - [`typescript_custom_section`](./reference/attributes/on-rust-exports/typescript_custom_section.md)
       - [`getter` and `setter`](./reference/attributes/on-rust-exports/getter-and-setter.md)
+      - [`inspectable`](./reference/attributes/on-rust-exports/inspectable.md)
 
 - [`web-sys`](./web-sys/index.md)
   - [Using `web-sys`](./web-sys/using-web-sys.md)


### PR DESCRIPTION
This was missed in PR #1876

I saw that 0.2.56 was released this morning, but noticed I forgot to actually get the `inspectable` docs into the guide 🤦‍♀ 

I'm not sure if this can be deployed now or if it has to wait until the next release, but I'm fine either way