### PR TITLE
Fixing require to be ignored by Webpack

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1247,7 +1247,7 @@ impl<'a> Context<'a> {
             self.global(&format!(
                 "
                     const l{0} = typeof {0} === 'undefined' ? \
-                        require('util').{0} : {0};\
+                        module.require('util').{0} : {0};\
                 ",
                 s
             ));

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1247,7 +1247,7 @@ impl<'a> Context<'a> {
             self.global(&format!(
                 "
                     const l{0} = typeof {0} === 'undefined' ? \
-                        module.require('util').{0} : {0};\
+                        (0, module.require)('util').{0} : {0};\
                 ",
                 s
             ));

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -1,6 +1,6 @@
 import * as wasm from './reference_test_bg.wasm';
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? require('util').TextDecoder : TextDecoder;
+const lTextDecoder = typeof TextDecoder === 'undefined' ? module.require('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
 

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -1,6 +1,6 @@
 import * as wasm from './reference_test_bg.wasm';
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? module.require('util').TextDecoder : TextDecoder;
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
 

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -1,6 +1,6 @@
 import * as wasm from './reference_test_bg.wasm';
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? module.require('util').TextDecoder : TextDecoder;
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
 
@@ -20,7 +20,7 @@ function getStringFromWasm0(ptr, len) {
 
 let WASM_VECTOR_LEN = 0;
 
-const lTextEncoder = typeof TextEncoder === 'undefined' ? module.require('util').TextEncoder : TextEncoder;
+const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
 
 let cachedTextEncoder = new lTextEncoder('utf-8');
 

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -1,6 +1,6 @@
 import * as wasm from './reference_test_bg.wasm';
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? require('util').TextDecoder : TextDecoder;
+const lTextDecoder = typeof TextDecoder === 'undefined' ? module.require('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
 
@@ -20,7 +20,7 @@ function getStringFromWasm0(ptr, len) {
 
 let WASM_VECTOR_LEN = 0;
 
-const lTextEncoder = typeof TextEncoder === 'undefined' ? require('util').TextEncoder : TextEncoder;
+const lTextEncoder = typeof TextEncoder === 'undefined' ? module.require('util').TextEncoder : TextEncoder;
 
 let cachedTextEncoder = new lTextEncoder('utf-8');
 


### PR DESCRIPTION
Some bundlers (such as Webpack) will process `require` even if it's inside of a conditional branch. Since we only want the `require` to run in Node, we want Webpack to [completely ignore it](https://github.com/webpack/webpack/issues/8826). Using `module.require` seems to be the best way to do that.

I would really rather just remove the `require` completely, but [NodeJS 10 is supported until 2021-04-01](https://en.wikipedia.org/wiki/Node.js#Releases), so we can't remove it until then.

Fixes https://github.com/rustwasm/wasm-bindgen/issues/2116