### PR TITLE
Update the `walrus` dependency

### DIFF
--- a/crates/anyref-xform/Cargo.toml
+++ b/crates/anyref-xform/Cargo.toml
@@ -13,7 +13,7 @@ edition = '2018'
 
 [dependencies]
 anyhow = "1.0"
-walrus = "0.14.0"
+walrus = "0.16.0"
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/anyref-xform/tests/table.wat
+++ b/crates/anyref-xform/tests/table.wat
@@ -28,5 +28,6 @@
   (table (;0;) 2 funcref)
   (table (;1;) 32 anyref)
   (export "func" (table 0))
-  (elem (;0;) (i32.const 0) func $foo $closure0 anyref shim))
+  (elem (;0;) (i32.const 0) func $foo)
+  (elem (;1;) (i32.const 1) func $closure0 anyref shim))
 ;)

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 rustc-demangle = "0.1.13"
 serde_json = "1.0"
 tempfile = "3.0"
-walrus = "0.14.0"
+walrus = "0.16.1"
 wasm-bindgen-anyref-xform = { path = '../anyref-xform', version = '=0.2.62' }
 wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.62' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.62' }
@@ -26,5 +26,5 @@ wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.62' }
 wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.62' }
 wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.62' }
 wit-text = "0.1.1"
-wit-walrus = "0.1.0"
+wit-walrus = "0.2.0"
 wit-validator = "0.1.0"

--- a/crates/cli-support/src/descriptors.rs
+++ b/crates/cli-support/src/descriptors.rs
@@ -107,19 +107,9 @@ impl WasmBindgenDescriptorsSection {
         // For all indirect functions that were closure descriptors, delete them
         // from the function table since we've executed them and they're not
         // necessary in the final binary.
-        let table_id = match interpreter.function_table_id() {
-            Some(id) => id,
-            None => return Ok(()),
-        };
-        let table = module.tables.get_mut(table_id);
-        let table = match &mut table.kind {
-            walrus::TableKind::Function(f) => f,
-            _ => unreachable!(),
-        };
-        for idx in element_removal_list {
+        for (segment, idx) in element_removal_list {
             log::trace!("delete element {}", idx);
-            assert!(table.elements[idx].is_some());
-            table.elements[idx] = None;
+            module.elements.get_mut(segment).members[idx] = None;
         }
 
         // And finally replace all calls of `wbindgen_describe_closure` with a

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1145,18 +1145,9 @@ impl Invocation {
             // The function table never changes right now, so we can statically
             // look up the desired function.
             CallTableElement(idx) => {
-                let table = module
-                    .tables
-                    .main_function_table()?
-                    .ok_or_else(|| anyhow!("no function table found"))?;
-                let functions = match &module.tables.get(table).kind {
-                    walrus::TableKind::Function(f) => f,
-                    _ => bail!("should have found a function table"),
-                };
-                let id = functions
-                    .elements
-                    .get(*idx as usize)
-                    .and_then(|id| *id)
+                let entry = wasm_bindgen_wasm_conventions::get_function_table_entry(module, *idx)?;
+                let id = entry
+                    .func
                     .ok_or_else(|| anyhow!("function table wasn't filled in a {}", idx))?;
                 Invocation::Core { id, defer: false }
             }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -373,6 +373,11 @@ impl Bindgen {
             for id in ids {
                 module.exports.delete(id);
             }
+            // Clean up element segments as well if they have holes in them
+            // after some of our transformations, because non-anyref engines
+            // only support contiguous arrays of function references in element
+            // segments.
+            anyref::force_contiguous_elements(&mut module)?;
         }
 
         // If wasm interface types are enabled then the `__wbindgen_throw`
@@ -560,13 +565,6 @@ impl OutputMode {
     fn web(&self) -> bool {
         match self {
             OutputMode::Web => true,
-            _ => false,
-        }
-    }
-
-    fn bundler(&self) -> bool {
-        match self {
-            OutputMode::Bundler { .. } => true,
             _ => false,
         }
     }

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -313,7 +313,9 @@ impl AdapterType {
             walrus::ValType::F32 => AdapterType::F32,
             walrus::ValType::F64 => AdapterType::F64,
             walrus::ValType::Anyref => AdapterType::Anyref,
-            walrus::ValType::V128 => return None,
+            walrus::ValType::Funcref | walrus::ValType::Nullref | walrus::ValType::V128 => {
+                return None
+            }
         })
     }
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ rouille = { version = "3.0.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
-walrus = { version = "0.14.0", features = ['parallel'] }
+walrus = { version = "0.16.0", features = ['parallel'] }
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.62" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.62" }
 
@@ -34,11 +34,11 @@ diff = "0.1"
 predicates = "1.0.0"
 rayon = "1.0"
 tempfile = "3.0"
-walrus = "0.14"
+walrus = "0.16"
 wit-printer = "0.1"
 wit-text = "0.1"
 wit-validator = "0.1"
-wit-walrus = "0.1"
+wit-walrus = "0.2"
 
 [[test]]
 name = "reference"

--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -152,6 +152,13 @@ fn sanitize_wasm(wasm: &Path) -> Result<String> {
     for mem in module.memories.iter_mut() {
         mem.data_segments.drain();
     }
+    let ids = module.elements.iter().map(|d| d.id()).collect::<Vec<_>>();
+    for id in ids {
+        module.elements.delete(id);
+    }
+    for table in module.tables.iter_mut() {
+        table.elem_segments.drain();
+    }
     let ids = module
         .exports
         .iter()

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-walrus = "0.14.0"
+walrus = "0.16.0"
 
 [dev-dependencies]
 rayon = "1.0"
 wasmprinter = "0.2"
-wast = "3.0"
+wast = "15.0"
 wat = "1.0"
 
 [[test]]

--- a/crates/multi-value-xform/src/lib.rs
+++ b/crates/multi-value-xform/src/lib.rs
@@ -162,10 +162,12 @@ fn xform_one(
                 round_up_to_alignment(results_size, 8) + 8
             }
             walrus::ValType::V128 => round_up_to_alignment(results_size, 16) + 16,
-            walrus::ValType::Anyref => anyhow::bail!(
-                "cannot multi-value transform functions that return \
-                 anyref, since they can't go into linear memory"
-            ),
+            walrus::ValType::Anyref | walrus::ValType::Funcref | walrus::ValType::Nullref => {
+                anyhow::bail!(
+                    "cannot multi-value transform functions that return \
+                     reference types, since they can't go into linear memory"
+                )
+            }
         };
     }
     // Round up to 16-byte alignment, since that's what LLVM's emitted Wasm code
@@ -284,7 +286,9 @@ fn xform_one(
                 );
                 offset += 16;
             }
-            walrus::ValType::Anyref => unreachable!(),
+            walrus::ValType::Anyref | walrus::ValType::Funcref | walrus::ValType::Nullref => {
+                unreachable!()
+            }
         }
     }
 

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-walrus = "0.14.0"
+walrus = "0.16.0"
 wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.62" }

--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -401,6 +401,9 @@ fn inject_start(
                         match segment.offset {
                             InitExpr::Global(id) => body.global_get(id),
                             InitExpr::Value(v) => body.const_(v),
+                            InitExpr::RefNull | InitExpr::RefFunc(_) => {
+                                panic!("not a valid i32 initializer")
+                            }
                         };
                         body.i32_const(0)
                             .i32_const(segment.len as i32)

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -10,5 +10,5 @@ description = "Utilities for working with Wasm codegen conventions (usually esta
 edition = "2018"
 
 [dependencies]
-walrus = "0.14.0"
+walrus = "0.16.0"
 anyhow = "1.0"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -14,7 +14,8 @@ edition = '2018'
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
-walrus = "0.14.0"
+walrus = "0.16.0"
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.62" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
This commit updates the `walrus` crate used in `wasm-bindgen`. The major
change here is how `walrus` handles element segments, exposing segments
rather than trying to keep a contiugous array of all the elements and
doing the splitting itself. That means that we need to do mroe logic
here in `wasm-bindgen` to juggle indices, segments, etc.