### PR TITLE
web-sys: Add Blob.stream() method

### DIFF
--- a/crates/web-sys/src/features/gen_Blob.rs
+++ b/crates/web-sys/src/features/gen_Blob.rs
@@ -212,6 +212,14 @@ extern "C" {
         end: f64,
         content_type: &str,
     ) -> Result<Blob, JsValue>;
+    #[cfg(feature = "ReadableStream")]
+    # [ wasm_bindgen ( method , structural , js_class = "Blob" , js_name = stream ) ]
+    #[doc = "The `stream()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Blob/stream)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ReadableStream`*"]
+    pub fn stream(this: &Blob) -> ReadableStream;
     # [ wasm_bindgen ( method , structural , js_class = "Blob" , js_name = text ) ]
     #[doc = "The `text()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/Blob.webidl
+++ b/crates/web-sys/webidls/enabled/Blob.webidl
@@ -29,6 +29,8 @@ interface Blob {
              [Clamp] optional long long end,
              optional DOMString contentType);
 
+  // read from the Blob.
+  [NewObject] ReadableStream stream();
   [NewObject] Promise<DOMString> text();
   [NewObject] Promise<ArrayBuffer> arrayBuffer();
 };


### PR DESCRIPTION
This enables a ReadableStream to be obtained for a file, which can then
be handled with e.g. https://github.com/MattiasBuelens/wasm-streams

```rust
let file: web_sys::File = ...;
let stream = wasm_streams::readable::ReadableStream::from(
    file.stream()
        .unchecked_into::<wasm_streams::readable::sys::ReadableStream>(),
);
```

WebIDL source: https://w3c.github.io/FileAPI/#blob-section
Docs: https://developer.mozilla.org/en-US/docs/Web/API/Blob/stream