### PR TITLE
Add ability to rename enums (js_name = new_name)

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -251,7 +251,8 @@ pub struct StructField {
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
 #[derive(Clone)]
 pub struct Enum {
-    pub name: Ident,
+    pub rust_name: Ident,
+    pub js_name: String,
     pub variants: Vec<Variant>,
     pub comments: Vec<String>,
     pub hole: u32,

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1113,7 +1113,7 @@ impl<'a> ToTokens for DescribeImport<'a> {
 
 impl ToTokens for ast::Enum {
     fn to_tokens(&self, into: &mut TokenStream) {
-        let enum_name = &self.name;
+        let enum_name = &self.rust_name;
         let hole = &self.hole;
         let cast_clauses = self.variants.iter().map(|variant| {
             let variant_name = &variant.name;

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -212,7 +212,7 @@ fn shared_function<'a>(func: &'a ast::Function, _intern: &'a Interner) -> Functi
 
 fn shared_enum<'a>(e: &'a ast::Enum, intern: &'a Interner) -> Enum<'a> {
     Enum {
-        name: intern.intern(&e.name),
+        name: &e.js_name,
         variants: e
             .variants
             .iter()

--- a/tests/wasm/enums.js
+++ b/tests/wasm/enums.js
@@ -28,3 +28,7 @@ exports.js_expect_enum = (a, b) => {
 exports.js_expect_enum_none = a => {
   assert.strictEqual(a, undefined);
 };
+
+exports.js_renamed_enum = b => {
+  assert.strictEqual(wasm.JsRenamedEnum.B, b);
+};

--- a/tests/wasm/enums.rs
+++ b/tests/wasm/enums.rs
@@ -9,6 +9,7 @@ extern "C" {
     fn js_handle_optional_enums(x: Option<Color>) -> Option<Color>;
     fn js_expect_enum(x: Color, y: Option<Color>);
     fn js_expect_enum_none(x: Option<Color>);
+    fn js_renamed_enum(b: RenamedEnum);
 }
 
 #[wasm_bindgen]
@@ -28,6 +29,13 @@ pub mod inner {
         Yellow = 34,
         Red = 2,
     }
+}
+
+#[wasm_bindgen(js_name = JsRenamedEnum)]
+#[derive(Copy, Clone)]
+pub enum RenamedEnum {
+    A = 10,
+    B = 20,
 }
 
 #[wasm_bindgen]
@@ -81,4 +89,9 @@ fn test_optional_enum_values() {
     js_expect_enum(Yellow, Some(Yellow));
     js_expect_enum(Red, Some(Red));
     js_expect_enum_none(None);
+}
+
+#[wasm_bindgen_test]
+fn test_renamed_enum() {
+    js_renamed_enum(RenamedEnum::B);
 }


### PR DESCRIPTION
Closes https://github.com/rustwasm/wasm-bindgen/issues/2054

Enables renaming an enum with `js_name = "NewName"`
