### PR TITLE
use enums in function signatures within typescript definitions

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1156,6 +1156,9 @@ impl<'a> ToTokens for DescribeImport<'a> {
 impl ToTokens for ast::Enum {
     fn to_tokens(&self, into: &mut TokenStream) {
         let enum_name = &self.rust_name;
+        let name_str = self.js_name.to_string();
+        let name_len = name_str.len() as u32;
+        let name_chars = name_str.chars().map(|c| c as u32);
         let hole = &self.hole;
         let cast_clauses = self.variants.iter().map(|variant| {
             let variant_name = &variant.name;
@@ -1205,6 +1208,8 @@ impl ToTokens for ast::Enum {
                 fn describe() {
                     use wasm_bindgen::describe::*;
                     inform(ENUM);
+                    inform(#name_len);
+                    #(inform(#name_chars);)*
                     inform(#hole);
                 }
             }

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -64,7 +64,7 @@ pub enum Descriptor {
     String,
     Externref,
     NamedExternref(String),
-    Enum { hole: u32 },
+    Enum { name: String, hole: u32 },
     RustStruct(String),
     Char,
     Option(Box<Descriptor>),
@@ -134,7 +134,11 @@ impl Descriptor {
             CACHED_STRING => Descriptor::CachedString,
             STRING => Descriptor::String,
             EXTERNREF => Descriptor::Externref,
-            ENUM => Descriptor::Enum { hole: get(data) },
+            ENUM => {
+                let name = get_string(data);
+                let hole = get(data);
+                Descriptor::Enum { name, hole }
+            }
             RUST_STRUCT => {
                 let name = get_string(data);
                 Descriptor::RustStruct(name)

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1233,6 +1233,7 @@ fn adapter2ts(ty: &AdapterType, dst: &mut String) {
         }
         AdapterType::NamedExternref(name) => dst.push_str(name),
         AdapterType::Struct(name) => dst.push_str(name),
+        AdapterType::Enum(name) => dst.push_str(name),
         AdapterType::Function => dst.push_str("any"),
     }
 }

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -99,7 +99,18 @@ impl InstructionBuilder<'_, '_> {
                 self.get(AdapterType::F64);
                 self.output.push(AdapterType::F64);
             }
-            Descriptor::Enum { .. } => self.number(WitVT::U32, WasmVT::I32),
+            Descriptor::Enum { name, .. } => {
+                let std = wit_walrus::Instruction::IntToWasm {
+                    input: WitVT::U32,
+                    output: WasmVT::I32,
+                    trap: false,
+                };
+                self.instruction(
+                    &[AdapterType::Enum(name.clone())],
+                    Instruction::Standard(std),
+                    &[AdapterType::I32],
+                );
+            }
             Descriptor::Ref(d) => self.incoming_ref(false, d)?,
             Descriptor::RefMut(d) => self.incoming_ref(true, d)?,
             Descriptor::Option(d) => self.incoming_option(d)?,
@@ -280,9 +291,9 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             }
-            Descriptor::Enum { hole } => {
+            Descriptor::Enum { name, hole } => {
                 self.instruction(
-                    &[AdapterType::U32.option()],
+                    &[AdapterType::Enum(name.clone()).option()],
                     Instruction::I32FromOptionEnum { hole: *hole },
                     &[AdapterType::I32],
                 );

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -60,7 +60,7 @@ impl InstructionBuilder<'_, '_> {
                 self.get(AdapterType::F64);
                 self.output.push(AdapterType::F64);
             }
-            Descriptor::Enum { .. } => self.outgoing_i32(AdapterType::U32),
+            Descriptor::Enum { name, .. } => self.outgoing_i32(AdapterType::Enum(name.clone())),
 
             Descriptor::Char => {
                 self.instruction(
@@ -281,11 +281,11 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::String.option()],
                 );
             }
-            Descriptor::Enum { hole } => {
+            Descriptor::Enum { name, hole } => {
                 self.instruction(
                     &[AdapterType::I32],
                     Instruction::OptionEnumFromI32 { hole: *hole },
-                    &[AdapterType::U32.option()],
+                    &[AdapterType::Enum(name.clone()).option()],
                 );
             }
             Descriptor::RustStruct(name) => {

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -84,6 +84,7 @@ pub enum AdapterType {
     Vector(VectorKind),
     Option(Box<AdapterType>),
     Struct(String),
+    Enum(String),
     NamedExternref(String),
     Function,
 }
@@ -347,6 +348,7 @@ impl AdapterType {
 
             AdapterType::I32 => wit_walrus::ValType::I32,
             AdapterType::I64 => wit_walrus::ValType::I64,
+            AdapterType::Enum(_) => wit_walrus::ValType::U32,
             AdapterType::Option(_)
             | AdapterType::Function
             | AdapterType::Struct(_)

--- a/crates/typescript-tests/src/enums.rs
+++ b/crates/typescript-tests/src/enums.rs
@@ -9,6 +9,15 @@ pub enum Shape {
 pub fn accepts_enum(_: Shape) {}
 
 #[wasm_bindgen]
-pub fn take_and_return_shape(s: Shape) -> Shape {
+pub fn take_and_return_enum(s: Shape) -> Shape {
+    s
+}
+
+
+#[wasm_bindgen]
+pub fn accepts_option_enum(_: Option<Shape>) {}
+
+#[wasm_bindgen]
+pub fn take_and_return_option_enum(s: Option<Shape>) -> Option<Shape> {
     s
 }

--- a/crates/typescript-tests/src/enums.rs
+++ b/crates/typescript-tests/src/enums.rs
@@ -2,7 +2,9 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub enum Shape {
-    Circle, Rectangle, Triangle
+    Circle,
+    Rectangle,
+    Triangle,
 }
 
 #[wasm_bindgen]
@@ -12,7 +14,6 @@ pub fn accepts_enum(_: Shape) {}
 pub fn take_and_return_enum(s: Shape) -> Shape {
     s
 }
-
 
 #[wasm_bindgen]
 pub fn accepts_option_enum(_: Option<Shape>) {}

--- a/crates/typescript-tests/src/enums.rs
+++ b/crates/typescript-tests/src/enums.rs
@@ -1,0 +1,14 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub enum Shape {
+    Circle, Rectangle, Triangle
+}
+
+#[wasm_bindgen]
+pub fn accepts_enum(_: Shape) {}
+
+#[wasm_bindgen]
+pub fn take_and_return_shape(s: Shape) -> Shape {
+    s
+}

--- a/crates/typescript-tests/src/enums.ts
+++ b/crates/typescript-tests/src/enums.ts
@@ -1,0 +1,4 @@
+import * as wbg from '../pkg/typescript_tests';
+
+const wbg_accepts_enum: (a: wbg.Shape) => void = wbg.accepts_enum;
+const take_and_return_shape: (a: wbg.Shape) => wbg.Shape = wbg.take_and_return_shape;

--- a/crates/typescript-tests/src/enums.ts
+++ b/crates/typescript-tests/src/enums.ts
@@ -1,4 +1,7 @@
 import * as wbg from '../pkg/typescript_tests';
 
 const wbg_accepts_enum: (a: wbg.Shape) => void = wbg.accepts_enum;
-const take_and_return_shape: (a: wbg.Shape) => wbg.Shape = wbg.take_and_return_shape;
+const wbg_take_and_return_enum: (a: wbg.Shape) => wbg.Shape = wbg.take_and_return_enum;
+
+const wbg_accepts_option_enum: (a: wbg.Shape | undefined) => void = wbg.accepts_option_enum;
+const wbg_take_and_return_option_enum: (a: wbg.Shape | undefined) => wbg.Shape | undefined = wbg.take_and_return_option_enum;

--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod custom_section;
+pub mod enums;
 pub mod getters_setters;
 pub mod omit_definition;
 pub mod opt_args_and_ret;


### PR DESCRIPTION
This is an attempt at fixing #2154 by generating TypeScript definitions that use the correct type for enums within function arguments and return types rather than just `number`.

I’m quite unfamiliar with this codebase so it’s very possible that my approach will require further tweaks, but I hope it’s at least a good start.

I’ve adapted the backend crate’s `codegen` module to output the `js_name` for Enums within the descriptor and likewise adapted the cli-support crate to load that information. To have it appear in the TS definitions, I’ve added `AdapterType::Enum(String)` which compiles to the same adapter code but carries the name alongside it.

I’ve also added a new pair of files to the typescript_tests crate to handle these cases.