### PR TITLE
Don't emit mutable globals

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -560,17 +560,12 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
         }
 
         Instruction::Retptr { size } => {
-            let sp = match js.cx.aux.shadow_stack_pointer {
-                Some(s) => js.cx.export_name_of(s),
-                // In theory this shouldn't happen since malloc is included in
-                // most wasm binaries (and may be gc'd out) and that almost
-                // always pulls in a stack pointer. We can try to synthesize
-                // something here later if necessary.
-                None => bail!("failed to find shadow stack pointer"),
-            };
-            js.prelude(&format!("const retptr = wasm.{}.value - {};", sp, size));
-            js.prelude(&format!("wasm.{}.value = retptr;", sp));
-            js.finally(&format!("wasm.{}.value += {};", sp, size));
+            js.cx.inject_stack_pointer_shim()?;
+            js.prelude(&format!(
+                "const retptr = wasm.__wbindgen_add_to_stack_pointer(-{});",
+                size
+            ));
+            js.finally(&format!("wasm.__wbindgen_add_to_stack_pointer({});", size));
             js.stack.push("retptr".to_string());
         }
 


### PR DESCRIPTION
A proposed fix for https://github.com/rustwasm/wasm-bindgen/issues/2386, based on @alexcrichton's comment here: https://github.com/rustwasm/wasm-bindgen/issues/2386#issuecomment-738266000

We emit a shim function that sets the stack pointer, so we can avoid emitting mutable globals.
Mutable globals aren't supported everywhere Wasm is.

This PR seems to pass tests, but I believe it doesn't actually avoid exporting the stack pointer yet.
I'm not sure where to look for that, and I imagine we should add a test to ensure we actually don't export mutable globals.

This is my first foray into the `wasm-bindgen` codebase, so I expect there to be some mistakes in this code.

I think I might still need to modify `export_shadow_stack_pointer` to not export it to the wasm module...