### PR TITLE
Support name alias on type directly for methods

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -139,6 +139,7 @@ pub struct ImportFunction {
 pub enum ImportFunctionKind {
     Method {
         class: String,
+        rust_class_str: String,
         ty: syn::Type,
         kind: MethodKind,
     },
@@ -185,6 +186,7 @@ pub struct ImportStatic {
 pub struct ImportType {
     pub vis: syn::Visibility,
     pub rust_name: Ident,
+    pub rust_name_str: String,
     pub js_name: String,
     pub attrs: Vec<syn::Attribute>,
     pub typescript_type: Option<String>,

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -140,6 +140,7 @@ pub enum ImportFunctionKind {
     Method {
         class: String,
         rust_class_str: String,
+        aliased_by_js_class: bool,
         ty: syn::Type,
         kind: MethodKind,
     },
@@ -187,6 +188,7 @@ pub struct ImportType {
     pub vis: syn::Visibility,
     pub rust_name: Ident,
     pub rust_name_str: String,
+    pub aliased_by_js_name: bool,
     pub js_name: String,
     pub attrs: Vec<syn::Attribute>,
     pub typescript_type: Option<String>,

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -263,9 +263,18 @@ fn shared_import_function<'a>(
     intern: &'a Interner,
 ) -> Result<ImportFunction<'a>, Diagnostic> {
     let method = match &i.kind {
-        ast::ImportFunctionKind::Method { class, kind, .. } => {
+        ast::ImportFunctionKind::Method {
+            class,
+            rust_class_str,
+            kind,
+            ..
+        } => {
             let kind = from_ast_method_kind(&i.function, intern, kind)?;
-            Some(MethodData { class, kind })
+            Some(MethodData {
+                class,
+                kind,
+                rust_class_str,
+            })
         }
         ast::ImportFunctionKind::Normal => None,
     };
@@ -291,6 +300,7 @@ fn shared_import_static<'a>(i: &'a ast::ImportStatic, intern: &'a Interner) -> I
 fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner) -> ImportType<'a> {
     ImportType {
         name: &i.js_name,
+        rust_name_str: &i.rust_name_str,
         instanceof_shim: &i.instanceof_shim,
         vendor_prefixes: i.vendor_prefixes.iter().map(|x| intern.intern(x)).collect(),
     }

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -267,6 +267,7 @@ fn shared_import_function<'a>(
             class,
             rust_class_str,
             kind,
+            aliased_by_js_class,
             ..
         } => {
             let kind = from_ast_method_kind(&i.function, intern, kind)?;
@@ -274,6 +275,7 @@ fn shared_import_function<'a>(
                 class,
                 kind,
                 rust_class_str,
+                aliased_by_js_class: *aliased_by_js_class,
             })
         }
         ast::ImportFunctionKind::Normal => None,
@@ -301,6 +303,7 @@ fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner) -> Impor
     ImportType {
         name: &i.js_name,
         rust_name_str: &i.rust_name_str,
+        aliased_by_js_name: i.aliased_by_js_name,
         instanceof_shim: &i.instanceof_shim,
         vendor_prefixes: i.vendor_prefixes.iter().map(|x| intern.intern(x)).collect(),
     }

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -85,6 +85,7 @@ pub fn process(
                 decode::ImportKind::Function(f) => {
                     let decode::ImportFunction { method, .. } = f;
                     if let Some(data) = method {
+                        // same as above, not insert if class_name is not aliased
                         if data.aliased_by_js_class {
                             cx.import_alias_name_map
                                 .entry(data.rust_class_str.to_string())

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -561,11 +561,16 @@ impl<'a> Context<'a> {
         // to the WebAssembly instance.
         let (id, import) = match method {
             Some(data) => {
-                let class_name = self
-                    .import_alias_name_map
-                    .get(&data.rust_class_str.to_string())
-                    .unwrap_or(&data.class.to_string())
-                    .clone();
+                // if js_class is set explicitly, ignoire other aliases.
+                // if js_namespace is set, imports would be determined by js_namespace
+                let class_name = if data.aliased_by_js_class || (&import.js_namespace).is_some() {
+                    data.class.to_string()
+                } else {
+                    self.import_alias_name_map
+                        .get(&data.rust_class_str.to_string())
+                        .unwrap_or(&data.class.to_string())
+                        .clone()
+                };
                 let class = self.determine_import(import, class_name.as_str())?;
                 match &data.kind {
                     // NB: `structural` is ignored for constructors since the

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -553,8 +553,15 @@ impl<'a> Context<'a> {
                     .get(&rust_class_name)
                     .unwrap_or(&class_name)
                     .clone();
-                if class_name != class_name_from_type {
-                    bail!("js_class of method: {:?} of {:?} is {:?}, not same as js_name: {:?} of {:?}", function.name, data.rust_class_str, data.class, class_name_from_type, data.rust_class_str);
+                if rust_class_name != class_name && class_name != class_name_from_type {
+                    bail!(
+                        "js_class of {:?}'s method {:?} is {:?}, not same as {:?}'s js_name: {:?}",
+                        function.name,
+                        class_name,
+                        rust_class_name,
+                        rust_class_name,
+                        class_name_from_type
+                    );
                 }
                 let class = self.determine_import(import, class_name_from_type.as_str())?;
                 match &data.kind {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -452,9 +452,10 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 kind,
             }
         } else if let Some(cls) = opts.static_method_of() {
+            let rust_class_str = cls.to_string();
             let (class, aliased_by_js_class) = match opts.js_class().map(|p| p.0.into()) {
                 Some(p) => (p, true),
-                _ => (cls.to_string(), false),
+                _ => (rust_class_str.clone(), false),
             };
             let ty = ident_ty(cls.clone());
 
@@ -465,7 +466,7 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
 
             ast::ImportFunctionKind::Method {
                 class,
-                rust_class_str: cls.to_string(),
+                rust_class_str,
                 aliased_by_js_class,
                 ty,
                 kind,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -443,8 +443,10 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 kind: operation_kind,
             });
 
+            let rust_class_str = class_name.to_string();
             ast::ImportFunctionKind::Method {
                 class: class_name,
+                rust_class_str,
                 ty: class.clone(),
                 kind,
             }
@@ -460,7 +462,12 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 kind: operation_kind,
             });
 
-            ast::ImportFunctionKind::Method { class, ty, kind }
+            ast::ImportFunctionKind::Method {
+                class,
+                rust_class_str: cls.to_string(),
+                ty,
+                kind,
+            }
         } else if opts.constructor().is_some() {
             let class = match js_ret {
                 Some(ref ty) => ty,
@@ -481,6 +488,7 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
 
             ast::ImportFunctionKind::Method {
                 class: class_name.to_string(),
+                rust_class_str: class_name.to_string(),
                 ty: class.clone(),
                 kind: ast::MethodKind::Constructor,
             }
@@ -562,6 +570,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ForeignItemType {
             doc_comment: None,
             instanceof_shim: shim,
             is_type_of,
+            rust_name_str: self.ident.to_string(),
             rust_name: self.ident,
             typescript_type,
             js_name,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -433,9 +433,10 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 _ => bail_span!(class, "first argument of method must be a path"),
             };
             let class_name = extract_path_ident(class_name)?;
+            let rust_class_str = class_name.to_string();
             let (class_name, aliased_by_js_class) = match opts.js_class().map(|p| p.0.into()) {
                 Some(p) => (p, true),
-                _ => (class_name.to_string(), false),
+                _ => (rust_class_str.clone(), false),
             };
 
             let kind = ast::MethodKind::Operation(ast::Operation {
@@ -443,7 +444,6 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 kind: operation_kind,
             });
 
-            let rust_class_str = class_name.to_string();
             ast::ImportFunctionKind::Method {
                 class: class_name,
                 rust_class_str,
@@ -483,14 +483,15 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
                 _ => bail_span!(self, "return value of constructor must be a bare path"),
             };
             let class_name = extract_path_ident(class_name)?;
+            let rust_class_str = class_name.to_string();
             let (class_name, aliased_by_js_class) = match opts.js_class().map(|p| p.0.into()) {
                 Some(p) => (p, true),
-                _ => (class_name.to_string(), false),
+                _ => (rust_class_str.clone(), false),
             };
 
             ast::ImportFunctionKind::Method {
                 class: class_name.to_string(),
-                rust_class_str: class_name.to_string(),
+                rust_class_str,
                 aliased_by_js_class,
                 ty: class.clone(),
                 kind: ast::MethodKind::Constructor,

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -52,6 +52,7 @@ macro_rules! shared_api {
 
         struct MethodData<'a> {
             class: &'a str,
+            rust_class_str: &'a str,
             kind: MethodKind<'a>,
         }
 
@@ -81,6 +82,7 @@ macro_rules! shared_api {
 
         struct ImportType<'a> {
             name: &'a str,
+            rust_name_str: &'a str,
             instanceof_shim: &'a str,
             vendor_prefixes: Vec<&'a str>,
         }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -53,6 +53,7 @@ macro_rules! shared_api {
         struct MethodData<'a> {
             class: &'a str,
             rust_class_str: &'a str,
+            aliased_by_js_class: bool,
             kind: MethodKind<'a>,
         }
 
@@ -83,6 +84,7 @@ macro_rules! shared_api {
         struct ImportType<'a> {
             name: &'a str,
             rust_name_str: &'a str,
+            aliased_by_js_name: bool,
             instanceof_shim: &'a str,
             vendor_prefixes: Vec<&'a str>,
         }

--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -112,6 +112,16 @@ class StaticMethodCheck {
   static static_method_of_right_this() {
     assert.ok(this === StaticMethodCheck);
   }
+  static static_method_for_type_alias(val) {
+    return val * 6;
+  }
+  constructor(val) {
+    this.inner_value = val * 7;
+  }
+
+  get getter_for_type_alias() {
+    return this.inner_value;
+  }
 }
 
 exports.StaticMethodCheck = StaticMethodCheck;

--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -124,7 +124,18 @@ class StaticMethodCheck {
   }
 }
 
+class StaticMethodCheck2 {
+  constructor(val) {
+    this.inner_value = val * 7;
+  }
+
+  get getter_for_type_alias() {
+    return this.inner_value;
+  }
+}
+
 exports.StaticMethodCheck = StaticMethodCheck;
+exports.StaticMethodCheck2 = StaticMethodCheck2;
 
 exports.receive_undefined = val => {
   assert.strictEqual(val, undefined);

--- a/tests/wasm/imports.js
+++ b/tests/wasm/imports.js
@@ -115,13 +115,6 @@ class StaticMethodCheck {
   static static_method_for_type_alias(val) {
     return val * 6;
   }
-  constructor(val) {
-    this.inner_value = val * 7;
-  }
-
-  get getter_for_type_alias() {
-    return this.inner_value;
-  }
 }
 
 class StaticMethodCheck2 {

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -81,6 +81,18 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = same_js_namespace_from_module)]
     fn func_from_module_1_same_js_namespace(s: i32) -> i32;
+
+    #[wasm_bindgen(js_name = "StaticMethodCheck")]
+    type StaticClassAliasedFromType;
+
+    #[wasm_bindgen(static_method_of = StaticClassAliasedFromType)]
+    fn static_method_for_type_alias(s: i32) -> i32;
+
+    #[wasm_bindgen(constructor)]
+    fn new_for_type_alias(s: i32) -> StaticClassAliasedFromType;
+
+    #[wasm_bindgen(method, getter)]
+    fn getter_for_type_alias(this: &StaticClassAliasedFromType) -> i32;
 }
 
 #[wasm_bindgen(module = "tests/wasm/imports_2.js")]
@@ -323,4 +335,18 @@ fn func_from_two_modules_same_js_name() {
 fn func_from_two_modules_same_js_namespace() {
     assert_eq!(func_from_module_1_same_js_namespace(2), 10);
     assert_eq!(func_from_module_2_same_js_namespace(2), 12);
+}
+
+#[wasm_bindgen_test]
+fn func_test_for_static_method_for_type_alias() {
+    assert_eq!(
+        StaticClassAliasedFromType::static_method_for_type_alias(3),
+        18
+    );
+}
+
+#[wasm_bindgen_test]
+fn func_test_for_new_and_method_for_type_alias() {
+    let instance = StaticClassAliasedFromType::new_for_type_alias(4);
+    assert_eq!(instance.getter_for_type_alias(), 28);
 }

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -88,11 +88,14 @@ extern "C" {
     #[wasm_bindgen(static_method_of = StaticClassAliasedFromType)]
     fn static_method_for_type_alias(s: i32) -> i32;
 
+    #[wasm_bindgen(js_name = "StaticMethodCheck2")]
+    type StaticClassAliasedFromType2;
+
     #[wasm_bindgen(constructor)]
-    fn new_for_type_alias(s: i32) -> StaticClassAliasedFromType;
+    fn new_for_type_alias(s: i32) -> StaticClassAliasedFromType2;
 
     #[wasm_bindgen(method, getter)]
-    fn getter_for_type_alias(this: &StaticClassAliasedFromType) -> i32;
+    fn getter_for_type_alias(this: &StaticClassAliasedFromType2) -> i32;
 }
 
 #[wasm_bindgen(module = "tests/wasm/imports_2.js")]
@@ -347,6 +350,6 @@ fn func_test_for_static_method_for_type_alias() {
 
 #[wasm_bindgen_test]
 fn func_test_for_new_and_method_for_type_alias() {
-    let instance = StaticClassAliasedFromType::new_for_type_alias(4);
+    let instance = StaticClassAliasedFromType2::new_for_type_alias(4);
     assert_eq!(instance.getter_for_type_alias(), 28);
 }


### PR DESCRIPTION
This PR tries to fix #2040.

It could also help to address the following case:

```rust
#[wasm_bindgen(module = "my-great-module")]
extern "C" {

    #[wasm_bindgen]
    pub type MModule;

    #[wasm_bindgen(constructor, js_class = "JKModule")]
    pub fn new() -> MModule;

    #[wasm_bindgen(static_method_of = MModule)]
    pub fn init();
}
```

Currently, for snippet above, `wasm-bindgen` imports both `JKModule` and `MModule`, which I don't think is perfect -- in rust code, both methods actually belong to the same type. Probably just importing `JKModule` would be clearer (or is it by design?).

Now a global name-alias map will be built before determining imports so that for each import we can check if any name-alias exists and if we should import aliased name instead.

Not sure if this modification follows the initial design of `js_class` -- for `globalThis` in `js-sys`, multiple `js_class` for type `global` is actually used.