### PR TITLE
Fix name collisions with test functions and intrinsics

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -63,7 +63,7 @@ fn main() -> anyhow::Result<()> {
     let mut tests = Vec::new();
 
     for export in wasm.exports.iter() {
-        if !export.name.starts_with("__wbg_test") {
+        if !export.name.starts_with("__wbgt_") {
             continue;
         }
         tests.push(export.name.to_string());

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -59,11 +59,7 @@ pub fn wasm_bindgen_test(
     // We generate a `#[no_mangle]` with a known prefix so the test harness can
     // later slurp up all of these functions and pass them as arguments to the
     // main test harness. This is the entry point for all tests.
-    let name = format!(
-        "__wbg_test_{}_{}",
-        ident,
-        CNT.fetch_add(1, Ordering::SeqCst)
-    );
+    let name = format!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
     let name = Ident::new(&name, Span::call_site());
     tokens.extend(
         (quote! {


### PR DESCRIPTION
There was an unfortunate collision with how test symbols were named and
the various bindings functions exported by wasm-bindgen. This commit
fixes these issues by using a separate prefix for `#[wasm_bindgen_test]`
than other `#[wasm_bindgen]` functions which should avoid the name
clash.

Closes #2121