### PR TITLE
Fix compile error with futures crate using a renamed function

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -204,7 +204,7 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2020-06-03
+          toolchain: nightly-2020-08-27
       - script: rustup component add rust-src
         displayName: "install rust-src"
       - script: |

--- a/crates/futures/src/task/multithread.rs
+++ b/crates/futures/src/task/multithread.rs
@@ -36,7 +36,7 @@ impl AtomicWaker {
         // the corresponding `waitAsync` that was waiting for the transition
         // from SLEEPING to AWAKE.
         unsafe {
-            core::arch::wasm32::atomic_notify(
+            core::arch::wasm32::memory_atomic_notify(
                 &self.state as *const AtomicI32 as *mut i32,
                 1, // Number of threads to notify
             );


### PR DESCRIPTION
A while ago the function [core::arch::wasm32::atomic_notify](https://doc.rust-lang.org/stable/core/arch/wasm32/fn.atomic_notify.html) was renamed to [core::arch::wasm32::memory_atomic_notify](https://doc.rust-lang.org/nightly/core/arch/wasm32/fn.memory_atomic_notify.html) in nightly. This pull request fixes [issue 2285](https://github.com/rustwasm/wasm-bindgen/issues/2285).