### PR TITLE
Automatically start execution on import.

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -161,7 +161,6 @@ function executeBenchmark(name, bm) {
 // Load wasm files and when they're done (plus the DOM) then we initialize
 // everything
 const wasms = [];
-wasms.push(wbindgen_init('./pkg/wasm_bindgen_benchmark_bg.wasm'));
 wasms.push(fetch('./raw.wasm')
   .then(r => r.arrayBuffer())
   .then(m => WebAssembly.instantiate(m, { './globals.js': globals }))

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -220,11 +220,16 @@ impl<'a> Context<'a> {
                 js.push_str("let wasm;\n");
                 init = self.gen_init(needs_manual_start, None)?;
                 footer.push_str(&format!(
-                    "self.{} = Object.assign(init, __exports);\n",
-                    global
+                    "self.{} = Object.assign(init{}, __exports);\n",
+                    global,
+                    if needs_manual_start && auto_start {
+                        "()"
+                    } else {
+                        ""
+                    }
                 ));
                 if needs_manual_start && auto_start {
-                    footer.push_str("self.wasm_bindgen();\n");
+                    footer.push_str(&format!("self.{}.init = init;\n", global));
                 }
             }
 
@@ -284,9 +289,16 @@ impl<'a> Context<'a> {
                 self.imports_post.push_str("let wasm;\n");
                 init = self.gen_init(needs_manual_start, Some(&mut imports))?;
                 if needs_manual_start && auto_start {
-                    footer.push_str("init();\n");
+                    footer.push_str("export { init };\n");
                 }
-                footer.push_str("export default init;\n");
+                footer.push_str(&format!(
+                    "export default init{};\n",
+                    if needs_manual_start && auto_start {
+                        "()"
+                    } else {
+                        ""
+                    }
+                ));
             }
         }
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -41,6 +41,7 @@ pub struct Bindgen {
     multi_value: bool,
     wasm_interface_types: bool,
     encode_into: EncodeInto,
+    auto_start: bool,
 }
 
 pub struct Output {
@@ -108,6 +109,7 @@ impl Bindgen {
             multi_value: multi_value || wasm_interface_types,
             wasm_interface_types,
             encode_into: EncodeInto::Test,
+            auto_start: true,
         }
     }
 
@@ -249,6 +251,11 @@ impl Bindgen {
 
     pub fn encode_into(&mut self, mode: EncodeInto) -> &mut Bindgen {
         self.encode_into = mode;
+        self
+    }
+
+    pub fn auto_start(&mut self, auto_start: bool) -> &mut Bindgen {
+        self.auto_start = auto_start;
         self
     }
 
@@ -412,7 +419,7 @@ impl Bindgen {
                 .unwrap();
             let mut cx = js::Context::new(&mut module, self, &adapters, &aux)?;
             cx.generate()?;
-            let (js, ts) = cx.finalize(stem)?;
+            let (js, ts) = cx.finalize(stem, self.auto_start)?;
             Generated::Js(JsGenerated {
                 snippets: aux.snippets.clone(),
                 local_modules: aux.local_modules.clone(),

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -35,6 +35,7 @@ Options:
     --remove-producers-section   Remove the telemetry `producers` section
     --encode-into MODE           Whether or not to use TextEncoder#encodeInto,
                                  valid values are [test, always, never]
+    --no-auto-start              Disable automatic start
     --nodejs                     Deprecated, use `--target nodejs`
     --web                        Deprecated, use `--target web`
     --no-modules                 Deprecated, use `--target no-modules`
@@ -59,6 +60,7 @@ struct Args {
     flag_remove_producers_section: bool,
     flag_keep_debug: bool,
     flag_encode_into: Option<String>,
+    flag_no_auto_start: bool,
     flag_target: Option<String>,
     arg_input: Option<PathBuf>,
 }
@@ -109,7 +111,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .keep_debug(args.flag_keep_debug)
         .remove_name_section(args.flag_remove_name_section)
         .remove_producers_section(args.flag_remove_producers_section)
-        .typescript(typescript);
+        .typescript(typescript)
+        .auto_start(!args.flag_no_auto_start);
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name)?;
     }

--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -26,6 +26,7 @@ RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' \
 cargo run --manifest-path ../../crates/cli/Cargo.toml \
   --bin wasm-bindgen -- \
   ../../target/wasm32-unknown-unknown/release/raytrace_parallel.wasm --out-dir . \
+  --no-auto-start \
   --no-modules
 
 python3 -m http.server

--- a/examples/wasm2js/index.html
+++ b/examples/wasm2js/index.html
@@ -5,5 +5,5 @@
   <body>
     <p>Open up the developer console to see "Hello, World!"</p>
   </body>
-  <script src=index.js type=module></script>
+  <script src=pkg/wasm2js.js type=module></script>
 </html>

--- a/examples/wasm2js/index.js
+++ b/examples/wasm2js/index.js
@@ -1,4 +1,0 @@
-// Import our JS shim and initialize it, executing the start function when it's
-// ready.
-import init from './pkg/wasm2js.js';
-init();

--- a/examples/websockets/index.html
+++ b/examples/websockets/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>WebSockets example</title>
-    <script type="module" src="index.js"></script>
+    <script type="module" src="pkg/websockets.js"></script>
 </head>
 <bodt>
 </bodt>

--- a/examples/websockets/index.js
+++ b/examples/websockets/index.js
@@ -1,5 +1,0 @@
-import init from './pkg/websockets.js';
-
-window.addEventListener('load', async () => {
-    await init('./pkg/websockets_bg.wasm');
-});

--- a/examples/without-a-bundler-no-modules/index.html
+++ b/examples/without-a-bundler-no-modules/index.html
@@ -19,7 +19,7 @@
       const { add } = wasm_bindgen;
 
       async function run() {
-        await wasm_bindgen('./pkg/without_a_bundler_no_modules_bg.wasm');
+        await wasm_bindgen;
 
         const result = add(1, 2);
         console.log(`1 + 2 = ${result}`);

--- a/examples/without-a-bundler/index.html
+++ b/examples/without-a-bundler/index.html
@@ -8,27 +8,18 @@
       // Use ES module import syntax to import functionality from the module
       // that we have compiled.
       //
-      // Note that the `default` import is an initialization function which
+      // Note that the `default` import is an initialization promise which
       // will "boot" the module and make it ready to use. Currently browsers
       // don't support natively imported WebAssembly as an ES module, but
       // eventually the manual initialization won't be required!
       import init, { add } from './pkg/without_a_bundler.js';
 
       async function run() {
-        // First up we need to actually load the wasm file, so we use the
-        // default export to inform it where the wasm file is located on the
-        // server, and then we wait on the returned promise to wait for the
-        // wasm to be loaded.
-        // It may look like this: `await init('./pkg/without_a_bundler_bg.wasm');`,
-        // but there is also a handy default inside `init` function, which uses
-        // `import.meta` to locate the wasm file relatively to js file
+        // First we wait on the promise to wait for the wasm to be loaded.
         //
-        // Note that instead of a string here you can also pass in an instance
-        // of `WebAssembly.Module` which allows you to compile your own module.
-        // Also note that the promise, when resolved, yields the wasm module's
-        // exports which is the same as importing the `*_bg` module in other
-        // modes
-        await init();
+        // Note that the promise, when resolved, yields the wasm module's exports
+        // which is the same as importing the `*_bg` module in other modes
+        await init;
 
         // And afterwards we can use all the functionality defined in wasm.
         const result = add(1, 2);

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -68,3 +68,8 @@ sections.
 When generating bundler-compatible code (see the section on [deployment]) this
 indicates that the bundled code is always intended to go into a browser so a few
 checks for Node.js can be elided.
+
+### `--no-auto-start`
+
+When generating web-compatible code, start executing start function on importing
+the file.

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -71,5 +71,5 @@ checks for Node.js can be elided.
 
 ### `--no-auto-start`
 
-When generating web-compatible code, start executing start function on importing
+When generating web-compatible code, start executing the `start` function on importing
 the file.


### PR DESCRIPTION
This changes `wasm-bindgen` to start execution when importing the `js` file by default and adds a flag to disable this behaviour.

The `no-modules` part currently relies on #1938, I can change that if necessary.

Currently what this does is change `init`/`wasm_bindgen` from a function into a promise. The original function is now in an exported `init` or respectively in `wasm_bindgen` init.

Having worked on this PR a little, made me realize that there is some bigger design work necessary, I can't change this PR in a draft, but discussion is obviously in #1939.

I would like to get some feedback on the documentation/description of the added flag.

Fixes #1939.