### PR TITLE
Allow changing the `wasm-bindgen-test-runner` timeout via an env variable

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -55,7 +55,7 @@ pub struct LegacyNewSessionParameters {
 /// binary, controlling it, running tests, scraping output, displaying output,
 /// etc. It will return `Ok` if all tests finish successfully, and otherwise it
 /// will return an error if some tests failed.
-pub fn run(server: &SocketAddr, shell: &Shell) -> Result<(), Error> {
+pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error> {
     let driver = Driver::find()?;
     let mut drop_log: Box<dyn FnMut()> = Box::new(|| ());
     let driver_url = match driver.location() {
@@ -145,7 +145,7 @@ pub fn run(server: &SocketAddr, shell: &Shell) -> Result<(), Error> {
     //       information.
     shell.status("Waiting for test to finish...");
     let start = Instant::now();
-    let max = Duration::new(20, 0);
+    let max = Duration::new(timeout, 0);
     while start.elapsed() < max {
         if client.text(&id, &output)?.contains("test result: ") {
             break;
@@ -170,7 +170,7 @@ pub fn run(server: &SocketAddr, shell: &Shell) -> Result<(), Error> {
         // output, so we shouldn't need the driver logs to get printed.
         drop_log();
     } else {
-        println!("failed to detect test as having been run");
+        println!("Failed to detect test as having been run. It might have timed out.");
         if output.len() > 0 {
             println!("output div contained:\n{}", tab(&output));
         }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -116,6 +116,14 @@ integration test.\
         }
     }
 
+    let timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
+        .map(|timeout| timeout.parse().expect("Could not parse 'WASM_BINDGEN_TEST_TIMEOUT'"))
+        .unwrap_or(20);
+
+    if debug {
+        println!("Set timeout to {} seconds...", timeout);
+    }
+
     // Make the generated bindings available for the tests to execute against.
     shell.status("Executing bindgen...");
     let mut b = Bindgen::new();
@@ -167,6 +175,6 @@ integration test.\
     }
 
     thread::spawn(|| srv.run());
-    headless::run(&addr, &shell)?;
+    headless::run(&addr, &shell, timeout)?;
     Ok(())
 }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -117,7 +117,11 @@ integration test.\
     }
 
     let timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
-        .map(|timeout| timeout.parse().expect("Could not parse 'WASM_BINDGEN_TEST_TIMEOUT'"))
+        .map(|timeout| {
+            timeout
+                .parse()
+                .expect("Could not parse 'WASM_BINDGEN_TEST_TIMEOUT'")
+        })
         .unwrap_or(20);
 
     if debug {


### PR DESCRIPTION
This PR would close https://github.com/rustwasm/wasm-bindgen/issues/1801.