### PR TITLE
Installation instructions for wasm-bindgen CLI tool

### DIFF
--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -11,9 +11,13 @@ always be listed via `wasm-bindgen --help`.
 
 ## Installation
 
-The command line tool is available through a separate crate, `wasm-bindgen-cli`:
+Although the command line tool is available through its own crate, `wasm-bindgen-cli`, the recommended way to install it is through installing the `wasm-pack` crate:
 
 ```
+# Recommended:
+cargo install wasm-pack
+
+# OR
 cargo install wasm-bindgen-cli
 ```
 

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -9,6 +9,14 @@ always be listed via `wasm-bindgen --help`.
 
 [wasm-pack]: https://github.com/rustwasm/wasm-pack
 
+## Installation
+
+The command line tool is available through a separate crate, `wasm-bindgen-cli`:
+
+```
+cargo install wasm-bindgen-cli
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
How to install the CLI tool was not obvious to me from the manual. I first tried `cargo install wasm-bindgen` to get the `wasm-bindgen` CLI tool, but was surprised by the error message:

```
error: specified package wasm-bindgen v0.2.58 has no binaries"
```

This patch instructs how to install `wasm-bindgen-cli`.