### PR TITLE
webidl: Keep track of data discarded in type conversion

### DIFF
--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -323,11 +323,13 @@ impl<'src> FirstPassRecord<'src> {
 
     fn dictionary_field(&self, field: &'src DictionaryMember<'src>) -> Option<DictionaryField> {
         // use argument position now as we're just binding setters
-        let ty = field
+        let (ty, confession) = field
             .type_
             .to_idl_type(self)
             .to_syn_type(TypePosition::Argument)
-            .unwrap_or(None)?;
+            .unwrap_or((None, None));
+
+        let ty = ty?;
 
         // Slice types aren't supported because they don't implement
         // `Into<JsValue>`
@@ -376,6 +378,7 @@ impl<'src> FirstPassRecord<'src> {
             name: rust_ident(&snake_case_ident(field.identifier.0)),
             js_name: field.identifier.0.to_string(),
             ty,
+            confession,
         })
     }
 
@@ -444,7 +447,8 @@ impl<'src> FirstPassRecord<'src> {
         unstable: bool,
     ) {
         let idl_type = member.const_type.to_idl_type(self);
-        let ty = idl_type.to_syn_type(TypePosition::Return).unwrap().unwrap();
+        // FIXME dismissing confession
+        let ty = idl_type.to_syn_type(TypePosition::Return).unwrap().0.unwrap();
 
         let js_name = member.identifier.0;
         let name = rust_ident(shouty_snake_case_ident(js_name).as_str());
@@ -576,11 +580,12 @@ impl<'src> FirstPassRecord<'src> {
 
         let catch = throws(attrs);
 
-        let ty = type_
+        // FIXME dismissing confession
+        let (ty, _) = type_
             .type_
             .to_idl_type(self)
             .to_syn_type(TypePosition::Return)
-            .unwrap_or(None);
+            .unwrap_or((None, None));
 
         // Skip types which can't be converted
         if let Some(ty) = ty {
@@ -597,11 +602,12 @@ impl<'src> FirstPassRecord<'src> {
         }
 
         if !readonly {
-            let ty = type_
+            // FIXME dismissing confession
+            let (ty, _) = type_
                 .type_
                 .to_idl_type(self)
                 .to_syn_type(TypePosition::Argument)
-                .unwrap_or(None);
+                .unwrap_or((None, None));
 
             // Skip types which can't be converted
             if let Some(ty) = ty {
@@ -655,14 +661,17 @@ impl<'src> FirstPassRecord<'src> {
                     };
                     let pos = TypePosition::Argument;
 
+                    let (ty, confession) = idl_type::IdlType::Callback
+                            .to_syn_type(pos)
+                            .unwrap();
+                    let ty = ty.unwrap();
+
                     fields.push(DictionaryField {
                         required: false,
                         name: rust_ident(&snake_case_ident(identifier)),
                         js_name: identifier.to_string(),
-                        ty: idl_type::IdlType::Callback
-                            .to_syn_type(pos)
-                            .unwrap()
-                            .unwrap(),
+                        ty,
+                        confession,
                     })
                 }
                 _ => {


### PR DESCRIPTION
... and report it during documentation

Closes: https://github.com/rustwasm/wasm-bindgen/issues/2381

---

This adds a concept of "confessions" -- statements the `to_syn_type` can emit when it knows it does a suboptimal conversion (eg. because typed promises would need GATs, or for compatibility, or any other reasons).

That data is passed along with the converted argument types, and during documentation converted into text that helps the user find what to do with that type. #2381 provides an example case where I was left to reimplement something there was already a helper for, simply because that helper was not discoverable. The reader will still need to use the search function until I can get markupped (possibly intra-doc) links from syn::Type (see https://github.com/dtolnay/syn/issues/937).

It's still a bit rough around the edges, so please consider this as WIP; concretely, I'd like to overhaul the Confession structure to reduce redundancies between its variants. A high-level review at this stage would make sense already IMO, just don't get hung up on details like "why are there parallel vecs for the args and the confessions" because they're the type of thing still to enhance.

(On the "confessions" name: I'm open for any color of the bikeshed, but I prefer names that may sound a bit dramatic and maybe leave the reader thinking but give the gist over bland names like "additional type data" that leave the reader equally puzzled and could really mean anything else as well).