### PR TITLE
Fix *.d.ts generation

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -309,6 +309,7 @@ impl<'a, 'b> JsBuilder<'a, 'b> {
     }
 
     pub fn typescript_required(&mut self, ty: &str) {
+       self.typescript.pop();
         let name = self.arg_name();
         self.typescript.push(TypescriptArg {
             ty: ty.to_string(),
@@ -318,6 +319,7 @@ impl<'a, 'b> JsBuilder<'a, 'b> {
     }
 
     pub fn typescript_optional(&mut self, ty: &str) {
+        self.typescript.pop();
         let name = self.arg_name();
         self.typescript.push(TypescriptArg {
             ty: ty.to_string(),
@@ -460,6 +462,11 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
 
     match instr {
         Instruction::Standard(wit_walrus::Instruction::ArgGet(n)) => {
+            js.typescript.push(TypescriptArg {
+                  ty: "number".to_string(),
+                  optional: false,
+                  name: js.arg_name(),
+            });
             let arg = js.arg(*n).to_string();
             js.push(arg);
         }
@@ -473,6 +480,11 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
         | Instruction::CallAdapter(_)
         | Instruction::CallTableElement(_)
         | Instruction::Standard(wit_walrus::Instruction::DeferCallCore(_)) => {
+            js.typescript.push(TypescriptArg {
+               ty: "number".to_string(),
+               optional: false,
+               name: js.arg_name(),
+            });
             let invoc = Invocation::from(instr, js.cx.module)?;
             let (params, results) = invoc.params_results(js.cx);
 
@@ -875,7 +887,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
         }
 
         Instruction::BoolFromI32 => {
-            js.typescript_required("bool");
+            js.typescript_required("boolean");
             let val = js.pop();
             js.push(format!("{} !== 0", val));
         }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -290,7 +290,7 @@ impl Bindgen {
             }
         };
 
-        // This isn't the hardest thing in the world too support but we
+        // This isn't the hardest thing in the world to support but we
         // basically don't know how to rationalize #[wasm_bindgen(start)] and
         // the actual `start` function if present. Figure this out later if it
         // comes up, but otherwise we should continue to be compatible with


### PR DESCRIPTION
As of v0.2.56, the generated *.d.ts file is incorrect when there are f64 or f32 types in the parameters or return value.

This is not a particularly _good_ fix. Hopefully, it does help to illustrate the problem better - Typescript types are pushed to a Vec based on non-`ArgGet` `Instruction`s. For f64 and f32 types there are no associated non-`ArgGet` `Instruction`s.

Due to the grouping of a `match` at line 478 of `binding.rs`, this PR may affect the following other `Instruction`s, which I am unable to test and was unable to determine what the intended behaviour _should_ be:
```
Instruction::Standard(wit_walrus::Instruction::CallCore(_))
Instruction::CallAdapter(_)
Instruction::CallTableElement(_)
Instruction::Standard(wit_walrus::Instruction::DeferCallCore(_))
```

Fixes #1926