### PR TITLE
Update support for weak references

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,17 @@ jobs:
       #   displayName: "(anyref) Crate test suite (no debug)"
       # - script: cargo test --target wasm32-unknown-unknown --features serde-serialize --test wasm
       #   displayName: "(anyref) Crate test suite (with serde)"
+      - script: |
+          set -e
+          echo "##vso[task.setvariable variable=NODE_ARGS]--harmony-weak-refs"
+          echo "##vso[task.setvariable variable=WASM_BINDGEN_WEAKREF]1"
+        displayName: "Configure anyref passes"
+      - script: cargo test --target wasm32-unknown-unknown --test wasm
+        displayName: "(weakref) Crate test suite"
+      - script: WASM_BINDGEN_NO_DEBUG=1 cargo test --target wasm32-unknown-unknown --test wasm
+        displayName: "(weakref) Crate test suite (no debug)"
+      - script: cargo test --target wasm32-unknown-unknown --features serde-serialize --test wasm
+        displayName: "(weakref) Crate test suite (with serde)"
 
   - job: test_wasm_bindgen_windows
     displayName: "Run wasm-bindgen crate tests (Windows)"

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -114,9 +114,6 @@ intrinsics! {
         #[symbol = "__wbindgen_cb_drop"]
         #[signature = fn(Externref) -> Boolean]
         CallbackDrop,
-        #[symbol = "__wbindgen_cb_forget"]
-        #[signature = fn(Externref) -> Unit]
-        CallbackForget,
         #[symbol = "__wbindgen_number_new"]
         #[signature = fn(F64) -> Externref]
         NumberNew,

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -128,6 +128,11 @@ impl Bindgen {
         self
     }
 
+    pub fn weak_refs(&mut self, enable: bool) -> &mut Bindgen {
+        self.weak_refs = enable;
+        self
+    }
+
     /// Explicitly specify the already parsed input module.
     pub fn input_module(&mut self, name: &str, module: Module) -> &mut Bindgen {
         let name = name.to_string();

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -39,6 +39,7 @@ Options:
     --nodejs                     Deprecated, use `--target nodejs`
     --web                        Deprecated, use `--target web`
     --no-modules                 Deprecated, use `--target no-modules`
+    --weak-refs                  Enable usage of the JS weak references proposal
     -V --version                 Print the version number of wasm-bindgen
 ";
 
@@ -59,6 +60,7 @@ struct Args {
     flag_no_modules_global: Option<String>,
     flag_remove_name_section: bool,
     flag_remove_producers_section: bool,
+    flag_weak_refs: Option<bool>,
     flag_keep_debug: bool,
     flag_encode_into: Option<String>,
     flag_target: Option<String>,
@@ -114,6 +116,9 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .remove_producers_section(args.flag_remove_producers_section)
         .typescript(typescript)
         .omit_imports(args.flag_omit_imports);
+    if flags.flag_weak_refs {
+        b.weak_refs(true);
+    }
     if let Some(ref name) = args.flag_no_modules_global {
         b.no_modules_global(name)?;
     }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -778,6 +778,7 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
     #[wasm_bindgen(constructor)]
     #[deprecated(note = "recommended to use `Boolean::from` instead")]
+    #[allow(deprecated)]
     pub fn new(value: &JsValue) -> Boolean;
 
     /// The `valueOf()` method returns the primitive value of a `Boolean` object.
@@ -1843,6 +1844,7 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
     #[wasm_bindgen(constructor)]
     #[deprecated(note = "recommended to use `Number::from` instead")]
+    #[allow(deprecated)]
     pub fn new(value: &JsValue) -> Number;
 
     /// The `Number.parseInt()` method parses a string argument and returns an

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -41,6 +41,7 @@
   - [Optimizing for Size](./reference/optimize-size.md)
   - [Supported Rust Targets](./reference/rust-targets.md)
   - [Supported Browsers](./reference/browser-support.md)
+  - [Support for Weak References](./reference/weak-references.md)
   - [Supported Types](./reference/types.md)
     - [Imported JavaScript Types](./reference/types/imported-js-types.md)
     - [Exported Rust Types](./reference/types/exported-rust-types.md)

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -13,23 +13,23 @@ always be listed via `wasm-bindgen --help`.
 
 The recommend way to install the `wasm-bindgen` command line tool is with the
 `wasm-pack` installer described
-[here](https://rustwasm.github.io/wasm-pack/installer/). After installing 
+[here](https://rustwasm.github.io/wasm-pack/installer/). After installing
 `wasm-pack`, you are ready to build project invoking `wasm-pack build`.
 This command installs apropriate version of the `wasm-bindgen` command-line
 tool. The version of `wasm-bindgen` installed by `wasm-pack` is not available
  to be used directly via command line.
 
-It is not recommended to install `wasm-bindgen-cli` as its version must match 
-_exactly_ the version of `wasm-bindgen` that is specified in the project's 
-cargo.lock file. Using `wasm-pack` for building simplifies the build process 
-as `wasm-pack` ensures that the proper version of `wasm-bindgen` command-line 
-tool is used. That means that `wasm-pack` may install many different versions 
-of `wasm-bindgen`, but during the build `wasm-pack` will always make sure to 
+It is not recommended to install `wasm-bindgen-cli` as its version must match
+_exactly_ the version of `wasm-bindgen` that is specified in the project's
+cargo.lock file. Using `wasm-pack` for building simplifies the build process
+as `wasm-pack` ensures that the proper version of `wasm-bindgen` command-line
+tool is used. That means that `wasm-pack` may install many different versions
+of `wasm-bindgen`, but during the build `wasm-pack` will always make sure to
 use the correct one.
 
-Note: if, for any reason, you decide to use wasm-bindgen directly (this is 
-not recommended!) you will have to manually take care of using exactly the 
-same version of wasm-bindgen command-line tool (wasm-bindgen-cli) that 
+Note: if, for any reason, you decide to use wasm-bindgen directly (this is
+not recommended!) you will have to manually take care of using exactly the
+same version of wasm-bindgen command-line tool (wasm-bindgen-cli) that
 matches the version of wasm-bingden in cargo.lock.
 
 
@@ -101,3 +101,12 @@ sections.
 When generating bundler-compatible code (see the section on [deployment]) this
 indicates that the bundled code is always intended to go into a browser so a few
 checks for Node.js can be elided.
+
+### `--weak-refs`
+
+Enables usage of the [TC39 Weak References
+proposal](https://github.com/tc39/proposal-weakrefs), ensuring that all Rust
+memory is eventually deallocated regardless of whether you're calling `free` or
+not. This is off-by-default while we're waiting for support to percolate into
+all major browsers. For more information see the [documentation about weak
+references](./weak-references.md).

--- a/guide/src/reference/weak-references.md
+++ b/guide/src/reference/weak-references.md
@@ -1,0 +1,23 @@
+# Support for Weak References
+
+By default wasm-bindgen does not uses the [TC39 weak references
+proposal](https://github.com/tc39/proposal-weakrefs). This proposal just
+advanced to stage 4 at the time of this writing, but it will still stake some
+time for support to percolate into all the major browsers.
+
+Without weak references your JS integration may be susceptible to memory leaks
+in Rust, for example:
+
+* You could forget to call `.free()` on a JS object, leaving the Rust memory
+  allocated.
+* Rust closures converted to JS values (the `Closure` type) may not be executed
+  and cleaned up.
+* Rust closures have a `Closure::forget` method which explicitly doesn't free
+  the underlying memory.
+
+These issues are all solved with the weak references proposal in JS. The
+`--weak-refs` flag to the `wasm-bindgen` CLI will enable usage of
+`FinalizationRegistry` to ensure that all memory is cleaned up, regardless of
+whether it's explicitly deallocated or not. Note that explicit deallocation
+is always a possibility and supported, but if it's not called then memory will
+still be automatically deallocated with the `--weak-refs` flag.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,6 @@ externs! {
         fn __wbindgen_rethrow(a: u32) -> !;
 
         fn __wbindgen_cb_drop(idx: u32) -> u32;
-        fn __wbindgen_cb_forget(idx: u32) -> ();
 
         fn __wbindgen_describe(v: u32) -> ();
         fn __wbindgen_describe_closure(a: u32, b: u32, c: u32) -> u32;


### PR DESCRIPTION
This commit updates the `WASM_BINDGEN_WEAKREF` feature support to the
latest version of the weak references proposal in JS. This also updates
the `Closure` type to use finalization registries to ensure closures are
deallocated with the JS gc. This means that `Closure::forget` will not
actually leak memory in a weakref-using application.