### PR TITLE
Explictly drop instead of relying on RAII.

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -213,7 +213,7 @@ impl ToTokens for ast::Struct {
             #[doc(hidden)]
             #[allow(clippy::all)]
             pub unsafe extern "C" fn #free_fn(ptr: u32) {
-                <#name as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr);
+                drop(<#name as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr));
             }
 
             #[allow(clippy::all)]


### PR DESCRIPTION
This is functionally identical to the previous implementation but it subverts a linter warning on structs annotated with `#[must_use]`. 

An alternative solution might be to add an annotation to the generated function to `#[allow(unused)]` but this seems more focused and explicit.