### PR TITLE
Allow web-sys to emit correct typescript declarations from webidl

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -181,6 +181,7 @@ pub struct ImportType {
     pub rust_name: Ident,
     pub js_name: String,
     pub attrs: Vec<syn::Attribute>,
+    pub typescript_name: Option<String>,
     pub doc_comment: Option<String>,
     pub instanceof_shim: String,
     pub is_type_of: Option<syn::Expr>,

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -585,7 +585,7 @@ impl ToTokens for ast::ImportType {
             let typescript_name_chars = typescript_name.chars().map(|c| c as u32);
             quote! {
                 use wasm_bindgen::describe::*;
-                inform(RUST_STRUCT);
+                inform(NAMED_ANYREF);
                 inform(#typescript_name_len);
                 #(inform(#typescript_name_chars);)*
             }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -144,7 +144,6 @@ impl ToTokens for ast::Struct {
         let name_chars = name_str.chars().map(|c| c as u32);
         let new_fn = Ident::new(&shared::new_function(&name_str), Span::call_site());
         let free_fn = Ident::new(&shared::free_function(&name_str), Span::call_site());
-
         (quote! {
             #[allow(clippy::all)]
             impl wasm_bindgen::describe::WasmDescribe for #name {

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -31,6 +31,7 @@ tys! {
     SLICE
     VECTOR
     ANYREF
+    NAMED_ANYREF
     ENUM
     RUST_STRUCT
     CHAR
@@ -62,6 +63,7 @@ pub enum Descriptor {
     CachedString,
     String,
     Anyref,
+    NamedAnyref(String),
     Enum { hole: u32 },
     RustStruct(String),
     Char,
@@ -134,10 +136,12 @@ impl Descriptor {
             ANYREF => Descriptor::Anyref,
             ENUM => Descriptor::Enum { hole: get(data) },
             RUST_STRUCT => {
-                let name = (0..get(data))
-                    .map(|_| char::from_u32(get(data)).unwrap())
-                    .collect();
+                let name = get_string(data);
                 Descriptor::RustStruct(name)
+            }
+            NAMED_ANYREF => {
+                let name = get_string(data);
+                Descriptor::NamedAnyref(name)
             }
             CHAR => Descriptor::Char,
             UNIT => Descriptor::Unit,
@@ -198,6 +202,12 @@ fn get(a: &mut &[u32]) -> u32 {
     let ret = a[0];
     *a = &a[1..];
     ret
+}
+
+fn get_string(data: &mut &[u32]) -> String {
+    (0..get(data))
+        .map(|_| char::from_u32(get(data)).unwrap())
+        .collect()
 }
 
 impl Closure {

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1221,6 +1221,7 @@ fn adapter2ts(ty: &AdapterType, dst: &mut String) {
             adapter2ts(ty, dst);
             dst.push_str(" | undefined");
         }
+        AdapterType::NamedAnyref(name) => dst.push_str(name),
         AdapterType::Struct(name) => dst.push_str(name),
         AdapterType::Function => dst.push_str("any"),
     }

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -60,6 +60,13 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::NamedAnyref(name.clone())],
+                    Instruction::I32FromAnyrefOwned,
+                    &[AdapterType::I32]
+                )
+            }
             Descriptor::Anyref => {
                 self.instruction(
                     &[AdapterType::Anyref],

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -60,19 +60,19 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             }
-            Descriptor::NamedAnyref(name) => {
-                self.instruction(
-                    &[AdapterType::NamedAnyref(name.clone())],
-                    Instruction::I32FromAnyrefOwned,
-                    &[AdapterType::I32]
-                )
-            }
             Descriptor::Anyref => {
                 self.instruction(
                     &[AdapterType::Anyref],
                     Instruction::I32FromAnyrefOwned,
                     &[AdapterType::I32],
                 );
+            }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::NamedAnyref(name.clone())],
+                    Instruction::I32FromAnyrefOwned,
+                    &[AdapterType::I32]
+                )
             }
             Descriptor::RustStruct(class) => {
                 self.instruction(
@@ -168,6 +168,13 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::NamedAnyref(name.clone())],
+                    Instruction::I32FromAnyrefBorrow,
+                    &[AdapterType::I32],
+                );
+            }
             Descriptor::String | Descriptor::CachedString => {
                 // This allocation is cleaned up once it's received in Rust.
                 self.instruction(
@@ -225,6 +232,15 @@ impl InstructionBuilder<'_, '_> {
             Descriptor::Anyref => {
                 self.instruction(
                     &[AdapterType::Anyref.option()],
+                    Instruction::I32FromOptionAnyref {
+                        table_and_alloc: None,
+                    },
+                    &[AdapterType::I32],
+                );
+            }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::NamedAnyref(name.clone()).option()],
                     Instruction::I32FromOptionAnyref {
                         table_and_alloc: None,
                     },

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -169,6 +169,13 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::Anyref],
                 );
             }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::I32],
+                    Instruction::TableGet,
+                    &[AdapterType::NamedAnyref(name.clone())],
+                );
+            }
             Descriptor::CachedString => self.cached_string(false, false)?,
 
             Descriptor::String => {
@@ -232,6 +239,13 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                     Instruction::AnyrefLoadOwned,
                     &[AdapterType::Anyref.option()],
+                );
+            }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::I32],
+                    Instruction::AnyrefLoadOwned,
+                    &[AdapterType::NamedAnyref(name.clone()).option()],
                 );
             }
             Descriptor::I8 => self.out_option_sentinel(AdapterType::S8),
@@ -321,6 +335,15 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                     Instruction::TableGet,
                     &[AdapterType::Anyref.option()],
+                );
+            }
+            Descriptor::NamedAnyref(name) => {
+                // If this is `Some` then it's the index, otherwise if it's
+                // `None` then it's the index pointing to undefined.
+                self.instruction(
+                    &[AdapterType::I32],
+                    Instruction::TableGet,
+                    &[AdapterType::NamedAnyref(name.clone()).option()],
                 );
             }
             Descriptor::CachedString => self.cached_string(true, false)?,

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -39,6 +39,13 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::Anyref],
                 );
             }
+            Descriptor::NamedAnyref(name) => {
+                self.instruction(
+                    &[AdapterType::I32],
+                    Instruction::AnyrefLoadOwned,
+                    &[AdapterType::NamedAnyref(name.clone())],
+                );
+            }
             Descriptor::I8 => self.outgoing_i32(AdapterType::S8),
             Descriptor::U8 => self.outgoing_i32(AdapterType::U8),
             Descriptor::I16 => self.outgoing_i32(AdapterType::S16),

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -338,8 +338,6 @@ impl InstructionBuilder<'_, '_> {
                 );
             }
             Descriptor::NamedAnyref(name) => {
-                // If this is `Some` then it's the index, otherwise if it's
-                // `None` then it's the index pointing to undefined.
                 self.instruction(
                     &[AdapterType::I32],
                     Instruction::TableGet,

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -84,6 +84,7 @@ pub enum AdapterType {
     Vector(VectorKind),
     Option(Box<AdapterType>),
     Struct(String),
+    NamedAnyref(String),
     Function,
 }
 
@@ -322,7 +323,7 @@ impl AdapterType {
             AdapterType::I64 => walrus::ValType::I64,
             AdapterType::F32 => walrus::ValType::F32,
             AdapterType::F64 => walrus::ValType::F64,
-            AdapterType::Anyref => walrus::ValType::Anyref,
+            AdapterType::Anyref | AdapterType::NamedAnyref(_) => walrus::ValType::Anyref,
             _ => return None,
         })
     }
@@ -340,7 +341,7 @@ impl AdapterType {
             AdapterType::F32 => wit_walrus::ValType::F32,
             AdapterType::F64 => wit_walrus::ValType::F64,
             AdapterType::String => wit_walrus::ValType::String,
-            AdapterType::Anyref => wit_walrus::ValType::Anyref,
+            AdapterType::Anyref | AdapterType::NamedAnyref(_) => wit_walrus::ValType::Anyref,
 
             AdapterType::I32 => wit_walrus::ValType::I32,
             AdapterType::I64 => wit_walrus::ValType::I64,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -554,6 +554,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ForeignItemType {
             instanceof_shim: shim,
             is_type_of,
             rust_name: self.ident,
+            typescript_name: None,
             js_name,
             extends,
             vendor_prefixes,

--- a/crates/typescript-tests/Cargo.toml
+++ b/crates/typescript-tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 wasm-bindgen = { path = '../..' }
+web-sys = { path = '../web-sys', features = [ 'HtmlElement', 'Node', 'Document' ] }
 
 [lib]
 crate-type = ['cdylib']

--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -3,3 +3,4 @@ pub mod getters_setters;
 pub mod opt_args_and_ret;
 pub mod simple_fn;
 pub mod simple_struct;
+pub mod web_sys;

--- a/crates/typescript-tests/src/web_sys.rs
+++ b/crates/typescript-tests/src/web_sys.rs
@@ -1,0 +1,24 @@
+use wasm_bindgen::prelude::*;
+use web_sys::*;
+
+#[wasm_bindgen]
+pub struct DocStruct {
+    doc: Document,
+}
+
+#[wasm_bindgen]
+impl DocStruct {
+    pub fn new(doc: Document) -> Self {
+        Self { doc }
+    }
+
+    pub fn get_doc(&self) -> Document {
+        self.doc.clone()
+    }
+
+    pub fn append_element(&self, element: &HtmlElement) {
+        self.doc.body().unwrap().append_child(element).unwrap();
+    }
+
+    pub fn append_many(&self, _: &HtmlElement, _: &HtmlElement, _: &HtmlElement) {}
+}

--- a/crates/typescript-tests/src/web_sys.ts
+++ b/crates/typescript-tests/src/web_sys.ts
@@ -1,0 +1,26 @@
+import * as wbg from "../pkg/typescript_tests";
+
+const doc: Document = document;
+
+const docStruct = wbg.DocStruct.new(doc);
+
+const el: HTMLElement = document.createElement("a");
+
+docStruct.append_element(el);
+docStruct.append_many(el, el, el);
+
+const newDoc = docStruct.get_doc();
+
+// This test ensures that the correct Typescript types are
+// used. If "newDoc" is "any", then "event" will cause the
+// compilation to fail because of noImplicitAny.
+newDoc.addEventListener("load", event => {
+  console.log(event);
+});
+
+// Same as above, but testing that the param is a document.
+const listener: Parameters<
+  Parameters<typeof wbg["DocStruct"]["new"]>[0]["addEventListener"]
+>[1] = event => console.log(event);
+
+newDoc.addEventListener("load", listener);

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -568,6 +568,7 @@ impl<'src> FirstPassRecord<'src> {
             } else {
                 Some(syn::parse_quote! { |_| false })
             },
+            typescript_name: Some(name.to_string()),
             extends: Vec::new(),
             vendor_prefixes: Vec::new(),
         };

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -37,6 +37,7 @@ tys! {
     SLICE
     VECTOR
     ANYREF
+    NAMED_ANYREF
     ENUM
     RUST_STRUCT
     CHAR


### PR DESCRIPTION
This change adds the `NamedAnyref` adapter-type / descriptor, which behaves the same as an `Anyref` but also contains some information about the name. This allows web-sys to output the correct names for types instead of falling back to `any`.

If this feature is the kind of thing that the rustwasm team would like to merge - I'll make sure it's test covered. At the moment I just wanted to get it working and make sure it's something worth working on.

This is currently a breaking change but could be hidden behind a feature flag in web-sys.