### PR TITLE
Fix breakage from changing `Closure::forget`

### DIFF
--- a/guide/src/reference/weak-references.md
+++ b/guide/src/reference/weak-references.md
@@ -12,8 +12,8 @@ in Rust, for example:
   allocated.
 * Rust closures converted to JS values (the `Closure` type) may not be executed
   and cleaned up.
-* Rust closures have a `Closure::forget` method which explicitly doesn't free
-  the underlying memory.
+* Rust closures have `Closure::{into_js_value,forget}` methods which explicitly
+  do not free the underlying memory.
 
 These issues are all solved with the weak references proposal in JS. The
 `--weak-refs` flag to the `wasm-bindgen` CLI will enable usage of

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -374,10 +374,15 @@ where
     /// JS closure is GC'd. Weak references are not enabled by default since
     /// they're still a proposal for the JS standard. They can be enabled with
     /// `WASM_BINDGEN_WEAKREF=1` when running `wasm-bindgen`, however.
-    pub fn forget(self) -> JsValue {
+    pub fn into_js_value(self) -> JsValue {
         let idx = self.js.idx;
         mem::forget(self);
         JsValue::_new(idx)
+    }
+
+    /// Same as `into_js_value`, but doesn't return a value.
+    pub fn forget(self) {
+        drop(self.into_js_value());
     }
 }
 


### PR DESCRIPTION
Add a new method for now instead of changing `Closure::forget`