### PR TITLE
Getting the `no-modules` TypeScript `*.d.ts` Files Working

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -602,8 +602,7 @@ impl<'a> Context<'a> {
             * @returns {{Promise<InitOutput>}}\n\
             */\n\
             {setup_function_declaration} \
-                (module_or_path{}: InitInput | Promise<InitInput>{}): Promise<InitOutput>;
-        ",
+                (module_or_path{}: InitInput | Promise<InitInput>{}): Promise<InitOutput>;\n",
             memory_doc, arg_optional, memory_param,
             output = output,
             declare_or_export = declare_or_export,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -574,11 +574,12 @@ impl<'a> Context<'a> {
         let arg_optional = if has_module_or_path_optional { "?" } else { "" };
         // With TypeScript 3.8.3, I'm seeing that any "export"s at the root level cause TypeScript to ignore all "declare" statements.
         // So using "declare" everywhere for at least the NoModules option.
-        let declare_export_default;
+        // Also in (at least) the NoModules, the `init()` method is renamed to `wasm_bindgen()`.
+        let setup_function_declaration;
         if let OutputMode::NoModules { global : _ } = &self.config.mode {
-            declare_export_default = "declare";
+            setup_function_declaration = "declare function wasm_bindgen";
         } else {
-            declare_export_default = "export default";
+            setup_function_declaration = "export default function init";
         }
         Ok(format!(
             "\n\
@@ -596,13 +597,13 @@ impl<'a> Context<'a> {
             *\n\
             * @returns {{Promise<InitOutput>}}\n\
             */\n\
-            {declare_export_default} default function init \
+            {setup_function_declaration} \
                 (module_or_path{}: InitInput | Promise<InitInput>{}): Promise<InitOutput>;
         ",
             memory_doc, arg_optional, memory_param,
             output = output,
             declare_export = self.declare_or_export(),
-            declare_export_default = declare_export_default,
+            setup_function_declaration = setup_function_declaration,
         ))
     }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -547,7 +547,7 @@ impl<'a> Context<'a> {
     }
 
     fn declare_or_export(&self) -> String {
-        // With TypeScript 3.8.3, I'm seeing that any "export"s at the root level, cause TypeScript to ignore all "declare" statements.
+        // With TypeScript 3.8.3, I'm seeing that any "export"s at the root level cause TypeScript to ignore all "declare" statements.
         // So using "declare" everywhere for at least the NoModules option.
         if let OutputMode::NoModules { global : _ } = &self.config.mode {
             String::from("declare")
@@ -572,7 +572,7 @@ impl<'a> Context<'a> {
             ("", "")
         };
         let arg_optional = if has_module_or_path_optional { "?" } else { "" };
-        // With TypeScript 3.8.3, I'm seeing that any "export"s at the root level, cause TypeScript to ignore all "declare" statements.
+        // With TypeScript 3.8.3, I'm seeing that any "export"s at the root level cause TypeScript to ignore all "declare" statements.
         // So using "declare" everywhere for at least the NoModules option.
         let declare_export_default;
         if let OutputMode::NoModules { global : _ } = &self.config.mode {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -546,17 +546,6 @@ impl<'a> Context<'a> {
         Ok(imports)
     }
 
-    /// For a few instances where should (sometimes) use the "export" keyword in the TypeScript declaration file.
-    /// In particular, in no-modules mode, all functions/classes/enums are placed in a `declare`d namespace.
-    /// So they don't need to be `export`ed too (as of TypeScript 3.8.3 at least).
-    fn maybe_export(&self) -> String {
-        if self.config.mode.no_modules() {
-            String::from("")
-        } else {
-            String::from("export ")
-        }
-    }
-
     fn ts_for_init_fn(
         &self,
         has_memory: bool,
@@ -791,7 +780,7 @@ impl<'a> Context<'a> {
 
     fn write_class(&mut self, name: &str, class: &ExportedClass) -> Result<(), Error> {
         let mut dst = format!("class {} {{\n", name);
-        let mut ts_dst = format!("{}{}", self.maybe_export(), dst);
+        let mut ts_dst = format!("export {}", dst);
 
         if self.config.debug && !class.has_constructor {
             dst.push_str(
@@ -2361,8 +2350,7 @@ impl<'a> Context<'a> {
                     AuxExportKind::Function(name) => {
                         if let Some(ts_sig) = ts_sig {
                             self.typescript.push_str(&docs);
-                            self.typescript.push_str(&self.maybe_export());
-                            self.typescript.push_str("function ");
+                            self.typescript.push_str("export function ");
                             self.typescript.push_str(&name);
                             self.typescript.push_str(ts_sig);
                             self.typescript.push_str(";\n");
@@ -3091,9 +3079,8 @@ impl<'a> Context<'a> {
 
         if enum_.generate_typescript {
             self.typescript.push_str(&docs);
-            self.typescript.push_str(&self.maybe_export());
             self.typescript
-                .push_str(&format!("enum {} {{", enum_.name));
+                .push_str(&format!("export enum {} {{", enum_.name));
         }
         for (name, value, comments) in enum_.variants.iter() {
             let variant_docs = if comments.is_empty() {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -439,7 +439,7 @@ impl<'a> Context<'a> {
 
         // Before putting the static init code declaration info, put all existing typescript into a `wasm_bindgen` namespace declaration.
         // Not sure if this should happen in all cases, so just adding it to NoModules for now...
-        if let OutputMode::NoModules { global : _ } = &self.config.mode {
+        if self.config.mode.no_modules() {
             ts = String::from("declare namespace wasm_bindgen {\n\t");
             ts.push_str(&self.typescript.replace("\n", "\n\t"));
             ts.push_str("\n}\n");
@@ -550,7 +550,7 @@ impl<'a> Context<'a> {
     /// In particular, in no-modules mode, all functions/classes/enums are placed in a `declare`d namespace.
     /// So they don't need to be `export`ed too (as of TypeScript 3.8.3 at least).
     fn maybe_export(&self) -> String {
-        if let OutputMode::NoModules { global : _ } = &self.config.mode {
+        if self.config.mode.no_modules() {
             String::from("")
         } else {
             String::from("export ")
@@ -578,7 +578,7 @@ impl<'a> Context<'a> {
         // Also in (at least) the NoModules, the `init()` method is renamed to `wasm_bindgen()`.
         let setup_function_declaration;
         let declare_or_export;
-        if let OutputMode::NoModules { global : _ } = &self.config.mode {
+        if self.config.mode.no_modules() {
             declare_or_export = "declare";
             setup_function_declaration = "declare function wasm_bindgen";
         } else {

--- a/crates/typescript-tests/.gitignore
+++ b/crates/typescript-tests/.gitignore
@@ -1,2 +1,4 @@
 pkg
 dist
+src_no_modules
+dist_no_modules

--- a/crates/typescript-tests/no_modules.tsconfig.json
+++ b/crates/typescript-tests/no_modules.tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "target": "es6",
+        "noImplicitAny": true,
+        "sourceMap": true,
+        "outDir": "nowhere",
+    },
+    "include": [
+        "pkg/no_modules/typescript_tests.d.ts"
+    ]
+}

--- a/crates/typescript-tests/no_modules.tsconfig.json
+++ b/crates/typescript-tests/no_modules.tsconfig.json
@@ -3,9 +3,10 @@
         "target": "es6",
         "noImplicitAny": true,
         "sourceMap": true,
-        "outDir": "nowhere",
+        "outDir": "dist_no_modules",
     },
     "include": [
-        "pkg/no_modules/typescript_tests.d.ts"
+        "pkg/no_modules/*.d.ts",
+        "src_no_modules/*.ts",
     ]
 }

--- a/crates/typescript-tests/run.sh
+++ b/crates/typescript-tests/run.sh
@@ -32,4 +32,24 @@ cargo run -p wasm-bindgen-cli --bin wasm-bindgen -- \
   --target no-modules \
   --typescript
 
+rm -rf src_no_modules
+mkdir src_no_modules
+cd src
+for filename in *.ts; do
+  # Create TypeScript file copies that don't use the module system.
+  if grep -q "as wasm" "$filename"
+  then
+    echo "Ignoring $filename as it uses the *.wasm.d.ts file."
+  else
+    path="../src_no_modules/$filename"
+    # Copy over everything but the import statements.
+    grep -v -w "import" "$filename" > "$path"
+    # Then replace "wbg."/"wbg "/"wbg[" with "wasm_bindgen" (the namespace the .d.ts file uses).
+    sed -i "s/wbg\./wasm_bindgen./g" "$path"
+    sed -i "s/wbg /wasm_bindgen /g" "$path"
+    sed -i "s/wbg\[/wasm_bindgen[/g" "$path"
+  fi
+done
+cd ..
+
 npm run tsc -- -p no_modules.tsconfig.json

--- a/crates/typescript-tests/run.sh
+++ b/crates/typescript-tests/run.sh
@@ -23,3 +23,13 @@ if [ ! -d node_modules ]; then
 fi
 
 npm run tsc
+
+# Build using no-modules, and make sure can minimally be read by the TypeScript compiler.
+mkdir pkg/no_modules
+cargo run -p wasm-bindgen-cli --bin wasm-bindgen -- \
+  ../../target/wasm32-unknown-unknown/debug/typescript_tests.wasm \
+  --out-dir pkg/no_modules \
+  --target no-modules \
+  --typescript
+
+npm run tsc -- -p no_modules.tsconfig.json

--- a/crates/typescript-tests/run.sh
+++ b/crates/typescript-tests/run.sh
@@ -24,7 +24,7 @@ fi
 
 npm run tsc
 
-# Build using no-modules, and make sure can minimally be read by the TypeScript compiler.
+# Build using no-modules.
 mkdir pkg/no_modules
 cargo run -p wasm-bindgen-cli --bin wasm-bindgen -- \
   ../../target/wasm32-unknown-unknown/debug/typescript_tests.wasm \
@@ -32,19 +32,22 @@ cargo run -p wasm-bindgen-cli --bin wasm-bindgen -- \
   --target no-modules \
   --typescript
 
+# Then create copies of the TypeScript tests used on "--target web" (i.e. those in ./src) but adjust them to work with "--target no-modules".
+# Store the new generated test files under "src_no_modules".
 rm -rf src_no_modules
 mkdir src_no_modules
 cd src
 for filename in *.ts; do
-  # Create TypeScript file copies that don't use the module system.
-  if grep -q "as wasm" "$filename"
+  if grep -q "_bg.wasm" "$filename"
   then
+    # I am unsure how to import or test the "*_bg.wasm" file.
+    # So any test file that includes those is currently being skipped.
     echo "Ignoring $filename as it uses the *.wasm.d.ts file."
   else
     path="../src_no_modules/$filename"
-    # Copy over everything but the import statements.
+    # Copy over every line EXCEPT for the import statements (since "no-modules" has no modules to import).
     grep -v -w "import" "$filename" > "$path"
-    # Then replace "wbg."/"wbg "/"wbg[" with "wasm_bindgen" (the namespace the .d.ts file uses).
+    # Then replace all of the instances of "wbg" (the namespace all the tests use to import the *.d.ts files from "--target web") with "wasm_bindgen" (the namespace the `no-modules` *.d.ts files use).
     sed -i "s/wbg\./wasm_bindgen./g" "$path"
     sed -i "s/wbg /wasm_bindgen /g" "$path"
     sed -i "s/wbg\[/wasm_bindgen[/g" "$path"
@@ -52,4 +55,5 @@ for filename in *.ts; do
 done
 cd ..
 
+# Then try to build the typescript in the src_no_modules folder against the pkg/no_modules build.
 npm run tsc -- -p no_modules.tsconfig.json


### PR DESCRIPTION
Partially based on https://github.com/rustwasm/wasm-bindgen/issues/693.

The current `--target no-modules` TypeScript declaration files don't correctly describe what the JS interface looks like:
* The functions exported via `extern {` and `#[wasm_bindgen]` are stored in the `wasm_bindgen` namespace, but the TypeScript declaration files don't put them in any namespace.
* Everything else at the root level of the TypeScript file was `export`d. As of TypeScript 3.8.3, that meant it wasn't visible. So those were switched over to `declare` statements.

This tries to fix the above by adjusting the output for just `no-modules`. It also removes the bunch of extra spaces at the end of the declaration file.

As an example, the output went from:
```typescript
/* tslint:disable */
/* eslint-disable */
/**
* @param {number} id
*/
export function call_in(id: number): void;

export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;

export interface InitOutput {
  readonly memory: WebAssembly.Memory;
  readonly call_in: (a: number) => void;
}

/**
* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
* for everything else, calls `WebAssembly.instantiate` directly.
*
* @param {InitInput | Promise<InitInput>} module_or_path
*
* @returns {Promise<InitOutput>}
*/
export default function init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;
        
```
To:
```typescript
declare namespace wasm_bindgen {
	/* tslint:disable */
	/* eslint-disable */
	/**
	* @param {number} id
	*/
	export function call_in(id: number): void;
	
}

declare type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;

declare interface InitOutput {
  readonly memory: WebAssembly.Memory;
  readonly call_in: (a: number) => void;
}

/**
* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
* for everything else, calls `WebAssembly.instantiate` directly.
*
* @param {InitInput | Promise<InitInput>} module_or_path
*
* @returns {Promise<InitOutput>}
*/
declare function wasm_bindgen (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;

```
## Testing

When I ran `cargo test` and `cargo test --target wasm32-unknown-unknown` on my local setup, it reported all passes.