### PR TITLE
Remove outdated comment about path dependency.

### DIFF
--- a/guide/src/examples/hello-world.md
+++ b/guide/src/examples/hello-world.md
@@ -11,9 +11,7 @@ function in Rust.
 
 ## `Cargo.toml`
 
-The `Cargo.toml` enables depends on the `wasm-bindgen` crate. Here we're using
-a `path` dependency because this example lives in the `wasm-bindgen` repository
-itself, but you'd use the commented out version beneath it instead.
+The `Cargo.toml` lists the `wasm-bindgen` crate as a dependency.
 
 Also of note is the `crate-type = ["cdylib"]` which is largely used for wasm
 final artifacts today.


### PR DESCRIPTION
The "Hello, World!" chapter of the wasm-bindgen Guide contains an sentence about a path dependency in the `Cargo.toml` section: https://rustwasm.github.io/docs/wasm-bindgen/examples/hello-world.html

> The Cargo.toml enables depends on the wasm-bindgen crate. Here we're using a path dependency because this example lives in the wasm-bindgen repository itself, but you'd use the commented out version beneath it instead.

But then the quoted code section shows a regular version dependency:

```toml
[dependencies]
wasm-bindgen = "0.2.62"
```

The path dependency was turned into a regular version dependency in PR #1015.

This PR also changes the phrasing in the preceding sentence, to eliminate the odd "enables depends" fragment.