### PR TITLE
[WIP] add parameter to async function --> error

### DIFF
--- a/examples/fetch/index.js
+++ b/examples/fetch/index.js
@@ -2,7 +2,7 @@ const rust = import('./pkg');
 
 rust
   .then(m => {
-      return m.run().then((data) => {
+      return m.run("rustwasm/wasm-bindgen").then((data) => {
           console.log(data);
 
           console.log("The latest commit to the wasm-bindgen %s branch is:", data.name);

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -33,7 +33,7 @@ pub struct Signature {
 }
 
 #[wasm_bindgen]
-pub async fn run(repo: &str) -> Result<JsValue, JsValue> {
+pub async fn run(repo: String) -> Result<JsValue, JsValue> {
     let mut opts = RequestInit::new();
     opts.method("GET");
     opts.mode(RequestMode::Cors);

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -33,13 +33,15 @@ pub struct Signature {
 }
 
 #[wasm_bindgen]
-pub async fn run() -> Result<JsValue, JsValue> {
+pub async fn run(repo: &str) -> Result<JsValue, JsValue> {
     let mut opts = RequestInit::new();
     opts.method("GET");
     opts.mode(RequestMode::Cors);
 
+    let url = format!("https://api.github.com/repos/{}/branches/master", repo);
+
     let request = Request::new_with_str_and_init(
-        "https://api.github.com/repos/rustwasm/wasm-bindgen/branches/master",
+        &url,
         &opts,
     )?;
 


### PR DESCRIPTION
This change to the fetch example does not compile.
It would be great to include how to do this!

I got the example working locally:
```
cd examples/fetch
npm install
npm run serve
```
All is good!

Then I attempted to add a parameter to the async function, but the example fails to
compile with the following error:

```
$ cargo build
   Compiling fetch v0.1.0 (/Users/sallen/src/rust/wasm-bindgen/examples/fetch)
error[E0597]: `*arg0` does not live long enough
  --> examples/fetch/src/lib.rs:35:1
   |
35 | #[wasm_bindgen]
   | ^^^^^^^^^^^^^^-
   | |             |
   | |             `*arg0` dropped here while still borrowed
   | |             argument requires that `*arg0` is borrowed for `'static`
   | borrowed value does not live long enough

error: aborting due to previous error

For more information about this error, try `rustc --explain E0597`.
error: could not compile `fetch`.
```

Perhaps I don't know the correct syntax for this.  
It would be fabulous if the example illustrated how to pass a parameter.  
If someone can give me a hint, I can add it :) 
