### PR TITLE
Add typescript_type attribute

### DIFF
--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -5,4 +5,5 @@ pub mod opt_args_and_ret;
 pub mod optional_fields;
 pub mod simple_fn;
 pub mod simple_struct;
+pub mod typescript_type;
 pub mod web_sys;

--- a/crates/typescript-tests/src/typescript_type.rs
+++ b/crates/typescript-tests/src/typescript_type.rs
@@ -1,0 +1,37 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const ITEXT_STYLE: &'static str = r#"
+interface ITextStyle {
+    bold: boolean;
+    italic: boolean;
+    size: number;
+}
+"#;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(typescript_type = "ITextStyle")]
+    pub type ITextStyle;
+}
+
+#[wasm_bindgen]
+#[derive(Default)]
+pub struct TextStyle {
+    pub bold: bool,
+    pub italic: bool,
+    pub size: i32,
+}
+
+#[wasm_bindgen]
+impl TextStyle {
+    #[wasm_bindgen(constructor)]
+    pub fn new(_i: ITextStyle) {
+        // parse JsValue
+    }
+
+    pub fn optional_new(_i: Option<ITextStyle>) -> TextStyle {
+        // parse JsValueo
+        TextStyle::default()
+    }
+}

--- a/crates/typescript-tests/src/typescript_type.ts
+++ b/crates/typescript-tests/src/typescript_type.ts
@@ -1,0 +1,9 @@
+import * as wbg from '../pkg/typescript_tests';
+
+const style: wbg.TextStyle = new wbg.TextStyle({
+  bold: true,
+  italic: true,
+  size: 42,
+});
+
+const optional_style: wbg.TextStyle = wbg.TextStyle.optional_new();

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -82,6 +82,7 @@
       - [`getter` and `setter`](./reference/attributes/on-rust-exports/getter-and-setter.md)
       - [`inspectable`](./reference/attributes/on-rust-exports/inspectable.md)
       - [`skip_typescript`](./reference/attributes/on-rust-exports/skip_typescript.md)
+      - [`typescript_type`](./reference/attributes/on-rust-exports/typescript_type.md)
 
 - [`web-sys`](./web-sys/index.md)
   - [Using `web-sys`](./web-sys/using-web-sys.md)

--- a/guide/src/reference/attributes/on-rust-exports/typescript_type.md
+++ b/guide/src/reference/attributes/on-rust-exports/typescript_type.md
@@ -1,5 +1,8 @@
-use wasm_bindgen::prelude::*;
+# typescript_type
 
+The `typescript_type` allows us to use typescript declarations in `typescript_custom_section` as arguments for rust functions! For example:
+
+```rust
 #[wasm_bindgen(typescript_custom_section)]
 const ITEXT_STYLE: &'static str = r#"
 interface ITextStyle {
@@ -32,7 +35,22 @@ impl TextStyle {
     }
 
     pub fn optional_new(_i: Option<ITextStyle>) -> TextStyle {
-        // parse JsValue
+        // parse JsValueo
         TextStyle::default()
     }
 }
+```
+
+We can write our `typescript` code like: 
+
+```ts
+import { ITextStyle, TextStyle } from "./my_awesome_module";
+
+const style: TextStyle = new TextStyle({
+  bold: true,
+  italic: true,
+  size: 42,
+});
+
+const optional_style: TextStyle = TextStyle.optional_new();
+```


### PR DESCRIPTION
## proc-macro attribute 

`#[wasn_bindgen(plain_object)]`

### Motivation

Ref to @Pauan 's [suggestion][0] in #1591, I just wrote an attribute named `plain_object`.

I am writing a wasm UI library these days, and I have to duplicate some types for 3 times(in my project, rust for 2 and ts for 1) without the ability exporting typed struct from rust...

I feel very excited about `wasm`, and never thinking about that I can contribute to `wasm-bindgen` one day, hope this pr can help.

### Solution

1. Add an attribute named `plain_object`
2. Not generating `constructor` with `palin_object`
2. Hide `free() void;` while generating `.d.ts`


### Result
Now we can export rust types like:

```rust
#[wasm_bindgen(plain_object)]
pub struct Ping {
    pong: bool
}
```

And in typescript file:

```ts
import * as r from "pkg";

const p: r.Ping = {
    pong: true,
};
```

### Confusions

I'm quite a newbie in programming, not sure about if just hide `free() void;` in `d.ts` is okay.

[0]: https://github.com/rustwasm/wasm-bindgen/issues/1591#issuecomment-501784387