### PR TITLE
Trims trailing whitespaces in doc comments in generated d.ts

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3356,7 +3356,7 @@ fn check_duplicated_getter_and_setter_names(
 fn format_doc_comments(comments: &str, js_doc_comments: Option<String>) -> String {
     let body: String = comments.lines().map(|c| format!("*{}\n", c)).collect();
     let doc = if let Some(docs) = js_doc_comments {
-        docs.lines().map(|l| format!("* {} \n", l)).collect()
+        docs.lines().map(|l| format!("* {}\n", l)).collect()
     } else {
         String::new()
     };


### PR DESCRIPTION
The doc comments in the generated d.ts file contains trailing whitespaces. This simply removes the whitespaces.