### PR TITLE
Fix #2089

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2097,7 +2097,19 @@ impl<'a> Context<'a> {
     fn prestore_global_import_identifiers(&mut self) -> Result<(), Error> {
         for import in self.aux.import_map.values() {
             let js = match import {
-                AuxImport::Value(AuxValue::Bare(js)) => js,
+                AuxImport::Value(AuxValue::Bare(js))
+                | AuxImport::Value(AuxValue::ClassGetter(js, ..))
+                | AuxImport::Value(AuxValue::Getter(js, ..))
+                | AuxImport::Value(AuxValue::ClassSetter(js, ..))
+                | AuxImport::Value(AuxValue::Setter(js, ..))
+                | AuxImport::ValueWithThis(js, ..)
+                | AuxImport::Instanceof(js)
+                | AuxImport::Static(js)
+                | AuxImport::StructuralClassGetter(js, ..)
+                | AuxImport::StructuralClassSetter(js, ..)
+                | AuxImport::IndexingGetterOfClass(js)
+                | AuxImport::IndexingSetterOfClass(js)
+                | AuxImport::IndexingDeleterOfClass(js) => js,
                 _ => continue,
             };
             if let JsImportName::Global { .. } = js.name {

--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -132,6 +132,10 @@ exports.Math = {
   func_from_module_math: (a) => a * 2
 }
 
+exports.Number = {
+  func_from_module_number: () => 3.0
+}
+
 exports.same_name_from_import = (a) => a * 3;
 
 exports.same_js_namespace_from_module = {

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -73,6 +73,9 @@ extern "C" {
     #[wasm_bindgen(js_namespace = Math)]
     fn func_from_module_math(a: i32) -> i32;
 
+    #[wasm_bindgen(js_namespace = Number)]
+    fn func_from_module_number() -> f64;
+
     #[wasm_bindgen(js_name = "same_name_from_import")]
     fn same_name_from_import_1(s: i32) -> i32;
 
@@ -95,6 +98,10 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = Math, js_name = "sqrt")]
     fn func_from_global_math(s: f64) -> f64;
+
+    type Number;
+    #[wasm_bindgen(getter, static_method_of = Number, js_name = "NAN")]
+    fn static_getter_from_global_number() -> f64;
 }
 
 #[wasm_bindgen_test]
@@ -301,7 +308,11 @@ fn func_from_global_and_module_same_js_namespace() {
     assert_eq!(func_from_global_math(4.0), 2.0);
     assert_eq!(func_from_module_math(2), 4);
 }
-
+#[wasm_bindgen_test]
+fn getter_from_global_and_module_same_name() {
+    assert!(Number::static_getter_from_global_number().is_nan());
+    assert_eq!(func_from_module_number(), 3.0);
+}
 #[wasm_bindgen_test]
 fn func_from_two_modules_same_js_name() {
     assert_eq!(same_name_from_import_1(1), 3);


### PR DESCRIPTION
Fix #2089.

The case provided there could be reduced to:

```rust
use wasm_bindgen::prelude::*;

#[wasm_bindgen(module = vscode)]
extern "C" {
    #[wasm_bindgen(js_namespace = window)]
    fn f1();
}

#[wasm_bindgen]
extern "C" {
    type window;

    #[wasm_bindgen(getter, static_method_of = window)]
    fn f2();
}

#[wasm_bindgen]
pub fn yoyo() {
    f1();
    window::f2();
}
```

Seems `prestore_global_import_identifiers` didn't exhaustively match all possible `JsImport` so that `StructuralClassGetter` doesn't work here.

A test added.