### PR TITLE
Add documentation for importing `export default`

### DIFF
--- a/guide/src/reference/attributes/on-js-imports/js_name.md
+++ b/guide/src/reference/attributes/on-js-imports/js_name.md
@@ -58,4 +58,30 @@ extern "C" {
 }
 ```
 
+The `js_name` attribute can also be used in situations where a JavaScript module uses 
+`export default`. In this case, setting the `js_name` attribute to "default" on the 
+`type` declaration, and the [`js_class` attribute][jsclass] to "default" on any methods 
+on the exported object will generate the correct imports.
+
+
+For example, a module that would be imported directly in JavaScript:
+
+```javascript
+import Foo from "bar";
+
+let f = new Foo();
+```
+
+Could be accessed using this definition in Rust:
+
+```rust
+#[wasm_bindgen(module = "bar")]
+extern "C" {
+    #[wasm_bindgen(js_name = default)
+    type Foo;
+    #[wasm_bindgen(constructor, js_class = default)]
+    pub fn new() -> Foo;
+}
+```
+
 [jsclass]: js_class.html


### PR DESCRIPTION
Added some documentation to the `js_name` page about using it to import
JavaScript modules that use `export default`.

I couldn't find this in the documentation, and only found out about it by finding a closed issue about it. I'm not sure if this is the best place for it. Maybe it could use its own page? It seems like a common enough pattern in JavaScript modules that calling it out seemed like it would be helpful. It certainly would have saved me some time.