### PR TITLE
feat(test): test CLI on windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,30 @@ jobs:
       - script: cargo test -p wasm-bindgen-wasm-interpreter
         displayName: "wasm-bindgen-wasm-interpreter tests"
 
+  - job: test_cli_windows
+    displayName: "Run wasm-bindgen-cli crate tests (Windows)"
+    pool:
+      vmImage: vs2017-win2016
+    steps:
+      - template: ci/azure-install-rust.yml
+      # Temporarily disable sccache because it is failing on CI.
+      # - template: ci/azure-install-sccache.yml
+      - script: rustup target add wasm32-unknown-unknown
+        displayName: "install wasm target"
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '>=13.0'
+      - script: cargo test -p wasm-bindgen-cli-support
+        displayName: "wasm-bindgen-cli-support tests"
+      - script: cargo test -p wasm-bindgen-cli
+        displayName: "wasm-bindgen-cli tests"
+      - script: cargo test -p wasm-bindgen-anyref-xform
+        displayName: "wasm-bindgen-anyref-xform tests"
+      - script: cargo test -p wasm-bindgen-multi-value-xform
+        displayName: "wasm-bindgen-multi-value-xform tests"
+      - script: cargo test -p wasm-bindgen-wasm-interpreter
+        displayName: "wasm-bindgen-wasm-interpreter tests"
+
   - job: test_web_sys
     displayName: "Run web-sys crate tests"
     steps:


### PR DESCRIPTION
we're running into a geckodriver issue on windows (appears to be just a CI issue, but hard to say)- but i had the occasion to take a look at the azure-pipelines config here. it looks like the library portion of this project is tested on all 3 platforms, but the cli tool is not. 

i know it's a non-zero addition to ask ya'll to add tests, but it would be very help to have the cli tests run on windows so we can catch issues that might begin here first. my concern is mostly wasm-bindgen-test, since it's significantly more tenuous x-platform.

would love to hear your thoughts!