### PR TITLE
Add --target electron-renderer (for generating electron preloads)

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,7 +22,7 @@ Options:
     --out-dir DIR                Output directory
     --out-name VAR               Set a custom output filename (Without extension. Defaults to crate name)
     --target TARGET              What type of output to generate, valid
-                                 values are [web, bundler, nodejs, no-modules],
+                                 values are [web, bundler, nodejs, no-modules, electron-renderer],
                                  and the default is [bundler]
     --no-modules-global VAR      Name of the global variable to initialize
     --browser                    Hint that JS should only be compatible with a browser
@@ -35,6 +35,7 @@ Options:
     --remove-producers-section   Remove the telemetry `producers` section
     --encode-into MODE           Whether or not to use TextEncoder#encodeInto,
                                  valid values are [test, always, never]
+    --electron-renderer          Deprecated, use `--target electron-renderer`
     --nodejs                     Deprecated, use `--target nodejs`
     --web                        Deprecated, use `--target web`
     --no-modules                 Deprecated, use `--target no-modules`
@@ -46,6 +47,7 @@ struct Args {
     flag_nodejs: bool,
     flag_browser: bool,
     flag_web: bool,
+    flag_electron_renderer: bool,
     flag_no_modules: bool,
     flag_typescript: bool,
     flag_no_typescript: bool,
@@ -96,12 +98,14 @@ fn rmain(args: &Args) -> Result<(), Error> {
             "web" => b.web(true)?,
             "no-modules" => b.no_modules(true)?,
             "nodejs" => b.nodejs(true)?,
+            "electron-renderer" => b.electron_renderer(true)?,
             s => bail!("invalid encode-into mode: `{}`", s),
         };
     }
     b.input_path(input)
         .nodejs(args.flag_nodejs)?
         .web(args.flag_web)?
+        .electron_renderer(args.flag_electron_renderer)?
         .browser(args.flag_browser)?
         .no_modules(args.flag_no_modules)?
         .debug(args.flag_debug)


### PR DESCRIPTION
### What does this PR do?

1. It causes imports to be omitted from the `pkg/output.js`
2. It creates a `pkg/preloads.js` with the omitted imports from 1), but in a format suitable for electron-renderer processes with node integration disabled

### Why is this needed?

#### Background

Electron apps use a multi-process model. For this PR we only need to care about the renderer process. We assume that the primary renderer process app script is `pkg/output.js`.

The electron renderer process can make use of node modules, but (by default) only if they are provided through a `preloads.js` script. This is because the primary renderer process script (our `pkg/output.js`) _does not_ have access to node `require` and will not resolve node modules. However, the `preloads.js` script _does_ have node `require` in scope, and can make use of all the normal node functionality.

This separation is intended to prevent XSS to RCE attacks. You can read more about it [here](https://electronjs.org/docs/tutorial/security#2-do-not-enable-nodejs-integration-for-remote-content).

#### How this PR addresses this issue

The output generated from `wasm-bindgen` and `wasm-pack`, when using node modules, contains imports that use `require`. Since `require` is not available to the primary renderer process script, an electron app using this output will fail to load with an error about `require` not being in scope.

The solution to that problem is to omit the imports and to not generate code that uses `require`. That's what 1) does.

That still leaves the issue of how to make those imports available to the renderer script. That's what 2) does, by generating an appropriate `preloads.js` script.

### Can't you just use webpack with one of the `electron` targets for this?

No. The webpack `electron` targets do not help with 1) or with 2).

What the `electron-renderer` and `electron-preload` targets do can be seen [here](https://github.com/webpack/webpack/blob/9f3c2d3db4b99274dbba644b6bf03ecdb1a4fb64/lib/WebpackOptionsApply.js#L179-L217).

For the most part they just disable the generation of chunked modules for certain globals (like `electron`, and `ipc`).

However, the `electron-renderer` target is still treated as a [node target](https://github.com/webpack/webpack/blob/9f3c2d3db4b99274dbba644b6bf03ecdb1a4fb64/lib/WebpackOptionsApply.js#L191), where the generated modules are included into the final output using `require`, which is exactly what we don't want.

In fact, the webpack `electron-renderer` target does not work with current electron because of this. There is an issue referencing the problem [here](https://github.com/webpack/webpack/issues/8862) but no resolution.

### Demonstration

I've uploaded two branches for illustration purposes.

#### Branch: webpack-activity-monitor

The first branch is [webpack-activity-monitor](https://github.com/interfaces-rs/electron-sys/tree/webpack-activity-monitor/examples/activity-monitor).

If you checkout the code and go to the `examples/activity-monitor`, you can run the following to start the example:

```
npm i
npn run build
npm start
```

This branch adapts the template from [rustwasm/rust-webpack-template](https://github.com/rustwasm/rust-webpack-template) but only uses webpack for the electron renderer script.

If you start the app, you can see that it doesn't function properly. In fact, it fails exactly at the parts where one of the imports (`os.cpus` from `node-sys`) is used. It doesn't throw an error, but the results are null (I'm not entirely sure why it behaves this way instead of throwing an error, but in any case it doesn't work).

If you uncomment the [following line](https://github.com/interfaces-rs/electron-sys/blob/8a583eb12e65177089545e8a3d68a6877f8ec1dd/examples/activity-monitor/webpack.config.ts#L17) in the `webpack.config.ts`, you might expect that the example would work, since we are using the `electron-renderer` target. Instead, the example still fails, but now it does give an error -- specifically `ReferenceError: require is not defined`.

This demonstrates that the `electron-renderer` target doesn't address the problem this PR is intended to solve.

I have tried experimenting with several combinations of the plugins (e.g., `externals`, `IgnorePlugin`, etc.) to see if it is possible to ignore the imports in `pkg/output.js` but none of them see to do the right thing (see the next section).

#### Branch: webpack-activity-monitor-bundler

The second branch is [webpack-activity-monitor-bundler](https://github.com/interfaces-rs/electron-sys/tree/webpack-activity-monitor-bundler/examples/activity-monitor).

This branch also adapts the template from [rustwasm/rust-webpack-template](https://github.com/rustwasm/rust-webpack-template) and only uses webpack on the renderer script. The difference between this and the other branch is that I preprocess the `pkg/output.js` to strip the imports _before_ being compiled with webpack. (See the `pack-app-renderer-postprocess` npm script.)

Now, if you run the following, the app compiles and runs as expected:

```
npm i
npn run build
npm start
```

This demonstrates the following:

1) the imports in the `pkg/output.js` are the main source of the problem
2) it's possible to use webpack and wasm-pack with the bundler target for electron (previously I didn't think this worked, but testing all of this has been complicated)

Regarding 2), I've verified that it's possible to use _either_ the `web` target or the `bundler` target from wasm-pack for electron apps. Using the `web` target is simpler, but in real world apps it's more likely that the `bundler` target would be used for various reasons. That leads me to propose an alternative interface for this functionality.

### Alternatives

Rather than adding `--target electron-renderer`, we could instead add two separate flags: `--omit-module-imports` and `--generate-preloads`. These flags would function independently of the choice of `--target`.

After some consideration, this is probably the better option. Most real world applications will probably end up using `--target bundler`, but some may still want to use `--target web` (especially modern apps making full use of modules or other bundlers like rollup). 

Furthermore, real world applications are likely going to make use of multiple preload scripts with more complex structure than what we would auto-generate.

In fact, the most conservative solution would be to not even provide a `--generate-preloads` flag but only an `--omit-module-imports` flag. That might be okay, but it would still be nice to have some sort of feedback as to which modules are omitted so the user an idea as to how they should construct the preloads script. I don't know the ideal way to do this. The omitted imports could be reported on stdout or something at the very least.