### PR TITLE
Add CI example for GitHub Actions

### DIFF
--- a/guide/src/wasm-bindgen-test/continuous-integration.md
+++ b/guide/src/wasm-bindgen-test/continuous-integration.md
@@ -64,13 +64,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: jetli/wasm-pack-action@v0.2.0
 
-      - name: Cargo test
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          command: test
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - name: Wasm test
-        run: wasm-pack test --headless --chrome
+      - run: cargo test
+      - run: wasm-pack test --headless --chrome
+      - run: wasm-pack test --headless --firefox
 ```

--- a/guide/src/wasm-bindgen-test/continuous-integration.md
+++ b/guide/src/wasm-bindgen-test/continuous-integration.md
@@ -53,3 +53,24 @@ test_script:
   - set GECKODRIVER=C:\Tools\WebDriver\geckodriver.exe
   - cargo test --target wasm32-unknown-unknown
 ```
+
+## GitHub Actions
+
+```yaml
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jetli/wasm-pack-action@v0.2.0
+
+      - name: Cargo test
+        uses: actions-rs/cargo@v1.0.1
+        with:
+          command: test
+
+      - name: Wasm test
+        run: wasm-pack test --headless --chrome
+```


### PR DESCRIPTION
Adds an example workflow to the guide for using
`wasm-pack test` with GitHub actions