### PR TITLE
fix contributing docs url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
 See the ["Contributing" section of the `wasm-bindgen`
-guide](https://rustwasm.github.io/wasm-bindgen/contributing/index.html).
+guide](https://rustwasm.github.io/docs/wasm-bindgen/contributing/index.html).

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.
 
-[contributing]: https://rustwasm.github.io/wasm-bindgen/contributing/index.html
+[contributing]: https://rustwasm.github.io/docs/wasm-bindgen/contributing/index.html


### PR DESCRIPTION
Contributing docs url are unpublished in README.md and CONTRIBUTING.md.

I fixed them to be published url.

## before
https://rustwasm.github.io/wasm-bindgen/contributing/index.html

## after
https://rustwasm.github.io/docs/wasm-bindgen/contributing/index.html