### PR TITLE
Add userVisibleOnly property to PushSubscriptionOptionsInit

### DIFF
--- a/crates/web-sys/src/features/gen_PushSubscriptionOptionsInit.rs
+++ b/crates/web-sys/src/features/gen_PushSubscriptionOptionsInit.rs
@@ -36,4 +36,21 @@ impl PushSubscriptionOptionsInit {
         let _ = r;
         self
     }
+    #[doc = "Change the `userVisibleOnly` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `PushSubscriptionOptionsInit`*"]
+    pub fn user_visible_only(&mut self, val: bool) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("userVisibleOnly"),
+            &JsValue::from(val),
+        );
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
 }

--- a/crates/web-sys/webidls/enabled/PushManager.webidl
+++ b/crates/web-sys/webidls/enabled/PushManager.webidl
@@ -8,7 +8,7 @@
 */
 
 dictionary PushSubscriptionOptionsInit {
-  // boolean userVisibleOnly = false;
+  boolean userVisibleOnly = false;
   (BufferSource or DOMString)? applicationServerKey = null;
 };
 


### PR DESCRIPTION
Fixes #2287.

The PushSubscriptionOptionsInit is currently missing the
`userVisibleOnly` property.

Signed-off-by: johnsonw <wjohnson@whamcloud.com>