### PR TITLE
try to fix js_name error when both `getter` and `setter` used

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -330,12 +330,6 @@ impl Function {
     pub fn infer_setter_property(&self) -> Result<String, Diagnostic> {
         let name = self.name.to_string();
 
-        // if `#[wasm_bindgen(js_name = "...")]` is used then that explicitly
-        // because it was hand-written anyway.
-        if self.renamed_via_js_name {
-            return Ok(name);
-        }
-
         // Otherwise we infer names based on the Rust function name.
         if !name.starts_with("set_") {
             bail_span!(

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 
+use ast::OperationKind;
 use backend::ast;
 use backend::util::{ident_ty, ShortHash};
 use backend::Diagnostic;
@@ -710,7 +711,16 @@ fn function_from_decl(
 
     let (name, name_span, renamed_via_js_name) =
         if let Some((js_name, js_name_span)) = opts.js_name() {
-            (js_name.to_string(), js_name_span, true)
+            let kind = operation_kind(&opts);
+            let prefix = match kind {
+                OperationKind::Setter(_) => "set_",
+                _ => "",
+            };
+            (
+                format!("{}{}", prefix, js_name.to_string()),
+                js_name_span,
+                true,
+            )
         } else {
             (decl_name.to_string(), decl_name.span(), false)
         };

--- a/tests/wasm/getters_and_setters.js
+++ b/tests/wasm/getters_and_setters.js
@@ -49,6 +49,48 @@ exports._7_js = (rules) => {
     return rules;
 }
 
+exports._8_js = (rules) => {
+    let value = rules.new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name;
+    assert.equal(value, 8);
+    rules.new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name = value * 2;
+    return rules;
+}
+
+exports._9_js = (rules) => {
+    let value = rules.new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name;
+    assert.equal(value, 9);
+    rules.new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name = value * 2;
+    return rules;
+}
+
+exports._10_js = (rules) => {
+    let value = rules.new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name;
+    assert.equal(value, 10);
+    rules.new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name = value * 2;
+    return rules;
+}
+
+exports._11_js = (rules) => {
+    let value = rules.new_js_name__getter_with_name__no_getter_without_name_for_field__same_getter_setter_name;
+    assert.equal(value, 11);
+    rules.new_js_name__setter_with_name__no_setter_without_name_for_field__same_getter_setter_name = value * 2;
+    return rules;
+}
+
+exports._12_js = (rules) => {
+    let value = rules.new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name;
+    assert.equal(value, 12);
+    rules.new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name = value * 2;
+    return rules;
+}
+
+exports._13_js = (rules) => {
+    let value = rules.new_js_name__getter_with_name__no_getter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name;
+    assert.equal(value, 13);
+    rules.new_js_name__setter_with_name__no_setter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name = value * 2;
+    return rules;
+}
+
 exports.test_getter_compute = x => {
   assert.equal(x.foo, 3)
 };

--- a/tests/wasm/getters_and_setters.rs
+++ b/tests/wasm/getters_and_setters.rs
@@ -12,6 +12,12 @@ extern "C" {
     fn _5_js(rules: Rules) -> Rules;
     fn _6_js(rules: Rules) -> Rules;
     fn _7_js(rules: Rules) -> Rules;
+    fn _8_js(rules: Rules) -> Rules;
+    fn _9_js(rules: Rules) -> Rules;
+    fn _10_js(rules: Rules) -> Rules;
+    fn _11_js(rules: Rules) -> Rules;
+    fn _12_js(rules: Rules) -> Rules;
+    fn _13_js(rules: Rules) -> Rules;
 
     fn test_getter_compute(x: GetterCompute);
     fn test_setter_compute(x: SetterCompute);
@@ -86,6 +92,106 @@ impl Rules {
     pub fn set_js_name__setter_with_name__no_setter_without_name_for_field(&mut self, field: i32) {
         self.field = field;
     }
+
+    #[wasm_bindgen(getter, js_name = new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name)]
+    pub fn js_name__no_getter_with_name__getter_without_name__same_getter_setter_name(
+        &self,
+    ) -> i32 {
+        self.field
+    }
+    #[wasm_bindgen(js_name = new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name, setter)]
+    pub fn set_js_name__no_setter_with_name__setter_without_name__same_getter_setter_name(
+        &mut self,
+        field: i32,
+    ) {
+        self.field = field;
+    }
+
+    #[wasm_bindgen(getter, js_name = new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name)]
+    pub fn js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name(
+        &self,
+    ) -> i32 {
+        self.field
+    }
+    #[wasm_bindgen(js_name = new_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name, setter)]
+    pub fn set_js_name__no_getter_setter_with_name__getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name(
+        &mut self,
+        field: i32,
+    ) {
+        self.field = field;
+    }
+
+    #[wasm_bindgen(
+        getter = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name,
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name)]
+    pub fn js_name__getter_with_name__no_getter_without_name__same_getter_setter_name(
+        &self,
+    ) -> i32 {
+        self.field
+    }
+    #[wasm_bindgen(
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name,
+        setter = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name)]
+    pub fn set_js_name__setter_with_name__no_setter_without_name__same_getter_setter_name(
+        &mut self,
+        field: i32,
+    ) {
+        self.field = field;
+    }
+
+    #[wasm_bindgen(
+        getter = new_js_name__getter_with_name__no_getter_without_name_for_field__same_getter_setter_name,
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name__no_same_field_name)]
+    pub fn js_name__getter_with_name__no_getter_without_name__same_getter_setter_name__no_same_field_name(
+        &self,
+    ) -> i32 {
+        self.field
+    }
+    #[wasm_bindgen(
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name__no_same_field_name,
+        setter = new_js_name__setter_with_name__no_setter_without_name_for_field__same_getter_setter_name)]
+    pub fn set_js_name__setter_with_name__no_setter_without_name__same_getter_setter_name__no_same_field_name(
+        &mut self,
+        field: i32,
+    ) {
+        self.field = field;
+    }
+
+    #[wasm_bindgen(
+        getter = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name,
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name__same_getter_setter_origin_name)]
+    pub fn js_name__getter_setter_with_name__no_getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name(
+        &self,
+    ) -> i32 {
+        self.field
+    }
+    #[wasm_bindgen(
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name__same_getter_setter_origin_name,
+        setter = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name)]
+    pub fn set_js_name__getter_setter_with_name__no_getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name(
+        &mut self,
+        field: i32,
+    ) {
+        self.field = field;
+    }
+
+    #[wasm_bindgen(
+        getter = new_js_name__getter_with_name__no_getter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name,
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name__same_getter_setter_origin_name__no_same_field_name)]
+    pub fn js_name__getter_setter_with_name__no_getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name__no_same_field_name(
+        &self,
+    ) -> i32 {
+        self.field
+    }
+    #[wasm_bindgen(
+        js_name = new_js_name__getter_setter_with_name__no_getter_setter_without_name_for_method__same_getter_setter_name__same_getter_setter_origin_name__no_same_field_name,
+        setter = new_js_name__setter_with_name__no_setter_without_name_for_field__same_getter_setter_name__same_getter_setter_origin_name)]
+    pub fn set_js_name__getter_setter_with_name__no_getter_setter_without_name__same_getter_setter_name__same_getter_setter_origin_name__no_same_field_name(
+        &mut self,
+        field: i32,
+    ) {
+        self.field = field;
+    }
 }
 
 #[wasm_bindgen_test]
@@ -128,6 +234,42 @@ fn _6_rust() {
 fn _7_rust() {
     let rules = _7_js(Rules { field: 7 });
     assert_eq!(rules.field, 14);
+}
+
+#[wasm_bindgen_test]
+fn _8_rust() {
+    let rules = _8_js(Rules { field: 8 });
+    assert_eq!(rules.field, 16);
+}
+
+#[wasm_bindgen_test]
+fn _9_rust() {
+    let rules = _9_js(Rules { field: 9 });
+    assert_eq!(rules.field, 18);
+}
+
+#[wasm_bindgen_test]
+fn _10_rust() {
+    let rules = _10_js(Rules { field: 10 });
+    assert_eq!(rules.field, 20);
+}
+
+#[wasm_bindgen_test]
+fn _11_rust() {
+    let rules = _11_js(Rules { field: 11 });
+    assert_eq!(rules.field, 22);
+}
+
+#[wasm_bindgen_test]
+fn _12_rust() {
+    let rules = _12_js(Rules { field: 12 });
+    assert_eq!(rules.field, 24);
+}
+
+#[wasm_bindgen_test]
+fn _13_rust() {
+    let rules = _13_js(Rules { field: 13 });
+    assert_eq!(rules.field, 26);
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Related to #2072 

The error may come from Line 492 in codegen.rs:

```rust
        (quote! {
            #(#attrs)*
            #[allow(non_snake_case)]
            #[cfg_attr(
                all(target_arch = "wasm32", not(target_os = "emscripten")),
                export_name = #export_name, // this line...
            )]
            #[allow(clippy::all)]
            pub extern "C" fn #generated_name(#(#args),*) -> #projection::Abi {
                #start_check
                // Scope all local variables to be destroyed after we call the
                // function to ensure that `#convert_ret`, if it panics, doesn't
                // leak anything.
                let #ret = {
                    #(#arg_conversions)*
                    #receiver(#(#converted_arguments),*)
                };
                #convert_ret
            }
        })
        .to_tokens(into);
```
When both `getter` and `setter` are used, a name conflict occurs since `export_name` for both are the same.
