### PR TITLE
Add default module to `init` for `no-modules` output mode.

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -437,6 +437,18 @@ impl<'a> Context<'a> {
                         module = import.meta.url.replace(/\\.js$/, '_bg.wasm');
                     }"
             }
+            OutputMode::NoModules { .. } => {
+                "\
+                    if (typeof module === 'undefined') {
+                        let src
+                        if (self.document === undefined) {
+                            src = self.location.href
+                        } else {
+                            src = self.document.currentScript.src
+                        }
+                        module = src.replace(/\\.js$/, '_bg.wasm')
+                    }"
+            }
             _ => "",
         };
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -440,13 +440,13 @@ impl<'a> Context<'a> {
             OutputMode::NoModules { .. } => {
                 "\
                     if (typeof module === 'undefined') {
-                        let src
+                        let src;
                         if (self.document === undefined) {
-                            src = self.location.href
+                            src = self.location.href;
                         } else {
-                            src = self.document.currentScript.src
+                            src = self.document.currentScript.src;
                         }
-                        module = src.replace(/\\.js$/, '_bg.wasm')
+                        module = src.replace(/\\.js$/, '_bg.wasm');
                     }"
             }
             _ => "",


### PR DESCRIPTION
Also checks if we are in a worker scope.

Related: #1559.