### PR TITLE
Update lazy_static dependency to "1.0.2"

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -17,7 +17,7 @@ extra-traits = ["syn/extra-traits"]
 
 [dependencies]
 bumpalo = "3.0.0"
-lazy_static = "1.0.0"
+lazy_static = "1.0.2"
 log = "0.4"
 proc-macro2 = "1.0"
 quote = '1.0'

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -22,6 +22,6 @@ quote = '1.0'
 syn = { version = '1.0', features = ['full'] }
 wasm-bindgen-backend = { version = "=0.2.69", path = "../backend" }
 weedle = "0.11"
-lazy_static = "1.0.0"
+lazy_static = "1.0.2"
 sourcefile = "0.1"
 structopt = "0.3.9"


### PR DESCRIPTION
This fixes a bug that can happen in combination with `cargo +nightly update -Z minimal-versions` on dependent projects.

([I'd like to add this check to my CI script](https://github.com/Tamschi/lignin-dom/pull/6), but it's not a blocking issue otherwise.)

#### Cause

See <https://github.com/rust-lang-nursery/lazy-static.rs/pull/107>.

#### Replication

- Create a new project with a `Cargo.toml` like this:

  ```toml
  [package]
  name = "dependency-test"
  version = "0.0.0"
  edition = "2018"
  publish = false

  [dependencies]
  wasm-bindgen = "0.2.69"
  ```

- `cargo +nightly update -Z minimal-versions && cargo check`

#### Error

```
error: cannot find macro `__lazy_static_internal` in this scope
    --> […]\wasm-bindgen-backend-0.2.69\src\codegen.rs:1282:9
     |
1282 | /         lazy_static::lazy_static! {
1283 | |             static ref DESCRIPTORS_EMITTED: Mutex<HashSet<String>> = Default::default();
1284 | |         }
     | |_________^
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find value `DESCRIPTORS_EMITTED` in this scope
    --> […]\wasm-bindgen-backend-0.2.69\src\codegen.rs:1288:13
     |
1288 |         if !DESCRIPTORS_EMITTED
     |             ^^^^^^^^^^^^^^^^^^^ not found in this scope
```

#### Fix

Attached. See also <https://github.com/rust-lang-nursery/lazy-static.rs/releases/tag/1.0.2> to confirm this is the correct version.

#### Thanks!