### PR TITLE
Remove obsolete note from raytrace-parallel example

### DIFF
--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-# A few steps are necessary to get this build working which makes it slightly
+# A couple of steps are necessary to get this build working which makes it slightly
 # nonstandard compared to most other builds.
 #
 # * First, the Rust standard library needs to be recompiled with atomics
@@ -11,11 +11,6 @@ set -ex
 # * Next we need to compile everything with the `atomics` and `bulk-memory`
 #   features enabled, ensuring that LLVM will generate atomic instructions,
 #   shared memory, passive segments, etc.
-#
-# * Finally, `-Zbuild-std` is still in development, and one of its downsides
-#   right now is rust-lang/wg-cargo-std-aware#47 where using `rust-lld` doesn't
-#   work by default, which the wasm target uses. To work around that we find it
-#   and put it in PATH
 
 RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' \
   cargo build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort


### PR DESCRIPTION
This step was removed in 91aaf884d69fb834474e3be6796fbfee2301825d