### PR TITLE
Store richer adapter types, don't use instructions for TypeScript

### DIFF
--- a/crates/cli-support/src/multivalue.rs
+++ b/crates/cli-support/src/multivalue.rs
@@ -67,7 +67,7 @@ fn extract_xform<'a>(
     if let Some(Instruction::Retptr) = instructions.first().map(|e| &e.instr) {
         instructions.remove(0);
         let mut types = Vec::new();
-        instructions.retain(|instruction| match instruction.instr {
+        instructions.retain(|instruction| match &instruction.instr {
             Instruction::LoadRetptr { ty, .. } => {
                 types.push(ty.to_wasm().unwrap());
                 false

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -64,7 +64,7 @@ pub enum AdapterJsImportKind {
     Normal,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum AdapterType {
     S8,
     S16,
@@ -82,6 +82,9 @@ pub enum AdapterType {
     I32,
     I64,
     Vector(VectorKind),
+    Option(Box<AdapterType>),
+    Struct(String),
+    Function,
 }
 
 #[derive(Debug, Clone)]
@@ -338,10 +341,19 @@ impl AdapterType {
             AdapterType::F64 => wit_walrus::ValType::F64,
             AdapterType::String => wit_walrus::ValType::String,
             AdapterType::Anyref => wit_walrus::ValType::Anyref,
+
             AdapterType::I32 => wit_walrus::ValType::I32,
             AdapterType::I64 => wit_walrus::ValType::I64,
-            AdapterType::Bool | AdapterType::Vector(_) => return None,
+            AdapterType::Option(_)
+            | AdapterType::Function
+            | AdapterType::Struct(_)
+            | AdapterType::Bool
+            | AdapterType::Vector(_) => return None,
         })
+    }
+
+    pub fn option(self) -> AdapterType {
+        AdapterType::Option(Box::new(self))
     }
 }
 

--- a/crates/typescript-tests/src/simple_struct.rs
+++ b/crates/typescript-tests/src/simple_struct.rs
@@ -13,4 +13,8 @@ impl A {
     pub fn other() {}
 
     pub fn foo(&self) {}
+
+    pub fn ret_bool(&self) -> bool { true }
+    pub fn take_bool(&self, _: bool) {}
+    pub fn take_many(&self, _: bool, _: f64, _: u32) {}
 }

--- a/crates/typescript-tests/src/simple_struct.ts
+++ b/crates/typescript-tests/src/simple_struct.ts
@@ -4,3 +4,6 @@ const a = new wbg.A();
 wbg.A.other();
 a.foo();
 a.free();
+const b: boolean = a.ret_bool()
+a.take_bool(b);
+a.take_many(b, 1, 2);


### PR DESCRIPTION
This commit updates how TypeScript signature are generated from adapters
in wasm-bindgen. A richer set of `AdapterType` types are now stored
which record information about optional types and such. These direct
`AdapterType` values are then used to calculate the TypeScript
signature, rather than following the instructions in an adapter function
(which only works anyway for wasm-bindgen generated adapters).

This should be more robust since it reads the actual true signature of
the adapter to generate the TypeScript signature, rather than attempting
to ad-hoc-ly infer it from the various instructions, which was already
broken.

A number of refactorings were involved here, but the main pieces are:

* The `AdapterType` type is a bit more rich now to describe more
  Rust-like types.
* The `TypescriptArg` structure is now gone and instead return values
  are directly inferred from type signatures of adapters.
* The `typescript_{required,optional}` methods are no longer needed.
* The return of `JsBuilder::process` was enhanced to return more values,
  rather than storing some return values on the structure itself.

Closes #1926