### PR TITLE
Fix typo in example code block

### DIFF
--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -15,7 +15,7 @@ implements the `std::future::Future` trait which allows naturally using it in an
 
 ```rust
 async fn get_from_js() -> Result<JsValue, JsValue> {
-    let promise = js_sys::Promise::resolved(&42.into());
+    let promise = js_sys::Promise::resolve(&42.into());
     let result = wasm_bindgen_futures::JsFuture::from(promise).await?;
     Ok(result)
 }


### PR DESCRIPTION
Typo was found in example code at guide/src/reference/js-promises-and-rust-futures.md.
Could you please find and review this fix?

Many thanks,

-noritada