### PR TITLE
add deno target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
   "examples/char",
   "examples/closures",
   "examples/console_log",
+  "examples/deno",
   "examples/dom",
   "examples/duck-typed-interfaces",
   "examples/fetch",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -167,7 +167,7 @@ jobs:
       - script: mv _package.json package.json && npm install && rm package.json
         displayName: "run npm install"
       - script: |
-          for dir in `ls examples | grep -v README | grep -v asm.js | grep -v raytrace | grep -v without-a-bundler | grep -v websockets | grep -v webxr`; do
+          for dir in `ls examples | grep -v README | grep -v asm.js | grep -v raytrace | grep -v without-a-bundler | grep -v websockets | grep -v webxr | grep -v deno`; do
             (cd examples/$dir &&
             ln -fs ../../node_modules . &&
             npm run build -- --output-path $BUILD_ARTIFACTSTAGINGDIRECTORY/exbuild/$dir) || exit 1;
@@ -177,6 +177,16 @@ jobs:
         inputs:
           artifactName: examples1
           targetPath: '$(Build.ArtifactStagingDirectory)'
+
+  - job: test_deno
+    displayName: "Build and test the deno example"
+    steps:
+      - template: ci/azure-install-rust.yml
+      - script: rustup target add wasm32-unknown-unknown
+        displayName: "install wasm target"
+      - template: ci/azure-install-deno.yml
+      - script: cd examples/deno && ./build.sh && $HOME/.deno/bin/deno run --allow-read test.ts
+        displayName: "build and run deno example"
 
   - job: build_raytrace
     displayName: "Build raytrace examples"

--- a/ci/azure-install-deno.yml
+++ b/ci/azure-install-deno.yml
@@ -1,0 +1,3 @@
+steps:
+  - script: curl -fsSL https://deno.land/x/install/install.sh | sh
+    displayName: "install deno"

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -564,25 +564,9 @@ impl OutputMode {
         }
     }
 
-    fn always_run_in_browser(&self) -> bool {
-        match self {
-            OutputMode::Web => true,
-            OutputMode::NoModules { .. } => true,
-            OutputMode::Bundler { browser_only } => *browser_only,
-            _ => false,
-        }
-    }
-
     fn web(&self) -> bool {
         match self {
             OutputMode::Web => true,
-            _ => false,
-        }
-    }
-
-    fn deno(&self) -> bool {
-        match self {
-            OutputMode::Deno { .. } => true,
             _ => false,
         }
     }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -74,6 +74,7 @@ enum OutputMode {
     Web,
     NoModules { global: String },
     Node { experimental_modules: bool },
+    Deno,
 }
 
 enum Input {
@@ -206,6 +207,14 @@ impl Bindgen {
                 OutputMode::Bundler { browser_only } => *browser_only = true,
                 _ => bail!("cannot specify `--browser` with other output types"),
             }
+        }
+        Ok(self)
+    }
+
+    pub fn deno(&mut self, deno: bool) -> Result<&mut Bindgen, Error> {
+        if deno {
+            self.switch_mode(OutputMode::Deno, "--target deno")?;
+            self.encode_into(EncodeInto::Always);
         }
         Ok(self)
     }
@@ -526,7 +535,8 @@ impl OutputMode {
             | OutputMode::Web
             | OutputMode::Node {
                 experimental_modules: true,
-            } => true,
+            }
+            | OutputMode::Deno => true,
             _ => false,
         }
     }
@@ -566,6 +576,13 @@ impl OutputMode {
     fn web(&self) -> bool {
         match self {
             OutputMode::Web => true,
+            _ => false,
+        }
+    }
+
+    fn deno(&self) -> bool {
+        match self {
+            OutputMode::Deno { .. } => true,
             _ => false,
         }
     }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
@@ -1,0 +1,73 @@
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Error};
+
+use crate::node::{exec, SHARED_SETUP};
+
+pub fn execute(
+    module: &str,
+    tmpdir: &Path,
+    args: &[OsString],
+    tests: &[String],
+) -> Result<(), Error> {
+    let mut js_to_execute = format!(
+        r#"import * as wasm from "./{0}.js";
+
+        {console_override}
+
+        // global.__wbg_test_invoke = f => f();
+
+        // Forward runtime arguments. These arguments are also arguments to the
+        // `wasm-bindgen-test-runner` which forwards them to deno which we
+        // forward to the test harness. this is basically only used for test
+        // filters for now.
+        cx.args(Deno.args.slice(1));
+
+        const ok = await cx.run(tests.map(n => wasm.__wasm[n]));
+        if (!ok) Deno.exit(1);
+
+        const tests = [];
+    "#,
+        module,
+        console_override = SHARED_SETUP,
+    );
+
+    for test in tests {
+        js_to_execute.push_str(&format!("tests.push('{}')\n", test));
+    }
+
+    let js_path = tmpdir.join("run.js");
+    fs::write(&js_path, js_to_execute).context("failed to write JS file")?;
+
+    /*
+    // Augment `NODE_PATH` so things like `require("tests/my-custom.js")` work
+    // and Rust code can import from custom JS shims. This is a bit of a hack
+    // and should probably be removed at some point.
+    let path = env::var("NODE_PATH").unwrap_or_default();
+    let mut path = env::split_paths(&path).collect::<Vec<_>>();
+    path.push(env::current_dir().unwrap());
+    path.push(tmpdir.to_path_buf());
+    let extra_node_args = env::var("NODE_ARGS")
+        .unwrap_or_default()
+        .split(",")
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>();
+    exec(
+        Command::new("node")
+            .env("NODE_PATH", env::join_paths(&path).unwrap())
+            .args(&extra_node_args)
+            .arg(&js_path)
+            .args(args),
+    )*/
+    exec(
+        Command::new("deno")
+            .arg("run")
+            .arg("--allow-read")
+            .arg(&js_path)
+            .args(args),
+    )
+}

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -27,6 +27,12 @@ mod node;
 mod server;
 mod shell;
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum TestMode {
+    Node,
+    Browser,
+}
+
 fn main() -> anyhow::Result<()> {
     env_logger::init();
     let mut args = env::args_os().skip(1);
@@ -81,14 +87,20 @@ fn main() -> anyhow::Result<()> {
     // That's done on a per-test-binary basis with the
     // `wasm_bindgen_test_configure` macro, which emits a custom section for us
     // to read later on.
-    let mut node = true;
-    if let Some(section) = wasm.customs.remove_raw("__wasm_bindgen_test_unstable") {
-        node = !section.data.contains(&0x01);
-    }
+
+    let custom_section = wasm.customs.remove_raw("__wasm_bindgen_test_unstable");
+    let test_mode = match custom_section {
+        Some(section) if section.data.contains(&0x01) => TestMode::Browser,
+        Some(_) => bail!("invalid __wasm_bingen_test_unstable value"),
+        None => TestMode::Node,
+    };
+
     let headless = env::var("NO_HEADLESS").is_err();
     let debug = env::var("WASM_BINDGEN_NO_DEBUG").is_err();
 
     // Gracefully handle requests to execute only node or only web tests.
+    let node = test_mode == TestMode::Node;
+
     if env::var_os("WASM_BINDGEN_TEST_ONLY_NODE").is_some() {
         if !node {
             println!(
@@ -131,9 +143,12 @@ integration test.\
     // Make the generated bindings available for the tests to execute against.
     shell.status("Executing bindgen...");
     let mut b = Bindgen::new();
+    match test_mode {
+        TestMode::Node => b.nodejs(true)?,
+        TestMode::Browser => b.web(true)?,
+    };
+
     b.debug(debug)
-        .nodejs(node)?
-        .web(!node)?
         .input_module(module, wasm)
         .keep_debug(false)
         .emit_start(false)
@@ -141,44 +156,44 @@ integration test.\
         .context("executing `wasm-bindgen` over the wasm file")?;
     shell.clear();
 
-    // If we're executing in node.js, that module will take it from here.
-    if node {
-        return node::execute(&module, &tmpdir, &args.collect::<Vec<_>>(), &tests);
+    let args: Vec<_> = args.collect();
+
+    match test_mode {
+        TestMode::Node => node::execute(&module, &tmpdir, &args, &tests)?,
+        TestMode::Browser => {
+            let srv = server::spawn(
+                &if headless {
+                    "127.0.0.1:0".parse().unwrap()
+                } else {
+                    "127.0.0.1:8000".parse().unwrap()
+                },
+                headless,
+                &module,
+                &tmpdir,
+                &args,
+                &tests,
+            )
+            .context("failed to spawn server")?;
+            let addr = srv.server_addr();
+
+            // TODO: eventually we should provide the ability to exit at some point
+            // (gracefully) here, but for now this just runs forever.
+            if !headless {
+                println!(
+                    "Interactive browsers tests are now available at http://{}",
+                    addr
+                );
+                println!("");
+                println!("Note that interactive mode is enabled because `NO_HEADLESS`");
+                println!("is specified in the environment of this process. Once you're");
+                println!("done with testing you'll need to kill this server with");
+                println!("Ctrl-C.");
+                return Ok(srv.run());
+            }
+
+            thread::spawn(|| srv.run());
+            headless::run(&addr, &shell, timeout)?;
+        }
     }
-
-    // Otherwise we're executing in a browser. Spawn a server which serves up
-    // the local generated files over an HTTP server.
-    let srv = server::spawn(
-        &if headless {
-            "127.0.0.1:0".parse().unwrap()
-        } else {
-            "127.0.0.1:8000".parse().unwrap()
-        },
-        headless,
-        &module,
-        &tmpdir,
-        &args.collect::<Vec<_>>(),
-        &tests,
-    )
-    .context("failed to spawn server")?;
-    let addr = srv.server_addr();
-
-    // TODO: eventually we should provide the ability to exit at some point
-    // (gracefully) here, but for now this just runs forever.
-    if !headless {
-        println!(
-            "Interactive browsers tests are now available at http://{}",
-            addr
-        );
-        println!("");
-        println!("Note that interactive mode is enabled because `NO_HEADLESS`");
-        println!("is specified in the environment of this process. Once you're");
-        println!("done with testing you'll need to kill this server with");
-        println!("Ctrl-C.");
-        return Ok(srv.run());
-    }
-
-    thread::spawn(|| srv.run());
-    headless::run(&addr, &shell, timeout)?;
     Ok(())
 }

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,7 +22,7 @@ Options:
     --out-dir DIR                Output directory
     --out-name VAR               Set a custom output filename (Without extension. Defaults to crate name)
     --target TARGET              What type of output to generate, valid
-                                 values are [web, bundler, nodejs, no-modules],
+                                 values are [web, bundler, nodejs, no-modules, deno],
                                  and the default is [bundler]
     --no-modules-global VAR      Name of the global variable to initialize
     --browser                    Hint that JS should only be compatible with a browser
@@ -98,6 +98,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
             "web" => b.web(true)?,
             "no-modules" => b.no_modules(true)?,
             "nodejs" => b.nodejs(true)?,
+            "deno" => b.deno(true)?,
             s => bail!("invalid encode-into mode: `{}`", s),
         };
     }

--- a/examples/deno/Cargo.toml
+++ b/examples/deno/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "deno"
+version = "0.1.0"
+authors = ["The wasm-bindgen Developers"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.63"

--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -1,0 +1,16 @@
+# Using deno
+
+You can build the example with
+
+```sh
+$ ./build.sh
+```
+
+and test it with
+
+```sh
+$ deno run --allow-read test.ts
+```
+
+The `--allow-read` flag is needed because the wasm file is read during runtime.
+This will be fixed when https://github.com/denoland/deno/issues/5609 is resolved.

--- a/examples/deno/build.sh
+++ b/examples/deno/build.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+cargo build --target wasm32-unknown-unknown --release
+cargo run --package wasm-bindgen-cli --bin wasm-bindgen -- \
+	--out-dir pkg --target deno ${CARGO_TARGET_DIR:-../../target}/wasm32-unknown-unknown/release/deno.wasm

--- a/examples/deno/crate/.gitignore
+++ b/examples/deno/crate/.gitignore
@@ -1,0 +1,1 @@
+/deno.wasm

--- a/examples/deno/defined-in-js.js
+++ b/examples/deno/defined-in-js.js
@@ -1,0 +1,17 @@
+export class MyClass {
+  constructor() {
+    this._number = 42;
+  }
+
+  get number() {
+    return this._number;
+  }
+
+  set number(n) {
+    return (this._number = n);
+  }
+
+  render() {
+    return `My number is: ${this.number}`;
+  }
+}

--- a/examples/deno/src/lib.rs
+++ b/examples/deno/src/lib.rs
@@ -1,0 +1,37 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(module = "/defined-in-js.js")]
+extern "C" {
+    type MyClass;
+
+    #[wasm_bindgen(constructor)]
+    fn new() -> MyClass;
+
+    #[wasm_bindgen(method, getter)]
+    fn number(this: &MyClass) -> u32;
+    #[wasm_bindgen(method, setter)]
+    fn set_number(this: &MyClass, number: u32) -> MyClass;
+    #[wasm_bindgen(method)]
+    fn render(this: &MyClass) -> String;
+}
+
+// lifted from the `console_log` example
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+#[wasm_bindgen(inline_js = "export function add(a, b) { return a + b; }")]
+extern "C" {
+    fn add(a: u32, b: u32) -> u32;
+}
+
+#[wasm_bindgen]
+pub fn greet(name: String) {
+    log(&format!("Hello from {}!", name)); // should output "Hello from Rust!"
+
+    let x = MyClass::new();
+    assert_eq!(x.number(), add(40, 2));
+    log(&x.render());
+}

--- a/examples/deno/src/lib.rs
+++ b/examples/deno/src/lib.rs
@@ -26,6 +26,10 @@ extern "C" {
 extern "C" {
     fn add(a: u32, b: u32) -> u32;
 }
+#[wasm_bindgen(inline_js = "export function test() {}")]
+extern "C" {
+    fn test();
+}
 
 #[wasm_bindgen]
 pub fn greet(name: String) {
@@ -33,5 +37,6 @@ pub fn greet(name: String) {
 
     let x = MyClass::new();
     assert_eq!(x.number(), add(40, 2));
+    test();
     log(&x.render());
 }

--- a/examples/deno/test.ts
+++ b/examples/deno/test.ts
@@ -1,0 +1,3 @@
+import { greet } from "./pkg/deno.js";
+
+greet("Deno");

--- a/guide/src/reference/deployment.md
+++ b/guide/src/reference/deployment.md
@@ -14,12 +14,14 @@ should behave the same way in this respect. The values possible here are:
 | [`bundler`]     | Suitable for loading in bundlers like Webpack              |
 | [`web`]         | Directly loadable in a web browser                         |
 | [`nodejs`]      | Loadable via `require` as a Node.js module                 |
+| [`deno`]        | Loadable using imports from Deno modules                   |
 | [`no-modules`]  | Like `web`, but older and doesn't use ES modules           |
 
 [`bundler`]: #bundlers
 [`web`]: #without-a-bundler
 [`no-modules`]: #without-a-bundler
 [`nodejs`]: #nodejs
+[`deno`]: #Deno
 
 ## Bundlers
 
@@ -69,7 +71,7 @@ documentation, but the highlights of this output are:
 The CLI also supports an output mode called `--target no-modules` which is
 similar to the `web` target in that it requires manual initialization of the
 wasm and is intended to be included in web pages without any further
-postprocessing.  See the [without a bundler example][nomex] for some more
+postprocessing. See the [without a bundler example][nomex] for some more
 information about `--target no-modules`.
 
 ## Node.js
@@ -87,6 +89,18 @@ as it has a JS shim generated as well).
 
 Note that this method requires a version of Node.js with WebAssembly support,
 which is currently Node 8 and above.
+
+## Deno
+
+**`--target deno`**
+
+To deploy WebAssembly to Deno, use the `--target deno` flag.
+To then import your module inside deno, use
+
+```ts
+// @deno-types="./out/crate_name.d.ts"
+import { yourFunction } from "./out/crate_name.js";
+```
 
 ## NPM
 


### PR DESCRIPTION
adds a new `OutputMode` for [Deno](https://deno.land/).

Exports and js-imports are generated like `OutputMode::Web` or `OutputMode::Node { experimental_modules: true }`.

`wasm`-files cannot be imported directly, so the file is read at runtime. If embedding the file as a base64 string or similar is preferable, I can try to do that.