### PR TITLE
Add another example to js_namespace

### DIFF
--- a/guide/src/reference/attributes/on-js-imports/js_namespace.md
+++ b/guide/src/reference/attributes/on-js-imports/js_namespace.md
@@ -11,11 +11,16 @@ name (like a class or function name) it'll be accessed through this namespace.
 extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
+    
+    type Foo;
+    #[wasm_bindgen(constructor, js_namespace = Bar)]
+    fn new() -> Foo;
 }
 
 log("hello, console!");
+Foo::new();
 ```
 
-This is an example of how to bind `console.log` in Rust. The `log` function will
-be available in the Rust module and will be invoked as `console.log` in
+This is an example of how to bind namespaced items in Rust. The `log` and `Foo::new` functions will
+be available in the Rust module and will be invoked as `console.log` and `new Bar.Foo` in
 JavaScript.


### PR DESCRIPTION
I tried to use `js_namespace` on a type instead of a function which confused me. This PR adds another example which demonstrates how to properly use it with a type.