### PR TITLE
Update webidl files based on latest spec

### DIFF
--- a/crates/web-sys/webidls/enabled/DOMTokenList.webidl
+++ b/crates/web-sys/webidls/enabled/DOMTokenList.webidl
@@ -10,6 +10,8 @@
  * liability, trademark and document use rules apply.
  */
 
+// updated using https://dom.spec.whatwg.org/#interface-domtokenlist
+
 interface DOMTokenList {
   readonly attribute unsigned long length;
   getter DOMString? item(unsigned long index);
@@ -27,5 +29,5 @@ interface DOMTokenList {
   [CEReactions, SetterThrows]
   attribute DOMString value;
   stringifier DOMString ();
-  iterable<DOMString?>;
+  iterable<DOMString>;
 };

--- a/crates/web-sys/webidls/enabled/NodeList.webidl
+++ b/crates/web-sys/webidls/enabled/NodeList.webidl
@@ -10,9 +10,11 @@
  * liability, trademark and document use rules apply.
  */
 
+// Updated using https://dom.spec.whatwg.org/#interface-nodelist
+
 [ProbablyShortLivingWrapper]
 interface NodeList {
   getter Node? item(unsigned long index);
   readonly attribute unsigned long length;
-  iterable<Node?>;
+  iterable<Node>;
 };


### PR DESCRIPTION
Update webidl files based on

 - https://dom.spec.whatwg.org/#interface-domtokenlist
 - https://dom.spec.whatwg.org/#interface-nodelist

This is a non-breaking change as iterables are currently ignored.