### PR TITLE
Handle the possibility that the class name is in its own Group

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -875,7 +875,11 @@ impl<'a> MacroParse<BindgenAttrs> for &'a mut syn::ItemImpl {
                 "#[wasm_bindgen] generic impls aren't supported"
             );
         }
-        let name = match *self.self_ty {
+        let self_ty = match &*self.self_ty {
+            syn::Type::Group(syn::TypeGroup { elem, .. }) => &**elem,
+            otherwise => &otherwise,
+        };
+        let name = match self_ty {
             syn::Type::Path(syn::TypePath {
                 qself: None,
                 ref path,

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -45,11 +45,9 @@ pub fn wasm_bindgen_test(
     }
     let ident = match body.next() {
         Some(TokenTree::Ident(token)) => token,
-        Some(TokenTree::Group(g)) => {
-            match g.stream().into_iter().next() {
-                Some(TokenTree::Ident(token)) => token,
-                _ => panic!("expected a function name"),
-            }
+        Some(TokenTree::Group(g)) => match g.stream().into_iter().next() {
+            Some(TokenTree::Ident(token)) => token,
+            _ => panic!("expected a function name"),
         },
         _ => panic!("expected a function name"),
     };

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -43,14 +43,7 @@ pub fn wasm_bindgen_test(
             }
         }
     }
-    let ident = match body.next() {
-        Some(TokenTree::Ident(token)) => token,
-        Some(TokenTree::Group(g)) => match g.stream().into_iter().next() {
-            Some(TokenTree::Ident(token)) => token,
-            _ => panic!("expected a function name"),
-        },
-        _ => panic!("expected a function name"),
-    };
+    let ident = find_ident(&mut body).expect("expected a function name");
 
     let mut tokens = Vec::<TokenTree>::new();
 
@@ -81,4 +74,14 @@ pub fn wasm_bindgen_test(
     tokens.extend(body);
 
     tokens.into_iter().collect::<TokenStream>().into()
+}
+
+fn find_ident(iter: &mut token_stream::IntoIter) -> Option<Ident> {
+    match iter.next()? {
+        TokenTree::Ident(i) => Some(i),
+        TokenTree::Group(g) if g.delimiter() == Delimiter::None => {
+            find_ident(&mut g.stream().into_iter())
+        }
+        _ => None,
+    }
 }

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -45,6 +45,12 @@ pub fn wasm_bindgen_test(
     }
     let ident = match body.next() {
         Some(TokenTree::Ident(token)) => token,
+        Some(TokenTree::Group(g)) => {
+            match g.stream().into_iter().next() {
+                Some(TokenTree::Ident(token)) => token,
+                _ => panic!("expected a function name"),
+            }
+        },
         _ => panic!("expected a function name"),
     };
 


### PR DESCRIPTION
Closes #2158.

I'm not sure if this is the best way to go about fixing this or if there are other places where this kind of thing should be added.

If it's helpful, @dtolnay's fix for `proc-macro-hack` is [here](https://github.com/dtolnay/proc-macro-hack/pull/57/files). 