### PR TITLE
Allow constructors to be immutable and add it for ImageData

### DIFF
--- a/crates/web-sys/src/features/gen_ImageData.rs
+++ b/crates/web-sys/src/features/gen_ImageData.rs
@@ -46,7 +46,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`*"]
     pub fn new_with_u8_clamped_array(
-        data: ::wasm_bindgen::Clamped<&mut [u8]>,
+        data: ::wasm_bindgen::Clamped<&[u8]>,
         sw: u32,
     ) -> Result<ImageData, JsValue>;
     #[wasm_bindgen(catch, constructor, js_class = "ImageData")]
@@ -56,7 +56,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`*"]
     pub fn new_with_u8_clamped_array_and_sh(
-        data: ::wasm_bindgen::Clamped<&mut [u8]>,
+        data: ::wasm_bindgen::Clamped<&[u8]>,
         sw: u32,
         sh: u32,
     ) -> Result<ImageData, JsValue>;

--- a/crates/web-sys/tests/wasm/image_data.rs
+++ b/crates/web-sys/tests/wasm/image_data.rs
@@ -1,0 +1,19 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+use web_sys::HtmlAnchorElement;
+use wasm_bindgen::{Clamped};
+#[wasm_bindgen(module = "/tests/wasm/element.js")]
+extern "C" {
+    fn new_a() -> HtmlAnchorElement;
+}
+
+#[wasm_bindgen_test]
+fn test_anchor_element() {
+    // This test is to make sure there is no weird mutability going on.
+    let buf = vec![1,2,3,255];
+    let image_data =
+    web_sys::ImageData::new_with_u8_clamped_array(Clamped(&buf), 1).unwrap();
+    let mut data = image_data.data();
+    data[1] = 4;
+    assert_eq!(buf[1], 2);
+}

--- a/crates/web-sys/tests/wasm/image_data.rs
+++ b/crates/web-sys/tests/wasm/image_data.rs
@@ -10,9 +10,8 @@ extern "C" {
 #[wasm_bindgen_test]
 fn test_anchor_element() {
     // This test is to make sure there is no weird mutability going on.
-    let buf = vec![1,2,3,255];
-    let image_data =
-    web_sys::ImageData::new_with_u8_clamped_array(Clamped(&buf), 1).unwrap();
+    let buf = vec![1, 2, 3, 255];
+    let image_data = web_sys::ImageData::new_with_u8_clamped_array(Clamped(&buf), 1).unwrap();
     let mut data = image_data.data();
     data[1] = 4;
     assert_eq!(buf[1], 2);

--- a/crates/web-sys/tests/wasm/image_data.rs
+++ b/crates/web-sys/tests/wasm/image_data.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::Clamped;
 use wasm_bindgen_test::*;
 use web_sys::HtmlAnchorElement;
-use wasm_bindgen::{Clamped};
 #[wasm_bindgen(module = "/tests/wasm/element.js")]
 extern "C" {
     fn new_a() -> HtmlAnchorElement;

--- a/crates/web-sys/tests/wasm/main.rs
+++ b/crates/web-sys/tests/wasm/main.rs
@@ -21,6 +21,7 @@ pub mod hr_element;
 pub mod html_element;
 pub mod html_html_element;
 pub mod input_element;
+pub mod image_data;
 //TODO: Both menu-related tests completely break in Chrome, but run fine in Firefox.
 //pub mod menu_element;
 //pub mod menu_item_element;

--- a/crates/web-sys/tests/wasm/main.rs
+++ b/crates/web-sys/tests/wasm/main.rs
@@ -20,8 +20,8 @@ pub mod history;
 pub mod hr_element;
 pub mod html_element;
 pub mod html_html_element;
-pub mod input_element;
 pub mod image_data;
+pub mod input_element;
 //TODO: Both menu-related tests completely break in Chrome, but run fine in Firefox.
 //pub mod menu_element;
 //pub mod menu_item_element;

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -42,6 +42,8 @@ lazy_static! {
 
 
     pub(crate) static ref IMMUTABLE_SLICE_WHITELIST: BTreeSet<&'static str> = BTreeSet::from_iter(vec![
+        // ImageData
+        "ImageData",
         // WebGlRenderingContext, WebGl2RenderingContext
         "uniform1fv",
         "uniform2fv",

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -101,7 +101,10 @@ pub(crate) struct CallbackInterfaceData<'src> {
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, Copy)]
 pub(crate) enum OperationId<'src> {
-    Constructor,
+    /// The name of a constructor in crates/web-sys/webidls/enabled/*.webidl
+    ///
+    /// ex: Constructor(Some("ImageData"))
+    Constructor(Option<&'src str>),
     NamedConstructor(IgnoreTraits<&'src str>),
     /// The name of a function in crates/web-sys/webidls/enabled/*.webidl
     ///
@@ -390,7 +393,7 @@ fn process_interface_attribute<'src>(
                 record,
                 FirstPassOperationType::Interface,
                 self_name,
-                &[OperationId::Constructor],
+                &[OperationId::Constructor(Some(self_name))],
                 &list.args.body.list,
                 &return_ty,
                 &None,
@@ -402,7 +405,7 @@ fn process_interface_attribute<'src>(
                 record,
                 FirstPassOperationType::Interface,
                 self_name,
-                &[OperationId::Constructor],
+                &[OperationId::Constructor(Some(self_name))],
                 &[],
                 &return_ty,
                 &None,

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -413,7 +413,7 @@ impl<'src> FirstPassRecord<'src> {
     ) {
         match id {
             OperationId::Operation(Some(_)) => {}
-            OperationId::Constructor
+            OperationId::Constructor(_)
             | OperationId::NamedConstructor(_)
             | OperationId::Operation(None)
             | OperationId::IndexingGetter

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -505,7 +505,7 @@ impl<'src> FirstPassRecord<'src> {
             OperationId::Constructor(Some(op)) => op,
             _ => return idl_type,
         };
-        
+
         if IMMUTABLE_SLICE_WHITELIST.contains(op) {
             flag_slices_immutable(&mut idl_type)
         }

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -297,7 +297,7 @@ impl<'src> FirstPassRecord<'src> {
             // > value of a type corresponding to the interface the
             // > `[Constructor]` extended attribute appears on, **or throw an
             // > exception**.
-            OperationId::Constructor => {
+            OperationId::Constructor(_) => {
                 ("new", InterfaceMethodKind::Constructor(None), false, true)
             }
             OperationId::NamedConstructor(n) => (
@@ -502,9 +502,10 @@ impl<'src> FirstPassRecord<'src> {
     fn maybe_adjust<'a>(&self, mut idl_type: IdlType<'a>, id: &'a OperationId) -> IdlType<'a> {
         let op = match id {
             OperationId::Operation(Some(op)) => op,
+            OperationId::Constructor(Some(op)) => op,
             _ => return idl_type,
         };
-
+        
         if IMMUTABLE_SLICE_WHITELIST.contains(op) {
             flag_slices_immutable(&mut idl_type)
         }


### PR DESCRIPTION
This fixes #2364 and makes it easy to any constructor to me immutable.

Also includes a test to make sure that there is no magic things going on and that the original array is not modified(at least form the WASM side of things)