### PR TITLE
The example should output "Hello from Rust!"

### DIFF
--- a/examples/import_js/crate/defined-in-js.js
+++ b/examples/import_js/crate/defined-in-js.js
@@ -1,5 +1,5 @@
 export function name() {
-    return 'World';
+    return 'Rust';
 }
 
 export class MyClass {

--- a/examples/import_js/crate/src/lib.rs
+++ b/examples/import_js/crate/src/lib.rs
@@ -26,7 +26,7 @@ extern "C" {
 
 #[wasm_bindgen(start)]
 pub fn run() {
-    log(&format!("Hello, {}!", name()));
+    log(&format!("Hello from {}!", name())); // should output "Hello from Rust!"
 
     let x = MyClass::new();
     assert_eq!(x.number(), 42);


### PR DESCRIPTION
Thanks for your examples, I'm learning a lot from them.
In this one in particular, the HTML says the user should see "Hello from Rust!" on the console, however it says "Hello, World!". 
This is a proposed fix.