### PR TITLE
Add electron support via --omit-imports

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -316,6 +316,11 @@ impl<'a> Context<'a> {
 
     fn js_import_header(&self) -> Result<String, Error> {
         let mut imports = String::new();
+
+        if self.config.omit_imports {
+            return Ok(imports)
+        }
+
         match &self.config.mode {
             OutputMode::NoModules { .. } => {
                 for (module, _items) in self.js_imports.iter() {

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -26,6 +26,7 @@ pub struct Bindgen {
     mode: OutputMode,
     debug: bool,
     typescript: bool,
+    omit_imports: bool,
     demangle: bool,
     keep_debug: bool,
     remove_name_section: bool,
@@ -97,6 +98,7 @@ impl Bindgen {
             },
             debug: false,
             typescript: false,
+            omit_imports: false,
             demangle: true,
             keep_debug: false,
             remove_name_section: false,
@@ -219,6 +221,11 @@ impl Bindgen {
 
     pub fn typescript(&mut self, typescript: bool) -> &mut Bindgen {
         self.typescript = typescript;
+        self
+    }
+
+    pub fn omit_imports(&mut self, omit_imports: bool) -> &mut Bindgen {
+        self.omit_imports = omit_imports;
         self
     }
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -28,6 +28,7 @@ Options:
     --browser                    Hint that JS should only be compatible with a browser
     --typescript                 Output a TypeScript definition file (on by default)
     --no-typescript              Don't emit a *.d.ts file
+    --omit-imports               Don't emit imports in generated JavaScript
     --debug                      Include otherwise-extraneous debug checks in output
     --no-demangle                Don't demangle Rust symbol names
     --keep-debug                 Keep debug sections in wasm files
@@ -49,6 +50,7 @@ struct Args {
     flag_no_modules: bool,
     flag_typescript: bool,
     flag_no_typescript: bool,
+    flag_omit_imports: bool,
     flag_out_dir: Option<PathBuf>,
     flag_out_name: Option<String>,
     flag_debug: bool,
@@ -109,7 +111,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .keep_debug(args.flag_keep_debug)
         .remove_name_section(args.flag_remove_name_section)
         .remove_producers_section(args.flag_remove_producers_section)
-        .typescript(typescript);
+        .typescript(typescript)
+        .omit_imports(args.flag_omit_imports);
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name)?;
     }

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -48,6 +48,15 @@ is on by default.
 By default, a `*.d.ts` TypeScript declaration file is generated for the
 generated JavaScript bindings, but this flag will disable that.
 
+### `--omit-imports`
+
+When the `module` attribute is used with the `wasm-bindgen` macro, the code
+generator will emit corresponding `import` or `require` statements in the header
+section of the generated javascript. This flag causes those import statements to
+be omitted. This is necessary for some use cases, such as generating javascript
+which is intended to be used with Electron (with node integration disabled),
+where the imports are instead handled through a separate preload script.
+
 ### `--debug`
 
 Generates a bit more JS and wasm in "debug mode" to help catch programmer


### PR DESCRIPTION
This PR adds support for using `wasm-bindgen-cli` for Electron apps through the addition of two flags: `--omit-imports` and `--preloads`. See #1928 for context (the "Alternatives" section at the end of the OP).

@alexcrichton I think this is a better approach since it doesn't require adding a new target. I've also cleaned up the implementation and included your feedback from the original PR. If you think this looks good, we could go with this PR and I'll close the old one.

I'm also open to renaming the flags or modifying the documentation if you have thoughts about that.