### PR TITLE
No longer fail if env vars do not exist.

### DIFF
--- a/crates/backend/src/util.rs
+++ b/crates/backend/src/util.rs
@@ -136,12 +136,15 @@ impl<T: Hash> fmt::Display for ShortHash<T> {
         // hashing for a lot of symbols.
         if !HASHED.load(SeqCst) {
             let mut h = DefaultHasher::new();
+
+            // If the environment variables cannot be found, use defaults.
             env::var("CARGO_PKG_NAME")
-                .expect("should have CARGO_PKG_NAME env var")
+                .unwrap_or_else(|_| "UNKNOWN".to_string())
                 .hash(&mut h);
             env::var("CARGO_PKG_VERSION")
-                .expect("should have CARGO_PKG_VERSION env var")
+                .unwrap_or_else(|_| "0.0.0".to_string())
                 .hash(&mut h);
+
             // This may chop off 32 bits on 32-bit platforms, but that's ok, we
             // just want something to mix in below anyway.
             HASH.store(h.finish() as usize, SeqCst);


### PR DESCRIPTION
This change prevents the ShortHash from failing if environment variables
CARGO_PKG_NAME and CARGO_PKG_VERSION are not present. This allows the
wasm_bindgen macro to work on platforms that do not support environment
variables and build systems that use rustc directly.