### PR TITLE
Adjust Bluetooth IDL for Rust

### DIFF
--- a/crates/web-sys/src/features/gen_Bluetooth.rs
+++ b/crates/web-sys/src/features/gen_Bluetooth.rs
@@ -204,17 +204,6 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn get_devices(this: &Bluetooth) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "Bluetooth" , js_name = requestDevice)]
-    #[doc = "The `requestDevice()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Bluetooth`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn request_device(this: &Bluetooth) -> ::js_sys::Promise;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "RequestDeviceOptions")]
     # [wasm_bindgen (method , structural , js_class = "Bluetooth" , js_name = requestDevice)]
     #[doc = "The `requestDevice()` method."]
@@ -225,8 +214,5 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn request_device_with_options(
-        this: &Bluetooth,
-        options: &RequestDeviceOptions,
-    ) -> ::js_sys::Promise;
+    pub fn request_device(this: &Bluetooth, options: &RequestDeviceOptions) -> ::js_sys::Promise;
 }

--- a/crates/web-sys/src/features/gen_Navigator.rs
+++ b/crates/web-sys/src/features/gen_Navigator.rs
@@ -115,7 +115,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn bluetooth(this: &Navigator) -> Bluetooth;
+    pub fn bluetooth(this: &Navigator) -> Option<Bluetooth>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Clipboard")]
     # [wasm_bindgen (structural , method , getter , js_class = "Navigator" , js_name = clipboard)]

--- a/crates/web-sys/webidls/unstable/Bluetooth.webidl
+++ b/crates/web-sys/webidls/unstable/Bluetooth.webidl
@@ -26,7 +26,7 @@ interface Bluetooth : EventTarget {
   [SameObject]
   readonly attribute BluetoothDevice? referringDevice;
   Promise<sequence<BluetoothDevice>> getDevices();
-  Promise<BluetoothDevice> requestDevice(optional RequestDeviceOptions options = {});
+  Promise<BluetoothDevice> requestDevice(RequestDeviceOptions options);
 };
 
 Bluetooth includes BluetoothDeviceEventHandlers;
@@ -232,5 +232,5 @@ typedef (DOMString or unsigned long) BluetoothDescriptorUUID;
 [SecureContext]
 partial interface Navigator {
   [SameObject]
-  readonly attribute Bluetooth bluetooth;
+  readonly attribute Bluetooth? bluetooth;
 };


### PR DESCRIPTION
* navigator.bluetooth is optional -- it may be manatory by the
  WebBluetooth spec, but the Rust code should still be able to handle
  the errors resulting from a browser not implementing the spec at all
  without panicking.

* requestDevice: While it's marked optional upstream, practically it's
  mandatory (the default value, an empty dictionary, is not accepted).

Contributes-To: https://github.com/rustwasm/wasm-bindgen/issues/2381

---

These two don't fully resolve #2381, but the easy parts. The navigator.bluetooth part is necessary in the sense that without this, panics on unsupported browsers need manual workarounds to avoid. The latter is more of a usability thing (keeping name clutter low).