### PR TITLE
Rename fn to main_js in guide/src/reference/attributes/on-rust-exports/start.md

### DIFF
--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -6,7 +6,7 @@ soon as the wasm module is instantiated.
 
 ```rust
 #[wasm_bindgen(start)]
-pub fn main() {
+pub fn main_js() {
     // executed automatically ...
 }
 ```
@@ -21,6 +21,7 @@ There's a few caveats to be aware of when using the `start` attribute:
 
 * The `start` function must take no arguments and must either return `()` or
   `Result<(), JsValue>`
+* The name of the annotated function can't be `main`
 * Only one `start` function can be placed into a module, including its
   dependencies. If more than one is specified then `wasm-bindgen` will fail when
   the CLI is run. It's recommended that only applications use this attribute.


### PR DESCRIPTION
Because the tests fail, when a function annotated with `#[wasm_bindgen(start)]` is named `main`, this PR changes the name in the example in the wasm_bindgen book to `main_js` and says, that it can't be named `main`.

The information that it can't be named `main` is from https://github.com/rust-gamedev/wg/issues/51, and solved #2206.

## Changes
* rename function from `main` to `main_js`
* add hint that function can't be named `main`