### PR TITLE
Fixing bug with Firefox extension content scripts

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4747,9 +4747,11 @@ pub fn global() -> Object {
             fn get_global() -> Result<Object, JsValue>;
         }
 
-        let static_object = Global::get_global_this()
-            .or_else(|_| Global::get_self())
+        // The order is important: in Firefox Extension Content Scripts `globalThis`
+        // is a Sandbox (not Window), so `globalThis` must be checked after `window`.
+        let static_object = Global::get_self()
             .or_else(|_| Global::get_window())
+            .or_else(|_| Global::get_global_this())
             .or_else(|_| Global::get_global());
         if let Ok(obj) = static_object {
             if !obj.is_undefined() {


### PR DESCRIPTION
As explained in the comment, in Firefox extension content scripts `globalThis` is a `Sandbox` not a `Window`, so this fixes the order of checks.