### PR TITLE
Adding in wrapper file to fix circular dependency with Webpack 5

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -167,7 +167,7 @@ impl<'a> Context<'a> {
         Ok(())
     }
 
-    pub fn finalize(&mut self, module_name: &str) -> Result<(String, String), Error> {
+    pub fn finalize(&mut self, module_name: &str) -> Result<(String, String, Option<String>), Error> {
         // Finalize all bindings for JS classes. This is where we'll generate JS
         // glue for all classes as well as finish up a few final imports like
         // `__wrap` and such.
@@ -273,9 +273,10 @@ impl<'a> Context<'a> {
         &mut self,
         module_name: &str,
         needs_manual_start: bool,
-    ) -> Result<(String, String), Error> {
+    ) -> Result<(String, String, Option<String>), Error> {
         let mut ts = self.typescript.clone();
         let mut js = String::new();
+        let mut start = None;
 
         if let OutputMode::NoModules { global } = &self.config.mode {
             js.push_str(&format!("let {};\n(function() {{\n", global));
@@ -340,7 +341,7 @@ impl<'a> Context<'a> {
                 ));
                 for (id, js) in crate::sorted_iter(&self.wasm_import_definitions) {
                     let import = self.module.imports.get_mut(*id);
-                    import.module = format!("./{}.js", module_name);
+                    import.module = format!("./{}_bg.js", module_name);
                     footer.push_str("\nexport const ");
                     footer.push_str(&import.name);
                     footer.push_str(" = ");
@@ -348,7 +349,7 @@ impl<'a> Context<'a> {
                     footer.push_str(";\n");
                 }
                 if needs_manual_start {
-                    footer.push_str("\nwasm.__wbindgen_start();\n");
+                    start = Some("\nwasm.__wbindgen_start();\n".to_string());
                 }
             }
 
@@ -394,7 +395,7 @@ impl<'a> Context<'a> {
             js = js.replace("\n\n\n", "\n\n");
         }
 
-        Ok((js, ts))
+        Ok((js, ts, start))
     }
 
     fn js_import_header(&self) -> Result<String, Error> {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -167,7 +167,10 @@ impl<'a> Context<'a> {
         Ok(())
     }
 
-    pub fn finalize(&mut self, module_name: &str) -> Result<(String, String, Option<String>), Error> {
+    pub fn finalize(
+        &mut self,
+        module_name: &str,
+    ) -> Result<(String, String, Option<String>), Error> {
         // Finalize all bindings for JS classes. This is where we'll generate JS
         // glue for all classes as well as finish up a few final imports like
         // `__wrap` and such.

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -61,6 +61,7 @@ struct JsGenerated {
     mode: OutputMode,
     js: String,
     ts: String,
+    start: Option<String>,
     snippets: HashMap<String, Vec<String>>,
     local_modules: HashMap<String, String>,
     npm_dependencies: HashMap<String, (PathBuf, String)>,
@@ -421,7 +422,7 @@ impl Bindgen {
                 .unwrap();
             let mut cx = js::Context::new(&mut module, self, &adapters, &aux)?;
             cx.generate()?;
-            let (js, ts) = cx.finalize(stem)?;
+            let (js, ts, start) = cx.finalize(stem)?;
             Generated::Js(JsGenerated {
                 snippets: aux.snippets.clone(),
                 local_modules: aux.local_modules.clone(),
@@ -430,6 +431,7 @@ impl Bindgen {
                 npm_dependencies: cx.npm_dependencies.clone(),
                 js,
                 ts,
+                start,
             })
         };
 
@@ -613,7 +615,7 @@ impl Output {
             Generated::InterfaceTypes => self.stem.clone(),
             Generated::Js(_) => format!("{}_bg", self.stem),
         };
-        let wasm_path = out_dir.join(wasm_name).with_extension("wasm");
+        let wasm_path = out_dir.join(&wasm_name).with_extension("wasm");
         fs::create_dir_all(out_dir)?;
         let wasm_bytes = self.module.emit_wasm();
         fs::write(&wasm_path, wasm_bytes)
@@ -660,9 +662,24 @@ impl Output {
         } else {
             "js"
         };
+
+        fn write<P, C>(path: P, contents: C) -> Result<(), anyhow::Error> where P: AsRef<Path>, C: AsRef<[u8]> {
+            fs::write(&path, contents).with_context(|| format!("failed to write `{}`", path.as_ref().display()))
+        }
+
         let js_path = out_dir.join(&self.stem).with_extension(extension);
-        fs::write(&js_path, reset_indentation(&gen.js))
-            .with_context(|| format!("failed to write `{}`", js_path.display()))?;
+
+        match gen.start {
+            Some(ref start) => {
+                let js_name = format!("{}_bg.{}", self.stem, extension);
+
+                write(&js_path, format!("import * as wasm from \"./{}.wasm\";\nexport * from \"./{}\";{}", wasm_name, js_name, start))?;
+                write(&out_dir.join(&js_name), reset_indentation(&gen.js))?;
+            },
+            None => {
+                write(&js_path, reset_indentation(&gen.js))?;
+            },
+        }
 
         if gen.typescript {
             let ts_path = js_path.with_extension("d.ts");

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -663,8 +663,13 @@ impl Output {
             "js"
         };
 
-        fn write<P, C>(path: P, contents: C) -> Result<(), anyhow::Error> where P: AsRef<Path>, C: AsRef<[u8]> {
-            fs::write(&path, contents).with_context(|| format!("failed to write `{}`", path.as_ref().display()))
+        fn write<P, C>(path: P, contents: C) -> Result<(), anyhow::Error>
+        where
+            P: AsRef<Path>,
+            C: AsRef<[u8]>,
+        {
+            fs::write(&path, contents)
+                .with_context(|| format!("failed to write `{}`", path.as_ref().display()))
         }
 
         let js_path = out_dir.join(&self.stem).with_extension(extension);
@@ -673,12 +678,18 @@ impl Output {
             Some(ref start) => {
                 let js_name = format!("{}_bg.{}", self.stem, extension);
 
-                write(&js_path, format!("import * as wasm from \"./{}.wasm\";\nexport * from \"./{}\";{}", wasm_name, js_name, start))?;
+                write(
+                    &js_path,
+                    format!(
+                        "import * as wasm from \"./{}.wasm\";\nexport * from \"./{}\";{}",
+                        wasm_name, js_name, start
+                    ),
+                )?;
                 write(&out_dir.join(&js_name), reset_indentation(&gen.js))?;
-            },
+            }
             None => {
                 write(&js_path, reset_indentation(&gen.js))?;
-            },
+            }
         }
 
         if gen.typescript {

--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -112,7 +112,7 @@ fn runtest(test: &Path) -> Result<()> {
         let wat = sanitize_wasm(&wasm)?;
         assert_same(&wat, &test.with_extension("wat"))?;
     } else {
-        let js = fs::read_to_string(td.path().join("reference_test.js"))?;
+        let js = fs::read_to_string(td.path().join("reference_test_bg.js"))?;
         assert_same(&js, &test.with_extension("js"))?;
         let wat = sanitize_wasm(&td.path().join("reference_test_bg.wasm"))?;
         assert_same(&wat, &test.with_extension("wat"))?;

--- a/crates/cli/tests/reference/anyref-empty.js
+++ b/crates/cli/tests/reference/anyref-empty.js
@@ -11,5 +11,3 @@ export const __wbindgen_init_anyref_table = function() {
     ;
 };
 
-wasm.__wbindgen_start();
-

--- a/crates/cli/tests/reference/anyref-empty.wat
+++ b/crates/cli/tests/reference/anyref-empty.wat
@@ -1,6 +1,6 @@
 (module
   (type (;0;) (func))
-  (import "./reference_test.js" "__wbindgen_init_anyref_table" (func (;0;) (type 0)))
+  (import "./reference_test_bg.js" "__wbindgen_init_anyref_table" (func (;0;) (type 0)))
   (table (;0;) 32 anyref)
   (memory (;0;) 16)
   (export "memory" (memory 0))

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -64,5 +64,3 @@ export const __wbindgen_init_anyref_table = function() {
     ;
 };
 
-wasm.__wbindgen_start();
-

--- a/crates/cli/tests/reference/anyref-import-catch.wat
+++ b/crates/cli/tests/reference/anyref-import-catch.wat
@@ -2,7 +2,7 @@
   (type (;0;) (func))
   (type (;1;) (func (result i32)))
   (type (;2;) (func (param i32)))
-  (import "./reference_test.js" "__wbindgen_init_anyref_table" (func (;0;) (type 0)))
+  (import "./reference_test_bg.js" "__wbindgen_init_anyref_table" (func (;0;) (type 0)))
   (func $__wbindgen_exn_store (type 2) (param i32))
   (func $__anyref_table_alloc (type 1) (result i32))
   (func $exported (type 0))

--- a/crates/cli/tests/reference/anyref-nop.js
+++ b/crates/cli/tests/reference/anyref-nop.js
@@ -17,5 +17,3 @@ export const __wbindgen_init_anyref_table = function() {
     ;
 };
 
-wasm.__wbindgen_start();
-

--- a/crates/cli/tests/reference/anyref-nop.wat
+++ b/crates/cli/tests/reference/anyref-nop.wat
@@ -1,6 +1,6 @@
 (module
   (type (;0;) (func))
-  (import "./reference_test.js" "__wbindgen_init_anyref_table" (func (;0;) (type 0)))
+  (import "./reference_test_bg.js" "__wbindgen_init_anyref_table" (func (;0;) (type 0)))
   (func $foo (type 0))
   (table (;0;) 32 anyref)
   (memory (;0;) 17)


### PR DESCRIPTION
The ESM integration spec has changed so that bindings are no longer live (they are "snapshotted" during the linking phase). Normally this isn't a big deal, but it changes the behavior for circular dependencies.

Webpack 5 implements the new ESM integration spec, whereas Webpack 4 implements the old ESM integration spec. That means that wasm-bindgen works fine in Webpack 4 but is broken in Webpack 5.

To explain more clearly why the circular dependencies are now a problem:

1. The `index.js` file imports `index_bg.wasm` which in turn imports `index.js`. This is necessary because `index_bg.wasm` needs to use the glue code defined in `index.js`, and `index.js` needs to export the functions defined in `index_bg.wasm`.

2. This situation is covered in detail in [the ESM integration proposal](https://github.com/WebAssembly/esm-integration/blob/master/proposals/esm-integration/EXAMPLES.md#js---wasm-cycle-where-js-is-higher-in-the-module-graph).

   The short explanation is that when `index_bg.wasm` imports `index.js`, it immediately snapshots the bindings from `index.js` *before* the `index.js` file has been evaluated. That means the bindings are in a "temporal dead zone" which means they will error when they are used.
 
   The only way to fix this is to export function *declarations* (e.g. `export function foo() { ... }`), which means that `export const foo = ...;` and `export class Foo { ... }` will not work.

3. The other option is to import the `index_bg.wasm` file first, in which case [the situation is reversed](https://github.com/WebAssembly/esm-integration/blob/master/proposals/esm-integration/EXAMPLES.md#wasm---js-cycle-where-wasm-is-higher-in-the-module-graph): now `index_bg.wasm` can correctly access all of the `index.js` exports, but `index.js` cannot use any of the `index_bg.wasm` exports at the top level.

So this PR fixes the problem in the following way:

1. The `index.js` file is renamed to `index_bg.js` (and `index_bg.wasm` imports `index_bg.js`).

2. The `index_bg.js` file no longer calls `wasm.__wbindgen_start()` (because it cannot call any `index_bg.wasm` exports at the top level).

3. A new `index.js` file is created which imports the `index_bg.wasm` file *first*, then imports the `index_bg.js` file, then calls `wasm.__wbindgen_start()`:

   ```js
   import * as wasm from "./index_bg.wasm";
   export * from "./index_bg.js";
   wasm.__wbindgen_start();
   ```

   The ordering is important: by importing `index_bg.wasm` first, it gives us the [correct circular ordering](https://github.com/WebAssembly/esm-integration/blob/master/proposals/esm-integration/EXAMPLES.md#wasm---js-cycle-where-wasm-is-higher-in-the-module-graph).

So the end result is that we just needed a tiny `index.js` wrapper file in order to force the correct evaluation order, so this was actually a very small change.