### PR TITLE
Add skip_typescript attribute to prevent .d.ts emit

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -221,6 +221,7 @@ pub struct Function {
     pub rust_attrs: Vec<syn::Attribute>,
     pub rust_vis: syn::Visibility,
     pub r#async: bool,
+    pub generate_typescript: bool,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -231,6 +232,7 @@ pub struct Struct {
     pub fields: Vec<StructField>,
     pub comments: Vec<String>,
     pub is_inspectable: bool,
+    pub generate_typescript: bool,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -243,6 +245,7 @@ pub struct StructField {
     pub getter: Ident,
     pub setter: Ident,
     pub comments: Vec<String>,
+    pub generate_typescript: bool,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
@@ -252,6 +255,7 @@ pub struct Enum {
     pub variants: Vec<Variant>,
     pub comments: Vec<String>,
     pub hole: u32,
+    pub generate_typescript: bool,
 }
 
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -206,6 +206,7 @@ fn shared_function<'a>(func: &'a ast::Function, _intern: &'a Interner) -> Functi
     Function {
         arg_names,
         name: &func.name,
+        generate_typescript: func.generate_typescript,
     }
 }
 
@@ -218,6 +219,7 @@ fn shared_enum<'a>(e: &'a ast::Enum, intern: &'a Interner) -> Enum<'a> {
             .map(|v| shared_variant(v, intern))
             .collect(),
         comments: e.comments.iter().map(|s| &**s).collect(),
+        generate_typescript: e.generate_typescript,
     }
 }
 
@@ -307,6 +309,7 @@ fn shared_struct<'a>(s: &'a ast::Struct, intern: &'a Interner) -> Struct<'a> {
             .collect(),
         comments: s.comments.iter().map(|s| &**s).collect(),
         is_inspectable: s.is_inspectable,
+        generate_typescript: s.generate_typescript,
     }
 }
 
@@ -318,6 +321,7 @@ fn shared_struct_field<'a>(s: &'a ast::StructField, intern: &'a Interner) -> Str
         },
         readonly: s.readonly,
         comments: s.comments.iter().map(|s| &**s).collect(),
+        generate_typescript: s.generate_typescript,
     }
 }
 

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -454,6 +454,7 @@ impl<'a> Context<'a> {
                 comments: concatenate_comments(&export.comments),
                 arg_names: Some(export.function.arg_names),
                 kind,
+                generate_typescript: export.function.generate_typescript,
             },
         );
         Ok(())
@@ -767,6 +768,7 @@ impl<'a> Context<'a> {
                 .iter()
                 .map(|v| (v.name.to_string(), v.value))
                 .collect(),
+            generate_typescript: enum_.generate_typescript,
         };
         self.aux.enums.push(aux);
         Ok(())
@@ -799,6 +801,7 @@ impl<'a> Context<'a> {
                         class: struct_.name.to_string(),
                         field: field.name.to_string(),
                     },
+                    generate_typescript: field.generate_typescript,
                 },
             );
 
@@ -824,6 +827,7 @@ impl<'a> Context<'a> {
                         class: struct_.name.to_string(),
                         field: field.name.to_string(),
                     },
+                    generate_typescript: field.generate_typescript,
                 },
             );
         }
@@ -831,6 +835,7 @@ impl<'a> Context<'a> {
             name: struct_.name.to_string(),
             comments: concatenate_comments(&struct_.comments),
             is_inspectable: struct_.is_inspectable,
+            generate_typescript: struct_.generate_typescript,
         };
         self.aux.structs.push(aux);
 
@@ -1048,6 +1053,7 @@ impl<'a> Context<'a> {
                 comments: String::new(),
                 arg_names: None,
                 kind,
+                generate_typescript: true,
             };
             assert!(self.aux.export_map.insert(id, export).is_none());
         }

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -73,6 +73,8 @@ pub struct AuxExport {
     pub arg_names: Option<Vec<String>>,
     /// What kind of function this is and where it shows up
     pub kind: AuxExportKind,
+    /// Whether typescript bindings should be generated for this export.
+    pub generate_typescript: bool,
 }
 
 /// All possible kinds of exports from a wasm module.
@@ -131,7 +133,10 @@ pub struct AuxEnum {
     /// The copied Rust comments to forward to JS
     pub comments: String,
     /// A list of variants with their name and value
+    /// and whether typescript bindings should be generated for each variant
     pub variants: Vec<(String, u32)>,
+    /// Whether typescript bindings should be generated for this enum.
+    pub generate_typescript: bool,
 }
 
 #[derive(Debug)]
@@ -142,6 +147,8 @@ pub struct AuxStruct {
     pub comments: String,
     /// Whether to generate helper methods for inspecting the class
     pub is_inspectable: bool,
+    /// Whether typescript bindings should be generated for this struct.
+    pub generate_typescript: bool,
 }
 
 /// All possible types of imports that can be imported by a wasm module.

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -100,6 +100,7 @@ macro_rules! shared_api {
             name: &'a str,
             variants: Vec<EnumVariant<'a>>,
             comments: Vec<&'a str>,
+            generate_typescript: bool,
         }
 
         struct EnumVariant<'a> {
@@ -110,6 +111,7 @@ macro_rules! shared_api {
         struct Function<'a> {
             arg_names: Vec<String>,
             name: &'a str,
+            generate_typescript: bool,
         }
 
         struct Struct<'a> {
@@ -117,12 +119,14 @@ macro_rules! shared_api {
             fields: Vec<StructField<'a>>,
             comments: Vec<&'a str>,
             is_inspectable: bool,
+            generate_typescript: bool,
         }
 
         struct StructField<'a> {
             name: &'a str,
             readonly: bool,
             comments: Vec<&'a str>,
+            generate_typescript: bool,
         }
 
         struct LocalModule<'a> {

--- a/crates/typescript-tests/Cargo.toml
+++ b/crates/typescript-tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 wasm-bindgen = { path = '../..' }
 web-sys = { path = '../web-sys', features = [ 'HtmlElement', 'Node', 'Document' ] }
+js-sys = { path = '../js-sys' }
 
 [lib]
 crate-type = ['cdylib']

--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod custom_section;
 pub mod getters_setters;
+pub mod omit_definition;
 pub mod opt_args_and_ret;
 pub mod optional_fields;
 pub mod simple_fn;

--- a/crates/typescript-tests/src/omit_definition.rs
+++ b/crates/typescript-tests/src/omit_definition.rs
@@ -1,0 +1,34 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TYPE_GET_VALUE: &'static str =
+    "export function take_function(func: (x: number) => void): void;";
+
+#[wasm_bindgen(skip_typescript)]
+pub fn take_function(_: js_sys::Function) {}
+
+#[wasm_bindgen]
+pub struct MyExportedStruct {
+    #[wasm_bindgen(skip_typescript)]
+    pub field: bool,
+}
+
+#[wasm_bindgen]
+impl MyExportedStruct {
+    #[wasm_bindgen(skip_typescript)]
+    pub fn method(&mut self) {
+        self.field = !self.field;
+    }
+
+    #[wasm_bindgen(skip_typescript)]
+    pub fn static_func() {
+        panic!("oh no!");
+    }
+}
+
+#[wasm_bindgen(skip_typescript)]
+pub enum MyEnum {
+    One,
+    Two,
+    Three,
+}

--- a/crates/typescript-tests/src/omit_definition.ts
+++ b/crates/typescript-tests/src/omit_definition.ts
@@ -1,0 +1,26 @@
+import * as wbg from '../pkg/typescript_tests';
+
+wbg.take_function((value) => {
+    // `value` should be inferred as `number` because of the
+    // custom typescript section. If `typescript = false` does
+    // not prevent the generation of a signature that takes any
+    // function, then this will trigger a noImplicitAny error.
+    console.log(value);
+});
+
+declare function assert<T>(message: T): void;
+
+type EnableIfEnum = "MyEnum" extends keyof typeof wbg ? never : string;
+assert<EnableIfEnum>("`MyEnum` type should not be exported.");
+
+type EnableIfStruct = "MyStruct" extends keyof typeof wbg ? never : string;
+assert<EnableIfStruct>("`MyStruct` type should not be exported.");
+
+type EnableIfField = "field" extends keyof wbg.MyExportedStruct ? never : string;
+assert<EnableIfField>("`field` should not exist on `MyExportedStruct`.");
+
+type EnableIfMethod = "method" extends keyof wbg.MyExportedStruct ? never : string;
+assert<EnableIfMethod>("`method` should not exist on `MyExportedStruct`.");
+
+type EnableIfStaticMethod = "static_func" extends keyof typeof wbg.MyExportedStruct ? never : string;
+assert<EnableIfStaticMethod>("`static_func` should not exist on `MyExportedStruct`.");

--- a/guide/src/reference/attributes/on-rust-exports/skip_typescript.md
+++ b/guide/src/reference/attributes/on-rust-exports/skip_typescript.md
@@ -1,0 +1,42 @@
+# `skip_typescript`
+
+By default, Rust exports exposed to JavaScript will generate TypeScript definitions (unless `--no-typescript` is used). The `skip_typescript` attribute can be used to disable type generation per function, enum, struct, or field. For example:
+
+```rust
+#[wasm_bindgen(skip_typescript)]
+pub enum MyHiddenEnum {
+    One,
+    Two,
+    Three
+}
+
+#[wasm_bindgen]
+pub struct MyPoint {
+    pub x: u32,
+
+    #[wasm_bindgen(skip_typescript)]
+    pub y: u32,
+}
+
+#[wasm_bindgen]
+impl MyPoint {
+
+    #[wasm_bindgen(skip_typescript)]
+    pub fn stringify(&self) -> String {
+        format!("({}, {})", self.x, self.y)
+    }
+}
+```
+
+Will generate the following `.d.ts` file:
+
+```ts
+/* tslint:disable */
+/* eslint-disable */
+export class MyPoint {
+  free(): void;
+  x: number;
+}
+```
+
+When combined with [the `typescript_custom_section` attribute](typescript_custom_section.html), this can be used to manually specify more specific function types instead of using the generated definitions.


### PR DESCRIPTION
Fixes #1691 by adding support for a `skip_typescript` attribute which disables generation of type definitions for a particular Rust export.