### PR TITLE
Fixing the TypeScript type for the init function

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -461,7 +461,11 @@ impl<'a> Context<'a> {
         Ok(imports)
     }
 
-    fn ts_for_init_fn(&self, has_memory: bool, has_module_or_path_optional: bool) -> Result<String, Error> {
+    fn ts_for_init_fn(
+        &self,
+        has_memory: bool,
+        has_module_or_path_optional: bool,
+    ) -> Result<String, Error> {
         let output = crate::wasm2es6js::interface(&self.module)?;
 
         let (memory_doc, memory_param) = if has_memory {

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -44,6 +44,55 @@ impl Config {
     }
 }
 
+pub fn interface(module: &Module) -> Result<String, Error> {
+    let mut exports = String::new();
+
+    for entry in module.exports.iter() {
+        let id = match entry.item {
+            walrus::ExportItem::Function(i) => i,
+            walrus::ExportItem::Memory(_) => {
+                exports.push_str(&format!(
+                    "  readonly {}: WebAssembly.Memory;\n",
+                    entry.name,
+                ));
+                continue;
+            }
+            walrus::ExportItem::Table(_) => {
+                exports.push_str(&format!(
+                    "  readonly {}: WebAssembly.Table;\n",
+                    entry.name,
+                ));
+                continue;
+            }
+            walrus::ExportItem::Global(_) => continue,
+        };
+
+        let func = module.funcs.get(id);
+        let ty = module.types.get(func.ty());
+        let mut args = String::new();
+        for (i, _) in ty.params().iter().enumerate() {
+            if i > 0 {
+                args.push_str(", ");
+            }
+            args.push((b'a' + (i as u8)) as char);
+            args.push_str(": number");
+        }
+
+        exports.push_str(&format!(
+            "  readonly {name}: ({args}) => {ret};\n",
+            name = entry.name,
+            args = args,
+            ret = match ty.results().len() {
+                0 => "void",
+                1 => "number",
+                _ => "Array",
+            },
+        ));
+    }
+
+    Ok(exports)
+}
+
 pub fn typescript(module: &Module) -> Result<String, Error> {
     let mut exports = format!("/* tslint:disable */\n/* eslint-disable */\n");
 

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -51,17 +51,11 @@ pub fn interface(module: &Module) -> Result<String, Error> {
         let id = match entry.item {
             walrus::ExportItem::Function(i) => i,
             walrus::ExportItem::Memory(_) => {
-                exports.push_str(&format!(
-                    "  readonly {}: WebAssembly.Memory;\n",
-                    entry.name,
-                ));
+                exports.push_str(&format!("  readonly {}: WebAssembly.Memory;\n", entry.name,));
                 continue;
             }
             walrus::ExportItem::Table(_) => {
-                exports.push_str(&format!(
-                    "  readonly {}: WebAssembly.Table;\n",
-                    entry.name,
-                ));
+                exports.push_str(&format!("  readonly {}: WebAssembly.Table;\n", entry.name,));
                 continue;
             }
             walrus::ExportItem::Global(_) => continue,


### PR DESCRIPTION
When generating the `init` function for the `web` target, the TypeScript type was outdated, so this PR fixes that:

```ts
export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;

export interface InitOutput {
  readonly memory: WebAssembly.Memory;
  readonly main_js: () => void;
  readonly __wbindgen_malloc: (a: number) => number;
  readonly __wbindgen_realloc: (a: number, b: number, c: number) => number;
  readonly __wbindgen_export_2: WebAssembly.Table;
  readonly __wbindgen_free: (a: number, b: number) => void;
  readonly __wbindgen_exn_store: (a: number) => void;
  readonly __wbindgen_start: () => void;
}

/**
* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
* for everything else, calls `WebAssembly.instantiate` directly.
*
* @param {InitInput | Promise<InitInput>} module_or_path
*
* @returns {Promise<InitOutput>}
*/
export default function init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;
```