### PR TITLE
Pass actual stack pointers around instead of address 8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,11 +211,12 @@ jobs:
     displayName: "Build benchmarks"
     steps:
       - template: ci/azure-install-rust.yml
-      - template: ci/azure-install-wasm-pack.yml
-      - script: wasm-pack build --target web benchmarks
+      - script: rustup target add wasm32-unknown-unknown
+        displayName: "add target"
+      - script: cargo build --manifest-path benchmarks/Cargo.toml --release --target wasm32-unknown-unknown
         displayName: "build benchmarks"
-      - script: rm -f benchmarks/pkg/.gitignore
-        displayName: "remove stray gitignore"
+      - script: cargo run -p wasm-bindgen-cli target/wasm32-unknown-unknown/release/wasm_bindgen_benchmark.wasm --out-dir benchmarks/pkg --target web
+        displayName: "run wasm-bindgen"
       - task: PublishPipelineArtifact@0
         inputs:
           artifactName: benchmarks

--- a/crates/cli-support/src/multivalue.rs
+++ b/crates/cli-support/src/multivalue.rs
@@ -64,7 +64,7 @@ fn extract_xform<'a>(
     // If the first instruction is a `Retptr`, then this must be an exported
     // adapter which calls a wasm-defined function. Something we'd like to
     // adapt to multi-value!
-    if let Some(Instruction::Retptr) = instructions.first().map(|e| &e.instr) {
+    if let Some(Instruction::Retptr { .. }) = instructions.first().map(|e| &e.instr) {
         instructions.remove(0);
         let mut types = Vec::new();
         instructions.retain(|instruction| match &instruction.instr {

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -234,7 +234,7 @@ fn translate_instruction(
             mem: *mem,
             malloc: *malloc,
         }),
-        StoreRetptr { .. } | LoadRetptr { .. } | Retptr => {
+        StoreRetptr { .. } | LoadRetptr { .. } | Retptr { .. } => {
             bail!("return pointers aren't supported in wasm interface types");
         }
         I32FromBool | BoolFromI32 => {

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -113,8 +113,11 @@ pub enum Instruction {
         offset: usize,
         mem: walrus::MemoryId,
     },
-    /// An instruction which pushes the return pointer onto the stack.
-    Retptr,
+    /// An instruction which pushes the return pointer onto the stack, reserving
+    /// `size` bytes of space.
+    Retptr {
+        size: u32,
+    },
 
     /// Pops a `bool` from the stack and pushes an `i32` equivalent
     I32FromBool,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ Command line interface of the `#[wasm_bindgen]` attribute and project. For more
 information see https://github.com/rustwasm/wasm-bindgen.
 """
 edition = '2018'
+default-run = 'wasm-bindgen'
 
 [dependencies]
 curl = "0.4.13"


### PR DESCRIPTION
This commit updates the implementation of passing return pointers from
JS to wasm to actually modify the wasm's shadow stack pointer instead of
manufacturing the arbitrary address of 8. The purpose of this is to
correctly handle threaded scenarios where each thread will write to its
own area instead of everyone trying to compete at address 8.

The implementation here will lazily, if necessary, export the stack
pointer we find the module and modify it as necessary.

Closes #2218