### PR TITLE
Update `Map.for_each` docs

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1300,7 +1300,14 @@ extern "C" {
 
     /// The `forEach()` method executes a provided function once per each
     /// key/value pair in the Map object, in insertion order.
-    ///
+    /// Note that the `Key` and `Value` are reversed compared to normal expectations:
+    /// # Examples
+    /// ```
+    /// let js_map = Map::new();
+    /// js_map.for_each(&mut |value, key| {
+    ///     // Do something here...
+    /// })
+    /// ```
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach)
     #[wasm_bindgen(method, js_name = forEach)]
     pub fn for_each(this: &Map, callback: &mut dyn FnMut(JsValue, JsValue));

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1300,7 +1300,7 @@ extern "C" {
 
     /// The `forEach()` method executes a provided function once per each
     /// key/value pair in the Map object, in insertion order.
-    /// Note that the `Key` and `Value` are reversed compared to normal expectations:
+    /// Note that in Javascript land the `Key` and `Value` are reversed compared to normal expectations:
     /// # Examples
     /// ```
     /// let js_map = Map::new();


### PR DESCRIPTION
Hello,

I'm currently taking a deep dive into wasm + rust and had this unexpected expected behavior happen to me: Javascript `foreach` methods are reversed with respect to the ordering of `key` and `value` compared to the `normal`. So I thought that it might be nice to explicitly state this in the docs.