### PR TITLE
Allow experimental features to be disabled by setting envvars to "0"

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -86,9 +86,15 @@ pub enum EncodeInto {
 
 impl Bindgen {
     pub fn new() -> Bindgen {
-        let anyref = env::var("WASM_BINDGEN_ANYREF").is_ok();
-        let wasm_interface_types = env::var("WASM_INTERFACE_TYPES").is_ok();
-        let multi_value = env::var("WASM_BINDGEN_MULTI_VALUE").is_ok();
+        let anyref = env::var("WASM_BINDGEN_ANYREF")
+            .map(|val| val == "1")
+            .unwrap_or(false);
+        let wasm_interface_types = env::var("WASM_INTERFACE_TYPES")
+            .map(|val| val == "1")
+            .unwrap_or(false);
+        let multi_value = env::var("WASM_BINDGEN_MULTI_VALUE")
+            .map(|val| val == "1")
+            .unwrap_or(false);
         Bindgen {
             input: Input::None,
             out_name: None,
@@ -102,7 +108,9 @@ impl Bindgen {
             remove_name_section: false,
             remove_producers_section: false,
             emit_start: true,
-            weak_refs: env::var("WASM_BINDGEN_WEAKREF").is_ok(),
+            weak_refs: env::var("WASM_BINDGEN_WEAKREF")
+                .map(|val| val == "1")
+                .unwrap_or(false),
             threads: threads_config(),
             anyref: anyref || wasm_interface_types,
             multi_value: multi_value || wasm_interface_types,


### PR DESCRIPTION
It's surprising that the WASM_INTERFACE_TYPES feature (and other
experimental features) can be enabled by setting their environment
variables to "0".  With this change, these features will only be enabled
if their respective environment variable is set to "1".

This change was motivated because after setting `WASM_INTERFACE_TYPES=1` to do some testing, I tried to set them to "0" to disable them and it took me a little while to figure out why I wasn't seeing the results I expected.