### PR TITLE
Implement extern "C" async functions.

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -972,7 +972,8 @@ impl TryToTokens for ast::ImportFunction {
             }
             Some(ref ty) => {
                 if self.function.r#async {
-                    abi_ret = quote! { <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>::Abi };
+                    abi_ret =
+                        quote! { <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>::Abi };
                     let future = quote! {
                         wasm_bindgen_futures::JsFuture::from(
                             <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>
@@ -996,7 +997,8 @@ impl TryToTokens for ast::ImportFunction {
             }
             None => {
                 if self.function.r#async {
-                    abi_ret = quote! { <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>::Abi };
+                    abi_ret =
+                        quote! { <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>::Abi };
                     let future = quote! {
                         wasm_bindgen_futures::JsFuture::from(
                             <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>
@@ -1076,7 +1078,7 @@ impl TryToTokens for ast::ImportFunction {
         );
 
         let maybe_async = if self.function.r#async {
-            Some(quote!{async})
+            Some(quote! {async})
         } else {
             None
         };

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -971,22 +971,52 @@ impl TryToTokens for ast::ImportFunction {
                 );
             }
             Some(ref ty) => {
-                abi_ret = quote! {
-                    <#ty as wasm_bindgen::convert::FromWasmAbi>::Abi
-                };
-                convert_ret = quote! {
-                    <#ty as wasm_bindgen::convert::FromWasmAbi>
-                        ::from_abi(#ret_ident)
-                };
+                if self.function.r#async {
+                    abi_ret = quote! { <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>::Abi };
+                    let future = quote! {
+                        wasm_bindgen_futures::JsFuture::from(
+                            <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>
+                                ::from_abi(#ret_ident)
+                        ).await
+                    };
+                    convert_ret = if self.catch {
+                        quote! { Ok(#future?) }
+                    } else {
+                        quote! { #future.expect("unexpected exception") }
+                    };
+                } else {
+                    abi_ret = quote! {
+                        <#ty as wasm_bindgen::convert::FromWasmAbi>::Abi
+                    };
+                    convert_ret = quote! {
+                        <#ty as wasm_bindgen::convert::FromWasmAbi>
+                            ::from_abi(#ret_ident)
+                    };
+                }
             }
             None => {
-                abi_ret = quote! { () };
-                convert_ret = quote! { () };
+                if self.function.r#async {
+                    abi_ret = quote! { <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>::Abi };
+                    let future = quote! {
+                        wasm_bindgen_futures::JsFuture::from(
+                            <js_sys::Promise as wasm_bindgen::convert::FromWasmAbi>
+                                ::from_abi(#ret_ident)
+                        ).await
+                    };
+                    convert_ret = if self.catch {
+                        quote! { #future?; Ok(()) }
+                    } else {
+                        quote! { #future.expect("uncaught exception"); }
+                    };
+                } else {
+                    abi_ret = quote! { () };
+                    convert_ret = quote! { () };
+                }
             }
         }
 
         let mut exceptional_ret = quote!();
-        if self.catch {
+        if self.catch && !self.function.r#async {
             convert_ret = quote! { Ok(#convert_ret) };
             exceptional_ret = quote! {
                 wasm_bindgen::__rt::take_last_exception()?;
@@ -1045,12 +1075,17 @@ impl TryToTokens for ast::ImportFunction {
             &self.rust_name,
         );
 
+        let maybe_async = if self.function.r#async {
+            Some(quote!{async})
+        } else {
+            None
+        };
         let invocation = quote! {
             #(#attrs)*
             #[allow(bad_style)]
             #[doc = #doc_comment]
             #[allow(clippy::all)]
-            #vis fn #rust_name(#me #(#arguments),*) #ret {
+            #vis #maybe_async fn #rust_name(#me #(#arguments),*) #ret {
                 #extern_fn
 
                 unsafe {
@@ -1096,6 +1131,8 @@ impl<'a> ToTokens for DescribeImport<'a> {
         let nargs = f.function.arguments.len() as u32;
         let inform_ret = match &f.js_ret {
             Some(ref t) => quote! { <#t as WasmDescribe>::describe(); },
+            // async functions always return a JsValue, even if they say to return ()
+            None if f.function.r#async => quote! { <JsValue as WasmDescribe>::describe(); },
             None => quote! { <() as WasmDescribe>::describe(); },
         };
 

--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -25,6 +25,31 @@ Here we can see how converting a `Promise` to Rust creates a `impl Future<Output
 = Result<JsValue, JsValue>>`. This corresponds to `then` and `catch` in JS where
 a successful promise becomes `Ok` and an erroneous promise becomes `Err`.
 
+You can also import a JS async function directly with a `extern "C"` block, and
+the promise will be converted to a future automatically. For now the return type
+must be `JsValue` or no return at all:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    async fn async_func_1() -> JsValue;
+    async fn async_func_2();
+}
+```
+
+The `async` can be combined with the `catch` attribute to manage errors from the
+JS promise:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(catch)]
+    async fn async_func_3() -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch)]
+    async fn async_func_4() -> Result<(), JsValue>;
+}
+```
+
 Next up you'll probably want to export a Rust function to JS that returns a
 promise. To do this you can use an `async` function and `#[wasm_bindgen]`:
 

--- a/tests/wasm/futures.js
+++ b/tests/wasm/futures.js
@@ -14,3 +14,26 @@ exports.call_exports = async function() {
   assert.strictEqual(8, (await wasm.async_return_8()).val);
   await assert.rejects(wasm.async_throw(), /async message/);
 };
+
+exports.call_promise = async function() {
+    return "ok";
+}
+
+exports.call_promise_ok = async function() {
+    return "ok";
+}
+
+exports.call_promise_err = async function() {
+    throw "error";
+}
+
+exports.call_promise_unit = async function() {
+    console.log("asdfasdf");
+}
+
+exports.call_promise_ok_unit = async function() {
+}
+
+exports.call_promise_err_unit = async function() {
+    throw "error";
+}

--- a/tests/wasm/futures.rs
+++ b/tests/wasm/futures.rs
@@ -3,14 +3,26 @@ use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/futures.js")]
 extern "C" {
-    fn call_exports() -> js_sys::Promise;
+    #[wasm_bindgen(catch)]
+    async fn call_exports() -> Result<JsValue, JsValue>;
+
+    async fn call_promise() -> JsValue;
+    #[wasm_bindgen(catch)]
+    async fn call_promise_ok() -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch)]
+    async fn call_promise_err() -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen]
+    async fn call_promise_unit();
+    #[wasm_bindgen(catch)]
+    async fn call_promise_ok_unit() -> Result<(), JsValue>;
+    #[wasm_bindgen(catch)]
+    async fn call_promise_err_unit() -> Result<(), JsValue>;
 }
 
 #[wasm_bindgen_test]
 async fn smoke() {
-    wasm_bindgen_futures::JsFuture::from(call_exports())
-        .await
-        .unwrap();
+    call_exports().await.unwrap();
 }
 
 #[wasm_bindgen]
@@ -69,4 +81,43 @@ pub async fn async_return_8() -> Result<AsyncCustomReturn, AsyncCustomReturn> {
 #[wasm_bindgen]
 pub async fn async_throw() -> Result<(), js_sys::Error> {
     Err(js_sys::Error::new("async message"))
+}
+
+#[wasm_bindgen_test]
+async fn test_promise() {
+    assert_eq!(call_promise().await.as_string(), Some(String::from("ok")))
+}
+
+#[wasm_bindgen_test]
+async fn test_promise_ok() {
+    assert_eq!(
+        call_promise_ok().await.map(|j| j.as_string()),
+        Ok(Some(String::from("ok")))
+    )
+}
+
+#[wasm_bindgen_test]
+async fn test_promise_err() {
+    assert_eq!(
+        call_promise_err().await.map_err(|j| j.as_string()),
+        Err(Some(String::from("error")))
+    )
+}
+
+#[wasm_bindgen_test]
+async fn test_promise_unit() {
+    call_promise_unit().await
+}
+
+#[wasm_bindgen_test]
+async fn test_promise_ok_unit() {
+    call_promise_ok_unit().await.unwrap()
+}
+
+#[wasm_bindgen_test]
+async fn test_promise_err_unit() {
+    assert_eq!(
+        call_promise_err_unit().await.map_err(|j| j.as_string()),
+        Err::<(), _>(Some(String::from("error")))
+    )
 }

--- a/tests/wasm/futures.rs
+++ b/tests/wasm/futures.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
+#[rustfmt::skip]
 #[wasm_bindgen(module = "tests/wasm/futures.js")]
 extern "C" {
     #[wasm_bindgen(catch)]


### PR DESCRIPTION
It converts a JS Promise into a wasm_bindgen_futures::JsFuture that
implements Future<Result<JsValue, JsValue>>.

Fixes issue #2189. Now you can write:
```rust
#[wasm_bindgen]
extern "C" {
    async fn js_test() -> Result<JsValue, JsValue>;
}
```
And the generated code will do the conversion automatically.

Currently there is the limitation that the return value must be `Result<JsValue, JsValue>`, because that is the `Output` type of a `wasm_bindgen_futures::JsFuture`.

I've added a custom error message if the user does not specify a return type, and let the compiler complaint if they write a different type.

I've tried doing automatic conversions to be able to return `Result<i32, JsValue>` for example, but I could make it work for every case. I think that these kind of conversions (unboxing?) is never done in the generated code. Maybe if `wasm_bindgen_futures::JsFuture` were generic on the return type...

I noticed that one of the test cases used a manually-written promise, so I abused a bit and converted it to the new format. I don't know if it is appropriate or if more tests are needed.

About the documentation, writing English is not my best talent, so feel free to rewrite it at will.