### PR TITLE
bool -> boolean in generated TypeScript code

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -875,7 +875,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
         }
 
         Instruction::BoolFromI32 => {
-            js.typescript_required("bool");
+            js.typescript_required("boolean");
             let val = js.pop();
             js.push(format!("{} !== 0", val));
         }

--- a/crates/typescript-tests/src/simple_fn.rs
+++ b/crates/typescript-tests/src/simple_fn.rs
@@ -2,3 +2,6 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn greet(_: &str) {}
+
+#[wasm_bindgen]
+pub fn take_and_return_bool(_: bool) -> bool { true }

--- a/crates/typescript-tests/src/simple_fn.ts
+++ b/crates/typescript-tests/src/simple_fn.ts
@@ -3,3 +3,4 @@ import * as wasm from '../pkg/typescript_tests_bg';
 
 const wbg_greet: (a: string) => void = wbg.greet;
 const wasm_greet: (a: number, b: number) => void = wasm.greet;
+const take_and_return_bool: (a: boolean) => boolean = wbg.take_and_return_bool;


### PR DESCRIPTION
[TypeScript uses](https://www.typescriptlang.org/docs/handbook/basic-types.html#boolean) the name `boolean` rather than `bool`. There is one instance of `bool` used instead in `wasm-bindgen`. This fixes the typo.

I believe this fixes the issue behind `test1` in #1926.