### PR TITLE
Add get/set for `TypedArray`s.

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4884,6 +4884,14 @@ macro_rules! arrays {
             /// input values from a specified array.
             #[wasm_bindgen(method)]
             pub fn set(this: &$name, src: &JsValue, offset: u32);
+
+            /// Gets the value at `idx`, equivalent to the javascript `my_var = arr[idx]`.
+            #[wasm_bindgen(method, structural, indexing_getter)]
+            pub fn get_(this: &$name, idx: u32) -> $ty;
+
+            /// Sets the value at `idx`, equivalent to the javascript `arr[idx] = value`.
+            #[wasm_bindgen(method, structural, indexing_setter)]
+            pub fn set_(this: &$name, idx: u32, value: $ty);
         }
 
         impl $name {

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4887,11 +4887,11 @@ macro_rules! arrays {
 
             /// Gets the value at `idx`, equivalent to the javascript `my_var = arr[idx]`.
             #[wasm_bindgen(method, structural, indexing_getter)]
-            pub fn get_(this: &$name, idx: u32) -> $ty;
+            pub fn get_array_like(this: &$name, idx: u32) -> $ty;
 
             /// Sets the value at `idx`, equivalent to the javascript `arr[idx] = value`.
             #[wasm_bindgen(method, structural, indexing_setter)]
-            pub fn set_(this: &$name, idx: u32, value: $ty);
+            pub fn set_array_like(this: &$name, idx: u32, value: $ty);
         }
 
         impl $name {

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4887,11 +4887,11 @@ macro_rules! arrays {
 
             /// Gets the value at `idx`, equivalent to the javascript `my_var = arr[idx]`.
             #[wasm_bindgen(method, structural, indexing_getter)]
-            pub fn get_array_like(this: &$name, idx: u32) -> $ty;
+            pub fn get_index(this: &$name, idx: u32) -> $ty;
 
             /// Sets the value at `idx`, equivalent to the javascript `arr[idx] = value`.
             #[wasm_bindgen(method, structural, indexing_setter)]
-            pub fn set_array_like(this: &$name, idx: u32, value: $ty);
+            pub fn set_index(this: &$name, idx: u32, value: $ty);
         }
 
         impl $name {

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -89,6 +89,19 @@ fn new_fill() {
     each!(test_fill);
 }
 
+macro_rules! test_get_set {
+    ($arr:ident) => {{
+        let arr = $arr::new(&1.into());
+        assert_eq!(arr.get_(0) as f64, 0 as f64);
+        arr.set_(0, 1 as _);
+        assert_eq!(arr.get_(0) as f64, 1 as f64);
+    }};
+}
+#[wasm_bindgen_test]
+fn new_get_set() {
+    each!(test_get_set);
+}
+
 macro_rules! test_slice {
     ($arr:ident) => {{
         let arr = $arr::new(&4.into());

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -92,9 +92,9 @@ fn new_fill() {
 macro_rules! test_get_set {
     ($arr:ident) => {{
         let arr = $arr::new(&1.into());
-        assert_eq!(arr.get_(0) as f64, 0 as f64);
-        arr.set_(0, 1 as _);
-        assert_eq!(arr.get_(0) as f64, 1 as f64);
+        assert_eq!(arr.get_array_like(0) as f64, 0 as f64);
+        arr.set_array_like(0, 1 as _);
+        assert_eq!(arr.get_array_like(0) as f64, 1 as f64);
     }};
 }
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -92,9 +92,9 @@ fn new_fill() {
 macro_rules! test_get_set {
     ($arr:ident) => {{
         let arr = $arr::new(&1.into());
-        assert_eq!(arr.get_array_like(0) as f64, 0 as f64);
-        arr.set_array_like(0, 1 as _);
-        assert_eq!(arr.get_array_like(0) as f64, 1 as f64);
+        assert_eq!(arr.get_index(0) as f64, 0 as f64);
+        arr.set_index(0, 1 as _);
+        assert_eq!(arr.get_index(0) as f64, 1 as f64);
     }};
 }
 #[wasm_bindgen_test]


### PR DESCRIPTION
This provides the ability to do

```
let value = array[idx];
array[idx] = value;
```
for typed arrays. They are named with an underscore so thay do not clash with the `set` method, which does something different.