### PR TITLE
feat: cast JSValue from/to u64

### DIFF
--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -79,6 +79,10 @@ fn opt_f64() -> Descriptor {
     Descriptor::Option(Box::new(Descriptor::F64))
 }
 
+fn opt_u64() -> Descriptor {
+    Descriptor::Option(Box::new(Descriptor::U64))
+}
+
 intrinsics! {
     pub enum Intrinsic {
         #[symbol = "__wbindgen_jsval_eq"]
@@ -117,6 +121,9 @@ intrinsics! {
         #[symbol = "__wbindgen_number_new"]
         #[signature = fn(F64) -> Externref]
         NumberNew,
+        #[symbol = "__wbindgen_bigint_new"]
+        #[signature = fn(U64) -> Externref]
+        BigIntNew,
         #[symbol = "__wbindgen_string_new"]
         #[signature = fn(ref_string()) -> Externref]
         StringNew,
@@ -129,6 +136,9 @@ intrinsics! {
         #[symbol = "__wbindgen_number_get"]
         #[signature = fn(ref_externref()) -> opt_f64()]
         NumberGet,
+        #[symbol = "__wbindgen_bigint_get"]
+        #[signature = fn(ref_externref()) -> opt_u64()]
+        BigIntGet,
         #[symbol = "__wbindgen_string_get"]
         #[signature = fn(ref_externref()) -> opt_string()]
         StringGet,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2905,6 +2905,11 @@ impl<'a> Context<'a> {
                 args[0].clone()
             }
 
+            Intrinsic::BigIntNew => {
+                assert_eq!(args.len(), 1);
+                args[0].clone()
+            }
+
             Intrinsic::StringNew => {
                 assert_eq!(args.len(), 1);
                 args[0].clone()
@@ -2924,6 +2929,12 @@ impl<'a> Context<'a> {
                 assert_eq!(args.len(), 1);
                 prelude.push_str(&format!("const obj = {};\n", args[0]));
                 format!("typeof(obj) === 'number' ? obj : undefined")
+            }
+
+            Intrinsic::BigIntGet => {
+                assert_eq!(args.len(), 1);
+                prelude.push_str(&format!("const obj = {};\n", args[0]));
+                format!("typeof(obj) === 'bigint' ? obj : undefined")
             }
 
             Intrinsic::StringGet => {

--- a/guide/src/reference/browser-support.md
+++ b/guide/src/reference/browser-support.md
@@ -58,10 +58,7 @@ also like to be aware of it!
   forbids the usage of 64-bit integers (Rust types `i64` and `u64`) in
   exported/imported functions. When using `wasm-bindgen`, however, `u64` is
   allowed! The reason for this is that it's translated to the `BigInt` type in
-  JS. The `BigInt` class, however, is only currently supported in Chrome 67+ and
-  Firefox 68+ (as of the time of this writing) and isn't supported in Edge or
-  Safari, for example. For more, up-to-date details, see [`BigInt` on Can I
-  use...][ciu_bigint].
+  JS. The `BigInt` class is supported in all modern browsers.
 
 If you find other incompatibilities please report them to us! We'd love to
 either keep this list up-to-date or fix the underlying bugs :)
@@ -72,4 +69,3 @@ either keep this list up-to-date or fix the underlying bugs :)
 [`text-encoding`]: https://www.npmjs.com/package/text-encoding
 [soq]: https://stackoverflow.com/questions/40662142/polyfill-for-textdecoder/46549188#46549188
 [mdntepi]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#Polyfill
-[ciu_bigint]: https://caniuse.com/#feat=bigint

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use core::marker;
 use core::mem;
 use core::ops::{Deref, DerefMut};
 
-use crate::convert::{FromWasmAbi, WasmOptionalF64, WasmSlice};
+use crate::convert::{FromWasmAbi, WasmOptional64, WasmOptionalF64, WasmSlice};
 
 macro_rules! if_std {
     ($($i:item)*) => ($(
@@ -143,6 +143,15 @@ impl JsValue {
         unsafe { JsValue::_new(__wbindgen_number_new(n)) }
     }
 
+    /// Creates a new JS value which is a bigint.
+    ///
+    /// This function creates a JS value representing a bigint (a heap
+    /// allocated bigint) and returns a handle to the JS version of it.
+    #[inline]
+    pub fn from_u64(n: u64) -> JsValue {
+        unsafe { JsValue::_new(__wbindgen_bigint_new(n)) }
+    }
+
     /// Creates a new JS value which is a boolean.
     ///
     /// This function creates a JS object representing a boolean (a heap
@@ -240,6 +249,15 @@ impl JsValue {
     /// `None`.
     pub fn as_f64(&self) -> Option<f64> {
         unsafe { FromWasmAbi::from_abi(__wbindgen_number_get(self.idx)) }
+    }
+
+    /// Returns the `u64` value of this JS value if it's an instance of a
+    /// bigint.
+    ///
+    /// If this JS value is not an instance of a bigint then this returns
+    /// `None`.
+    pub fn as_u64(&self) -> Option<u64> {
+        unsafe { FromWasmAbi::from_abi(__wbindgen_bigint_get(self.idx)) }
     }
 
     /// Tests whether this JS value is a JS string.
@@ -359,6 +377,13 @@ impl PartialEq<bool> for JsValue {
     }
 }
 
+impl PartialEq<u64> for JsValue {
+    #[inline]
+    fn eq(&self, other: &u64) -> bool {
+        self.as_u64() == Some(*other)
+    }
+}
+
 impl PartialEq<str> for JsValue {
     #[inline]
     fn eq(&self, other: &str) -> bool {
@@ -395,6 +420,13 @@ impl<'a> From<&'a str> for JsValue {
     }
 }
 
+impl From<bool> for JsValue {
+    #[inline]
+    fn from(s: bool) -> JsValue {
+        JsValue::from_bool(s)
+    }
+}
+
 if_std! {
     impl<'a> From<&'a String> for JsValue {
         #[inline]
@@ -411,10 +443,10 @@ if_std! {
     }
 }
 
-impl From<bool> for JsValue {
+impl From<u64> for JsValue {
     #[inline]
-    fn from(s: bool) -> JsValue {
-        JsValue::from_bool(s)
+    fn from(n: u64) -> JsValue {
+        JsValue::from_u64(n)
     }
 }
 
@@ -492,6 +524,7 @@ externs! {
 
         fn __wbindgen_string_new(ptr: *const u8, len: usize) -> u32;
         fn __wbindgen_number_new(f: f64) -> u32;
+        fn __wbindgen_bigint_new(n: u64) -> u32;
         fn __wbindgen_symbol_named_new(ptr: *const u8, len: usize) -> u32;
         fn __wbindgen_symbol_anonymous_new() -> u32;
 
@@ -506,6 +539,7 @@ externs! {
         fn __wbindgen_is_falsy(idx: u32) -> u32;
 
         fn __wbindgen_number_get(idx: u32) -> WasmOptionalF64;
+        fn __wbindgen_bigint_get(idx: u32) -> WasmOptional64;
         fn __wbindgen_boolean_get(idx: u32) -> u32;
         fn __wbindgen_string_get(idx: u32) -> WasmSlice;
 

--- a/tests/wasm/api.js
+++ b/tests/wasm/api.js
@@ -10,6 +10,8 @@ exports.js_works = () => {
     assert.strictEqual(wasm.api_bar('a'), 'a');
     assert.strictEqual(wasm.api_baz(), 1);
     wasm.api_baz2(2, 'a');
+    assert.strictEqual(wasm.api_faz(), 18446744073709551614n);
+    wasm.api_faz2(18446744073709551615n, 'a');
 
     assert.strictEqual(wasm.api_js_null(), null);
     assert.strictEqual(wasm.api_js_undefined(), undefined);

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -39,6 +39,17 @@ pub fn api_baz2(a: &JsValue, b: &JsValue) {
 }
 
 #[wasm_bindgen]
+pub fn api_faz() -> JsValue {
+    JsValue::from(18446744073709551614u64)
+}
+
+#[wasm_bindgen]
+pub fn api_faz2(a: &JsValue, b: &JsValue) {
+    assert_eq!(a.as_u64(), Some(18446744073709551615u64));
+    assert_eq!(b.as_u64(), None);
+}
+
+#[wasm_bindgen]
 pub fn api_js_null() -> JsValue {
     JsValue::null()
 }


### PR DESCRIPTION
This PR tries to add support for `JSValue::as_u64`, and `JSValue::from_u64`. I can't seem to get it to a functioning state though.

In Chrome 86 (with experimental wasm features enabled) my attempts fail the error below. I don't understand why this happens though. I would understand this error if this occurred on a exported function (because of the disallowed `i64` type in the function signature). But as that is not the case (function never directly touches JS), I don't get it.

```
TypeError: wasm function signature contains illegal type
            at wasm_bindgen::JsValue::from_u64::h34ae9b79359a621f (<anonymous>:wasm-function[8442]:0x1e2046)
            at <wasm_bindgen::JsValue as core::convert::From<u64>>::from::h1c482d09df9df836 (<anonymous>:wasm-function[9106]:0x1ec14c)
            at wasm::api::api_faz::h498cfaecbd4acab5 (<anonymous>:wasm-function[12674]:0x211e08)
            at api_faz (<anonymous>:wasm-function[8813]:0x1e7ba9)
            at Object.module.exports.api_faz (/mnt/f9/Projects/github.com/rustwasm/wasm-bindgen/target/wasm32-unknown-unknown/wbg-tmp/wasm-bindgen-test.js:504:20)
            at exports.js_works (/mnt/f9/Projects/github.com/rustwasm/wasm-bindgen/tests/wasm/api.js:13:29)
            at wasm::api::js_works::haa9d61ac0376a8a3 (<anonymous>:wasm-function[10685]:0x200618)
            at wasm::api::works::h78bff9502dc41e95 (<anonymous>:wasm-function[12841]:0x212712)
            at core::ops::function::FnOnce::call_once::h363f2b57eb52eb28 (<anonymous>:wasm-function[10732]:0x200def)
            at wasm_bindgen_test::__rt::Context::execute_sync::{{closure}}::h098a2e306ed5fa39 (<anonymous>:wasm-function[2625]:0x14384d)
```

This is my first time touching wasm-bindgen, or low level wasm in general, so it is also highly likely I am just completely misunderstanding how this should work. Could anyone point me in the right direction?

Closes #2350 