### PR TITLE
Changed externref_table to use geometric resizing, giving amortized constant time additions

### DIFF
--- a/src/externref.rs
+++ b/src/externref.rs
@@ -5,6 +5,7 @@ use std::mem;
 use std::ptr;
 use std::slice;
 use std::vec::Vec;
+use std::cmp::max;
 
 externs! {
     #[link(wasm_import_module = "__wbindgen_externref_xform__")]
@@ -32,8 +33,9 @@ impl Slab {
     fn alloc(&mut self) -> usize {
         let ret = self.head;
         if ret == self.data.len() {
-            if self.data.len() == self.data.capacity() {
-                let extra = 128;
+            let curr_len = self.data.len();
+            if curr_len == self.data.capacity() {
+                let extra = max(128, curr_len);
                 let r = unsafe { __wbindgen_externref_table_grow(extra) };
                 if r == -1 {
                     internal_error("table grow failure")


### PR DESCRIPTION
Previously `__wbindgen_externref_table_grow` was called in `alloc `adding a constant size each time.

This results in taking Theta(N) time amortized to pass a single new `JsValue `to wasm, where N is number/size of existing items.

**Changes**

This pull request resizes geometrically, giving amortized constant additions to the externref_table.  

Specifically, `max(128, curr_len)`, so that we the larger of 128*usize, or the size of the current array.

This results in a growth factor of 2, the same as Rust's `Vec` growth factor

**Testing**:

It fixes #2291, where it took over 150 seconds to add 1.2 million `JsValues`'s to a Vec on my PC with reference types enabled.   
Now, it takes only 0.7-0.9 seconds.

----

**Pros**
Reduces complexity from` Theta(N^2)` to pass` N` `JsValue`s to wasm to `Theta(N)`
**Cons**
Slightly more memory required -- After resizing, the table will be half full.

I'm setting this as draft, since this is my first PR! :) 
All tests passed for me. Tell me if I missed anything!