### PR TITLE
ts declaration file name for wasm import

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -702,7 +702,7 @@ impl Output {
         }
 
         if gen.typescript {
-            let ts_path = wasm_path.with_extension("d.ts");
+            let ts_path = wasm_path.with_extension("wasm.d.ts");
             let ts = wasm2es6js::typescript(&self.module)?;
             fs::write(&ts_path, ts)
                 .with_context(|| format!("failed to write `{}`", ts_path.display()))?;

--- a/crates/typescript-tests/src/memory.ts
+++ b/crates/typescript-tests/src/memory.ts
@@ -1,3 +1,3 @@
-import * as wasm from '../pkg/typescript_tests_bg';
+import * as wasm from '../pkg/typescript_tests_bg.wasm';
 
 const memory: WebAssembly.Memory = wasm.memory;

--- a/crates/typescript-tests/src/simple_fn.ts
+++ b/crates/typescript-tests/src/simple_fn.ts
@@ -1,5 +1,5 @@
 import * as wbg from '../pkg/typescript_tests';
-import * as wasm from '../pkg/typescript_tests_bg';
+import * as wasm from '../pkg/typescript_tests_bg.wasm';
 
 const wbg_greet: (a: string) => void = wbg.greet;
 const wasm_greet: (a: number, b: number) => void = wasm.greet;


### PR DESCRIPTION
Fixes import of wasm memory in a typescript setup with type safety #2200 