### PR TITLE
add reverse mappings from value to name on enums exported from rust/wasm

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3068,6 +3068,7 @@ impl<'a> Context<'a> {
                 variants.push_str(&variant_docs);
             }
             variants.push_str(&format!("{}:{},", name, value));
+            variants.push_str(&format!("\"{}\":\"{}\",", value, name));
             if enum_.generate_typescript {
                 self.typescript.push_str("\n");
                 if !variant_docs.is_empty() {

--- a/tests/wasm/enums.js
+++ b/tests/wasm/enums.js
@@ -5,7 +5,10 @@ exports.js_c_style_enum = () => {
     assert.strictEqual(wasm.Color.Green, 0);
     assert.strictEqual(wasm.Color.Yellow, 1);
     assert.strictEqual(wasm.Color.Red, 2);
-    assert.strictEqual(Object.keys(wasm.Color).length, 3);
+    assert.strictEqual(wasm.Color[0], 'Green');
+    assert.strictEqual(wasm.Color[1], 'Yellow');
+    assert.strictEqual(wasm.Color[2], 'Red');
+    assert.strictEqual(Object.keys(wasm.Color).length, 6);
 
     assert.strictEqual(wasm.enum_cycle(wasm.Color.Green), wasm.Color.Yellow);
 };
@@ -14,7 +17,10 @@ exports.js_c_style_enum_with_custom_values = () => {
     assert.strictEqual(wasm.ColorWithCustomValues.Green, 21);
     assert.strictEqual(wasm.ColorWithCustomValues.Yellow, 34);
     assert.strictEqual(wasm.ColorWithCustomValues.Red, 2);
-    assert.strictEqual(Object.keys(wasm.ColorWithCustomValues).length, 3);
+    assert.strictEqual(wasm.ColorWithCustomValues[21], 'Green');
+    assert.strictEqual(wasm.ColorWithCustomValues[34], 'Yellow');
+    assert.strictEqual(wasm.ColorWithCustomValues[2], 'Red');
+    assert.strictEqual(Object.keys(wasm.ColorWithCustomValues).length, 6);
 
     assert.strictEqual(wasm.enum_with_custom_values_cycle(wasm.ColorWithCustomValues.Green), wasm.ColorWithCustomValues.Yellow);
 };

--- a/tests/wasm/node.js
+++ b/tests/wasm/node.js
@@ -27,7 +27,10 @@ exports.test_works = function() {
   assert.strictEqual(wasm.Color.Green, 0);
   assert.strictEqual(wasm.Color.Yellow, 1);
   assert.strictEqual(wasm.Color.Red, 2);
-  assert.strictEqual(Object.keys(wasm.Color).length, 3);
+  assert.strictEqual(wasm.Color[0], 'Green');
+  assert.strictEqual(wasm.Color[1], 'Yellow');
+  assert.strictEqual(wasm.Color[2], 'Red');
+  assert.strictEqual(Object.keys(wasm.Color).length, 6);
   assert.strictEqual(wasm.cycle(wasm.Color.Green), wasm.Color.Yellow);
 
   wasm.node_math(1.0, 2.0);


### PR DESCRIPTION
This PR adds reverse mappings to enums exported from Rust, so that the string corresponding to a particular integer value can be obtained easily. This matches what TypeScript does for enums defined directly by TypeScript code.

I’ve updated the corresponding tests to take this into account.

This goes some way towards resolving #2045, albeit the approach is still a little different - I’ve kept the `Object.freeze` call that wasm-bindgen performs on its enums (whereas TypeScript does not seem to return a frozen object at all). Here’s an example of how they compare:

```javascript
// TypeScript output
var Shape;
(function (Shape) {
    Shape[Shape["Circle"] = 1] = "Circle";
    Shape[Shape["Triangle"] = 3] = "Triangle";
    Shape[Shape["Rectangle"] = 4] = "Rectangle";
})(Shape || (Shape = {}));

// wasm-bindgen output
module.exports.Shape = Object.freeze({ Circle:1,"1":"Circle",Triangle:3,"3":"Triangle",Rectangle:4,"4":"Rectangle", });
```

Nevertheless, having reverse mappings still makes it more compatible with TypeScript code.