### PR TITLE
Fix canvas is not a self closing tag.

### DIFF
--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -3,6 +3,6 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
-    <canvas id="canvas" height="150" width="150" />
+    <canvas id="canvas" height="150" width="150"></canvas>
   </body>
 </html>

--- a/examples/duck-typed-interfaces/index.html
+++ b/examples/duck-typed-interfaces/index.html
@@ -3,7 +3,7 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
-    <canvas id="canvas" height="150" width="150" />
+    <canvas id="canvas" height="150" width="150"></canvas>
     <script src='./index.js'></script>
   </body>
 </html>

--- a/examples/webgl/index.html
+++ b/examples/webgl/index.html
@@ -3,6 +3,6 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
-    <canvas id="canvas" height="150" width="150" />
+    <canvas id="canvas" height="150" width="150"></canvas>
   </body>
 </html>

--- a/examples/webxr/index.html
+++ b/examples/webxr/index.html
@@ -3,6 +3,6 @@
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
   </head>
   <body>
-    <canvas id="canvas" height="150" width="150" />
+    <canvas id="canvas" height="150" width="150"></canvas>
   </body>
 </html>


### PR DESCRIPTION
I'm sorry I'm no good in English.
I got in trouble with the sample. It happened in Firefox 84.0.
canvas is not a self closing tag. As a result, the element written after canvas is not displayed in the browser.