### PR TITLE
Typo in code snippet found in asynchronous-tests.md, ln 22

### DIFF
--- a/guide/src/wasm-bindgen-test/asynchronous-tests.md
+++ b/guide/src/wasm-bindgen-test/asynchronous-tests.md
@@ -19,7 +19,7 @@ async fn my_async_test() {
     let promise = js_sys::Promise::resolve(&JsValue::from(42));
 
     // Convert that promise into a future and make the test wait on it.
-    let x = JsFuture::from(promise).await.unwrap();:
+    let x = JsFuture::from(promise).await.unwrap();
     assert_eq!(x, 42);
 }
 ```


### PR DESCRIPTION
## Document 
https://rustwasm.github.io/docs/wasm-bindgen/wasm-bindgen-test/asynchronous-tests.html

## Summary
Compilation error with code snippet, extra trailing colon.

Currently:
```
    // Convert that promise into a future and make the test wait on it.
    let x = JsFuture::from(promise).await.unwrap();:
```

Should be:
```
    // Convert that promise into a future and make the test wait on it.
    let x = JsFuture::from(promise).await.unwrap();
```


## Tested With
Cargo.toml
```
[dev-dependencies]
wasm-bindgen-test = "0.3" and above
```

## Issue
#2199