### PR TITLE
test for OptionIntoWasmAbi for Option<&Closure>

### DIFF
--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -136,6 +136,28 @@ where
     }
 }
 
+impl<'a, 'b, A, R> IntoWasmAbi for Option<&'a (dyn Fn(&A) -> R + 'b)>
+where
+    A: RefFromWasmAbi,
+    R: ReturnWasmAbi,
+{
+    type Abi = WasmSlice;
+    fn into_abi(self) -> Self::Abi {
+        unsafe {
+            match self {
+                Some(some_closure) => {
+                    let (a, b): (usize, usize) = mem::transmute(some_closure);
+                    WasmSlice {
+                        ptr: a as u32,
+                        len: b as u32,
+                    }
+                }
+                None => WasmSlice { ptr: 0, len: 0 },
+            }
+        }
+    }
+}
+
 #[allow(non_snake_case)]
 unsafe extern "C" fn invoke1_ref<A: RefFromWasmAbi, R: ReturnWasmAbi>(
     a: usize,

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -143,17 +143,15 @@ where
 {
     type Abi = WasmSlice;
     fn into_abi(self) -> Self::Abi {
-        unsafe {
-            match self {
-                Some(some_closure) => {
-                    let (a, b): (usize, usize) = mem::transmute(some_closure);
-                    WasmSlice {
-                        ptr: a as u32,
-                        len: b as u32,
-                    }
+        match self {
+            Some(some_closure) => unsafe {
+                let (a, b): (usize, usize) = mem::transmute(some_closure);
+                WasmSlice {
+                    ptr: a as u32,
+                    len: b as u32,
                 }
-                None => WasmSlice { ptr: 0, len: 0 },
-            }
+            },
+            None => WasmSlice { ptr: 0, len: 0 },
         }
     }
 }

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -136,12 +136,11 @@ where
     }
 }
 
-impl<'a, 'b, A, R> OptionIntoWasmAbi for Option<&'a (dyn Fn(&A) -> R + 'b)>
+impl<'a, 'b, A, R> OptionIntoWasmAbi for &'a (dyn Fn(&A) -> R + 'b)
 where
     A: RefFromWasmAbi,
     R: ReturnWasmAbi,
 {
-    type Abi = WasmSlice;
     fn none() -> Self::Abi {
         WasmSlice { ptr: 0, len: 0 }
     }

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -2,7 +2,7 @@ use core::mem;
 
 use crate::convert::slices::WasmSlice;
 use crate::convert::RefFromWasmAbi;
-use crate::convert::{FromWasmAbi, IntoWasmAbi, ReturnWasmAbi};
+use crate::convert::{FromWasmAbi, IntoWasmAbi, OptionIntoWasmAbi, ReturnWasmAbi};
 use crate::describe::{inform, WasmDescribe, FUNCTION};
 use crate::throw_str;
 
@@ -136,23 +136,14 @@ where
     }
 }
 
-impl<'a, 'b, A, R> IntoWasmAbi for Option<&'a (dyn Fn(&A) -> R + 'b)>
+impl<'a, 'b, A, R> OptionIntoWasmAbi for Option<&'a (dyn Fn(&A) -> R + 'b)>
 where
     A: RefFromWasmAbi,
     R: ReturnWasmAbi,
 {
     type Abi = WasmSlice;
-    fn into_abi(self) -> Self::Abi {
-        match self {
-            Some(some_closure) => unsafe {
-                let (a, b): (usize, usize) = mem::transmute(some_closure);
-                WasmSlice {
-                    ptr: a as u32,
-                    len: b as u32,
-                }
-            },
-            None => WasmSlice { ptr: 0, len: 0 },
-        }
+    fn none() -> Self::Abi {
+        WasmSlice { ptr: 0, len: 0 }
     }
 }
 

--- a/tests/wasm/closures.js
+++ b/tests/wasm/closures.js
@@ -136,3 +136,11 @@ exports.js_store_forgotten_closure = f => {
 exports.js_call_forgotten_closure = () => {
   FORGOTTEN_CLOSURE();
 };
+
+exports.option_works = a => {
+  if (a) {
+    a(2);
+  } else {
+    1;
+  }
+};

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -111,6 +111,8 @@ extern "C" {
 
     fn js_store_forgotten_closure(closure: &Closure<Fn()>);
     fn js_call_forgotten_closure();
+
+    fn option_works(a: Option<&Closure<FnMut(u32) -> u32>>) -> u32;
 }
 
 #[wasm_bindgen_test]
@@ -583,4 +585,11 @@ fn forget_works() {
     js_store_forgotten_closure(&a);
     a.forget();
     js_call_forgotten_closure();
+}
+
+#[wasm_bindgen_test]
+fn test_option_works() {
+    let a = Closure::wrap(Box::new(move |a| a + 1u32) as Box<FnMut(u32) -> u32>);
+    assert_eq!(option_works(None), 1u32);
+    assert_eq!(option_works(Some(&a)), 3u32);
 }


### PR DESCRIPTION
I added a test for #2191, but it shows it not working yet. Running:
```
cargo test --target wasm32-unknown-unknown --features nightly --test wasm
```
I get the error from #2173.:
```
error[E0277]: the trait bound `&wasm_bindgen::prelude::Closure<dyn std::ops::FnMut(u32) -> u32>: wasm_bindgen::convert::OptionIntoWasmAbi` is not satisfied
   --> tests/wasm/closures.rs:115:21
    |
115 |     fn option_works(a: Option<&Closure<FnMut(u32) -> u32>>) -> u32;
    |                     ^ the trait `wasm_bindgen::convert::OptionIntoWasmAbi` is not implemented for `&wasm_bindgen::prelude::Closure<dyn std::ops::FnMut(u32) -> u32>`
```