### PR TITLE
Handle Expr::Group in the macro parser

### DIFF
--- a/crates/typescript-tests/src/omit_definition.rs
+++ b/crates/typescript-tests/src/omit_definition.rs
@@ -32,3 +32,12 @@ pub enum MyEnum {
     Two,
     Three,
 }
+
+macro_rules! generate_ts {
+    ($lit:literal) => {
+        #[wasm_bindgen(typescript_custom_section)]
+        const _: &str = $lit;
+    };
+}
+
+generate_ts!("");


### PR DESCRIPTION
We explicitly match on `Expr` in a few locations so it's necessary to
peel back `Expr::Group` like we do with `Type::Group`.

Closes #2393