### PR TITLE
Update WebIDL to use `undefined` instead of `void`

### DIFF
--- a/crates/web-sys/webidls/enabled/AbortController.webidl
+++ b/crates/web-sys/webidls/enabled/AbortController.webidl
@@ -11,5 +11,5 @@
 interface AbortController {
   readonly attribute AbortSignal signal;
 
-  void abort();
+  undefined abort();
 };

--- a/crates/web-sys/webidls/enabled/AnalyserNode.webidl
+++ b/crates/web-sys/webidls/enabled/AnalyserNode.webidl
@@ -22,12 +22,12 @@ dictionary AnalyserOptions : AudioNodeOptions {
 interface AnalyserNode : AudioNode {
 
     // Real-time frequency-domain data
-    void getFloatFrequencyData(Float32Array array);
-    void getByteFrequencyData(Uint8Array array);
+    undefined getFloatFrequencyData(Float32Array array);
+    undefined getByteFrequencyData(Uint8Array array);
 
     // Real-time waveform data
-    void getFloatTimeDomainData(Float32Array array);
-    void getByteTimeDomainData(Uint8Array array);
+    undefined getFloatTimeDomainData(Float32Array array);
+    undefined getByteTimeDomainData(Uint8Array array);
 
     [SetterThrows, Pure]
     attribute unsigned long fftSize;

--- a/crates/web-sys/webidls/enabled/Animation.webidl
+++ b/crates/web-sys/webidls/enabled/Animation.webidl
@@ -37,16 +37,16 @@ interface Animation : EventTarget {
   readonly attribute Promise<Animation> finished;
            attribute EventHandler       onfinish;
            attribute EventHandler       oncancel;
-  void cancel ();
+  undefined cancel ();
   [Throws]
-  void finish ();
+  undefined finish ();
   [Throws, BinaryName="playFromJS"]
-  void play ();
+  undefined play ();
   [Throws, BinaryName="pauseFromJS"]
-  void pause ();
-  void updatePlaybackRate (double playbackRate);
+  undefined pause ();
+  undefined updatePlaybackRate (double playbackRate);
   [Throws]
-  void reverse ();
+  undefined reverse ();
 };
 
 // Non-standard extensions

--- a/crates/web-sys/webidls/enabled/AnimationEffect.webidl
+++ b/crates/web-sys/webidls/enabled/AnimationEffect.webidl
@@ -61,5 +61,5 @@ interface AnimationEffect {
   [BinaryName="getComputedTimingAsDict"]
   ComputedEffectTiming getComputedTiming();
   [Throws]
-  void updateTiming(optional OptionalEffectTiming timing);
+  undefined updateTiming(optional OptionalEffectTiming timing);
 };

--- a/crates/web-sys/webidls/enabled/AudioBuffer.webidl
+++ b/crates/web-sys/webidls/enabled/AudioBuffer.webidl
@@ -32,7 +32,7 @@ interface AudioBuffer {
     Float32Array getChannelData(unsigned long channel);
 
     [Throws]
-    void copyFromChannel(Float32Array destination, long channelNumber, optional unsigned long startInChannel = 0);
+    undefined copyFromChannel(Float32Array destination, long channelNumber, optional unsigned long startInChannel = 0);
     [Throws]
-    void copyToChannel(Float32Array source, long channelNumber, optional unsigned long startInChannel = 0);
+    undefined copyToChannel(Float32Array source, long channelNumber, optional unsigned long startInChannel = 0);
 };

--- a/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
@@ -35,9 +35,9 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
     attribute EventHandler onended;
 
     [Throws]
-    void start(optional double when = 0, optional double grainOffset = 0,
+    undefined start(optional double when = 0, optional double grainOffset = 0,
                optional double grainDuration);
 
     [Throws]
-    void stop (optional double when = 0);
+    undefined stop (optional double when = 0);
 };

--- a/crates/web-sys/webidls/enabled/AudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/AudioContext.webidl
@@ -22,9 +22,9 @@ interface AudioContext : BaseAudioContext {
     // Bug 1324545: AudioTimestamp                  getOutputTimestamp ();
 
     [Throws]
-    Promise<void> suspend();
+    Promise<undefined> suspend();
     [Throws]
-    Promise<void> close();
+    Promise<undefined> close();
 
     [NewObject, Throws]
     MediaElementAudioSourceNode createMediaElementSource(HTMLMediaElement mediaElement);

--- a/crates/web-sys/webidls/enabled/AudioListener.webidl
+++ b/crates/web-sys/webidls/enabled/AudioListener.webidl
@@ -22,10 +22,10 @@ interface AudioListener {
     attribute double speedOfSound;
 
     // Uses a 3D cartesian coordinate system
-    void setPosition(double x, double y, double z);
-    void setOrientation(double x, double y, double z, double xUp, double yUp, double zUp);
+    undefined setPosition(double x, double y, double z);
+    undefined setOrientation(double x, double y, double z, double xUp, double yUp, double zUp);
     [Deprecated="PannerNodeDoppler"]
-    void setVelocity(double x, double y, double z);
+    undefined setVelocity(double x, double y, double z);
 
 };
 

--- a/crates/web-sys/webidls/enabled/AudioNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioNode.webidl
@@ -33,21 +33,21 @@ interface AudioNode : EventTarget {
     [Throws]
     AudioNode connect(AudioNode destination, optional unsigned long output = 0, optional unsigned long input = 0);
     [Throws]
-    void connect(AudioParam destination, optional unsigned long output = 0);
+    undefined connect(AudioParam destination, optional unsigned long output = 0);
     [Throws]
-    void disconnect();
+    undefined disconnect();
     [Throws]
-    void disconnect(unsigned long output);
+    undefined disconnect(unsigned long output);
     [Throws]
-    void disconnect(AudioNode destination);
+    undefined disconnect(AudioNode destination);
     [Throws]
-    void disconnect(AudioNode destination, unsigned long output);
+    undefined disconnect(AudioNode destination, unsigned long output);
     [Throws]
-    void disconnect(AudioNode destination, unsigned long output, unsigned long input);
+    undefined disconnect(AudioNode destination, unsigned long output, unsigned long input);
     [Throws]
-    void disconnect(AudioParam destination);
+    undefined disconnect(AudioParam destination);
     [Throws]
-    void disconnect(AudioParam destination, unsigned long output);
+    undefined disconnect(AudioParam destination, unsigned long output);
 
     readonly attribute BaseAudioContext context;
     readonly attribute unsigned long numberOfInputs;

--- a/crates/web-sys/webidls/enabled/AudioScheduledSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioScheduledSourceNode.webidl
@@ -19,8 +19,8 @@ AudioScheduledSourceNode includes rustAudioScheduledSourceNode;
 interface mixin rustAudioScheduledSourceNode {
                     attribute EventHandler onended;
     [Throws]
-    void start (optional double when = 0);
+    undefined start (optional double when = 0);
 
     [Throws]
-    void stop (optional double when = 0);
+    undefined stop (optional double when = 0);
 };

--- a/crates/web-sys/webidls/enabled/AudioWorkletGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/AudioWorkletGlobalScope.webidl
@@ -9,7 +9,7 @@
 
 [Global=(Worklet,AudioWorklet),Exposed=AudioWorklet]
 interface AudioWorkletGlobalScope : WorkletGlobalScope {
-    void registerProcessor (DOMString name, VoidFunction processorCtor);
+    undefined registerProcessor (DOMString name, VoidFunction processorCtor);
     readonly  attribute   unsigned long long currentFrame;
     readonly  attribute   double currentTime;
     readonly  attribute   float sampleRate;

--- a/crates/web-sys/webidls/enabled/BaseAudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/BaseAudioContext.webidl
@@ -10,8 +10,8 @@
  * liability, trademark and document use rules apply.
  */
 
-callback DecodeSuccessCallback = void (AudioBuffer decodedData);
-callback DecodeErrorCallback = void (DOMException error);
+callback DecodeSuccessCallback = undefined (AudioBuffer decodedData);
+callback DecodeErrorCallback = undefined (DOMException error);
 
 enum AudioContextState {
     "suspended",
@@ -36,7 +36,7 @@ interface mixin rustBaseAudioContext {
     // Bug 1324552: readonly        attribute double               baseLatency;
 
     [Throws]
-    Promise<void> resume();
+    Promise<undefined> resume();
 
                     attribute EventHandler         onstatechange;
 

--- a/crates/web-sys/webidls/enabled/BiquadFilterNode.webidl
+++ b/crates/web-sys/webidls/enabled/BiquadFilterNode.webidl
@@ -39,7 +39,7 @@ interface BiquadFilterNode : AudioNode {
     readonly attribute AudioParam Q; // Quality factor
     readonly attribute AudioParam gain; // in Decibels
 
-    void getFrequencyResponse(Float32Array frequencyHz,
+    undefined getFrequencyResponse(Float32Array frequencyHz,
                               Float32Array magResponse,
                               Float32Array phaseResponse);
 

--- a/crates/web-sys/webidls/enabled/BroadcastChannel.webidl
+++ b/crates/web-sys/webidls/enabled/BroadcastChannel.webidl
@@ -13,9 +13,9 @@ interface BroadcastChannel : EventTarget {
   readonly attribute DOMString name;
 
   [Throws]
-  void postMessage(any message);
+  undefined postMessage(any message);
 
-  void close();
+  undefined close();
 
   attribute EventHandler onmessage;
   attribute EventHandler onmessageerror;

--- a/crates/web-sys/webidls/enabled/BrowserElement.webidl
+++ b/crates/web-sys/webidls/enabled/BrowserElement.webidl
@@ -4,7 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-callback BrowserElementNextPaintEventCallback = void ();
+callback BrowserElementNextPaintEventCallback = undefined ();
 
 enum BrowserFindCaseSensitivity { "case-sensitive", "case-insensitive" };
 enum BrowserFindDirection { "forward", "backward" };
@@ -29,19 +29,19 @@ interface mixin BrowserElementCommon {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void addNextPaintListener(BrowserElementNextPaintEventCallback listener);
+  undefined addNextPaintListener(BrowserElementNextPaintEventCallback listener);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void removeNextPaintListener(BrowserElementNextPaintEventCallback listener);
+  undefined removeNextPaintListener(BrowserElementNextPaintEventCallback listener);
 };
 
 interface mixin BrowserElementPrivileged {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void sendMouseEvent(DOMString type,
+  undefined sendMouseEvent(DOMString type,
                       unsigned long x,
                       unsigned long y,
                       unsigned long button,
@@ -52,7 +52,7 @@ interface mixin BrowserElementPrivileged {
    Pref="dom.mozBrowserFramesEnabled",
    Func="TouchEvent::PrefEnabled",
    ChromeOnly]
-  void sendTouchEvent(DOMString type,
+  undefined sendTouchEvent(DOMString type,
                       sequence<unsigned long> identifiers,
                       sequence<long> x,
                       sequence<long> y,
@@ -66,22 +66,22 @@ interface mixin BrowserElementPrivileged {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void goBack();
+  undefined goBack();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void goForward();
+  undefined goForward();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void reload(optional boolean hardReload = false);
+  undefined reload(optional boolean hardReload = false);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void stop();
+  undefined stop();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
@@ -104,7 +104,7 @@ interface mixin BrowserElementPrivileged {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void zoom(float zoom);
+  undefined zoom(float zoom);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
@@ -124,17 +124,17 @@ interface mixin BrowserElementPrivileged {
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void findAll(DOMString searchString, BrowserFindCaseSensitivity caseSensitivity);
+  undefined findAll(DOMString searchString, BrowserFindCaseSensitivity caseSensitivity);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void findNext(BrowserFindDirection direction);
+  undefined findNext(BrowserFindDirection direction);
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",
    ChromeOnly]
-  void clearMatch();
+  undefined clearMatch();
 
   [Throws,
    Pref="dom.mozBrowserFramesEnabled",

--- a/crates/web-sys/webidls/enabled/BrowserFeedWriter.webidl
+++ b/crates/web-sys/webidls/enabled/BrowserFeedWriter.webidl
@@ -11,10 +11,10 @@ interface BrowserFeedWriter {
   /**
    * Writes the feed content, assumes that the feed writer is initialized.
    */
-  void writeContent();
+  undefined writeContent();
 
   /**
    * Uninitialize the feed writer.
    */
-  void close();
+  undefined close();
 };

--- a/crates/web-sys/webidls/enabled/CSSGroupingRule.webidl
+++ b/crates/web-sys/webidls/enabled/CSSGroupingRule.webidl
@@ -13,5 +13,5 @@ interface CSSGroupingRule : CSSRule {
   [Throws]
   unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
   [Throws]
-  void deleteRule(unsigned long index);
+  undefined deleteRule(unsigned long index);
 };

--- a/crates/web-sys/webidls/enabled/CSSKeyframesRule.webidl
+++ b/crates/web-sys/webidls/enabled/CSSKeyframesRule.webidl
@@ -12,7 +12,7 @@ interface CSSKeyframesRule : CSSRule {
            attribute DOMString   name;
   readonly attribute CSSRuleList cssRules;
 
-  void            appendRule(DOMString rule);
-  void            deleteRule(DOMString select);
+  undefined            appendRule(DOMString rule);
+  undefined            deleteRule(DOMString select);
   CSSKeyframeRule? findRule(DOMString select);
 };

--- a/crates/web-sys/webidls/enabled/CSSStyleDeclaration.webidl
+++ b/crates/web-sys/webidls/enabled/CSSStyleDeclaration.webidl
@@ -24,7 +24,7 @@ interface CSSStyleDeclaration {
   DOMString getPropertyValue(DOMString property);
   DOMString getPropertyPriority(DOMString property);
   [CEReactions, NeedsSubjectPrincipal=NonSystem, Throws]
-  void setProperty(DOMString property, [TreatNullAs=EmptyString] DOMString value, [TreatNullAs=EmptyString] optional DOMString priority = "");
+  undefined setProperty(DOMString property, [TreatNullAs=EmptyString] DOMString value, [TreatNullAs=EmptyString] optional DOMString priority = "");
   [CEReactions, Throws]
   DOMString removeProperty(DOMString property);
 

--- a/crates/web-sys/webidls/enabled/CSSStyleSheet.webidl
+++ b/crates/web-sys/webidls/enabled/CSSStyleSheet.webidl
@@ -23,5 +23,5 @@ interface CSSStyleSheet : StyleSheet {
   [Throws, NeedsSubjectPrincipal]
   unsigned long insertRule(DOMString rule, optional unsigned long index = 0);
   [Throws, NeedsSubjectPrincipal]
-  void deleteRule(unsigned long index);
+  undefined deleteRule(unsigned long index);
 };

--- a/crates/web-sys/webidls/enabled/Cache.webidl
+++ b/crates/web-sys/webidls/enabled/Cache.webidl
@@ -18,11 +18,11 @@ interface Cache {
   [NewObject]
   Promise<sequence<Response>> matchAll(optional RequestInfo request, optional CacheQueryOptions options);
   [NewObject, NeedsCallerType]
-  Promise<void> add(RequestInfo request);
+  Promise<undefined> add(RequestInfo request);
   [NewObject, NeedsCallerType]
-  Promise<void> addAll(sequence<RequestInfo> requests);
+  Promise<undefined> addAll(sequence<RequestInfo> requests);
   [NewObject]
-  Promise<void> put(RequestInfo request, Response response);
+  Promise<undefined> put(RequestInfo request, Response response);
   [NewObject]
   Promise<boolean> delete(RequestInfo request, optional CacheQueryOptions options);
   [NewObject]

--- a/crates/web-sys/webidls/enabled/CanvasCaptureMediaStream.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasCaptureMediaStream.webidl
@@ -13,5 +13,5 @@
 [Pref="canvas.capturestream.enabled"]
 interface CanvasCaptureMediaStream : MediaStream {
     readonly attribute HTMLCanvasElement canvas;
-    void requestFrame();
+    undefined requestFrame();
 };

--- a/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
@@ -96,7 +96,7 @@ interface CanvasRenderingContext2D {
    * and Web Extensions (with a permission) only.
    */
   [Throws, Func="CanvasUtils::HasDrawWindowPrivilege"]
-  void drawWindow(Window window, double x, double y, double w, double h,
+  undefined drawWindow(Window window, double x, double y, double w, double h,
                   DOMString bgColor, optional unsigned long flags = 0);
 
   /**
@@ -104,7 +104,7 @@ interface CanvasRenderingContext2D {
    * backend to fallback to a software one. All state should be preserved.
    */
   [ChromeOnly]
-  void demote();
+  undefined demote();
 };
 
 CanvasRenderingContext2D includes CanvasState;
@@ -127,25 +127,25 @@ CanvasRenderingContext2D includes CanvasHitRegions;
 
 interface mixin CanvasState {
   // state
-  void save(); // push state on state stack
-  void restore(); // pop state stack and restore state
+  undefined save(); // push state on state stack
+  undefined restore(); // pop state stack and restore state
 };
 
 interface mixin CanvasTransform {
   // transformations (default transform is the identity matrix)
 // NOT IMPLEMENTED           attribute SVGMatrix currentTransform;
   [Throws, LenientFloat]
-  void scale(double x, double y);
+  undefined scale(double x, double y);
   [Throws, LenientFloat]
-  void rotate(double angle);
+  undefined rotate(double angle);
   [Throws, LenientFloat]
-  void translate(double x, double y);
+  undefined translate(double x, double y);
   [Throws, LenientFloat]
-  void transform(double a, double b, double c, double d, double e, double f);
+  undefined transform(double a, double b, double c, double d, double e, double f);
   [Throws, LenientFloat]
-  void setTransform(double a, double b, double c, double d, double e, double f);
+  undefined setTransform(double a, double b, double c, double d, double e, double f);
   [Throws]
-  void resetTransform();
+  undefined resetTransform();
   [NewObject, Throws]
   DOMMatrix getTransform();
 };
@@ -191,23 +191,23 @@ interface mixin CanvasFilters {
 
 interface mixin CanvasRect {
   [LenientFloat]
-  void clearRect(double x, double y, double w, double h);
+  undefined clearRect(double x, double y, double w, double h);
   [LenientFloat]
-  void fillRect(double x, double y, double w, double h);
+  undefined fillRect(double x, double y, double w, double h);
   [LenientFloat]
-  void strokeRect(double x, double y, double w, double h);
+  undefined strokeRect(double x, double y, double w, double h);
 };
 
 interface mixin CanvasDrawPath {
   // path API (see also CanvasPathMethods)
-  void beginPath();
-  void fill(optional CanvasWindingRule winding = "nonzero");
-  void fill(Path2D path, optional CanvasWindingRule winding = "nonzero");
-  void stroke();
-  void stroke(Path2D path);
-  void clip(optional CanvasWindingRule winding = "nonzero");
-  void clip(Path2D path, optional CanvasWindingRule winding = "nonzero");
-// NOT IMPLEMENTED  void resetClip();
+  undefined beginPath();
+  undefined fill(optional CanvasWindingRule winding = "nonzero");
+  undefined fill(Path2D path, optional CanvasWindingRule winding = "nonzero");
+  undefined stroke();
+  undefined stroke(Path2D path);
+  undefined clip(optional CanvasWindingRule winding = "nonzero");
+  undefined clip(Path2D path, optional CanvasWindingRule winding = "nonzero");
+// NOT IMPLEMENTED  undefined resetClip();
   [NeedsSubjectPrincipal]
   boolean isPointInPath(unrestricted double x, unrestricted double y, optional CanvasWindingRule winding = "nonzero");
   [NeedsSubjectPrincipal] // Only required because overloads can't have different extended attributes.
@@ -219,31 +219,31 @@ interface mixin CanvasDrawPath {
 };
 
 interface mixin CanvasUserInterface {
-  [Pref="canvas.focusring.enabled", Throws] void drawFocusIfNeeded(Element element);
-// NOT IMPLEMENTED  void drawSystemFocusRing(Path path, HTMLElement element);
+  [Pref="canvas.focusring.enabled", Throws] undefined drawFocusIfNeeded(Element element);
+// NOT IMPLEMENTED  undefined drawSystemFocusRing(Path path, HTMLElement element);
   [Pref="canvas.customfocusring.enabled"] boolean drawCustomFocusRing(Element element);
 // NOT IMPLEMENTED  boolean drawCustomFocusRing(Path path, HTMLElement element);
-// NOT IMPLEMENTED  void scrollPathIntoView();
-// NOT IMPLEMENTED  void scrollPathIntoView(Path path);
+// NOT IMPLEMENTED  undefined scrollPathIntoView();
+// NOT IMPLEMENTED  undefined scrollPathIntoView(Path path);
 };
 
 interface mixin CanvasText {
   // text (see also the CanvasPathDrawingStyles interface)
   [Throws, LenientFloat]
-  void fillText(DOMString text, double x, double y, optional double maxWidth);
+  undefined fillText(DOMString text, double x, double y, optional double maxWidth);
   [Throws, LenientFloat]
-  void strokeText(DOMString text, double x, double y, optional double maxWidth);
+  undefined strokeText(DOMString text, double x, double y, optional double maxWidth);
   [NewObject, Throws]
   TextMetrics measureText(DOMString text);
 };
 
 interface mixin CanvasDrawImage {
   [Throws, LenientFloat]
-  void drawImage(CanvasImageSource image, double dx, double dy);
+  undefined drawImage(CanvasImageSource image, double dx, double dy);
   [Throws, LenientFloat]
-  void drawImage(CanvasImageSource image, double dx, double dy, double dw, double dh);
+  undefined drawImage(CanvasImageSource image, double dx, double dy, double dw, double dh);
   [Throws, LenientFloat]
-  void drawImage(CanvasImageSource image, double sx, double sy, double sw, double sh, double dx, double dy, double dw, double dh);
+  undefined drawImage(CanvasImageSource image, double sx, double sy, double sw, double sh, double dx, double dy, double dw, double dh);
 };
 
 interface mixin CanvasImageData {
@@ -255,9 +255,9 @@ interface mixin CanvasImageData {
   [NewObject, Throws, NeedsSubjectPrincipal]
   ImageData getImageData(double sx, double sy, double sw, double sh);
   [Throws]
-  void putImageData(ImageData imagedata, double dx, double dy);
+  undefined putImageData(ImageData imagedata, double dx, double dy);
   [Throws]
-  void putImageData(ImageData imagedata, double dx, double dy, double dirtyX, double dirtyY, double dirtyWidth, double dirtyHeight);
+  undefined putImageData(ImageData imagedata, double dx, double dy, double dirtyX, double dirtyY, double dirtyWidth, double dirtyHeight);
 };
 
 interface mixin CanvasPathDrawingStyles {
@@ -271,7 +271,7 @@ interface mixin CanvasPathDrawingStyles {
   attribute double miterLimit; // (default 10)
 
   // dashed lines
-  [LenientFloat, Throws] void setLineDash(sequence<double> segments); // default empty
+  [LenientFloat, Throws] undefined setLineDash(sequence<double> segments); // default empty
   sequence<double> getLineDash();
   [LenientFloat] attribute double lineDashOffset;
 };
@@ -286,52 +286,52 @@ interface mixin CanvasTextDrawingStyles {
 
 interface mixin CanvasPathMethods {
   // shared path API methods
-  void closePath();
+  undefined closePath();
   [LenientFloat]
-  void moveTo(double x, double y);
+  undefined moveTo(double x, double y);
   [LenientFloat]
-  void lineTo(double x, double y);
+  undefined lineTo(double x, double y);
   [LenientFloat]
-  void quadraticCurveTo(double cpx, double cpy, double x, double y);
+  undefined quadraticCurveTo(double cpx, double cpy, double x, double y);
 
   [LenientFloat]
-  void bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
-
-  [Throws, LenientFloat]
-  void arcTo(double x1, double y1, double x2, double y2, double radius);
-// NOT IMPLEMENTED  [LenientFloat] void arcTo(double x1, double y1, double x2, double y2, double radiusX, double radiusY, double rotation);
-
-  [LenientFloat]
-  void rect(double x, double y, double w, double h);
+  undefined bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
 
   [Throws, LenientFloat]
-  void arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false);
+  undefined arcTo(double x1, double y1, double x2, double y2, double radius);
+// NOT IMPLEMENTED  [LenientFloat] undefined arcTo(double x1, double y1, double x2, double y2, double radiusX, double radiusY, double rotation);
+
+  [LenientFloat]
+  undefined rect(double x, double y, double w, double h);
 
   [Throws, LenientFloat]
-  void ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, optional boolean anticlockwise = false);
+  undefined arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false);
+
+  [Throws, LenientFloat]
+  undefined ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, optional boolean anticlockwise = false);
 };
 
 interface mixin CanvasHitRegions {
   // hit regions
-  [Pref="canvas.hitregions.enabled", Throws] void addHitRegion(optional HitRegionOptions options);
-  [Pref="canvas.hitregions.enabled"] void removeHitRegion(DOMString id);
-  [Pref="canvas.hitregions.enabled"] void clearHitRegions();
+  [Pref="canvas.hitregions.enabled", Throws] undefined addHitRegion(optional HitRegionOptions options);
+  [Pref="canvas.hitregions.enabled"] undefined removeHitRegion(DOMString id);
+  [Pref="canvas.hitregions.enabled"] undefined clearHitRegions();
 };
 
 interface CanvasGradient {
   // opaque object
   [Throws]
   // addColorStop should take a double
-  void addColorStop(float offset, DOMString color);
+  undefined addColorStop(float offset, DOMString color);
 };
 
 interface CanvasPattern {
   // opaque object
   // [Throws, LenientFloat] - could not do this overload because of bug 1020975
-  // void setTransform(double a, double b, double c, double d, double e, double f);
+  // undefined setTransform(double a, double b, double c, double d, double e, double f);
 
   // No throw necessary here - SVGMatrix is always good.
-  void setTransform(SVGMatrix matrix);
+  undefined setTransform(SVGMatrix matrix);
 };
 
 interface TextMetrics {
@@ -365,6 +365,6 @@ interface TextMetrics {
  Constructor(DOMString pathString)]
 interface Path2D
 {
-  void addPath(Path2D path, optional SVGMatrix transformation);
+  undefined addPath(Path2D path, optional SVGMatrix transformation);
 };
 Path2D includes CanvasPathMethods;

--- a/crates/web-sys/webidls/enabled/CharacterData.webidl
+++ b/crates/web-sys/webidls/enabled/CharacterData.webidl
@@ -18,13 +18,13 @@ interface CharacterData : Node {
   [Throws]
   DOMString substringData(unsigned long offset, unsigned long count);
   [Throws]
-  void appendData(DOMString data);
+  undefined appendData(DOMString data);
   [Throws]
-  void insertData(unsigned long offset, DOMString data);
+  undefined insertData(unsigned long offset, DOMString data);
   [Throws]
-  void deleteData(unsigned long offset, unsigned long count);
+  undefined deleteData(unsigned long offset, unsigned long count);
   [Throws]
-  void replaceData(unsigned long offset, unsigned long count, DOMString data);
+  undefined replaceData(unsigned long offset, unsigned long count, DOMString data);
 };
 
 CharacterData includes ChildNode;

--- a/crates/web-sys/webidls/enabled/CheckerboardReportService.webidl
+++ b/crates/web-sys/webidls/enabled/CheckerboardReportService.webidl
@@ -44,7 +44,7 @@ interface CheckerboardReportService {
   /**
    * Sets the state of the apz.record_checkerboarding pref.
    */
-  void setRecordingEnabled(boolean aEnabled);
+  undefined setRecordingEnabled(boolean aEnabled);
 
   /**
    * Flush any in-progress checkerboard reports. Since this happens
@@ -54,5 +54,5 @@ interface CheckerboardReportService {
    * this notification, the caller may call getReports() to obtain the flushed
    * reports, along with any other reports that are available.
    */
-  void flushActiveReports();
+  undefined flushActiveReports();
 };

--- a/crates/web-sys/webidls/enabled/ChildNode.webidl
+++ b/crates/web-sys/webidls/enabled/ChildNode.webidl
@@ -9,13 +9,13 @@
 
 interface mixin ChildNode {
   [CEReactions, Throws, Unscopable]
-  void before((Node or DOMString)... nodes);
+  undefined before((Node or DOMString)... nodes);
   [CEReactions, Throws, Unscopable]
-  void after((Node or DOMString)... nodes);
+  undefined after((Node or DOMString)... nodes);
   [CEReactions, Throws, Unscopable]
-  void replaceWith((Node or DOMString)... nodes);
+  undefined replaceWith((Node or DOMString)... nodes);
   [CEReactions, Unscopable]
-  void remove();
+  undefined remove();
 };
 
 interface mixin NonDocumentTypeChildNode {

--- a/crates/web-sys/webidls/enabled/ChildSHistory.webidl
+++ b/crates/web-sys/webidls/enabled/ChildSHistory.webidl
@@ -20,14 +20,14 @@ interface ChildSHistory {
 
   boolean canGo(long aOffset);
   [Throws]
-  void go(long aOffset);
+  undefined go(long aOffset);
 
   /**
    * Reload the current entry. The flags which should be passed to this
    * function are documented and defined in nsIWebNavigation.idl
    */
   [Throws]
-  void reload(unsigned long aReloadFlags);
+  undefined reload(unsigned long aReloadFlags);
 
   /**
    * Getter for the legacy nsISHistory implementation.

--- a/crates/web-sys/webidls/enabled/Client.webidl
+++ b/crates/web-sys/webidls/enabled/Client.webidl
@@ -23,7 +23,7 @@ interface Client {
   // readonly attribute boolean reserved;
 
   [Throws]
-  void postMessage(any message, optional sequence<object> transfer = []);
+  undefined postMessage(any message, optional sequence<object> transfer = []);
 };
 
 [Exposed=ServiceWorker]

--- a/crates/web-sys/webidls/enabled/Clients.webidl
+++ b/crates/web-sys/webidls/enabled/Clients.webidl
@@ -18,7 +18,7 @@ interface Clients {
   [NewObject]
   Promise<WindowClient?> openWindow(USVString url);
   [NewObject]
-  Promise<void> claim();
+  Promise<undefined> claim();
 };
 
 dictionary ClientQueryOptions {

--- a/crates/web-sys/webidls/enabled/CompositionEvent.webidl
+++ b/crates/web-sys/webidls/enabled/CompositionEvent.webidl
@@ -30,7 +30,7 @@ dictionary CompositionEventInit : UIEventInit {
 
 partial interface CompositionEvent
 {
-  void initCompositionEvent(DOMString typeArg,
+  undefined initCompositionEvent(DOMString typeArg,
                             optional boolean canBubbleArg = false,
                             optional boolean cancelableArg = false,
                             optional Window? viewArg = null,

--- a/crates/web-sys/webidls/enabled/Console.webidl
+++ b/crates/web-sys/webidls/enabled/Console.webidl
@@ -18,59 +18,59 @@ namespace console {
 
   // Logging
   [UseCounter]
-  void assert(optional boolean condition = false, any... data);
+  undefined assert(optional boolean condition = false, any... data);
   [UseCounter]
-  void clear();
+  undefined clear();
   [UseCounter]
-  void count(optional DOMString label = "default");
+  undefined count(optional DOMString label = "default");
   [UseCounter]
-  void countReset(optional DOMString label = "default");
+  undefined countReset(optional DOMString label = "default");
   [UseCounter]
-  void debug(any... data);
+  undefined debug(any... data);
   [UseCounter]
-  void error(any... data);
+  undefined error(any... data);
   [UseCounter]
-  void info(any... data);
+  undefined info(any... data);
   [UseCounter]
-  void log(any... data);
+  undefined log(any... data);
   [UseCounter]
-  void table(any... data); // FIXME: The spec is still unclear about this.
+  undefined table(any... data); // FIXME: The spec is still unclear about this.
   [UseCounter]
-  void trace(any... data);
+  undefined trace(any... data);
   [UseCounter]
-  void warn(any... data);
+  undefined warn(any... data);
   [UseCounter]
-  void dir(any... data); // FIXME: This doesn't follow the spec yet.
+  undefined dir(any... data); // FIXME: This doesn't follow the spec yet.
   [UseCounter]
-  void dirxml(any... data);
+  undefined dirxml(any... data);
 
   // Grouping
   [UseCounter]
-  void group(any... data);
+  undefined group(any... data);
   [UseCounter]
-  void groupCollapsed(any... data);
+  undefined groupCollapsed(any... data);
   [UseCounter]
-  void groupEnd();
+  undefined groupEnd();
 
   // Timing
   [UseCounter]
-  void time(optional DOMString label = "default");
+  undefined time(optional DOMString label = "default");
   [UseCounter]
-  void timeLog(optional DOMString label = "default", any... data);
+  undefined timeLog(optional DOMString label = "default", any... data);
   [UseCounter]
-  void timeEnd(optional DOMString label = "default");
+  undefined timeEnd(optional DOMString label = "default");
 
   // Mozilla only or Webcompat methods
 
   [UseCounter]
-  void _exception(any... data);
+  undefined _exception(any... data);
   [UseCounter]
-  void timeStamp(optional any data);
+  undefined timeStamp(optional any data);
 
   [UseCounter]
-  void profile(any... data);
+  undefined profile(any... data);
   [UseCounter]
-  void profileEnd(any... data);
+  undefined profileEnd(any... data);
 
   // invalid widl
   // [ChromeOnly]
@@ -151,40 +151,40 @@ dictionary ConsoleCounterError {
 // This is basically a copy of the console namespace.
 interface ConsoleInstance {
   // Logging
-  void assert(optional boolean condition = false, any... data);
-  void clear();
-  void count(optional DOMString label = "default");
-  void countReset(optional DOMString label = "default");
-  void debug(any... data);
-  void error(any... data);
-  void info(any... data);
-  void log(any... data);
-  void table(any... data); // FIXME: The spec is still unclear about this.
-  void trace(any... data);
-  void warn(any... data);
-  void dir(any... data); // FIXME: This doesn't follow the spec yet.
-  void dirxml(any... data);
+  undefined assert(optional boolean condition = false, any... data);
+  undefined clear();
+  undefined count(optional DOMString label = "default");
+  undefined countReset(optional DOMString label = "default");
+  undefined debug(any... data);
+  undefined error(any... data);
+  undefined info(any... data);
+  undefined log(any... data);
+  undefined table(any... data); // FIXME: The spec is still unclear about this.
+  undefined trace(any... data);
+  undefined warn(any... data);
+  undefined dir(any... data); // FIXME: This doesn't follow the spec yet.
+  undefined dirxml(any... data);
 
   // Grouping
-  void group(any... data);
-  void groupCollapsed(any... data);
-  void groupEnd();
+  undefined group(any... data);
+  undefined groupCollapsed(any... data);
+  undefined groupEnd();
 
   // Timing
-  void time(optional DOMString label = "default");
-  void timeLog(optional DOMString label = "default", any... data);
-  void timeEnd(optional DOMString label = "default");
+  undefined time(optional DOMString label = "default");
+  undefined timeLog(optional DOMString label = "default", any... data);
+  undefined timeEnd(optional DOMString label = "default");
 
   // Mozilla only or Webcompat methods
 
-  void _exception(any... data);
-  void timeStamp(optional any data);
+  undefined _exception(any... data);
+  undefined timeStamp(optional any data);
 
-  void profile(any... data);
-  void profileEnd(any... data);
+  undefined profile(any... data);
+  undefined profileEnd(any... data);
 };
 
-callback ConsoleInstanceDumpCallback = void (DOMString message);
+callback ConsoleInstanceDumpCallback = undefined (DOMString message);
 
 enum ConsoleLogLevel {
   "All", "Debug", "Log", "Info", "Clear", "Trace", "TimeLog", "TimeEnd", "Time",
@@ -223,7 +223,7 @@ enum ConsoleLevel { "log", "warning", "error" };
 // this interface is just for testing
 partial interface ConsoleInstance {
   [ChromeOnly]
-  void reportForServiceWorkerScope(DOMString scope, DOMString message,
+  undefined reportForServiceWorkerScope(DOMString scope, DOMString message,
                                    DOMString filename, unsigned long lineNumber,
                                    unsigned long columnNumber,
                                    ConsoleLevel level);

--- a/crates/web-sys/webidls/enabled/CredentialManagement.webidl
+++ b/crates/web-sys/webidls/enabled/CredentialManagement.webidl
@@ -22,7 +22,7 @@ interface CredentialsContainer {
   [Throws]
   Promise<Credential> store(Credential credential);
   [Throws]
-  Promise<void> preventSilentAccess();
+  Promise<undefined> preventSilentAccess();
 };
 
 dictionary CredentialRequestOptions {

--- a/crates/web-sys/webidls/enabled/CustomElementRegistry.webidl
+++ b/crates/web-sys/webidls/enabled/CustomElementRegistry.webidl
@@ -6,18 +6,18 @@
 [Func="CustomElementRegistry::IsCustomElementEnabled"]
 interface CustomElementRegistry {
   [CEReactions, Throws]
-  void define(DOMString name, Function functionConstructor,
+  undefined define(DOMString name, Function functionConstructor,
               optional ElementDefinitionOptions options);
   [ChromeOnly, Throws]
-  void setElementCreationCallback(DOMString name, CustomElementCreationCallback callback);
+  undefined setElementCreationCallback(DOMString name, CustomElementCreationCallback callback);
   any get(DOMString name);
   [Throws]
-  Promise<void> whenDefined(DOMString name);
-  [CEReactions] void upgrade(Node root);
+  Promise<undefined> whenDefined(DOMString name);
+  [CEReactions] undefined upgrade(Node root);
 };
 
 dictionary ElementDefinitionOptions {
   DOMString extends;
 };
 
-callback CustomElementCreationCallback = void (DOMString name);
+callback CustomElementCreationCallback = undefined (DOMString name);

--- a/crates/web-sys/webidls/enabled/CustomEvent.webidl
+++ b/crates/web-sys/webidls/enabled/CustomEvent.webidl
@@ -17,7 +17,7 @@ interface CustomEvent : Event
   readonly attribute any detail;
 
   // initCustomEvent is a Gecko specific deprecated method.
-  void initCustomEvent(DOMString type,
+  undefined initCustomEvent(DOMString type,
                        optional boolean canBubble = false,
                        optional boolean cancelable = false,
                        optional any detail = null);

--- a/crates/web-sys/webidls/enabled/DOMParser.webidl
+++ b/crates/web-sys/webidls/enabled/DOMParser.webidl
@@ -27,5 +27,5 @@ interface DOMParser {
   // Can be used to allow a DOMParser to parse XUL/XBL no matter what
   // principal it's using for the document.
   [ChromeOnly]
-  void forceEnableXULXBL();
+  undefined forceEnableXULXBL();
 };

--- a/crates/web-sys/webidls/enabled/DOMRequest.webidl
+++ b/crates/web-sys/webidls/enabled/DOMRequest.webidl
@@ -26,7 +26,7 @@ interface DOMRequest : EventTarget {
            [TreatNonCallableAsNull] optional AnyCallback? rejectCallback = null);
 
   [ChromeOnly]
-  void fireDetailedError(DOMException aError);
+  undefined fireDetailedError(DOMException aError);
 };
 
 DOMRequest includes DOMRequestShared;

--- a/crates/web-sys/webidls/enabled/DOMStringMap.webidl
+++ b/crates/web-sys/webidls/enabled/DOMStringMap.webidl
@@ -15,7 +15,7 @@
 interface DOMStringMap {
   getter DOMString (DOMString name);
   [CEReactions, Throws]
-  setter void (DOMString name, DOMString value);
+  setter undefined (DOMString name, DOMString value);
   [CEReactions]
-  deleter void (DOMString name);
+  deleter undefined (DOMString name);
 };

--- a/crates/web-sys/webidls/enabled/DOMTokenList.webidl
+++ b/crates/web-sys/webidls/enabled/DOMTokenList.webidl
@@ -17,9 +17,9 @@ interface DOMTokenList {
   getter DOMString? item(unsigned long index);
   boolean contains(DOMString token);
   [CEReactions, Throws]
-  void add(DOMString... tokens);
+  undefined add(DOMString... tokens);
   [CEReactions, Throws]
-  void remove(DOMString... tokens);
+  undefined remove(DOMString... tokens);
   [CEReactions, Throws]
   boolean replace(DOMString token, DOMString newToken);
   [CEReactions, Throws]

--- a/crates/web-sys/webidls/enabled/DataTransfer.webidl
+++ b/crates/web-sys/webidls/enabled/DataTransfer.webidl
@@ -14,7 +14,7 @@ interface DataTransfer {
 
   readonly attribute DataTransferItemList items;
 
-  void setDragImage(Element image, long x, long y);
+  undefined setDragImage(Element image, long x, long y);
 
   // ReturnValueNeedsContainsHack on .types because lots of extension
   // code was expecting .contains() back when it was a DOMStringList.
@@ -23,9 +23,9 @@ interface DataTransfer {
   [Throws, NeedsSubjectPrincipal]
   DOMString getData(DOMString format);
   [Throws, NeedsSubjectPrincipal]
-  void setData(DOMString format, DOMString data);
+  undefined setData(DOMString format, DOMString data);
   [Throws, NeedsSubjectPrincipal]
-  void clearData(optional DOMString format);
+  undefined clearData(optional DOMString format);
   [NeedsSubjectPrincipal]
   readonly attribute FileList? files;
 };

--- a/crates/web-sys/webidls/enabled/DataTransferItem.webidl
+++ b/crates/web-sys/webidls/enabled/DataTransferItem.webidl
@@ -11,12 +11,12 @@ interface DataTransferItem {
   readonly attribute DOMString kind;
   readonly attribute DOMString type;
   [Throws, NeedsSubjectPrincipal]
-  void getAsString(FunctionStringCallback? _callback);
+  undefined getAsString(FunctionStringCallback? _callback);
   [Throws, NeedsSubjectPrincipal]
   File? getAsFile();
 };
 
-callback FunctionStringCallback = void (DOMString data);
+callback FunctionStringCallback = undefined (DOMString data);
 
 partial interface DataTransferItem {
   [Pref="dom.webkitBlink.filesystem.enabled", BinaryName="getAsEntry", Throws,

--- a/crates/web-sys/webidls/enabled/DataTransferItemList.webidl
+++ b/crates/web-sys/webidls/enabled/DataTransferItemList.webidl
@@ -15,7 +15,7 @@ interface DataTransferItemList {
   [Throws, NeedsSubjectPrincipal]
   DataTransferItem? add(File data);
   [Throws, NeedsSubjectPrincipal]
-  void remove(unsigned long index);
+  undefined remove(unsigned long index);
   [Throws, NeedsSubjectPrincipal]
-  void clear();
+  undefined clear();
 };

--- a/crates/web-sys/webidls/enabled/DedicatedWorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/DedicatedWorkerGlobalScope.webidl
@@ -19,9 +19,9 @@ interface DedicatedWorkerGlobalScope : WorkerGlobalScope {
   readonly attribute DOMString name;
 
   [Throws]
-  void postMessage(any message, optional sequence<object> transfer = []);
+  undefined postMessage(any message, optional sequence<object> transfer = []);
 
-  void close();
+  undefined close();
 
   attribute EventHandler onmessage;
   attribute EventHandler onmessageerror;

--- a/crates/web-sys/webidls/enabled/DeviceOrientationEvent.webidl
+++ b/crates/web-sys/webidls/enabled/DeviceOrientationEvent.webidl
@@ -13,7 +13,7 @@ interface DeviceOrientationEvent : Event
   readonly attribute boolean absolute;
 
   // initDeviceOrientationEvent is a Gecko specific deprecated method.
-  void initDeviceOrientationEvent(DOMString type,
+  undefined initDeviceOrientationEvent(DOMString type,
                                   optional boolean canBubble = false,
                                   optional boolean cancelable = false,
                                   optional double? alpha = null,

--- a/crates/web-sys/webidls/enabled/Document.webidl
+++ b/crates/web-sys/webidls/enabled/Document.webidl
@@ -98,8 +98,8 @@ interface Document : Node {
 
   // NEW
   // No support for prepend/append yet
-  // void prepend((Node or DOMString)... nodes);
-  // void append((Node or DOMString)... nodes);
+  // undefined prepend((Node or DOMString)... nodes);
+  // undefined append((Node or DOMString)... nodes);
 
   // These are not in the spec, but leave them for now for backwards compat.
   // So sort of like Gecko extensions
@@ -144,9 +144,9 @@ partial interface Document {
   // dynamic markup insertion
   //(HTML only)Document open(optional DOMString type, optional DOMString replace);
   //(HTML only)WindowProxy open(DOMString url, DOMString name, DOMString features, optional boolean replace);
-  //(HTML only)void close();
-  //(HTML only)void write(DOMString... text);
-  //(HTML only)void writeln(DOMString... text);
+  //(HTML only)undefined close();
+  //(HTML only)undefined write(DOMString... text);
+  //(HTML only)undefined writeln(DOMString... text);
 
   // user interaction
   [Pure]
@@ -187,7 +187,7 @@ partial interface Document {
    *
    * @see <https://developer.mozilla.org/en/DOM/document.releaseCapture>
    */
-  void releaseCapture();
+  undefined releaseCapture();
 
   [ChromeOnly]
   readonly attribute URI? documentURIObject;
@@ -212,9 +212,9 @@ partial interface Document {
   [SameObject] readonly attribute HTMLCollection anchors;
   [SameObject] readonly attribute HTMLCollection applets;
 
-  //(HTML only)void clear();
-  //(HTML only)void captureEvents();
-  //(HTML only)void releaseEvents();
+  //(HTML only)undefined clear();
+  //(HTML only)undefined captureEvents();
+  //(HTML only)undefined releaseEvents();
 
   //(HTML only)[SameObject] readonly attribute HTMLAllCollection all;
 };
@@ -229,7 +229,7 @@ partial interface Document {
   readonly attribute boolean fullscreenEnabled;
 
   [Func="nsDocument::IsUnprefixedFullscreenEnabled"]
-  void exitFullscreen();
+  undefined exitFullscreen();
 
   // Events handlers
   [Func="nsDocument::IsUnprefixedFullscreenEnabled"]
@@ -241,7 +241,7 @@ partial interface Document {
 // https://w3c.github.io/pointerlock/#extensions-to-the-document-interface
 // https://w3c.github.io/pointerlock/#extensions-to-the-documentorshadowroot-mixin
 partial interface Document {
-  void exitPointerLock();
+  undefined exitPointerLock();
 
   // Event handlers
   attribute EventHandler onpointerlockchange;
@@ -262,7 +262,7 @@ partial interface Document {
     readonly attribute DOMString? preferredStyleSheetSet;
     [Constant]
     readonly attribute DOMStringList styleSheetSets;
-    void enableStyleSheetsForSet (DOMString? name);
+    undefined enableStyleSheetsForSet (DOMString? name);
 };
 
 // https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface
@@ -340,7 +340,7 @@ partial interface Document {
    * instance.
    */
   [ChromeOnly, Throws]
-  void removeAnonymousContent(AnonymousContent aContent);
+  undefined removeAnonymousContent(AnonymousContent aContent);
 };
 
 // http://w3c.github.io/selection-api/#extensions-to-document-interface
@@ -359,7 +359,7 @@ partial interface Document {
 // by user gesture.
 partial interface Document {
   [ChromeOnly]
-  void notifyUserGestureActivation();
+  undefined notifyUserGestureActivation();
 };
 
 // For more information on Flash classification, see

--- a/crates/web-sys/webidls/enabled/DragEvent.webidl
+++ b/crates/web-sys/webidls/enabled/DragEvent.webidl
@@ -9,7 +9,7 @@ interface DragEvent : MouseEvent
 {
   readonly attribute DataTransfer? dataTransfer;
 
-  void initDragEvent(DOMString type,
+  undefined initDragEvent(DOMString type,
                      optional boolean canBubble = false,
                      optional boolean cancelable = false,
                      optional Window? aView = null,

--- a/crates/web-sys/webidls/enabled/Element.webidl
+++ b/crates/web-sys/webidls/enabled/Element.webidl
@@ -43,13 +43,13 @@ interface Element : Node {
   [CEReactions, NeedsSubjectPrincipal=NonSystem, Throws]
   boolean toggleAttribute(DOMString name, optional boolean force);
   [CEReactions, NeedsSubjectPrincipal=NonSystem, Throws]
-  void setAttribute(DOMString name, DOMString value);
+  undefined setAttribute(DOMString name, DOMString value);
   [CEReactions, NeedsSubjectPrincipal=NonSystem, Throws]
-  void setAttributeNS(DOMString? namespace, DOMString name, DOMString value);
+  undefined setAttributeNS(DOMString? namespace, DOMString name, DOMString value);
   [CEReactions, Throws]
-  void removeAttribute(DOMString name);
+  undefined removeAttribute(DOMString name);
   [CEReactions, Throws]
-  void removeAttributeNS(DOMString? namespace, DOMString localName);
+  undefined removeAttributeNS(DOMString? namespace, DOMString localName);
   [Pure]
   boolean hasAttribute(DOMString name);
   [Pure]
@@ -78,7 +78,7 @@ interface Element : Node {
   Element? insertAdjacentElement(DOMString where, Element element); // historical
 
   [Throws]
-  void insertAdjacentText(DOMString where, DOMString data); // historical
+  undefined insertAdjacentText(DOMString where, DOMString data); // historical
 
   /**
    * The ratio of font-size-inflated text font size to computed font
@@ -98,10 +98,10 @@ interface Element : Node {
 
   // Pointer events methods.
   [Throws, Pref="dom.w3c_pointer_events.enabled"]
-  void setPointerCapture(long pointerId);
+  undefined setPointerCapture(long pointerId);
 
   [Throws, Pref="dom.w3c_pointer_events.enabled"]
-  void releasePointerCapture(long pointerId);
+  undefined releasePointerCapture(long pointerId);
 
   [Pref="dom.w3c_pointer_events.enabled"]
   boolean hasPointerCapture(long pointerId);
@@ -115,19 +115,19 @@ interface Element : Node {
    * element.
    *
    */
-  void setCapture(optional boolean retargetToElement = false);
+  undefined setCapture(optional boolean retargetToElement = false);
 
   /**
    * If this element has captured the mouse, release the capture. If another
    * element has captured the mouse, this method has no effect.
    */
-  void releaseCapture();
+  undefined releaseCapture();
 
   /*
    * Chrome-only version of setCapture that works outside of a mousedown event.
    */
   [ChromeOnly]
-  void setCaptureAlways(optional boolean retargetToElement = false);
+  undefined setCaptureAlways(optional boolean retargetToElement = false);
 
   // Obsolete methods.
   Attr? getAttributeNode(DOMString name);
@@ -186,19 +186,19 @@ partial interface Element {
   DOMRect getBoundingClientRect();
 
   // scrolling
-  void scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg);
+  undefined scrollIntoView(optional (boolean or ScrollIntoViewOptions) arg);
   // None of the CSSOM attributes are [Pure], because they flush
            attribute long scrollTop;   // scroll on setting
            attribute long scrollLeft;  // scroll on setting
   readonly attribute long scrollWidth;
   readonly attribute long scrollHeight;
 
-  void scroll(unrestricted double x, unrestricted double y);
-  void scroll(optional ScrollToOptions options);
-  void scrollTo(unrestricted double x, unrestricted double y);
-  void scrollTo(optional ScrollToOptions options);
-  void scrollBy(unrestricted double x, unrestricted double y);
-  void scrollBy(optional ScrollToOptions options);
+  undefined scroll(unrestricted double x, unrestricted double y);
+  undefined scroll(optional ScrollToOptions options);
+  undefined scrollTo(unrestricted double x, unrestricted double y);
+  undefined scrollTo(optional ScrollToOptions options);
+  undefined scrollBy(unrestricted double x, unrestricted double y);
+  undefined scrollBy(optional ScrollToOptions options);
 
   readonly attribute long clientTop;
   readonly attribute long clientLeft;
@@ -213,7 +213,7 @@ partial interface Element {
   [CEReactions, Pure,SetterThrows,TreatNullAs=EmptyString]
   attribute DOMString outerHTML;
   [CEReactions, Throws]
-  void insertAdjacentHTML(DOMString position, DOMString text);
+  undefined insertAdjacentHTML(DOMString position, DOMString text);
 };
 
 // http://www.w3.org/TR/selectors-api/#interface-definitions
@@ -255,11 +255,11 @@ Element includes GeometryUtils;
 // https://fullscreen.spec.whatwg.org/#api
 partial interface Element {
   [Throws, Func="nsDocument::IsUnprefixedFullscreenEnabled", NeedsCallerType]
-  void requestFullscreen();
+  undefined requestFullscreen();
 };
 
 // https://w3c.github.io/pointerlock/#extensions-to-the-element-interface
 partial interface Element {
   [NeedsCallerType]
-  void requestPointerLock();
+  undefined requestPointerLock();
 };

--- a/crates/web-sys/webidls/enabled/Event.webidl
+++ b/crates/web-sys/webidls/enabled/Event.webidl
@@ -29,15 +29,15 @@ interface Event {
   [Pure]
   readonly attribute unsigned short eventPhase;
 
-  void stopPropagation();
-  void stopImmediatePropagation();
+  undefined stopPropagation();
+  undefined stopImmediatePropagation();
 
   [Pure]
   readonly attribute boolean bubbles;
   [Pure]
   readonly attribute boolean cancelable;
   [NeedsCallerType]
-  void preventDefault();
+  undefined preventDefault();
   [Pure, NeedsCallerType]
   readonly attribute boolean defaultPrevented;
   [ChromeOnly, Pure]
@@ -52,7 +52,7 @@ interface Event {
   [Pure]
   readonly attribute DOMHighResTimeStamp timeStamp;
 
-  void initEvent(DOMString type,
+  undefined initEvent(DOMString type,
                  optional boolean bubbles = false,
                  optional boolean cancelable = false);
   attribute boolean cancelBubble;

--- a/crates/web-sys/webidls/enabled/EventListener.webidl
+++ b/crates/web-sys/webidls/enabled/EventListener.webidl
@@ -11,5 +11,5 @@
  */
 
 callback interface EventListener {
-  void handleEvent(Event event);
+  undefined handleEvent(Event event);
 };

--- a/crates/web-sys/webidls/enabled/EventSource.webidl
+++ b/crates/web-sys/webidls/enabled/EventSource.webidl
@@ -29,7 +29,7 @@ interface EventSource : EventTarget {
   attribute EventHandler onopen;
   attribute EventHandler onmessage;
   attribute EventHandler onerror;
-  void close();
+  undefined close();
 };
 
 dictionary EventSourceInit {

--- a/crates/web-sys/webidls/enabled/EventTarget.webidl
+++ b/crates/web-sys/webidls/enabled/EventTarget.webidl
@@ -28,12 +28,12 @@ interface EventTarget {
      value is true, while in chrome the default boolean value is
      false. */
   [Throws]
-  void addEventListener(DOMString type,
+  undefined addEventListener(DOMString type,
                         EventListener listener,
                         optional (AddEventListenerOptions or boolean) options,
                         optional boolean? wantsUntrusted = null);
   [Throws]
-  void removeEventListener(DOMString type,
+  undefined removeEventListener(DOMString type,
                            EventListener listener,
                            optional (EventListenerOptions or boolean) options);
   [Throws, NeedsCallerType]

--- a/crates/web-sys/webidls/enabled/ExtendableEvent.webidl
+++ b/crates/web-sys/webidls/enabled/ExtendableEvent.webidl
@@ -12,7 +12,7 @@
 interface ExtendableEvent : Event {
   // https://github.com/slightlyoff/ServiceWorker/issues/261
   [Throws]
-  void waitUntil(Promise<any> p);
+  undefined waitUntil(Promise<any> p);
 };
 
 dictionary ExtendableEventInit : EventInit {

--- a/crates/web-sys/webidls/enabled/External.webidl
+++ b/crates/web-sys/webidls/enabled/External.webidl
@@ -7,6 +7,6 @@
 [NoInterfaceObject, JSImplementation="@mozilla.org/sidebar;1"]
 interface External
 {
-  void AddSearchProvider(DOMString aDescriptionURL);
+  undefined AddSearchProvider(DOMString aDescriptionURL);
   unsigned long IsSearchProviderInstalled(DOMString aSearchURL);
 };

--- a/crates/web-sys/webidls/enabled/FetchEvent.webidl
+++ b/crates/web-sys/webidls/enabled/FetchEvent.webidl
@@ -16,7 +16,7 @@ interface FetchEvent : ExtendableEvent {
   readonly attribute boolean isReload;
 
   [Throws]
-  void respondWith(Promise<Response> r);
+  undefined respondWith(Promise<Response> r);
 };
 
 dictionary FetchEventInit : EventInit {

--- a/crates/web-sys/webidls/enabled/FetchObserver.webidl
+++ b/crates/web-sys/webidls/enabled/FetchObserver.webidl
@@ -5,7 +5,7 @@
  */
 
 callback interface ObserverCallback {
-  void handleEvent(FetchObserver observer);
+  undefined handleEvent(FetchObserver observer);
 };
 
 enum FetchState {

--- a/crates/web-sys/webidls/enabled/FileReader.webidl
+++ b/crates/web-sys/webidls/enabled/FileReader.webidl
@@ -15,15 +15,15 @@
 interface FileReader : EventTarget {
   // async read methods
   [Throws]
-  void readAsArrayBuffer(Blob blob);
+  undefined readAsArrayBuffer(Blob blob);
   [Throws]
-  void readAsBinaryString(Blob filedata);
+  undefined readAsBinaryString(Blob filedata);
   [Throws]
-  void readAsText(Blob blob, optional DOMString label);
+  undefined readAsText(Blob blob, optional DOMString label);
   [Throws]
-  void readAsDataURL(Blob blob);
+  undefined readAsDataURL(Blob blob);
 
-  void abort();
+  undefined abort();
 
   // states
   const unsigned short EMPTY = 0;

--- a/crates/web-sys/webidls/enabled/FileSystem.webidl
+++ b/crates/web-sys/webidls/enabled/FileSystem.webidl
@@ -11,15 +11,15 @@ dictionary FileSystemFlags {
 };
 
 callback interface FileSystemEntryCallback {
-    void handleEvent(FileSystemEntry entry);
+    undefined handleEvent(FileSystemEntry entry);
 };
 
 callback interface VoidCallback {
-    void handleEvent();
+    undefined handleEvent();
 };
 
 callback interface ErrorCallback {
-    void handleEvent(DOMException err);
+    undefined handleEvent(DOMException err);
 };
 
 interface FileSystem {

--- a/crates/web-sys/webidls/enabled/FileSystemDirectoryEntry.webidl
+++ b/crates/web-sys/webidls/enabled/FileSystemDirectoryEntry.webidl
@@ -7,12 +7,12 @@
 interface FileSystemDirectoryEntry : FileSystemEntry {
     FileSystemDirectoryReader createReader();
 
-    void getFile(optional USVString? path,
+    undefined getFile(optional USVString? path,
                  optional FileSystemFlags options,
                  optional FileSystemEntryCallback successCallback,
                  optional ErrorCallback errorCallback);
 
-    void getDirectory(optional USVString? path,
+    undefined getDirectory(optional USVString? path,
                       optional FileSystemFlags options,
                       optional FileSystemEntryCallback successCallback,
                       optional ErrorCallback errorCallback);

--- a/crates/web-sys/webidls/enabled/FileSystemDirectoryReader.webidl
+++ b/crates/web-sys/webidls/enabled/FileSystemDirectoryReader.webidl
@@ -5,7 +5,7 @@
  */
 
 callback interface FileSystemEntriesCallback {
-    void handleEvent(sequence<FileSystemEntry> entries);
+    undefined handleEvent(sequence<FileSystemEntry> entries);
 };
 
 interface FileSystemDirectoryReader {
@@ -13,6 +13,6 @@ interface FileSystemDirectoryReader {
     // readEntries can be called just once. The second time it returns no data.
 
     [Throws]
-    void readEntries(FileSystemEntriesCallback successCallback,
+    undefined readEntries(FileSystemEntriesCallback successCallback,
                      optional ErrorCallback errorCallback);
 };

--- a/crates/web-sys/webidls/enabled/FileSystemEntry.webidl
+++ b/crates/web-sys/webidls/enabled/FileSystemEntry.webidl
@@ -16,6 +16,6 @@ interface FileSystemEntry {
 
     readonly attribute FileSystem filesystem;
 
-    void getParent(optional FileSystemEntryCallback successCallback,
+    undefined getParent(optional FileSystemEntryCallback successCallback,
                    optional ErrorCallback errorCallback);
 };

--- a/crates/web-sys/webidls/enabled/FileSystemFileEntry.webidl
+++ b/crates/web-sys/webidls/enabled/FileSystemFileEntry.webidl
@@ -5,11 +5,11 @@
  */
 
 callback interface FileCallback {
-    void handleEvent(File file);
+    undefined handleEvent(File file);
 };
 
 interface FileSystemFileEntry : FileSystemEntry {
     [BinaryName="GetFile"]
-    void file (FileCallback successCallback,
+    undefined file (FileCallback successCallback,
                optional ErrorCallback errorCallback);
 };

--- a/crates/web-sys/webidls/enabled/FontFaceSet.webidl
+++ b/crates/web-sys/webidls/enabled/FontFaceSet.webidl
@@ -23,7 +23,7 @@ interface FontFaceSetIterator {
   [Throws] FontFaceSetIteratorResult next();
 };
 
-callback FontFaceSetForEachCallback = void (FontFace value, FontFace key, FontFaceSet set);
+callback FontFaceSetForEachCallback = undefined (FontFace value, FontFace key, FontFaceSet set);
 
 enum FontFaceSetLoadStatus { "loading", "loaded" };
 
@@ -34,14 +34,14 @@ interface FontFaceSet : EventTarget {
 
   // Emulate setlike behavior until we can use that directly.
   readonly attribute unsigned long size;
-  [Throws] void add(FontFace font);
+  [Throws] undefined add(FontFace font);
   boolean has(FontFace font);
   boolean delete(FontFace font);
-  void clear();
+  undefined clear();
   [NewObject] FontFaceSetIterator entries();
   // Iterator keys();
   [NewObject, Alias=keys, Alias="@@iterator"] FontFaceSetIterator values();
-  [Throws] void forEach(FontFaceSetForEachCallback cb, optional any thisArg);
+  [Throws] undefined forEach(FontFaceSetForEachCallback cb, optional any thisArg);
 
   // -- events for when loading state changes
   attribute EventHandler onloading;
@@ -57,7 +57,7 @@ interface FontFaceSet : EventTarget {
   [Throws] boolean check(DOMString font, optional DOMString text = " ");
 
   // async notification that font loading and layout operations are done
-  [Throws] readonly attribute Promise<void> ready;
+  [Throws] readonly attribute Promise<undefined> ready;
 
   // loading state, "loading" while one or more fonts loading, "loaded" otherwise
   readonly attribute FontFaceSetLoadStatus status;

--- a/crates/web-sys/webidls/enabled/FormData.webidl
+++ b/crates/web-sys/webidls/enabled/FormData.webidl
@@ -13,16 +13,16 @@ typedef (Blob or Directory or USVString) FormDataEntryValue;
  Exposed=(Window,Worker)]
 interface FormData {
   [Throws]
-  void append(USVString name, Blob value, optional USVString filename);
+  undefined append(USVString name, Blob value, optional USVString filename);
   [Throws]
-  void append(USVString name, USVString value);
-  void delete(USVString name);
+  undefined append(USVString name, USVString value);
+  undefined delete(USVString name);
   FormDataEntryValue? get(USVString name);
   sequence<FormDataEntryValue> getAll(USVString name);
   boolean has(USVString name);
   [Throws]
-  void set(USVString name, Blob value, optional USVString filename);
+  undefined set(USVString name, Blob value, optional USVString filename);
   [Throws]
-  void set(USVString name, USVString value);
+  undefined set(USVString name, USVString value);
   iterable<USVString, FormDataEntryValue>;
 };

--- a/crates/web-sys/webidls/enabled/FrameLoader.webidl
+++ b/crates/web-sys/webidls/enabled/FrameLoader.webidl
@@ -46,7 +46,7 @@ interface FrameLoader {
    * is being fired.
    */
   [Throws]
-  void addProcessChangeBlockingPromise(Promise<any> aPromise);
+  undefined addProcessChangeBlockingPromise(Promise<any> aPromise);
 
   /**
    * Find out whether the loader's frame is at too great a depth in
@@ -61,20 +61,20 @@ interface FrameLoader {
    * Throws an exception with non-remote frames.
    */
   [Throws]
-  void activateRemoteFrame();
+  undefined activateRemoteFrame();
 
   /**
    * Deactivate remote frame.
    * Throws an exception with non-remote frames.
    */
   [Throws]
-  void deactivateRemoteFrame();
+  undefined deactivateRemoteFrame();
 
   /**
    * @see nsIDOMWindowUtils sendMouseEvent.
    */
   [Throws]
-  void sendCrossProcessMouseEvent(DOMString aType,
+  undefined sendCrossProcessMouseEvent(DOMString aType,
                                   float aX,
                                   float aY,
                                   long aButton,
@@ -86,7 +86,7 @@ interface FrameLoader {
    * Activate event forwarding from client (remote frame) to parent.
    */
   [Throws]
-  void activateFrameEvent(DOMString aType, boolean capture);
+  undefined activateFrameEvent(DOMString aType, boolean capture);
 
   // Note, when frameloaders are swapped, also messageManagers are swapped.
   readonly attribute MessageSender? messageManager;
@@ -96,19 +96,19 @@ interface FrameLoader {
    * received by the Compositor, a MozAfterRemoteFrame event be sent
    * to the window.
    */
-  void requestNotifyAfterRemotePaint();
+  undefined requestNotifyAfterRemotePaint();
 
   /**
    * Close the window through the ownerElement.
    */
   [Throws]
-  void requestFrameLoaderClose();
+  undefined requestFrameLoaderClose();
 
   /**
    * Force a remote browser to recompute its dimension and screen position.
    */
   [Throws]
-  void requestUpdatePosition();
+  undefined requestUpdatePosition();
 
   /**
    * Print the current document.
@@ -119,7 +119,7 @@ interface FrameLoader {
    * @param aProgressListener optional print progress listener.
    */
   [Throws]
-  void print(unsigned long long aOuterWindowID,
+  undefined print(unsigned long long aOuterWindowID,
              nsIPrintSettings aPrintSettings,
              optional nsIWebProgressListener? aProgressListener = null);
 
@@ -212,7 +212,7 @@ interface FrameLoader {
 interface mixin WebBrowserPersistable
 {
   [Throws]
-  void startPersistence(unsigned long long aOuterWindowID,
+  undefined startPersistence(unsigned long long aOuterWindowID,
                         nsIWebBrowserPersistDocumentReceiver aRecv);
 };
 

--- a/crates/web-sys/webidls/enabled/Function.webidl
+++ b/crates/web-sys/webidls/enabled/Function.webidl
@@ -13,4 +13,4 @@
 
 callback Function = any(any... arguments);
 
-callback VoidFunction = void ();
+callback VoidFunction = undefined ();

--- a/crates/web-sys/webidls/enabled/FuzzingFunctions.webidl
+++ b/crates/web-sys/webidls/enabled/FuzzingFunctions.webidl
@@ -15,16 +15,16 @@ interface FuzzingFunctions {
   /**
    * Synchronously perform a garbage collection.
    */
-  static void garbageCollect();
+  static undefined garbageCollect();
 
   /**
    * Synchronously perform a cycle collection.
    */
-  static void cycleCollect();
+  static undefined cycleCollect();
 
   /**
    * Enable accessibility.
    */
   [Throws]
-  static void enableAccessibility();
+  static undefined enableAccessibility();
 };

--- a/crates/web-sys/webidls/enabled/GamepadServiceTest.webidl
+++ b/crates/web-sys/webidls/enabled/GamepadServiceTest.webidl
@@ -19,23 +19,23 @@ interface GamepadServiceTest
                                     unsigned long numAxes,
                                     unsigned long numHaptics);
 
-  void removeGamepad(unsigned long index);
+  undefined removeGamepad(unsigned long index);
 
-  void newButtonEvent(unsigned long index,
+  undefined newButtonEvent(unsigned long index,
                       unsigned long button,
                       boolean pressed,
                       boolean touched);
 
-  void newButtonValueEvent(unsigned long index,
+  undefined newButtonValueEvent(unsigned long index,
                            unsigned long button,
                            boolean pressed,
                            boolean touched,
                            double value);
 
-  void newAxisMoveEvent(unsigned long index,
+  undefined newAxisMoveEvent(unsigned long index,
                         unsigned long axis,
                         double value);
-  void newPoseMove(unsigned long index,
+  undefined newPoseMove(unsigned long index,
                    Float32Array? orient,
                    Float32Array? pos,
                    Float32Array? angVelocity,

--- a/crates/web-sys/webidls/enabled/Geolocation.webidl
+++ b/crates/web-sys/webidls/enabled/Geolocation.webidl
@@ -19,7 +19,7 @@ dictionary PositionOptions {
 [NoInterfaceObject]
 interface Geolocation {
   [Throws, NeedsCallerType]
-  void getCurrentPosition(PositionCallback successCallback,
+  undefined getCurrentPosition(PositionCallback successCallback,
                           optional PositionErrorCallback? errorCallback = null,
                           optional PositionOptions options);
 
@@ -28,9 +28,9 @@ interface Geolocation {
                      optional PositionErrorCallback? errorCallback = null,
                      optional PositionOptions options);
 
-  void clearWatch(long watchId);
+  undefined clearWatch(long watchId);
 };
 
-callback PositionCallback = void (Position position);
+callback PositionCallback = undefined (Position position);
 
-callback PositionErrorCallback = void (PositionError positionError);
+callback PositionErrorCallback = undefined (PositionError positionError);

--- a/crates/web-sys/webidls/enabled/HTMLButtonElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLButtonElement.webidl
@@ -42,7 +42,7 @@ interface HTMLButtonElement : HTMLElement {
   readonly attribute DOMString validationMessage;
   boolean checkValidity();
   boolean reportValidity();
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 
   readonly attribute NodeList labels;
 };

--- a/crates/web-sys/webidls/enabled/HTMLCanvasElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLCanvasElement.webidl
@@ -28,7 +28,7 @@ interface HTMLCanvasElement : HTMLElement {
   DOMString toDataURL(optional DOMString type = "",
                       optional any encoderOptions);
   [Throws, NeedsSubjectPrincipal]
-  void toBlob(BlobCallback _callback,
+  undefined toBlob(BlobCallback _callback,
               optional DOMString type = "",
               optional any encoderOptions);
 };
@@ -40,4 +40,4 @@ partial interface HTMLCanvasElement {
   OffscreenCanvas transferControlToOffscreen();
 };
 
-callback BlobCallback = void(Blob? blob);
+callback BlobCallback = undefined(Blob? blob);

--- a/crates/web-sys/webidls/enabled/HTMLDialogElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLDialogElement.webidl
@@ -17,9 +17,9 @@ interface HTMLDialogElement : HTMLElement {
   attribute boolean open;
   attribute DOMString returnValue;
   [CEReactions]
-  void show();
+  undefined show();
   [CEReactions, Throws]
-  void showModal();
+  undefined showModal();
   [CEReactions]
-  void close(optional DOMString returnValue);
+  undefined close(optional DOMString returnValue);
 };

--- a/crates/web-sys/webidls/enabled/HTMLDocument.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLDocument.webidl
@@ -20,11 +20,11 @@ interface HTMLDocument : Document {
   [CEReactions, Throws]
   WindowProxy? open(DOMString url, DOMString name, DOMString features, optional boolean replace = false);
   [CEReactions, Throws]
-  void close();
+  undefined close();
   [CEReactions, Throws]
-  void write(DOMString... text);
+  undefined write(DOMString... text);
   [CEReactions, Throws]
-  void writeln(DOMString... text);
+  undefined writeln(DOMString... text);
 
   [CEReactions, SetterThrows, SetterNeedsSubjectPrincipal]
            attribute DOMString designMode;
@@ -48,15 +48,15 @@ interface HTMLDocument : Document {
   [CEReactions, TreatNullAs=EmptyString] attribute DOMString alinkColor;
   [CEReactions, TreatNullAs=EmptyString] attribute DOMString bgColor;
 
-  void clear();
+  undefined clear();
 
   readonly attribute HTMLAllCollection all;
 
   // @deprecated These are old Netscape 4 methods. Do not use,
   //             the implementation is no-op.
   // XXXbz do we actually need these anymore?
-  void                      captureEvents();
-  void                      releaseEvents();
+  undefined                      captureEvents();
+  undefined                      releaseEvents();
 };
 
 partial interface HTMLDocument {

--- a/crates/web-sys/webidls/enabled/HTMLElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLElement.webidl
@@ -32,13 +32,13 @@ interface HTMLElement : Element {
   [CEReactions, SetterThrows, Pure]
            attribute boolean hidden;
   [NeedsCallerType]
-  void click();
+  undefined click();
   [CEReactions, SetterThrows, Pure]
            attribute long tabIndex;
   [Throws]
-  void focus();
+  undefined focus();
   [Throws]
-  void blur();
+  undefined blur();
   [CEReactions, SetterThrows, Pure]
            attribute DOMString accessKey;
   [Pure]

--- a/crates/web-sys/webidls/enabled/HTMLFieldSetElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLFieldSetElement.webidl
@@ -31,5 +31,5 @@ interface HTMLFieldSetElement : HTMLElement {
   boolean checkValidity();
   boolean reportValidity();
 
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 };

--- a/crates/web-sys/webidls/enabled/HTMLFormElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLFormElement.webidl
@@ -42,9 +42,9 @@ interface HTMLFormElement : HTMLElement {
   getter nsISupports (DOMString name);
 
   [Throws]
-  void submit();
+  undefined submit();
   [CEReactions]
-  void reset();
+  undefined reset();
   boolean checkValidity();
   boolean reportValidity();
 };

--- a/crates/web-sys/webidls/enabled/HTMLImageElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLImageElement.webidl
@@ -47,7 +47,7 @@ interface HTMLImageElement : HTMLElement {
   readonly attribute unsigned long naturalHeight;
   readonly attribute boolean complete;
            [NewObject]
-           Promise<void> decode();
+           Promise<undefined> decode();
 };
 
 // http://www.whatwg.org/specs/web-apps/current-work/#other-elements,-attributes-and-apis

--- a/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
@@ -101,9 +101,9 @@ interface HTMLInputElement : HTMLElement {
            attribute unsigned long width;
 /* TODO
   [Throws]
-  void stepUp(optional long n = 1);
+  undefined stepUp(optional long n = 1);
   [Throws]
-  void stepDown(optional long n = 1);
+  undefined stepDown(optional long n = 1);
 */
 
   [Pure]
@@ -114,11 +114,11 @@ interface HTMLInputElement : HTMLElement {
   readonly attribute DOMString validationMessage;
   boolean checkValidity();
   boolean reportValidity();
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 
   readonly attribute NodeList? labels;
 
-  void select();
+  undefined select();
 
   [Throws]
            attribute unsigned long? selectionStart;
@@ -127,13 +127,13 @@ interface HTMLInputElement : HTMLElement {
   [Throws]
            attribute DOMString? selectionDirection;
   [Throws]
-  void setRangeText(DOMString replacement);
+  undefined setRangeText(DOMString replacement);
 
   [Throws]
-  void setRangeText(DOMString replacement, unsigned long start,
+  undefined setRangeText(DOMString replacement, unsigned long start,
     unsigned long end, optional SelectionMode selectionMode = "preserve");
   [Throws]
-  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+  undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
   // also has obsolete members
 };
@@ -160,7 +160,7 @@ partial interface HTMLInputElement {
   Promise<sequence<File>> getFiles(optional boolean recursiveFlag = false);
 
   [Throws, Pref="dom.input.dirpicker"]
-  void chooseDirectory();
+  undefined chooseDirectory();
 };
 */
 
@@ -186,10 +186,10 @@ partial interface HTMLInputElement {
   DateTimeValue getDateTimeInputBoxValue();
 
   [Pref="dom.forms.datetime", ChromeOnly]
-  void updateDateTimeInputBox(optional DateTimeValue value);
+  undefined updateDateTimeInputBox(optional DateTimeValue value);
 
   [Pref="dom.forms.datetime", ChromeOnly]
-  void setDateTimePickerState(boolean open);
+  undefined setDateTimePickerState(boolean open);
 
   [Pref="dom.forms.datetime", ChromeOnly,
    BinaryName="getMinimumAsDouble"]

--- a/crates/web-sys/webidls/enabled/HTMLMediaElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLMediaElement.webidl
@@ -34,7 +34,7 @@ interface HTMLMediaElement : HTMLElement {
            attribute DOMString preload;
   [NewObject]
   readonly attribute TimeRanges buffered;
-  void load();
+  undefined load();
   DOMString canPlayType(DOMString type);
 
   // ready state
@@ -50,7 +50,7 @@ interface HTMLMediaElement : HTMLElement {
   [SetterThrows]
            attribute double currentTime;
   [Throws]
-  void fastSeek(double time);
+  undefined fastSeek(double time);
   readonly attribute unrestricted double duration;
   [ChromeOnly]
   readonly attribute boolean isEncrypted;
@@ -70,9 +70,9 @@ interface HTMLMediaElement : HTMLElement {
   [CEReactions, SetterThrows]
            attribute boolean loop;
   [Throws]
-  Promise<void> play();
+  Promise<undefined> play();
   [Throws]
-  void pause();
+  undefined pause();
 
   // TODO: Bug 847377 - mediaGroup and MediaController
   // media controller
@@ -104,9 +104,9 @@ interface HTMLMediaElement : HTMLElement {
 partial interface HTMLMediaElement {
   readonly attribute MediaKeys? mediaKeys;
 
-  // void, not any: https://www.w3.org/Bugs/Public/show_bug.cgi?id=26457
+  // undefined, not any: https://www.w3.org/Bugs/Public/show_bug.cgi?id=26457
   [NewObject]
-  Promise<void> setMediaKeys(MediaKeys? mediaKeys);
+  Promise<undefined> setMediaKeys(MediaKeys? mediaKeys);
 
   attribute EventHandler onencrypted;
 
@@ -145,7 +145,7 @@ partial interface HTMLMediaElement {
  */
 partial interface HTMLMediaElement {
   [Throws, Pref="media.seekToNextFrame.enabled"]
-  Promise<void> seekToNextFrame();
+  Promise<undefined> seekToNextFrame();
 };
 
 /*
@@ -159,7 +159,7 @@ partial interface HTMLMediaElement {
  */
 partial interface HTMLMediaElement {
   [Pref="media.test.video-suspend"]
-  void setVisible(boolean aVisible);
+  undefined setVisible(boolean aVisible);
 
   [Pref="media.test.video-suspend"]
   boolean hasSuspendTaint();

--- a/crates/web-sys/webidls/enabled/HTMLObjectElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLObjectElement.webidl
@@ -44,7 +44,7 @@ interface HTMLObjectElement : HTMLElement {
   readonly attribute DOMString validationMessage;
   boolean checkValidity();
   boolean reportValidity();
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 };
 
 // http://www.whatwg.org/specs/web-apps/current-work/#HTMLObjectElement-partial

--- a/crates/web-sys/webidls/enabled/HTMLOptionsCollection.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLOptionsCollection.webidl
@@ -14,11 +14,11 @@ interface HTMLOptionsCollection : HTMLCollection {
   [CEReactions, SetterThrows]
   attribute unsigned long length;
   [CEReactions, Throws]
-  setter void (unsigned long index, HTMLOptionElement? option);
+  setter undefined (unsigned long index, HTMLOptionElement? option);
   [CEReactions, Throws]
-  void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+  undefined add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
   [CEReactions, Throws]
-  void remove(long index);
+  undefined remove(long index);
   [Throws]
   attribute long selectedIndex;
 };

--- a/crates/web-sys/webidls/enabled/HTMLOutputElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLOutputElement.webidl
@@ -33,7 +33,7 @@ interface HTMLOutputElement : HTMLElement {
   readonly attribute DOMString validationMessage;
   boolean checkValidity();
   boolean reportValidity();
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 
   readonly attribute NodeList labels;
 };

--- a/crates/web-sys/webidls/enabled/HTMLSelectElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLSelectElement.webidl
@@ -36,11 +36,11 @@ interface HTMLSelectElement : HTMLElement {
   getter Element? item(unsigned long index);
   HTMLOptionElement? namedItem(DOMString name);
   [CEReactions, Throws]
-  void add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
+  undefined add((HTMLOptionElement or HTMLOptGroupElement) element, optional (HTMLElement or long)? before = null);
   [CEReactions]
-  void remove(long index);
+  undefined remove(long index);
   [CEReactions, Throws]
-  setter void (unsigned long index, HTMLOptionElement? option);
+  setter undefined (unsigned long index, HTMLOptionElement? option);
 
   readonly attribute HTMLCollection selectedOptions;
   [SetterThrows, Pure]
@@ -54,13 +54,13 @@ interface HTMLSelectElement : HTMLElement {
   readonly attribute DOMString validationMessage;
   boolean checkValidity();
   boolean reportValidity();
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 
   readonly attribute NodeList labels;
 
   // https://www.w3.org/Bugs/Public/show_bug.cgi?id=20720
   [CEReactions]
-  void remove();
+  undefined remove();
 };
 
 // Chrome only interface

--- a/crates/web-sys/webidls/enabled/HTMLTableElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLTableElement.webidl
@@ -17,26 +17,26 @@ interface HTMLTableElement : HTMLElement {
            attribute HTMLTableCaptionElement? caption;
   HTMLElement createCaption();
   [CEReactions]
-  void deleteCaption();
+  undefined deleteCaption();
            [CEReactions, SetterThrows]
            attribute HTMLTableSectionElement? tHead;
   HTMLElement createTHead();
   [CEReactions]
-  void deleteTHead();
+  undefined deleteTHead();
            [CEReactions, SetterThrows]
            attribute HTMLTableSectionElement? tFoot;
   HTMLElement createTFoot();
   [CEReactions]
-  void deleteTFoot();
+  undefined deleteTFoot();
   readonly attribute HTMLCollection tBodies;
   HTMLElement createTBody();
   readonly attribute HTMLCollection rows;
   [Throws]
   HTMLElement insertRow(optional long index = -1);
   [CEReactions, Throws]
-  void deleteRow(long index);
+  undefined deleteRow(long index);
   //         attribute boolean sortable;
-  //void stopSorting();
+  //undefined stopSorting();
 };
 
 partial interface HTMLTableElement {

--- a/crates/web-sys/webidls/enabled/HTMLTableRowElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLTableRowElement.webidl
@@ -19,7 +19,7 @@ interface HTMLTableRowElement : HTMLElement {
   [Throws]
   HTMLElement insertCell(optional long index = -1);
   [CEReactions, Throws]
-  void deleteCell(long index);
+  undefined deleteCell(long index);
 };
 
 partial interface HTMLTableRowElement {

--- a/crates/web-sys/webidls/enabled/HTMLTableSectionElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLTableSectionElement.webidl
@@ -17,7 +17,7 @@ interface HTMLTableSectionElement : HTMLElement {
   [Throws]
   HTMLElement insertRow(optional long index = -1);
   [CEReactions, Throws]
-  void deleteRow(long index);
+  undefined deleteRow(long index);
 };
 
 partial interface HTMLTableSectionElement {

--- a/crates/web-sys/webidls/enabled/HTMLTextAreaElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLTextAreaElement.webidl
@@ -59,11 +59,11 @@ interface HTMLTextAreaElement : HTMLElement {
   readonly attribute DOMString validationMessage;
   boolean checkValidity();
   boolean reportValidity();
-  void setCustomValidity(DOMString error);
+  undefined setCustomValidity(DOMString error);
 
   readonly attribute NodeList labels;
 
-  void select();
+  undefined select();
   [Throws]
            attribute unsigned long? selectionStart;
   [Throws]
@@ -71,10 +71,10 @@ interface HTMLTextAreaElement : HTMLElement {
   [Throws]
            attribute DOMString? selectionDirection;
   [Throws]
-  void setRangeText(DOMString replacement);
+  undefined setRangeText(DOMString replacement);
   [Throws]
-  void setRangeText(DOMString replacement, unsigned long start,
+  undefined setRangeText(DOMString replacement, unsigned long start,
     unsigned long end, optional SelectionMode selectionMode = "preserve");
   [Throws]
-  void setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+  undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 };

--- a/crates/web-sys/webidls/enabled/HashChangeEvent.webidl
+++ b/crates/web-sys/webidls/enabled/HashChangeEvent.webidl
@@ -10,7 +10,7 @@ interface HashChangeEvent : Event
   readonly attribute DOMString oldURL;
   readonly attribute DOMString newURL;
 
-  void initHashChangeEvent(DOMString typeArg,
+  undefined initHashChangeEvent(DOMString typeArg,
                            optional boolean canBubbleArg = false,
                            optional boolean cancelableArg = false,
                            optional DOMString oldURLArg = "",

--- a/crates/web-sys/webidls/enabled/Headers.webidl
+++ b/crates/web-sys/webidls/enabled/Headers.webidl
@@ -21,11 +21,11 @@ enum HeadersGuardEnum {
 [Constructor(optional HeadersInit init),
  Exposed=(Window,Worker)]
 interface Headers {
-  [Throws] void append(ByteString name, ByteString value);
-  [Throws] void delete(ByteString name);
+  [Throws] undefined append(ByteString name, ByteString value);
+  [Throws] undefined delete(ByteString name);
   [Throws] ByteString? get(ByteString name);
   [Throws] boolean has(ByteString name);
-  [Throws] void set(ByteString name, ByteString value);
+  [Throws] undefined set(ByteString name, ByteString value);
   iterable<ByteString, ByteString>;
 
   // Used to test different guard states from mochitest.

--- a/crates/web-sys/webidls/enabled/History.webidl
+++ b/crates/web-sys/webidls/enabled/History.webidl
@@ -21,13 +21,13 @@ interface History {
   [Throws]
   readonly attribute any state;
   [Throws]
-  void go(optional long delta = 0);
+  undefined go(optional long delta = 0);
   [Throws]
-  void back();
+  undefined back();
   [Throws]
-  void forward();
+  undefined forward();
   [Throws]
-  void pushState(any data, DOMString title, optional DOMString? url = null);
+  undefined pushState(any data, DOMString title, optional DOMString? url = null);
   [Throws]
-  void replaceState(any data, DOMString title, optional DOMString? url = null);
+  undefined replaceState(any data, DOMString title, optional DOMString? url = null);
 };

--- a/crates/web-sys/webidls/enabled/IDBCursor.webidl
+++ b/crates/web-sys/webidls/enabled/IDBCursor.webidl
@@ -30,13 +30,13 @@ interface IDBCursor {
     IDBRequest update (any value);
 
     [Throws]
-    void       advance ([EnforceRange] unsigned long count);
+    undefined       advance ([EnforceRange] unsigned long count);
 
     [Throws]
-    void       continue (optional any key);
+    undefined       continue (optional any key);
 
     [Throws]
-    void       continuePrimaryKey(any key, any primaryKey);
+    undefined       continuePrimaryKey(any key, any primaryKey);
 
     [Throws]
     IDBRequest delete ();

--- a/crates/web-sys/webidls/enabled/IDBDatabase.webidl
+++ b/crates/web-sys/webidls/enabled/IDBDatabase.webidl
@@ -21,13 +21,13 @@ interface IDBDatabase : EventTarget {
     IDBObjectStore createObjectStore (DOMString name, optional IDBObjectStoreParameters optionalParameters);
 
     [Throws]
-    void           deleteObjectStore (DOMString name);
+    undefined           deleteObjectStore (DOMString name);
 
     [Throws]
     IDBTransaction transaction ((DOMString or sequence<DOMString>) storeNames,
                                 optional IDBTransactionMode mode = "readonly");
 
-    void           close ();
+    undefined           close ();
 
                 attribute EventHandler       onabort;
                 attribute EventHandler       onclose;

--- a/crates/web-sys/webidls/enabled/IDBFileHandle.webidl
+++ b/crates/web-sys/webidls/enabled/IDBFileHandle.webidl
@@ -35,7 +35,7 @@ interface IDBFileHandle : EventTarget
   [Throws]
   IDBFileRequest? flush();
   [Throws]
-  void abort();
+  undefined abort();
 
   attribute EventHandler oncomplete;
   attribute EventHandler onabort;

--- a/crates/web-sys/webidls/enabled/IDBObjectStore.webidl
+++ b/crates/web-sys/webidls/enabled/IDBObjectStore.webidl
@@ -52,7 +52,7 @@ interface IDBObjectStore {
     IDBIndex   index (DOMString name);
 
     [Throws]
-    void       deleteIndex (DOMString indexName);
+    undefined       deleteIndex (DOMString indexName);
 
     [Throws]
     IDBRequest count (optional any key);

--- a/crates/web-sys/webidls/enabled/IDBTransaction.webidl
+++ b/crates/web-sys/webidls/enabled/IDBTransaction.webidl
@@ -31,7 +31,7 @@ interface IDBTransaction : EventTarget {
     IDBObjectStore objectStore (DOMString name);
 
     [Throws]
-    void           abort();
+    undefined           abort();
 
                 attribute EventHandler       onabort;
                 attribute EventHandler       oncomplete;

--- a/crates/web-sys/webidls/enabled/IIRFilterNode.webidl
+++ b/crates/web-sys/webidls/enabled/IIRFilterNode.webidl
@@ -17,5 +17,5 @@ dictionary IIRFilterOptions : AudioNodeOptions {
 [Pref="dom.webaudio.enabled",
 Constructor(BaseAudioContext context, IIRFilterOptions options)]
 interface IIRFilterNode : AudioNode {
-    void getFrequencyResponse(Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
+    undefined getFrequencyResponse(Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
 };

--- a/crates/web-sys/webidls/enabled/ImageBitmap.webidl
+++ b/crates/web-sys/webidls/enabled/ImageBitmap.webidl
@@ -47,7 +47,7 @@ interface ImageBitmap {
 // new interface type "Closeable".
 partial interface ImageBitmap {
   // Dispose of all graphical resources associated with this ImageBitmap.
-  void close();
+  undefined close();
 };
 
 // ImageBitmap-extensions

--- a/crates/web-sys/webidls/enabled/ImageBitmapRenderingContext.webidl
+++ b/crates/web-sys/webidls/enabled/ImageBitmapRenderingContext.webidl
@@ -32,9 +32,9 @@ interface ImageBitmapRenderingContext {
   // would be covered by the canvas's bitmap which are not covered by
   // the supplied ImageBitmap are rendered transparent black. Any CSS
   // styles affecting the display of the canvas are applied as usual.
-  void transferFromImageBitmap(ImageBitmap bitmap);
+  undefined transferFromImageBitmap(ImageBitmap bitmap);
 
   // Deprecated version of transferFromImageBitmap
   [Deprecated="ImageBitmapRenderingContext_TransferImageBitmap"]
-  void transferImageBitmap(ImageBitmap bitmap);
+  undefined transferImageBitmap(ImageBitmap bitmap);
 };

--- a/crates/web-sys/webidls/enabled/ImageDocument.webidl
+++ b/crates/web-sys/webidls/enabled/ImageDocument.webidl
@@ -23,20 +23,20 @@ interface ImageDocument : HTMLDocument {
   readonly attribute imgIRequest? imageRequest;
 
   /* Resize the image to fit visible area. */
-  void shrinkToFit();
+  undefined shrinkToFit();
 
   /* Restore image original size. */
-  void restoreImage();
+  undefined restoreImage();
 
   /* Restore the image, trying to keep a certain pixel in the same position.
    * The coordinate system is that of the shrunken image.
    */
-  void restoreImageTo(long x, long y);
+  undefined restoreImageTo(long x, long y);
 
   /* A helper method for switching between states.
    * The switching logic is as follows. If the image has been resized
    * restore image original size, otherwise if the image is overflowing
    * current visible area resize the image to fit the area.
    */
-  void toggleImageSize();
+  undefined toggleImageSize();
 };

--- a/crates/web-sys/webidls/enabled/InstallTrigger.webidl
+++ b/crates/web-sys/webidls/enabled/InstallTrigger.webidl
@@ -8,7 +8,7 @@
  * A callback function that webpages can implement to be notified when triggered
  * installs complete.
  */
-callback InstallTriggerCallback = void(DOMString url, short status);
+callback InstallTriggerCallback = undefined(DOMString url, short status);
 
 dictionary InstallTriggerData {
   DOMString URL;

--- a/crates/web-sys/webidls/enabled/IntersectionObserver.webidl
+++ b/crates/web-sys/webidls/enabled/IntersectionObserver.webidl
@@ -35,9 +35,9 @@ interface IntersectionObserver {
   readonly attribute DOMString rootMargin;
   [Constant,Cached]
   readonly attribute sequence<double> thresholds;
-  void observe(Element target);
-  void unobserve(Element target);
-  void disconnect();
+  undefined observe(Element target);
+  undefined unobserve(Element target);
+  undefined disconnect();
   sequence<IntersectionObserverEntry> takeRecords();
 
   [ChromeOnly]
@@ -45,7 +45,7 @@ interface IntersectionObserver {
 };
 
 callback IntersectionCallback =
-  void (sequence<IntersectionObserverEntry> entries, IntersectionObserver observer);
+  undefined (sequence<IntersectionObserverEntry> entries, IntersectionObserver observer);
 
 dictionary IntersectionObserverEntryInit {
   required DOMHighResTimeStamp time;

--- a/crates/web-sys/webidls/enabled/KeyEvent.webidl
+++ b/crates/web-sys/webidls/enabled/KeyEvent.webidl
@@ -230,7 +230,7 @@ interface KeyEvent
   // for compatibility with the other web browsers on Windows.
   const unsigned long DOM_VK_WIN_OEM_CLEAR  = 0xFE;
 
-  void initKeyEvent(DOMString type,
+  undefined initKeyEvent(DOMString type,
                     optional boolean canBubble = false,
                     optional boolean cancelable = false,
                     optional Window? view = null,

--- a/crates/web-sys/webidls/enabled/KeyboardEvent.webidl
+++ b/crates/web-sys/webidls/enabled/KeyboardEvent.webidl
@@ -36,7 +36,7 @@ interface KeyboardEvent : UIEvent
   readonly attribute DOMString code;
 
   [Throws]
-  void initKeyboardEvent(DOMString typeArg,
+  undefined initKeyboardEvent(DOMString typeArg,
                          optional boolean bubblesArg = false,
                          optional boolean cancelableArg = false,
                          optional Window? viewArg = null,

--- a/crates/web-sys/webidls/enabled/KeyframeEffect.webidl
+++ b/crates/web-sys/webidls/enabled/KeyframeEffect.webidl
@@ -34,7 +34,7 @@ interface KeyframeEffect : AnimationEffect {
   attribute IterationCompositeOperation     iterationComposite;
   attribute CompositeOperation              composite;
   [Throws] sequence<object> getKeyframes ();
-  [Throws] void             setKeyframes (object? keyframes);
+  [Throws] undefined             setKeyframes (object? keyframes);
 };
 
 // Non-standard extensions

--- a/crates/web-sys/webidls/enabled/ListBoxObject.webidl
+++ b/crates/web-sys/webidls/enabled/ListBoxObject.webidl
@@ -13,9 +13,9 @@ interface ListBoxObject : BoxObject {
   long getNumberOfVisibleRows();
   long getIndexOfFirstVisibleRow();
 
-  void ensureIndexIsVisible(long rowIndex);
-  void scrollToIndex(long rowIndex);
-  void scrollByLines(long numLines);
+  undefined ensureIndexIsVisible(long rowIndex);
+  undefined scrollToIndex(long rowIndex);
+  undefined scrollByLines(long numLines);
 
   Element? getItemAtIndex(long index);
   long getIndexOfItem(Element item);

--- a/crates/web-sys/webidls/enabled/LocalMediaStream.webidl
+++ b/crates/web-sys/webidls/enabled/LocalMediaStream.webidl
@@ -11,5 +11,5 @@
  */
 
 interface LocalMediaStream : MediaStream {
-    void stop();
+    undefined stop();
 };

--- a/crates/web-sys/webidls/enabled/Location.webidl
+++ b/crates/web-sys/webidls/enabled/Location.webidl
@@ -40,14 +40,14 @@ interface Location {
            attribute USVString hash;
 
   [Throws, NeedsSubjectPrincipal]
-  void assign(USVString url);
+  undefined assign(USVString url);
 
   [Throws, CrossOriginCallable, NeedsSubjectPrincipal]
-  void replace(USVString url);
+  undefined replace(USVString url);
 
   // XXXbz there is no forceget argument in the spec!  See bug 1037721.
   [Throws, NeedsSubjectPrincipal]
-  void reload(optional boolean forceget = false);
+  undefined reload(optional boolean forceget = false);
 
   // Bug 1085214 [SameObject] readonly attribute USVString[] ancestorOrigins;
 };

--- a/crates/web-sys/webidls/enabled/MIDIOutput.webidl
+++ b/crates/web-sys/webidls/enabled/MIDIOutput.webidl
@@ -10,6 +10,6 @@
 [SecureContext, Pref="dom.webmidi.enabled"]
 interface MIDIOutput : MIDIPort {
   [Throws]
-  void send(sequence<octet> data, optional DOMHighResTimeStamp timestamp);
-  void clear();
+  undefined send(sequence<octet> data, optional DOMHighResTimeStamp timestamp);
+  undefined clear();
 };

--- a/crates/web-sys/webidls/enabled/MediaKeySession.webidl
+++ b/crates/web-sys/webidls/enabled/MediaKeySession.webidl
@@ -19,7 +19,7 @@ interface MediaKeySession : EventTarget {
 
   readonly attribute unrestricted double expiration;
 
-  readonly attribute Promise<void> closed;
+  readonly attribute Promise<undefined> closed;
 
   readonly attribute MediaKeyStatusMap keyStatuses;
 
@@ -28,18 +28,18 @@ interface MediaKeySession : EventTarget {
   attribute EventHandler onmessage;
 
   [NewObject]
-  Promise<void> generateRequest(DOMString initDataType, BufferSource initData);
+  Promise<undefined> generateRequest(DOMString initDataType, BufferSource initData);
 
   [NewObject]
   Promise<boolean> load(DOMString sessionId);
 
   // session operations
   [NewObject]
-  Promise<void> update(BufferSource response);
+  Promise<undefined> update(BufferSource response);
 
   [NewObject]
-  Promise<void> close();
+  Promise<undefined> close();
 
   [NewObject]
-  Promise<void> remove();
+  Promise<undefined> remove();
 };

--- a/crates/web-sys/webidls/enabled/MediaKeys.webidl
+++ b/crates/web-sys/webidls/enabled/MediaKeys.webidl
@@ -30,7 +30,7 @@ interface MediaKeys {
   MediaKeySession createSession(optional MediaKeySessionType sessionType = "temporary");
 
   [NewObject]
-  Promise<void> setServerCertificate(BufferSource serverCertificate);
+  Promise<undefined> setServerCertificate(BufferSource serverCertificate);
 
   [Pref="media.eme.hdcp-policy-check.enabled", NewObject]
   Promise<MediaKeyStatus> getStatusForPolicy(optional MediaKeysPolicy policy);

--- a/crates/web-sys/webidls/enabled/MediaList.webidl
+++ b/crates/web-sys/webidls/enabled/MediaList.webidl
@@ -19,7 +19,7 @@ interface MediaList {
   readonly attribute unsigned long    length;
   getter DOMString?  item(unsigned long index);
   [Throws]
-  void               deleteMedium(DOMString oldMedium);
+  undefined               deleteMedium(DOMString oldMedium);
   [Throws]
-  void               appendMedium(DOMString newMedium);
+  undefined               appendMedium(DOMString newMedium);
 };

--- a/crates/web-sys/webidls/enabled/MediaQueryList.webidl
+++ b/crates/web-sys/webidls/enabled/MediaQueryList.webidl
@@ -15,10 +15,10 @@ interface MediaQueryList : EventTarget {
   readonly attribute boolean matches;
 
   [Throws]
-  void addListener(EventListener? listener);
+  undefined addListener(EventListener? listener);
 
   [Throws]
-  void removeListener(EventListener? listener);
+  undefined removeListener(EventListener? listener);
 
            attribute EventHandler onchange;
 };

--- a/crates/web-sys/webidls/enabled/MediaRecorder.webidl
+++ b/crates/web-sys/webidls/enabled/MediaRecorder.webidl
@@ -34,19 +34,19 @@ interface MediaRecorder : EventTarget {
   attribute EventHandler onwarning;
 
   [Throws]
-  void start(optional long timeSlice);
+  undefined start(optional long timeSlice);
 
   [Throws]
-  void stop();
+  undefined stop();
 
   [Throws]
-  void pause();
+  undefined pause();
 
   [Throws]
-  void resume();
+  undefined resume();
 
   [Throws]
-  void requestData();
+  undefined requestData();
 
   static boolean isTypeSupported(DOMString type);
 };

--- a/crates/web-sys/webidls/enabled/MediaSource.webidl
+++ b/crates/web-sys/webidls/enabled/MediaSource.webidl
@@ -34,12 +34,12 @@ interface MediaSource : EventTarget {
   [NewObject, Throws]
   SourceBuffer addSourceBuffer(DOMString type);
   [Throws]
-  void removeSourceBuffer(SourceBuffer sourceBuffer);
+  undefined removeSourceBuffer(SourceBuffer sourceBuffer);
   [Throws]
-  void endOfStream(optional MediaSourceEndOfStreamError error);
+  undefined endOfStream(optional MediaSourceEndOfStreamError error);
   [Throws]
-  void setLiveSeekableRange(double start, double end);
+  undefined setLiveSeekableRange(double start, double end);
   [Throws]
-  void clearLiveSeekableRange();
+  undefined clearLiveSeekableRange();
   static boolean isTypeSupported(DOMString type);
 };

--- a/crates/web-sys/webidls/enabled/MediaStream.webidl
+++ b/crates/web-sys/webidls/enabled/MediaStream.webidl
@@ -38,8 +38,8 @@ interface MediaStream : EventTarget {
     sequence<VideoStreamTrack> getVideoTracks ();
     sequence<MediaStreamTrack> getTracks ();
     MediaStreamTrack?          getTrackById (DOMString trackId);
-    void                       addTrack (MediaStreamTrack track);
-    void                       removeTrack (MediaStreamTrack track);
+    undefined                       addTrack (MediaStreamTrack track);
+    undefined                       removeTrack (MediaStreamTrack track);
     MediaStream                clone ();
     readonly    attribute boolean      active;
                 attribute EventHandler onaddtrack;
@@ -52,5 +52,5 @@ interface MediaStream : EventTarget {
     // Webrtc allows the remote side to name a stream whatever it wants, and we
     // need to surface this to content.
     [ChromeOnly]
-    void assignId(DOMString id);
+    undefined assignId(DOMString id);
 };

--- a/crates/web-sys/webidls/enabled/MediaStreamTrack.webidl
+++ b/crates/web-sys/webidls/enabled/MediaStreamTrack.webidl
@@ -82,16 +82,16 @@ interface MediaStreamTrack : EventTarget {
     readonly    attribute MediaStreamTrackState readyState;
                 attribute EventHandler          onended;
     MediaStreamTrack       clone ();
-    void                   stop ();
+    undefined                   stop ();
 //  MediaTrackCapabilities getCapabilities ();
     MediaTrackConstraints  getConstraints ();
     [NeedsCallerType]
     MediaTrackSettings     getSettings ();
 
     [Throws, NeedsCallerType]
-    Promise<void>          applyConstraints (optional MediaTrackConstraints constraints);
+    Promise<undefined>          applyConstraints (optional MediaTrackConstraints constraints);
 //              attribute EventHandler          onoverconstrained;
 
     [ChromeOnly]
-    void mutedChanged(boolean muted);
+    undefined mutedChanged(boolean muted);
 };

--- a/crates/web-sys/webidls/enabled/MessageEvent.webidl
+++ b/crates/web-sys/webidls/enabled/MessageEvent.webidl
@@ -43,7 +43,7 @@ interface MessageEvent : Event {
    * the similarly-named method on the Event interface, also setting the
    * data, origin, source, and lastEventId attributes of this appropriately.
    */
-  void initMessageEvent(DOMString type,
+  undefined initMessageEvent(DOMString type,
                         optional boolean bubbles = false,
                         optional boolean cancelable = false,
                         optional any data = null,

--- a/crates/web-sys/webidls/enabled/MessagePort.webidl
+++ b/crates/web-sys/webidls/enabled/MessagePort.webidl
@@ -10,10 +10,10 @@
 [Exposed=(Window,Worker,AudioWorklet,System)]
 interface MessagePort : EventTarget {
   [Throws]
-  void postMessage(any message, optional sequence<object> transferable = []);
+  undefined postMessage(any message, optional sequence<object> transferable = []);
 
-  void start();
-  void close();
+  undefined start();
+  undefined close();
 
   // event handlers
   attribute EventHandler onmessage;

--- a/crates/web-sys/webidls/enabled/MouseEvent.webidl
+++ b/crates/web-sys/webidls/enabled/MouseEvent.webidl
@@ -38,7 +38,7 @@ interface MouseEvent : UIEvent {
   readonly attribute long           movementY;
 
   // Deprecated in DOM Level 3:
-void initMouseEvent(DOMString typeArg,
+undefined initMouseEvent(DOMString typeArg,
                     optional boolean canBubbleArg = false,
                     optional boolean cancelableArg = false,
                     optional Window? viewArg = null,

--- a/crates/web-sys/webidls/enabled/MouseScrollEvent.webidl
+++ b/crates/web-sys/webidls/enabled/MouseScrollEvent.webidl
@@ -11,7 +11,7 @@ interface MouseScrollEvent : MouseEvent
 
   readonly attribute long axis;
 
-  void initMouseScrollEvent(DOMString type,
+  undefined initMouseScrollEvent(DOMString type,
                             optional boolean canBubble = false,
                             optional boolean cancelable = false,
                             optional Window? view = null,

--- a/crates/web-sys/webidls/enabled/MutationEvent.webidl
+++ b/crates/web-sys/webidls/enabled/MutationEvent.webidl
@@ -24,7 +24,7 @@ interface MutationEvent : Event
   readonly attribute unsigned short attrChange;
 
   [Throws]
-  void initMutationEvent(DOMString type,
+  undefined initMutationEvent(DOMString type,
                          optional boolean canBubble = false,
                          optional boolean cancelable = false,
                          optional Node? relatedNode = null,

--- a/crates/web-sys/webidls/enabled/MutationObserver.webidl
+++ b/crates/web-sys/webidls/enabled/MutationObserver.webidl
@@ -40,8 +40,8 @@ interface MutationRecord {
 [Constructor(MutationCallback mutationCallback)]
 interface MutationObserver {
   [Throws]
-  void observe(Node target, optional MutationObserverInit options);
-  void disconnect();
+  undefined observe(Node target, optional MutationObserverInit options);
+  undefined disconnect();
   sequence<MutationRecord> takeRecords();
 
   [ChromeOnly, Throws]
@@ -52,7 +52,7 @@ interface MutationObserver {
   attribute boolean mergeAttributeRecords;
 };
 
-callback MutationCallback = void (sequence<MutationRecord> mutations, MutationObserver observer);
+callback MutationCallback = undefined (sequence<MutationRecord> mutations, MutationObserver observer);
 
 dictionary MutationObserverInit {
   boolean childList = false;

--- a/crates/web-sys/webidls/enabled/Navigator.webidl
+++ b/crates/web-sys/webidls/enabled/Navigator.webidl
@@ -80,14 +80,14 @@ interface mixin NavigatorOnLine {
 interface mixin NavigatorContentUtils {
   // content handler registration
   [Throws, Func="nsGlobalWindowInner::RegisterProtocolHandlerAllowedForContext"]
-  void registerProtocolHandler(DOMString scheme, DOMString url, DOMString title);
+  undefined registerProtocolHandler(DOMString scheme, DOMString url, DOMString title);
   [Pref="dom.registerContentHandler.enabled", Throws]
-  void registerContentHandler(DOMString mimeType, DOMString url, DOMString title);
+  undefined registerContentHandler(DOMString mimeType, DOMString url, DOMString title);
   // NOT IMPLEMENTED
   //DOMString isProtocolHandlerRegistered(DOMString scheme, DOMString url);
   //DOMString isContentHandlerRegistered(DOMString mimeType, DOMString url);
-  //void unregisterProtocolHandler(DOMString scheme, DOMString url);
-  //void unregisterContentHandler(DOMString mimeType, DOMString url);
+  //undefined unregisterProtocolHandler(DOMString scheme, DOMString url);
+  //undefined unregisterContentHandler(DOMString mimeType, DOMString url);
 };
 
 [SecureContext, Exposed=(Window,Worker)]
@@ -98,7 +98,7 @@ interface mixin NavigatorStorage {
 
 interface mixin NavigatorStorageUtils {
   // NOT IMPLEMENTED
-  //void yieldForStorageUpdates();
+  //undefined yieldForStorageUpdates();
 };
 
 partial interface Navigator {
@@ -182,7 +182,7 @@ partial interface Navigator {
   [ChromeOnly, Pref="dom.vr.enabled"]
   readonly attribute boolean isWebVRContentPresenting;
   [ChromeOnly, Pref="dom.vr.enabled"]
-  void requestVRPresentation(VRDisplay display);
+  undefined requestVRPresentation(VRDisplay display);
 };
 partial interface Navigator {
   [Pref="dom.vr.test.enabled"]
@@ -195,8 +195,8 @@ partial interface Navigator {
   Promise<MIDIAccess> requestMIDIAccess(optional MIDIOptions options);
 };
 
-callback NavigatorUserMediaSuccessCallback = void (MediaStream stream);
-callback NavigatorUserMediaErrorCallback = void (MediaStreamError error);
+callback NavigatorUserMediaSuccessCallback = undefined (MediaStream stream);
+callback NavigatorUserMediaErrorCallback = undefined (MediaStreamError error);
 
 partial interface Navigator {
   [Throws, Func="Navigator::HasUserMediaSupport"]

--- a/crates/web-sys/webidls/enabled/Node.webidl
+++ b/crates/web-sys/webidls/enabled/Node.webidl
@@ -73,7 +73,7 @@ interface Node : EventTarget {
   [CEReactions, Throws]
   Node removeChild(Node child);
   [CEReactions]
-  void normalize();
+  undefined normalize();
 
   [CEReactions, Throws]
   Node cloneNode(optional boolean deep = false);

--- a/crates/web-sys/webidls/enabled/NodeIterator.webidl
+++ b/crates/web-sys/webidls/enabled/NodeIterator.webidl
@@ -27,5 +27,5 @@ interface NodeIterator {
   [Throws]
   Node? previousNode();
 
-  void detach();
+  undefined detach();
 };

--- a/crates/web-sys/webidls/enabled/Notification.webidl
+++ b/crates/web-sys/webidls/enabled/Notification.webidl
@@ -56,7 +56,7 @@ interface Notification : EventTarget {
   [Constant]
   readonly attribute any data;
 
-  void close();
+  undefined close();
 };
 
 dictionary NotificationOptions {
@@ -87,7 +87,7 @@ enum NotificationPermission {
   "granted"
 };
 
-callback NotificationPermissionCallback = void (NotificationPermission permission);
+callback NotificationPermissionCallback = undefined (NotificationPermission permission);
 
 enum NotificationDirection {
   "auto",

--- a/crates/web-sys/webidls/enabled/OfflineAudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/OfflineAudioContext.webidl
@@ -24,7 +24,7 @@ interface OfflineAudioContext : BaseAudioContext {
     [Throws]
     Promise<AudioBuffer> startRendering();
 
-    // TODO: Promise<void>        suspend (double suspendTime);
+    // TODO: Promise<undefined>        suspend (double suspendTime);
 
     readonly        attribute unsigned long length;
                     attribute EventHandler  oncomplete;

--- a/crates/web-sys/webidls/enabled/OfflineResourceList.webidl
+++ b/crates/web-sys/webidls/enabled/OfflineResourceList.webidl
@@ -33,14 +33,14 @@ interface OfflineResourceList : EventTarget {
    * Begin the application update process on the associated application cache.
    */
   [Throws, UseCounter]
-  void update();
+  undefined update();
 
   /**
    * Swap in the newest version of the application cache, or disassociate
    * from the cache if the cache group is obsolete.
    */
   [Throws, UseCounter]
-  void swapCache();
+  undefined swapCache();
 
   /* Events */
   [UseCounter]

--- a/crates/web-sys/webidls/enabled/OscillatorNode.webidl
+++ b/crates/web-sys/webidls/enabled/OscillatorNode.webidl
@@ -35,7 +35,7 @@ interface OscillatorNode : AudioScheduledSourceNode {
     readonly attribute AudioParam frequency; // in Hertz
     readonly attribute AudioParam detune; // in Cents
 
-    void setPeriodicWave(PeriodicWave periodicWave);
+    undefined setPeriodicWave(PeriodicWave periodicWave);
 };
 
 OscillatorNode includes rustAudioScheduledSourceNode;

--- a/crates/web-sys/webidls/enabled/PaintWorkletGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/PaintWorkletGlobalScope.webidl
@@ -9,5 +9,5 @@
 
 [Global=(Worklet,PaintWorklet),Exposed=PaintWorklet]
 interface PaintWorkletGlobalScope : WorkletGlobalScope {
-    void registerPaint(DOMString name, VoidFunction paintCtor);
+    undefined registerPaint(DOMString name, VoidFunction paintCtor);
 };

--- a/crates/web-sys/webidls/enabled/PannerNode.webidl
+++ b/crates/web-sys/webidls/enabled/PannerNode.webidl
@@ -46,10 +46,10 @@ interface PannerNode : AudioNode {
     attribute PanningModelType panningModel;
 
     // Uses a 3D cartesian coordinate system
-    void setPosition(double x, double y, double z);
-    void setOrientation(double x, double y, double z);
+    undefined setPosition(double x, double y, double z);
+    undefined setOrientation(double x, double y, double z);
     [Deprecated="PannerNodeDoppler"]
-    void setVelocity(double x, double y, double z);
+    undefined setVelocity(double x, double y, double z);
 
     // Cartesian coordinate for position
     readonly attribute AudioParam positionX;

--- a/crates/web-sys/webidls/enabled/ParentNode.webidl
+++ b/crates/web-sys/webidls/enabled/ParentNode.webidl
@@ -18,7 +18,7 @@ interface mixin ParentNode {
   readonly attribute unsigned long childElementCount;
 
   [CEReactions, Throws, Unscopable]
-  void prepend((Node or DOMString)... nodes);
+  undefined prepend((Node or DOMString)... nodes);
   [CEReactions, Throws, Unscopable]
-  void append((Node or DOMString)... nodes);
+  undefined append((Node or DOMString)... nodes);
 };

--- a/crates/web-sys/webidls/enabled/PaymentRequestUpdateEvent.webidl
+++ b/crates/web-sys/webidls/enabled/PaymentRequestUpdateEvent.webidl
@@ -13,7 +13,7 @@
  Func="mozilla::dom::PaymentRequest::PrefEnabled"]
 interface PaymentRequestUpdateEvent : Event {
   [Throws]
-  void updateWith(Promise<PaymentDetailsUpdate> detailsPromise);
+  undefined updateWith(Promise<PaymentDetailsUpdate> detailsPromise);
 };
 
 dictionary PaymentRequestUpdateEventInit : EventInit {

--- a/crates/web-sys/webidls/enabled/PaymentResponse.webidl
+++ b/crates/web-sys/webidls/enabled/PaymentResponse.webidl
@@ -28,5 +28,5 @@ interface PaymentResponse {
   readonly attribute DOMString?      payerPhone;
 
   [NewObject]
-  Promise<void> complete(optional PaymentComplete result = "unknown");
+  Promise<undefined> complete(optional PaymentComplete result = "unknown");
 };

--- a/crates/web-sys/webidls/enabled/PeerConnectionImpl.webidl
+++ b/crates/web-sys/webidls/enabled/PeerConnectionImpl.webidl
@@ -21,24 +21,24 @@
 interface PeerConnectionImpl  {
   /* Must be called first. Observer events dispatched on the thread provided */
   [Throws]
-  void initialize(PeerConnectionObserver observer, Window window,
+  undefined initialize(PeerConnectionObserver observer, Window window,
                   RTCConfiguration iceServers,
                   nsISupports thread);
 
   /* JSEP calls */
   [Throws]
-  void createOffer(optional RTCOfferOptions options);
+  undefined createOffer(optional RTCOfferOptions options);
   [Throws]
-  void createAnswer();
+  undefined createAnswer();
   [Throws]
-  void setLocalDescription(long action, DOMString sdp);
+  undefined setLocalDescription(long action, DOMString sdp);
   [Throws]
-  void setRemoteDescription(long action, DOMString sdp);
+  undefined setRemoteDescription(long action, DOMString sdp);
 
   /* Stats call, calls either |onGetStatsSuccess| or |onGetStatsError| on our
      observer. (see the |PeerConnectionObserver| interface) */
   [Throws]
-  void getStats(MediaStreamTrack? selector);
+  undefined getStats(MediaStreamTrack? selector);
 
   /* Adds the tracks created by GetUserMedia */
   [Throws]
@@ -47,7 +47,7 @@ interface PeerConnectionImpl  {
   [Throws]
   boolean checkNegotiationNeeded();
   [Throws]
-  void insertDTMF(TransceiverImpl transceiver, DOMString tones,
+  undefined insertDTMF(TransceiverImpl transceiver, DOMString tones,
                   optional unsigned long duration = 100,
                   optional unsigned long interToneGap = 70);
   [Throws]
@@ -58,31 +58,31 @@ interface PeerConnectionImpl  {
   DOMHighResTimeStamp getNowInRtpSourceReferenceTime();
 
   [Throws]
-  void replaceTrackNoRenegotiation(TransceiverImpl transceiverImpl,
+  undefined replaceTrackNoRenegotiation(TransceiverImpl transceiverImpl,
                                    MediaStreamTrack? withTrack);
   [Throws]
-  void closeStreams();
+  undefined closeStreams();
 
   [Throws]
-  void addRIDExtension(MediaStreamTrack recvTrack, unsigned short extensionId);
+  undefined addRIDExtension(MediaStreamTrack recvTrack, unsigned short extensionId);
   [Throws]
-  void addRIDFilter(MediaStreamTrack recvTrack, DOMString rid);
+  undefined addRIDFilter(MediaStreamTrack recvTrack, DOMString rid);
 
   // Inserts CSRC data for the RtpSourceObserver for testing
   [Throws]
-  void insertAudioLevelForContributingSource(MediaStreamTrack recvTrack,
+  undefined insertAudioLevelForContributingSource(MediaStreamTrack recvTrack,
                                              unsigned long source,
                                              DOMHighResTimeStamp timestamp,
                                              boolean hasLevel,
                                              byte level);
 
   [Throws]
-  void enablePacketDump(unsigned long level,
+  undefined enablePacketDump(unsigned long level,
                         mozPacketDumpType type,
                         boolean sending);
 
   [Throws]
-  void disablePacketDump(unsigned long level,
+  undefined disablePacketDump(unsigned long level,
                          mozPacketDumpType type,
                          boolean sending);
 
@@ -92,11 +92,11 @@ interface PeerConnectionImpl  {
    * into the SDP.
    */
   [Throws]
-  void addIceCandidate(DOMString candidate, DOMString mid, unsigned short level);
+  undefined addIceCandidate(DOMString candidate, DOMString mid, unsigned short level);
 
   /* Puts the SIPCC engine back to 'kIdle', shuts down threads, deletes state */
   [Throws]
-  void close();
+  undefined close();
 
   /* Notify DOM window if this plugin crash is ours. */
   boolean pluginCrash(unsigned long long pluginId, DOMString name);

--- a/crates/web-sys/webidls/enabled/PeerConnectionObserver.webidl
+++ b/crates/web-sys/webidls/enabled/PeerConnectionObserver.webidl
@@ -13,39 +13,39 @@
 interface PeerConnectionObserver
 {
   /* JSEP callbacks */
-  void onCreateOfferSuccess(DOMString offer);
-  void onCreateOfferError(unsigned long name, DOMString message);
-  void onCreateAnswerSuccess(DOMString answer);
-  void onCreateAnswerError(unsigned long name, DOMString message);
-  void onSetLocalDescriptionSuccess();
-  void onSetRemoteDescriptionSuccess();
-  void onSetLocalDescriptionError(unsigned long name, DOMString message);
-  void onSetRemoteDescriptionError(unsigned long name, DOMString message);
-  void onAddIceCandidateSuccess();
-  void onAddIceCandidateError(unsigned long name, DOMString message);
-  void onIceCandidate(unsigned short level, DOMString mid, DOMString candidate);
+  undefined onCreateOfferSuccess(DOMString offer);
+  undefined onCreateOfferError(unsigned long name, DOMString message);
+  undefined onCreateAnswerSuccess(DOMString answer);
+  undefined onCreateAnswerError(unsigned long name, DOMString message);
+  undefined onSetLocalDescriptionSuccess();
+  undefined onSetRemoteDescriptionSuccess();
+  undefined onSetLocalDescriptionError(unsigned long name, DOMString message);
+  undefined onSetRemoteDescriptionError(unsigned long name, DOMString message);
+  undefined onAddIceCandidateSuccess();
+  undefined onAddIceCandidateError(unsigned long name, DOMString message);
+  undefined onIceCandidate(unsigned short level, DOMString mid, DOMString candidate);
 
   /* Stats callbacks */
-  void onGetStatsSuccess(optional RTCStatsReportInternal report);
-  void onGetStatsError(unsigned long name, DOMString message);
+  undefined onGetStatsSuccess(optional RTCStatsReportInternal report);
+  undefined onGetStatsError(unsigned long name, DOMString message);
 
   /* Data channel callbacks */
-  void notifyDataChannel(RTCDataChannel channel);
+  undefined notifyDataChannel(RTCDataChannel channel);
 
   /* Notification of one of several types of state changed */
-  void onStateChange(PCObserverStateType state);
+  undefined onStateChange(PCObserverStateType state);
 
   /* Transceiver management; called when setRemoteDescription causes a
      transceiver to be created on the C++ side */
-  void onTransceiverNeeded(DOMString kind, TransceiverImpl transceiverImpl);
+  undefined onTransceiverNeeded(DOMString kind, TransceiverImpl transceiverImpl);
 
   /* DTMF callback */
-  void onDTMFToneChange(MediaStreamTrack track, DOMString tone);
+  undefined onDTMFToneChange(MediaStreamTrack track, DOMString tone);
 
   /* Packet dump callback */
-  void onPacket(unsigned long level, mozPacketDumpType type, boolean sending,
+  undefined onPacket(unsigned long level, mozPacketDumpType type, boolean sending,
                 ArrayBuffer packet);
 
   /* Transceiver sync */
-  void syncTransceivers();
+  undefined syncTransceivers();
 };

--- a/crates/web-sys/webidls/enabled/Performance.webidl
+++ b/crates/web-sys/webidls/enabled/Performance.webidl
@@ -43,8 +43,8 @@ partial interface Performance {
 // http://www.w3.org/TR/resource-timing/#extensions-performance-interface
 [Exposed=(Window,Worker)]
 partial interface Performance {
-  void clearResourceTimings();
-  void setResourceTimingBufferSize(unsigned long maxSize);
+  undefined clearResourceTimings();
+  undefined setResourceTimingBufferSize(unsigned long maxSize);
   attribute EventHandler onresourcetimingbufferfull;
 };
 
@@ -52,9 +52,9 @@ partial interface Performance {
 [Exposed=(Window,Worker)]
 partial interface Performance {
   [Throws]
-  void mark(DOMString markName);
-  void clearMarks(optional DOMString markName);
+  undefined mark(DOMString markName);
+  undefined clearMarks(optional DOMString markName);
   [Throws]
-  void measure(DOMString measureName, optional DOMString startMark, optional DOMString endMark);
-  void clearMeasures(optional DOMString measureName);
+  undefined measure(DOMString measureName, optional DOMString startMark, optional DOMString endMark);
+  undefined clearMeasures(optional DOMString measureName);
 };

--- a/crates/web-sys/webidls/enabled/PerformanceObserver.webidl
+++ b/crates/web-sys/webidls/enabled/PerformanceObserver.webidl
@@ -12,14 +12,14 @@ dictionary PerformanceObserverInit {
   boolean buffered = false;
 };
 
-callback PerformanceObserverCallback = void (PerformanceObserverEntryList entries,
+callback PerformanceObserverCallback = undefined (PerformanceObserverEntryList entries,
                                              PerformanceObserver observer);
 
 [Func="mozilla::dom::DOMPrefs::PerformanceObserverEnabled",
  Constructor(PerformanceObserverCallback callback),
  Exposed=(Window,Worker)]
 interface PerformanceObserver {
-    void observe(PerformanceObserverInit options);
-    void disconnect();
+    undefined observe(PerformanceObserverInit options);
+    undefined disconnect();
     PerformanceEntryList takeRecords();
 };

--- a/crates/web-sys/webidls/enabled/PluginArray.webidl
+++ b/crates/web-sys/webidls/enabled/PluginArray.webidl
@@ -14,5 +14,5 @@ interface PluginArray {
   [NeedsCallerType]
   getter Plugin? namedItem(DOMString name);
 
-  void refresh(optional boolean reloadDocuments = false);
+  undefined refresh(optional boolean reloadDocuments = false);
 };

--- a/crates/web-sys/webidls/enabled/PresentationConnection.webidl
+++ b/crates/web-sys/webidls/enabled/PresentationConnection.webidl
@@ -60,16 +60,16 @@ interface PresentationConnection : EventTarget {
    * This function only works when the state is "connected".
    */
   [Throws]
-  void send(DOMString data);
+  undefined send(DOMString data);
 
   [Throws]
-  void send(Blob data);
+  undefined send(Blob data);
 
   [Throws]
-  void send(ArrayBuffer data);
+  undefined send(ArrayBuffer data);
 
   [Throws]
-  void send(ArrayBufferView data);
+  undefined send(ArrayBufferView data);
 
   /*
    * It is triggered when receiving messages.
@@ -83,7 +83,7 @@ interface PresentationConnection : EventTarget {
    * This function only works when the state is "connected" or "connecting".
    */
   [Throws]
-  void close();
+  undefined close();
 
   /*
    * Both the controlling and receiving browsing context can terminate the
@@ -92,5 +92,5 @@ interface PresentationConnection : EventTarget {
    * This function only works when the state is not "connected".
    */
    [Throws]
-   void terminate();
+   undefined terminate();
 };

--- a/crates/web-sys/webidls/enabled/Promise.webidl
+++ b/crates/web-sys/webidls/enabled/Promise.webidl
@@ -7,7 +7,7 @@
  * Web IDL infrastructure.
  */
 
-callback PromiseJobCallback = void();
+callback PromiseJobCallback = undefined();
 
 [TreatNonCallableAsNull]
 callback AnyCallback = any (any value);

--- a/crates/web-sys/webidls/enabled/RTCDTMFSender.webidl
+++ b/crates/web-sys/webidls/enabled/RTCDTMFSender.webidl
@@ -9,7 +9,7 @@
 
 [JSImplementation="@mozilla.org/dom/rtcdtmfsender;1"]
 interface RTCDTMFSender : EventTarget {
-    void insertDTMF(DOMString tones,
+    undefined insertDTMF(DOMString tones,
                     optional unsigned long duration = 100,
                     optional unsigned long interToneGap = 70);
              attribute EventHandler  ontonechange;

--- a/crates/web-sys/webidls/enabled/RTCDataChannel.webidl
+++ b/crates/web-sys/webidls/enabled/RTCDataChannel.webidl
@@ -26,16 +26,16 @@ interface RTCDataChannel : EventTarget
   attribute EventHandler onopen;
   attribute EventHandler onerror;
   attribute EventHandler onclose;
-  void close();
+  undefined close();
   attribute EventHandler onmessage;
   attribute EventHandler onbufferedamountlow;
   attribute RTCDataChannelType binaryType;
   [Throws]
-  void send(DOMString data);
+  undefined send(DOMString data);
   [Throws]
-  void send(Blob data);
+  undefined send(Blob data);
   [Throws]
-  void send(ArrayBuffer data);
+  undefined send(ArrayBuffer data);
   [Throws]
-  void send(ArrayBufferView data);
+  undefined send(ArrayBufferView data);
 };

--- a/crates/web-sys/webidls/enabled/RTCIdentityProvider.webidl
+++ b/crates/web-sys/webidls/enabled/RTCIdentityProvider.webidl
@@ -8,7 +8,7 @@
 
 [NoInterfaceObject]
 interface RTCIdentityProviderRegistrar {
-  void register(RTCIdentityProvider idp);
+  undefined register(RTCIdentityProvider idp);
 
   /* Whether an IdP was passed to register() to chrome code. */
   [ChromeOnly]

--- a/crates/web-sys/webidls/enabled/RTCPeerConnection.webidl
+++ b/crates/web-sys/webidls/enabled/RTCPeerConnection.webidl
@@ -7,9 +7,9 @@
  * http://w3c.github.io/webrtc-pc/#interface-definition
  */
 
-callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);
-callback RTCPeerConnectionErrorCallback = void (DOMException error);
-callback RTCStatsCallback = void (RTCStatsReport report);
+callback RTCSessionDescriptionCallback = undefined (RTCSessionDescriptionInit description);
+callback RTCPeerConnectionErrorCallback = undefined (DOMException error);
+callback RTCStatsCallback = undefined (RTCStatsReport report);
 
 enum RTCSignalingState {
     "stable",
@@ -70,14 +70,14 @@ interface RTCPeerConnection : EventTarget  {
   static Promise<RTCCertificate> generateCertificate (AlgorithmIdentifier keygenAlgorithm);
 
   [Pref="media.peerconnection.identity.enabled"]
-  void setIdentityProvider (DOMString provider,
+  undefined setIdentityProvider (DOMString provider,
                             optional RTCIdentityProviderOptions options);
   [Pref="media.peerconnection.identity.enabled"]
   Promise<DOMString> getIdentityAssertion();
   Promise<RTCSessionDescriptionInit> createOffer (optional RTCOfferOptions options);
   Promise<RTCSessionDescriptionInit> createAnswer (optional RTCAnswerOptions options);
-  Promise<void> setLocalDescription (RTCSessionDescriptionInit description);
-  Promise<void> setRemoteDescription (RTCSessionDescriptionInit description);
+  Promise<undefined> setLocalDescription (RTCSessionDescriptionInit description);
+  Promise<undefined> setRemoteDescription (RTCSessionDescriptionInit description);
   readonly attribute RTCSessionDescription? localDescription;
   readonly attribute RTCSessionDescription? currentLocalDescription;
   readonly attribute RTCSessionDescription? pendingLocalDescription;
@@ -85,7 +85,7 @@ interface RTCPeerConnection : EventTarget  {
   readonly attribute RTCSessionDescription? currentRemoteDescription;
   readonly attribute RTCSessionDescription? pendingRemoteDescription;
   readonly attribute RTCSignalingState signalingState;
-  Promise<void> addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate)? candidate);
+  Promise<undefined> addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate)? candidate);
   readonly attribute boolean? canTrickleIceCandidates;
   readonly attribute RTCIceGatheringState iceGatheringState;
   readonly attribute RTCIceConnectionState iceConnectionState;
@@ -102,7 +102,7 @@ interface RTCPeerConnection : EventTarget  {
   sequence<MediaStream> getLocalStreams ();
   [Deprecated="RTCPeerConnectionGetStreams"]
   sequence<MediaStream> getRemoteStreams ();
-  void addStream (MediaStream stream);
+  undefined addStream (MediaStream stream);
 
   // replaces addStream; fails if already added
   // because a track can be part of multiple streams, stream parameters
@@ -111,7 +111,7 @@ interface RTCPeerConnection : EventTarget  {
   RTCRtpSender addTrack(MediaStreamTrack track,
                         MediaStream stream,
                         MediaStream... moreStreams);
-  void removeTrack(RTCRtpSender sender);
+  undefined removeTrack(RTCRtpSender sender);
 
   RTCRtpTransceiver addTransceiver((MediaStreamTrack or DOMString) trackOrKind,
                                    optional RTCRtpTransceiverInit init);
@@ -120,7 +120,7 @@ interface RTCPeerConnection : EventTarget  {
   sequence<RTCRtpReceiver> getReceivers();
   sequence<RTCRtpTransceiver> getTransceivers();
 
-  void close ();
+  undefined close ();
   attribute EventHandler onnegotiationneeded;
   attribute EventHandler onicecandidate;
   attribute EventHandler onsignalingstatechange;
@@ -143,24 +143,24 @@ interface RTCPeerConnection : EventTarget  {
 
 partial interface RTCPeerConnection {
 
-  // Dummy Promise<void> return values avoid "WebIDL.WebIDLError: error:
+  // Dummy Promise<undefined> return values aundefined "WebIDL.WebIDLError: error:
   // We have overloads with both Promise and non-Promise return types"
 
-  Promise<void> createOffer (RTCSessionDescriptionCallback successCallback,
+  Promise<undefined> createOffer (RTCSessionDescriptionCallback successCallback,
                              RTCPeerConnectionErrorCallback failureCallback,
                              optional RTCOfferOptions options);
-  Promise<void> createAnswer (RTCSessionDescriptionCallback successCallback,
+  Promise<undefined> createAnswer (RTCSessionDescriptionCallback successCallback,
                               RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> setLocalDescription (RTCSessionDescriptionInit description,
+  Promise<undefined> setLocalDescription (RTCSessionDescriptionInit description,
                                      VoidFunction successCallback,
                                      RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> setRemoteDescription (RTCSessionDescriptionInit description,
+  Promise<undefined> setRemoteDescription (RTCSessionDescriptionInit description,
                                       VoidFunction successCallback,
                                       RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> addIceCandidate (RTCIceCandidate candidate,
+  Promise<undefined> addIceCandidate (RTCIceCandidate candidate,
                                  VoidFunction successCallback,
                                  RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> getStats (MediaStreamTrack? selector,
+  Promise<undefined> getStats (MediaStreamTrack? selector,
                           RTCStatsCallback successCallback,
                           RTCPeerConnectionErrorCallback failureCallback);
 };

--- a/crates/web-sys/webidls/enabled/RTCPeerConnectionStatic.webidl
+++ b/crates/web-sys/webidls/enabled/RTCPeerConnectionStatic.webidl
@@ -19,7 +19,7 @@ enum RTCLifecycleEvent {
     "iceconnectionstatechange"
 };
 
-callback PeerConnectionLifecycleCallback = void (RTCPeerConnection pc,
+callback PeerConnectionLifecycleCallback = undefined (RTCPeerConnection pc,
                                                  unsigned long long windowId,
                                                  RTCLifecycleEvent eventType);
 
@@ -33,7 +33,7 @@ interface RTCPeerConnectionStatic {
      automatically unregistered when window goes away.
      Fires when a PC is created, and whenever the ICE connection state or
      gathering state changes. */
-  void registerPeerConnectionLifecycleCallback(
+  undefined registerPeerConnectionLifecycleCallback(
     PeerConnectionLifecycleCallback cb);
 };
 

--- a/crates/web-sys/webidls/enabled/RTCRtpReceiver.webidl
+++ b/crates/web-sys/webidls/enabled/RTCRtpReceiver.webidl
@@ -18,11 +18,11 @@ interface RTCRtpReceiver {
   sequence<RTCRtpSynchronizationSource> getSynchronizationSources();
 
   [ChromeOnly]
-  void setStreamIds(sequence<DOMString> streamIds);
+  undefined setStreamIds(sequence<DOMString> streamIds);
   [ChromeOnly]
-  void setRemoteSendBit(boolean sendBit);
+  undefined setRemoteSendBit(boolean sendBit);
   [ChromeOnly]
-  void processTrackAdditionsAndRemovals(
+  undefined processTrackAdditionsAndRemovals(
       RTCRtpTransceiver transceiver,
       object postProcessing);
 };

--- a/crates/web-sys/webidls/enabled/RTCRtpSender.webidl
+++ b/crates/web-sys/webidls/enabled/RTCRtpSender.webidl
@@ -70,9 +70,9 @@ dictionary RTCRtpParameters {
  JSImplementation="@mozilla.org/dom/rtpsender;1"]
 interface RTCRtpSender {
   readonly attribute MediaStreamTrack? track;
-  Promise<void> setParameters (optional RTCRtpParameters parameters);
+  Promise<undefined> setParameters (optional RTCRtpParameters parameters);
   RTCRtpParameters getParameters();
-  Promise<void> replaceTrack(MediaStreamTrack? withTrack);
+  Promise<undefined> replaceTrack(MediaStreamTrack? withTrack);
   Promise<RTCStatsReport> getStats();
   [Pref="media.peerconnection.dtmf.enabled"]
   readonly attribute RTCDTMFSender? dtmf;
@@ -80,9 +80,9 @@ interface RTCRtpSender {
   [ChromeOnly]
   sequence<MediaStream> getStreams();
   [ChromeOnly]
-  void setStreams(sequence<MediaStream> streams);
+  undefined setStreams(sequence<MediaStream> streams);
   [ChromeOnly]
-  void setTrack(MediaStreamTrack? track);
+  undefined setTrack(MediaStreamTrack? track);
   [ChromeOnly]
-  void checkWasCreatedByPc(RTCPeerConnection pc);
+  undefined checkWasCreatedByPc(RTCPeerConnection pc);
 };

--- a/crates/web-sys/webidls/enabled/RTCRtpTransceiver.webidl
+++ b/crates/web-sys/webidls/enabled/RTCRtpTransceiver.webidl
@@ -33,12 +33,12 @@ interface RTCRtpTransceiver {
              attribute RTCRtpTransceiverDirection  direction;
     readonly attribute RTCRtpTransceiverDirection? currentDirection;
 
-    void stop();
+    undefined stop();
     // TODO: bug 1396922
-    // void setCodecPreferences(sequence<RTCRtpCodecCapability> codecs);
+    // undefined setCodecPreferences(sequence<RTCRtpCodecCapability> codecs);
 
     [ChromeOnly]
-    void setRemoteTrackId(DOMString trackId);
+    undefined setRemoteTrackId(DOMString trackId);
     [ChromeOnly]
     boolean remoteTrackIdIs(DOMString trackId);
 
@@ -47,31 +47,31 @@ interface RTCRtpTransceiver {
     DOMString getRemoteTrackId();
 
     [ChromeOnly]
-    void setAddTrackMagic();
+    undefined setAddTrackMagic();
     [ChromeOnly]
     readonly attribute boolean addTrackMagic;
     [ChromeOnly]
     attribute boolean shouldRemove;
     [ChromeOnly]
-    void setCurrentDirection(RTCRtpTransceiverDirection direction);
+    undefined setCurrentDirection(RTCRtpTransceiverDirection direction);
     [ChromeOnly]
-    void setDirectionInternal(RTCRtpTransceiverDirection direction);
+    undefined setDirectionInternal(RTCRtpTransceiverDirection direction);
     [ChromeOnly]
-    void setMid(DOMString mid);
+    undefined setMid(DOMString mid);
     [ChromeOnly]
-    void unsetMid();
+    undefined unsetMid();
     [ChromeOnly]
-    void setStopped();
+    undefined setStopped();
 
     [ChromeOnly]
     DOMString getKind();
     [ChromeOnly]
     boolean hasBeenUsedToSend();
     [ChromeOnly]
-    void sync();
+    undefined sync();
 
     [ChromeOnly]
-    void insertDTMF(DOMString tones,
+    undefined insertDTMF(DOMString tones,
                     optional unsigned long duration = 100,
                     optional unsigned long interToneGap = 70);
 };

--- a/crates/web-sys/webidls/enabled/Range.webidl
+++ b/crates/web-sys/webidls/enabled/Range.webidl
@@ -27,23 +27,23 @@ interface Range {
   readonly attribute Node commonAncestorContainer;
 
   [Throws, BinaryName="setStartJS"]
-  void setStart(Node refNode, unsigned long offset);
+  undefined setStart(Node refNode, unsigned long offset);
   [Throws, BinaryName="setEndJS"]
-  void setEnd(Node refNode, unsigned long offset);
+  undefined setEnd(Node refNode, unsigned long offset);
   [Throws, BinaryName="setStartBeforeJS"]
-  void setStartBefore(Node refNode);
+  undefined setStartBefore(Node refNode);
   [Throws, BinaryName="setStartAfterJS"]
-  void setStartAfter(Node refNode);
+  undefined setStartAfter(Node refNode);
   [Throws, BinaryName="setEndBeforeJS"]
-  void setEndBefore(Node refNode);
+  undefined setEndBefore(Node refNode);
   [Throws, BinaryName="setEndAfterJS"]
-  void setEndAfter(Node refNode);
+  undefined setEndAfter(Node refNode);
   [BinaryName="collapseJS"]
-  void collapse(optional boolean toStart = false);
+  undefined collapse(optional boolean toStart = false);
   [Throws, BinaryName="selectNodeJS"]
-  void selectNode(Node refNode);
+  undefined selectNode(Node refNode);
   [Throws, BinaryName="selectNodeContentsJS"]
-  void selectNodeContents(Node refNode);
+  undefined selectNodeContents(Node refNode);
 
   const unsigned short START_TO_START = 0;
   const unsigned short START_TO_END = 1;
@@ -52,18 +52,18 @@ interface Range {
   [Throws]
   short compareBoundaryPoints(unsigned short how, Range sourceRange);
   [CEReactions, Throws]
-  void deleteContents();
+  undefined deleteContents();
   [CEReactions, Throws]
   DocumentFragment extractContents();
   [CEReactions, Throws]
   DocumentFragment cloneContents();
   [CEReactions, Throws]
-  void insertNode(Node node);
+  undefined insertNode(Node node);
   [CEReactions, Throws]
-  void surroundContents(Node newParent);
+  undefined surroundContents(Node newParent);
 
   Range cloneRange();
-  void detach();
+  undefined detach();
 
   [Throws]
   boolean isPointInRange(Node node, unsigned long offset);

--- a/crates/web-sys/webidls/enabled/Request.webidl
+++ b/crates/web-sys/webidls/enabled/Request.webidl
@@ -35,7 +35,7 @@ interface Request {
 
   // Bug 1124638 - Allow chrome callers to set the context.
   [ChromeOnly]
-  void overrideContentPolicyType(nsContentPolicyType context);
+  undefined overrideContentPolicyType(nsContentPolicyType context);
 };
 Request includes Body;
 

--- a/crates/web-sys/webidls/enabled/SVGAngle.webidl
+++ b/crates/web-sys/webidls/enabled/SVGAngle.webidl
@@ -28,8 +28,8 @@ interface SVGAngle {
            attribute DOMString valueAsString;
 
   [Throws]
-  void newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
+  undefined newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
   [Throws]
-  void convertToSpecifiedUnits(unsigned short unitType);
+  undefined convertToSpecifiedUnits(unsigned short unitType);
 };
 

--- a/crates/web-sys/webidls/enabled/SVGAnimationElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGAnimationElement.webidl
@@ -21,13 +21,13 @@ interface SVGAnimationElement : SVGElement {
   float getSimpleDuration();
 
   [Throws]
-  void beginElement();
+  undefined beginElement();
   [Throws]
-  void beginElementAt(float offset);
+  undefined beginElementAt(float offset);
   [Throws]
-  void endElement();
+  undefined endElement();
   [Throws]
-  void endElementAt(float offset);
+  undefined endElementAt(float offset);
 };
 
 SVGAnimationElement includes SVGTests;

--- a/crates/web-sys/webidls/enabled/SVGElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGElement.webidl
@@ -24,8 +24,8 @@ interface SVGElement : Element {
 
   [SetterThrows, Pure]
         attribute long tabIndex;
-  [Throws] void focus();
-  [Throws] void blur();
+  [Throws] undefined focus();
+  [Throws] undefined blur();
 };
 
 SVGElement includes GlobalEventHandlers;

--- a/crates/web-sys/webidls/enabled/SVGFEDropShadowElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGFEDropShadowElement.webidl
@@ -22,7 +22,7 @@ interface SVGFEDropShadowElement : SVGElement {
   [Constant]
   readonly attribute SVGAnimatedNumber stdDeviationY;
 
-  void setStdDeviation(float stdDeviationX, float stdDeviationY);
+  undefined setStdDeviation(float stdDeviationX, float stdDeviationY);
 };
 
 SVGFEDropShadowElement includes SVGFilterPrimitiveStandardAttributes;

--- a/crates/web-sys/webidls/enabled/SVGFEGaussianBlurElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGFEGaussianBlurElement.webidl
@@ -18,7 +18,7 @@ interface SVGFEGaussianBlurElement : SVGElement {
   [Constant]
   readonly attribute SVGAnimatedNumber stdDeviationY;
 
-  void setStdDeviation(float stdDeviationX, float stdDeviationY);
+  undefined setStdDeviation(float stdDeviationX, float stdDeviationY);
 };
 
 SVGFEGaussianBlurElement includes SVGFilterPrimitiveStandardAttributes;

--- a/crates/web-sys/webidls/enabled/SVGLength.webidl
+++ b/crates/web-sys/webidls/enabled/SVGLength.webidl
@@ -34,7 +34,7 @@ interface SVGLength {
            attribute DOMString valueAsString;
 
   [Throws]
-  void newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
+  undefined newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
   [Throws]
-  void convertToSpecifiedUnits(unsigned short unitType);
+  undefined convertToSpecifiedUnits(unsigned short unitType);
 };

--- a/crates/web-sys/webidls/enabled/SVGLengthList.webidl
+++ b/crates/web-sys/webidls/enabled/SVGLengthList.webidl
@@ -13,7 +13,7 @@
 interface SVGLengthList {
   readonly attribute unsigned long numberOfItems;
   [Throws]
-  void clear();
+  undefined clear();
   [Throws]
   SVGLength initialize(SVGLength newItem);
   [Throws]

--- a/crates/web-sys/webidls/enabled/SVGMarkerElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGMarkerElement.webidl
@@ -37,9 +37,9 @@ interface SVGMarkerElement : SVGElement {
   [Constant]
   readonly attribute SVGAnimatedAngle orientAngle;
 
-  void setOrientToAuto();
+  undefined setOrientToAuto();
   [Throws]
-  void setOrientToAngle(SVGAngle angle);
+  undefined setOrientToAngle(SVGAngle angle);
 };
 
 SVGMarkerElement includes SVGFitToViewBox;

--- a/crates/web-sys/webidls/enabled/SVGNumberList.webidl
+++ b/crates/web-sys/webidls/enabled/SVGNumberList.webidl
@@ -13,7 +13,7 @@
 interface SVGNumberList {
   readonly attribute unsigned long numberOfItems;
   [Throws]
-  void clear();
+  undefined clear();
   [Throws]
   SVGNumber initialize(SVGNumber newItem);
   [Throws]

--- a/crates/web-sys/webidls/enabled/SVGPointList.webidl
+++ b/crates/web-sys/webidls/enabled/SVGPointList.webidl
@@ -13,7 +13,7 @@
 interface SVGPointList {
   readonly attribute unsigned long numberOfItems;
   [Throws]
-  void clear();
+  undefined clear();
   [Throws]
   SVGPoint initialize(SVGPoint newItem);
   [Throws]

--- a/crates/web-sys/webidls/enabled/SVGSVGElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGSVGElement.webidl
@@ -33,21 +33,21 @@ interface SVGSVGElement : SVGGraphicsElement {
   [DependsOn=Nothing, Affects=Nothing]
   unsigned long suspendRedraw(unsigned long maxWaitMilliseconds);
   [DependsOn=Nothing, Affects=Nothing]
-  void unsuspendRedraw(unsigned long suspendHandleID);
+  undefined unsuspendRedraw(unsigned long suspendHandleID);
   [DependsOn=Nothing, Affects=Nothing]
-  void unsuspendRedrawAll();
+  undefined unsuspendRedrawAll();
   [DependsOn=Nothing, Affects=Nothing]
-  void forceRedraw();
-  void pauseAnimations();
-  void unpauseAnimations();
+  undefined forceRedraw();
+  undefined pauseAnimations();
+  undefined unpauseAnimations();
   boolean animationsPaused();
   float getCurrentTime();
-  void setCurrentTime(float seconds);
+  undefined setCurrentTime(float seconds);
   // NodeList getIntersectionList(SVGRect rect, SVGElement referenceElement);
   // NodeList getEnclosureList(SVGRect rect, SVGElement referenceElement);
   // boolean checkIntersection(SVGElement element, SVGRect rect);
   // boolean checkEnclosure(SVGElement element, SVGRect rect);
-  void deselectAll();
+  undefined deselectAll();
   [NewObject]
   SVGNumber createSVGNumber();
   [NewObject]

--- a/crates/web-sys/webidls/enabled/SVGStringList.webidl
+++ b/crates/web-sys/webidls/enabled/SVGStringList.webidl
@@ -14,7 +14,7 @@ interface SVGStringList {
   readonly attribute unsigned long length;
   readonly attribute unsigned long numberOfItems;
 
-  void clear();
+  undefined clear();
   [Throws]
   DOMString initialize(DOMString newItem);
   [Throws]
@@ -28,5 +28,5 @@ interface SVGStringList {
   DOMString removeItem(unsigned long index);
   [Throws]
   DOMString appendItem(DOMString newItem);
-  //setter void (unsigned long index, DOMString newItem);
+  //setter undefined (unsigned long index, DOMString newItem);
 };

--- a/crates/web-sys/webidls/enabled/SVGTextContentElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGTextContentElement.webidl
@@ -36,7 +36,7 @@ interface SVGTextContentElement : SVGGraphicsElement {
   float getRotationOfChar(unsigned long charnum);
   long getCharNumAtPosition(SVGPoint point);
   [Throws]
-  void selectSubString(unsigned long charnum, unsigned long nchars);
+  undefined selectSubString(unsigned long charnum, unsigned long nchars);
 };
 
 

--- a/crates/web-sys/webidls/enabled/SVGTransform.webidl
+++ b/crates/web-sys/webidls/enabled/SVGTransform.webidl
@@ -26,16 +26,16 @@ interface SVGTransform {
   readonly attribute float angle;
 
   [Throws]
-  void setMatrix(SVGMatrix matrix);
+  undefined setMatrix(SVGMatrix matrix);
   [Throws]
-  void setTranslate(float tx, float ty);
+  undefined setTranslate(float tx, float ty);
   [Throws]
-  void setScale(float sx, float sy);
+  undefined setScale(float sx, float sy);
   [Throws]
-  void setRotate(float angle, float cx, float cy);
+  undefined setRotate(float angle, float cx, float cy);
   [Throws]
-  void setSkewX(float angle);
+  undefined setSkewX(float angle);
   [Throws]
-  void setSkewY(float angle);
+  undefined setSkewY(float angle);
 };
 

--- a/crates/web-sys/webidls/enabled/SVGTransformList.webidl
+++ b/crates/web-sys/webidls/enabled/SVGTransformList.webidl
@@ -13,7 +13,7 @@
 interface SVGTransformList {
   readonly attribute unsigned long numberOfItems;
   [Throws]
-  void clear();
+  undefined clear();
   [Throws]
   SVGTransform initialize(SVGTransform newItem);
   [Throws]

--- a/crates/web-sys/webidls/enabled/ScreenOrientation.webidl
+++ b/crates/web-sys/webidls/enabled/ScreenOrientation.webidl
@@ -30,9 +30,9 @@ enum OrientationLockType {
 
 interface ScreenOrientation : EventTarget {
   [Throws]
-  Promise<void> lock(OrientationLockType orientation);
+  Promise<undefined> lock(OrientationLockType orientation);
   [Throws]
-  void unlock();
+  undefined unlock();
   [Throws, NeedsCallerType]
   readonly attribute OrientationType type;
   [Throws, NeedsCallerType]

--- a/crates/web-sys/webidls/enabled/ScrollAreaEvent.webidl
+++ b/crates/web-sys/webidls/enabled/ScrollAreaEvent.webidl
@@ -11,7 +11,7 @@ interface ScrollAreaEvent : UIEvent
   readonly attribute float width;
   readonly attribute float height;
 
-  void initScrollAreaEvent(DOMString type,
+  undefined initScrollAreaEvent(DOMString type,
                            optional boolean canBubble = false,
                            optional boolean cancelable = false,
                            optional Window? view = null,

--- a/crates/web-sys/webidls/enabled/ScrollBoxObject.webidl
+++ b/crates/web-sys/webidls/enabled/ScrollBoxObject.webidl
@@ -14,18 +14,18 @@ interface ScrollBoxObject : BoxObject {
    * Values will be clamped to legal values.
    */
   [Throws]
-  void scrollTo(long x, long y);
+  undefined scrollTo(long x, long y);
 
   /**
    * Scroll the given amount of device pixels to the right and down.
    * Values will be clamped to make the resuling position legal.
    */
   [Throws]
-  void scrollBy(long dx, long dy);
+  undefined scrollBy(long dx, long dy);
   [Throws]
-  void scrollByIndex(long dindexes);
+  undefined scrollByIndex(long dindexes);
   [Throws]
-  void scrollToElement(Element child);
+  undefined scrollToElement(Element child);
 
   /**
    * Get the current scroll position in css pixels.
@@ -41,5 +41,5 @@ interface ScrollBoxObject : BoxObject {
   readonly attribute long scrolledHeight;
 
   [Throws]
-  void ensureElementIsVisible(Element child);
+  undefined ensureElementIsVisible(Element child);
 };

--- a/crates/web-sys/webidls/enabled/Selection.webidl
+++ b/crates/web-sys/webidls/enabled/Selection.webidl
@@ -31,38 +31,38 @@ interface Selection {
    * Adds a range to the current selection.
    */
   [Throws, BinaryName="addRangeJS"]
-  void      addRange(Range range);
+  undefined      addRange(Range range);
   /**
    * Removes a range from the current selection.
    */
   [Throws]
-  void      removeRange(Range range);
+  undefined      removeRange(Range range);
   /**
    * Removes all ranges from the current selection.
    */
   [Throws]
-  void      removeAllRanges();
+  undefined      removeAllRanges();
   [Throws, BinaryName="RemoveAllRanges"]
-  void      empty();
+  undefined      empty();
   [Throws, BinaryName="collapseJS"]
-  void      collapse(Node? node, optional unsigned long offset = 0);
+  undefined      collapse(Node? node, optional unsigned long offset = 0);
   [Throws, BinaryName="collapseJS"]
-  void      setPosition(Node? node, optional unsigned long offset = 0);
+  undefined      setPosition(Node? node, optional unsigned long offset = 0);
   [Throws, BinaryName="collapseToStartJS"]
-  void      collapseToStart();
+  undefined      collapseToStart();
   [Throws, BinaryName="collapseToEndJS"]
-  void      collapseToEnd();
+  undefined      collapseToEnd();
   [Throws, BinaryName="extendJS"]
-  void      extend(Node node, optional unsigned long offset = 0);
+  undefined      extend(Node node, optional unsigned long offset = 0);
   [Throws, BinaryName="setBaseAndExtentJS"]
-  void      setBaseAndExtent(Node anchorNode,
+  undefined      setBaseAndExtent(Node anchorNode,
                              unsigned long anchorOffset,
                              Node focusNode,
                              unsigned long focusOffset);
   [Throws, BinaryName="selectAllChildrenJS"]
-  void      selectAllChildren(Node node);
+  undefined      selectAllChildren(Node node);
   [CEReactions, Throws]
-  void      deleteFromDocument();
+  undefined      deleteFromDocument();
   [Throws]
   boolean   containsNode(Node node,
                          optional boolean allowPartialContainment = false);
@@ -72,7 +72,7 @@ interface Selection {
 // Additional methods not currently in the spec
 partial interface Selection {
   [Throws]
-  void modify(DOMString alter, DOMString direction,
+  undefined modify(DOMString alter, DOMString direction,
               DOMString granularity);
 };
 
@@ -93,9 +93,9 @@ partial interface Selection {
   [ChromeOnly,Throws]
   DOMString  toStringWithFormat(DOMString formatType, unsigned long flags, long wrapColumn);
   [ChromeOnly]
-  void  addSelectionListener(nsISelectionListener newListener);
+  undefined  addSelectionListener(nsISelectionListener newListener);
   [ChromeOnly]
-  void  removeSelectionListener(nsISelectionListener listenerToRemove);
+  undefined  removeSelectionListener(nsISelectionListener listenerToRemove);
 
   [ChromeOnly,BinaryName="rawType"]
   readonly attribute short selectionType;
@@ -121,7 +121,7 @@ partial interface Selection {
    * @param aHPercent how to align the frame horizontally.
    */
   [ChromeOnly,Throws]
-  void scrollIntoView(short aRegion, boolean aIsSynchronous, short aVPercent, short aHPercent);
+  undefined scrollIntoView(short aRegion, boolean aIsSynchronous, short aVPercent, short aHPercent);
 
   /**
    * setColors() sets custom colors for the selection.
@@ -144,12 +144,12 @@ partial interface Selection {
    *                             selection.
    */
   [ChromeOnly,Throws]
-  void setColors(DOMString aForegroundColor, DOMString aBackgroundColor,
+  undefined setColors(DOMString aForegroundColor, DOMString aBackgroundColor,
                  DOMString aAltForegroundColor, DOMString aAltBackgroundColor);
 
   /**
    * resetColors() forget the customized colors which were set by setColors().
    */
   [ChromeOnly,Throws]
-  void resetColors();
+  undefined resetColors();
 };

--- a/crates/web-sys/webidls/enabled/ServiceWorker.webidl
+++ b/crates/web-sys/webidls/enabled/ServiceWorker.webidl
@@ -20,7 +20,7 @@ interface ServiceWorker : EventTarget {
   attribute EventHandler onstatechange;
 
   [Throws]
-  void postMessage(any message, optional sequence<object> transferable = []);
+  undefined postMessage(any message, optional sequence<object> transferable = []);
 };
 
 ServiceWorker includes AbstractWorker;

--- a/crates/web-sys/webidls/enabled/ServiceWorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/ServiceWorkerGlobalScope.webidl
@@ -20,7 +20,7 @@ interface ServiceWorkerGlobalScope : WorkerGlobalScope {
   [SameObject] readonly attribute ServiceWorkerRegistration registration;
 
   [Throws, NewObject]
-  Promise<void> skipWaiting();
+  Promise<undefined> skipWaiting();
 
   attribute EventHandler oninstall;
   attribute EventHandler onactivate;

--- a/crates/web-sys/webidls/enabled/ServiceWorkerRegistration.webidl
+++ b/crates/web-sys/webidls/enabled/ServiceWorkerRegistration.webidl
@@ -21,7 +21,7 @@ interface ServiceWorkerRegistration : EventTarget {
   readonly attribute ServiceWorkerUpdateViaCache updateViaCache;
 
   [Throws, NewObject]
-  Promise<void> update();
+  Promise<undefined> update();
 
   [Throws, NewObject]
   Promise<boolean> unregister();
@@ -45,7 +45,7 @@ partial interface ServiceWorkerRegistration {
 // https://notifications.spec.whatwg.org/
 partial interface ServiceWorkerRegistration {
   [Throws, Func="mozilla::dom::DOMPrefs::NotificationEnabledInServiceWorkers"]
-  Promise<void> showNotification(DOMString title, optional NotificationOptions options);
+  Promise<undefined> showNotification(DOMString title, optional NotificationOptions options);
   [Throws, Func="mozilla::dom::DOMPrefs::NotificationEnabledInServiceWorkers"]
   Promise<sequence<Notification>> getNotifications(optional GetNotificationOptions filter);
 };

--- a/crates/web-sys/webidls/enabled/SharedWorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/SharedWorkerGlobalScope.webidl
@@ -18,7 +18,7 @@ interface SharedWorkerGlobalScope : WorkerGlobalScope {
   [Replaceable]
   readonly attribute DOMString name;
 
-  void close();
+  undefined close();
 
   attribute EventHandler onconnect;
 };

--- a/crates/web-sys/webidls/enabled/SourceBuffer.webidl
+++ b/crates/web-sys/webidls/enabled/SourceBuffer.webidl
@@ -37,27 +37,27 @@ interface SourceBuffer : EventTarget {
   attribute EventHandler onerror;
   attribute EventHandler onabort;
   [Throws]
-  void appendBuffer(ArrayBuffer data);
+  undefined appendBuffer(ArrayBuffer data);
   [Throws]
-  void appendBuffer(ArrayBufferView data);
+  undefined appendBuffer(ArrayBufferView data);
   // Experimental function as proposed in:
   // https://github.com/w3c/media-source/issues/100 for promise proposal.
   [Throws, Func="mozilla::dom::MediaSource::ExperimentalEnabled"]
-  Promise<void> appendBufferAsync(ArrayBuffer data);
+  Promise<undefined> appendBufferAsync(ArrayBuffer data);
   [Throws, Func="mozilla::dom::MediaSource::ExperimentalEnabled"]
-  Promise<void> appendBufferAsync(ArrayBufferView data);
+  Promise<undefined> appendBufferAsync(ArrayBufferView data);
   //[Throws]
-  //void appendStream(Stream stream, [EnforceRange] optional unsigned long long maxSize);
+  //undefined appendStream(Stream stream, [EnforceRange] optional unsigned long long maxSize);
   [Throws]
-  void abort();
+  undefined abort();
   [Throws]
-  void remove(double start, unrestricted double end);
+  undefined remove(double start, unrestricted double end);
   // Experimental function as proposed in:
   // https://github.com/w3c/media-source/issues/100 for promise proposal.
   [Throws, Func="mozilla::dom::MediaSource::ExperimentalEnabled"]
-  Promise<void> removeAsync(double start, unrestricted double end);
+  Promise<undefined> removeAsync(double start, unrestricted double end);
   // Experimental function as proposed in:
   // https://github.com/w3c/media-source/issues/155
   [Throws, Func="mozilla::dom::MediaSource::ExperimentalEnabled"]
-  void changeType(DOMString type);
+  undefined changeType(DOMString type);
 };

--- a/crates/web-sys/webidls/enabled/SpeechGrammarList.webidl
+++ b/crates/web-sys/webidls/enabled/SpeechGrammarList.webidl
@@ -17,7 +17,7 @@ interface SpeechGrammarList {
     [Throws]
     getter SpeechGrammar item(unsigned long index);
     [Throws]
-    void addFromURI(DOMString src, optional float weight);
+    undefined addFromURI(DOMString src, optional float weight);
     [Throws]
-    void addFromString(DOMString string, optional float weight);
+    undefined addFromString(DOMString string, optional float weight);
 };

--- a/crates/web-sys/webidls/enabled/SpeechRecognition.webidl
+++ b/crates/web-sys/webidls/enabled/SpeechRecognition.webidl
@@ -26,9 +26,9 @@ interface SpeechRecognition : EventTarget {
 
     // methods to drive the speech interaction
     [Throws, NeedsCallerType]
-    void start(optional MediaStream stream);
-    void stop();
-    void abort();
+    undefined start(optional MediaStream stream);
+    undefined stop();
+    undefined abort();
 
     // event methods
     attribute EventHandler onaudiostart;

--- a/crates/web-sys/webidls/enabled/SpeechSynthesis.webidl
+++ b/crates/web-sys/webidls/enabled/SpeechSynthesis.webidl
@@ -16,15 +16,15 @@ interface SpeechSynthesis : EventTarget{
   readonly attribute boolean speaking;
   readonly attribute boolean paused;
 
-  void speak(SpeechSynthesisUtterance utterance);
-  void cancel();
-  void pause();
-  void resume();
+  undefined speak(SpeechSynthesisUtterance utterance);
+  undefined cancel();
+  undefined pause();
+  undefined resume();
   sequence<SpeechSynthesisVoice> getVoices();
 
   attribute EventHandler onvoiceschanged;
 
   [ChromeOnly]
   // Force an utterance to end. Circumvents bad speech service implementations.
-  void forceEnd();
+  undefined forceEnd();
 };

--- a/crates/web-sys/webidls/enabled/Storage.webidl
+++ b/crates/web-sys/webidls/enabled/Storage.webidl
@@ -22,13 +22,13 @@ interface Storage {
   getter DOMString? getItem(DOMString key);
 
   [Throws, NeedsSubjectPrincipal]
-  setter void setItem(DOMString key, DOMString value);
+  setter undefined setItem(DOMString key, DOMString value);
 
   [Throws, NeedsSubjectPrincipal]
-  deleter void removeItem(DOMString key);
+  deleter undefined removeItem(DOMString key);
 
   [Throws, NeedsSubjectPrincipal]
-  void clear();
+  undefined clear();
 
   [ChromeOnly]
   readonly attribute boolean isSessionOnly;

--- a/crates/web-sys/webidls/enabled/StorageEvent.webidl
+++ b/crates/web-sys/webidls/enabled/StorageEvent.webidl
@@ -20,7 +20,7 @@ interface StorageEvent : Event
   readonly attribute Storage? storageArea;
 
   // Bug 1016053 - This is not spec compliant.
-  void initStorageEvent(DOMString type,
+  undefined initStorageEvent(DOMString type,
                         optional boolean canBubble = false,
                         optional boolean cancelable = false,
                         optional DOMString? key = null,

--- a/crates/web-sys/webidls/enabled/TCPServerSocket.webidl
+++ b/crates/web-sys/webidls/enabled/TCPServerSocket.webidl
@@ -38,5 +38,5 @@ interface TCPServerSocket : EventTarget {
   /**
    * Close the server socket.
    */
-  void close();
+  undefined close();
 };

--- a/crates/web-sys/webidls/enabled/TCPSocket.webidl
+++ b/crates/web-sys/webidls/enabled/TCPSocket.webidl
@@ -34,7 +34,7 @@ interface TCPSocket : EventTarget {
   /**
    * Upgrade an insecure connection to use TLS. Throws if the ready state is not OPEN.
    */
-  [Throws] void upgradeToSecure();
+  [Throws] undefined upgradeToSecure();
 
   /**
    * The UTF16 host of this socket object.
@@ -61,7 +61,7 @@ interface TCPSocket : EventTarget {
    * Pause reading incoming data and invocations of the ondata handler until
    * resume is called. Can be called multiple times without resuming.
    */
-  void suspend();
+  undefined suspend();
 
   /**
    * Resume reading incoming data and invoking ondata as usual. There must be
@@ -69,17 +69,17 @@ interface TCPSocket : EventTarget {
    * socket is not suspended.
    */
   [Throws]
-  void resume();
+  undefined resume();
 
   /**
    * Close the socket.
    */
-  void close();
+  undefined close();
 
   /**
    * Close the socket immediately without waiting for unsent data.
    */
-  [ChromeOnly] void closeImmediately();
+  [ChromeOnly] undefined closeImmediately();
 
   /**
    * Write data to the socket.
@@ -151,7 +151,7 @@ interface TCPSocket : EventTarget {
   /**
    * After send has buffered more than 64k of data, it returns false to
    * indicate that the client should pause before sending more data, to
-   * avoid accumulating large buffers. This is only advisory, and the client
+   * aundefined accumulating large buffers. This is only advisory, and the client
    * is free to ignore it and buffer as much data as desired, but if reducing
    * the size of buffers is important (especially for a streaming application)
    * the "drain" event will be dispatched once the previously-buffered data has

--- a/crates/web-sys/webidls/enabled/TextEncoder.webidl
+++ b/crates/web-sys/webidls/enabled/TextEncoder.webidl
@@ -17,10 +17,10 @@ interface TextEncoder {
   readonly attribute DOMString encoding;
   /*
    * This is spec-wise USVString but marking it as
-   * DOMString to avoid duplicate work. Since the
+   * DOMString to aundefined duplicate work. Since the
    * UTF-16 to UTF-8 converter performs processing
    * that's equivalent to first converting a
-   * DOMString to a USVString, let's avoid having
+   * DOMString to a USVString, let's aundefined having
    * the binding code doing it, too.
    */
   [NewObject]

--- a/crates/web-sys/webidls/enabled/TextTrack.webidl
+++ b/crates/web-sys/webidls/enabled/TextTrack.webidl
@@ -34,9 +34,9 @@ interface TextTrack : EventTarget {
   readonly attribute TextTrackCueList? cues;
   readonly attribute TextTrackCueList? activeCues;
 
-  void addCue(VTTCue cue);
+  undefined addCue(VTTCue cue);
   [Throws]
-  void removeCue(VTTCue cue);
+  undefined removeCue(VTTCue cue);
 
            attribute EventHandler oncuechange;
 };

--- a/crates/web-sys/webidls/enabled/TimeEvent.webidl
+++ b/crates/web-sys/webidls/enabled/TimeEvent.webidl
@@ -14,7 +14,7 @@ interface TimeEvent : Event
 {
   readonly attribute long         detail;
   readonly attribute WindowProxy? view;
-  void initTimeEvent(DOMString aType,
+  undefined initTimeEvent(DOMString aType,
                      optional Window? aView = null,
                      optional long aDetail = 0);
 };

--- a/crates/web-sys/webidls/enabled/TouchEvent.webidl
+++ b/crates/web-sys/webidls/enabled/TouchEvent.webidl
@@ -22,7 +22,7 @@ interface TouchEvent : UIEvent {
   readonly attribute boolean ctrlKey;
   readonly attribute boolean shiftKey;
 
-  void initTouchEvent(DOMString type,
+  undefined initTouchEvent(DOMString type,
                       optional boolean canBubble = false,
                       optional boolean cancelable = false,
                       optional Window? view = null,

--- a/crates/web-sys/webidls/enabled/TransceiverImpl.webidl
+++ b/crates/web-sys/webidls/enabled/TransceiverImpl.webidl
@@ -18,6 +18,6 @@
 interface TransceiverImpl {
   MediaStreamTrack getReceiveTrack();
   [Throws]
-  void syncWithJS(RTCRtpTransceiver transceiver);
+  undefined syncWithJS(RTCRtpTransceiver transceiver);
 };
 

--- a/crates/web-sys/webidls/enabled/TreeBoxObject.webidl
+++ b/crates/web-sys/webidls/enabled/TreeBoxObject.webidl
@@ -70,25 +70,25 @@ interface TreeBoxObject : BoxObject {
   /**
    * Ensures that a row at a given index is visible.
    */
-  void ensureRowIsVisible(long index);
+  undefined ensureRowIsVisible(long index);
 
   /**
    * Ensures that a given cell in the tree is visible.
    */
   [Throws]
-  void ensureCellIsVisible(long row, TreeColumn? col);
+  undefined ensureCellIsVisible(long row, TreeColumn? col);
 
   /**
    * Scrolls such that the row at index is at the top of the visible view.
    */
-  void scrollToRow(long index);
+  undefined scrollToRow(long index);
 
   /**
    * Scroll the tree up or down by numLines lines. Positive
    * values move down in the tree. Prevents scrolling off the
    * end of the tree.
    */
-  void scrollByLines(long numLines);
+  undefined scrollByLines(long numLines);
 
   /**
    * Scroll the tree up or down by numPages pages. A page
@@ -96,16 +96,16 @@ interface TreeBoxObject : BoxObject {
    * Positive values move down in the tree. Prevents scrolling
    * off the end of the tree.
    */
-  void scrollByPages(long numPages);
+  undefined scrollByPages(long numPages);
 
   /**
    * Invalidation methods for fine-grained painting control.
    */
-  void invalidate();
-  void invalidateColumn(TreeColumn? col);
-  void invalidateRow(long index);
-  void invalidateCell(long row, TreeColumn? col);
-  void invalidateRange(long startIndex, long endIndex);
+  undefined invalidate();
+  undefined invalidateColumn(TreeColumn? col);
+  undefined invalidateRow(long index);
+  undefined invalidateCell(long row, TreeColumn? col);
+  undefined invalidateRange(long startIndex, long endIndex);
 
   /**
    * A hit test that can tell you what row the mouse is over.
@@ -133,7 +133,7 @@ interface TreeBoxObject : BoxObject {
    * DEPRECATED: please use above version
    */
   [Throws]
-  void getCellAt(long x, long y, object row, object column, object childElt);
+  undefined getCellAt(long x, long y, object row, object column, object childElt);
 
   /**
    * Find the coordinates of an element within a specific cell.
@@ -145,7 +145,7 @@ interface TreeBoxObject : BoxObject {
    * DEPRECATED: Please use above version
    */
   [Throws]
-  void getCoordsForCellItem(long row, TreeColumn col, DOMString element,
+  undefined getCoordsForCellItem(long row, TreeColumn col, DOMString element,
                             object x, object y, object width, object height);
 
   /**
@@ -160,7 +160,7 @@ interface TreeBoxObject : BoxObject {
    * rows were added or at which rows were removed.  For
    * non-contiguous additions/removals, this method should be called multiple times.
    */
-  void rowCountChanged(long index, long count);
+  undefined rowCountChanged(long index, long count);
 
   /**
    * Notify the tree that the view is about to perform a batch
@@ -168,21 +168,21 @@ interface TreeBoxObject : BoxObject {
    * This must be followed by calling endUpdateBatch(), otherwise the tree
    * will get out of sync.
    */
-  void beginUpdateBatch();
+  undefined beginUpdateBatch();
 
   /**
    * Notify the tree that the view has completed a batch update.
    */
-  void endUpdateBatch();
+  undefined endUpdateBatch();
 
   /**
    * Called on a theme switch to flush out the tree's style and image caches.
    */
-  void clearStyleAndImageCaches();
+  undefined clearStyleAndImageCaches();
 
   /**
    * Remove an image source from the image cache to allow its invalidation.
    */
   [Throws]
-  void removeImageCacheEntry(long row, TreeColumn col);
+  undefined removeImageCacheEntry(long row, TreeColumn col);
 };

--- a/crates/web-sys/webidls/enabled/TreeView.webidl
+++ b/crates/web-sys/webidls/enabled/TreeView.webidl
@@ -88,7 +88,7 @@ interface TreeView
    * specifies before/on/after the given |row|.
    */
   [Throws]
-  void drop(long row, long orientation, DataTransfer? dataTransfer);
+  undefined drop(long row, long orientation, DataTransfer? dataTransfer);
 
   /**
    * Methods used by the tree to draw thread lines in the tree.
@@ -141,29 +141,29 @@ interface TreeView
    * Called during initialization to link the view to the front end box object.
    */
   [Throws]
-  void setTree(TreeBoxObject? tree);
+  undefined setTree(TreeBoxObject? tree);
   
   /**
    * Called on the view when an item is opened or closed.
    */
   [Throws]
-  void toggleOpenState(long row);
+  undefined toggleOpenState(long row);
 
   /**
    * Called on the view when a header is clicked.
    */
   [Throws]
-  void cycleHeader(TreeColumn column);
+  undefined cycleHeader(TreeColumn column);
 
   /**
    * Should be called from a XUL onselect handler whenever the selection changes.
    */
-  void selectionChanged();
+  undefined selectionChanged();
 
   /**
    * Called on the view when a cell in a non-selectable cycling column (e.g., unread/flag/etc.) is clicked.
    */
-  void cycleCell(long row, TreeColumn column);
+  undefined cycleCell(long row, TreeColumn column);
   
   /**
    * isEditable is called to ask the view if the cell contents are editable.
@@ -186,28 +186,28 @@ interface TreeView
    * This method is only called for columns of type other than |text|.
    */
   [Throws]
-  void setCellValue(long row, TreeColumn column, DOMString value);
+  undefined setCellValue(long row, TreeColumn column, DOMString value);
 
   /**
    * setCellText is called when the contents of the cell have been edited by the user.
    */   
   [Throws]
-  void setCellText(long row, TreeColumn column, DOMString value);
+  undefined setCellText(long row, TreeColumn column, DOMString value);
 
   /**
    * A command API that can be used to invoke commands on the selection.  The tree
    * will automatically invoke this method when certain keys are pressed.  For example,
    * when the DEL key is pressed, performAction will be called with the "delete" string.
    */
-  void performAction(DOMString action);
+  undefined performAction(DOMString action);
 
   /**
    * A command API that can be used to invoke commands on a specific row.
    */
-  void performActionOnRow(DOMString action, long row);
+  undefined performActionOnRow(DOMString action, long row);
 
   /**
    * A command API that can be used to invoke commands on a specific cell.
    */
-  void performActionOnCell(DOMString action, long row, TreeColumn column);
+  undefined performActionOnCell(DOMString action, long row, TreeColumn column);
 };

--- a/crates/web-sys/webidls/enabled/U2F.webidl
+++ b/crates/web-sys/webidls/enabled/U2F.webidl
@@ -63,8 +63,8 @@ dictionary SignResponse {
     DOMString? errorMessage;
 };
 
-callback U2FRegisterCallback = void(RegisterResponse response);
-callback U2FSignCallback = void(SignResponse response);
+callback U2FRegisterCallback = undefined(RegisterResponse response);
+callback U2FSignCallback = undefined(SignResponse response);
 
 [SecureContext, Pref="security.webauth.u2f"]
 interface U2F {
@@ -79,14 +79,14 @@ interface U2F {
   const unsigned short TIMEOUT = 5;
 
   [Throws]
-  void register (DOMString appId,
+  undefined register (DOMString appId,
                  sequence<RegisterRequest> registerRequests,
                  sequence<RegisteredKey> registeredKeys,
                  U2FRegisterCallback callback,
                  optional long? opt_timeoutSeconds);
 
   [Throws]
-  void sign (DOMString appId,
+  undefined sign (DOMString appId,
              DOMString challenge,
              sequence<RegisteredKey> registeredKeys,
              U2FSignCallback callback,

--- a/crates/web-sys/webidls/enabled/UDPSocket.webidl
+++ b/crates/web-sys/webidls/enabled/UDPSocket.webidl
@@ -28,13 +28,13 @@ interface UDPSocket : EventTarget {
     readonly    attribute boolean          addressReuse;
     readonly    attribute boolean          loopback;
     readonly    attribute SocketReadyState readyState;
-    readonly    attribute Promise<void>    opened;
-    readonly    attribute Promise<void>    closed;
+    readonly    attribute Promise<undefined>    opened;
+    readonly    attribute Promise<undefined>    closed;
 //    readonly    attribute ReadableStream   input; //Bug 1056444: Stream API is not ready
 //    readonly    attribute WriteableStream  output; //Bug 1056444: Stream API is not ready
                 attribute EventHandler     onmessage; //Bug 1056444: use event interface before Stream API is ready
-    Promise<void> close ();
-    [Throws] void    joinMulticastGroup (DOMString multicastGroupAddress);
-    [Throws] void    leaveMulticastGroup (DOMString multicastGroupAddress);
+    Promise<undefined> close ();
+    [Throws] undefined    joinMulticastGroup (DOMString multicastGroupAddress);
+    [Throws] undefined    leaveMulticastGroup (DOMString multicastGroupAddress);
     [Throws] boolean send ((DOMString or Blob or ArrayBuffer or ArrayBufferView) data, optional DOMString? remoteAddress, optional unsigned short? remotePort); //Bug 1056444: use send method before Stream API is ready
 };

--- a/crates/web-sys/webidls/enabled/UIEvent.webidl
+++ b/crates/web-sys/webidls/enabled/UIEvent.webidl
@@ -15,7 +15,7 @@ interface UIEvent : Event
 {
   readonly attribute WindowProxy? view;
   readonly attribute long         detail;
-  void initUIEvent(DOMString aType,
+  undefined initUIEvent(DOMString aType,
                    optional boolean aCanBubble = false,
                    optional boolean aCancelable = false,
                    optional Window? aView = null,

--- a/crates/web-sys/webidls/enabled/URL.webidl
+++ b/crates/web-sys/webidls/enabled/URL.webidl
@@ -44,7 +44,7 @@ partial interface URL {
   [Throws]
   static DOMString createObjectURL(Blob blob);
   [Throws]
-  static void revokeObjectURL(DOMString url);
+  static undefined revokeObjectURL(DOMString url);
   [ChromeOnly, Throws]
   static boolean isValidURL(DOMString url);
 };

--- a/crates/web-sys/webidls/enabled/URLSearchParams.webidl
+++ b/crates/web-sys/webidls/enabled/URLSearchParams.webidl
@@ -16,15 +16,15 @@
 [Constructor(optional (sequence<sequence<USVString>> or record<USVString, USVString> or USVString) init = ""),
  Exposed=(Window,Worker,WorkerDebugger,System)]
 interface URLSearchParams {
-  void append(USVString name, USVString value);
-  void delete(USVString name);
+  undefined append(USVString name, USVString value);
+  undefined delete(USVString name);
   USVString? get(USVString name);
   sequence<USVString> getAll(USVString name);
   boolean has(USVString name);
-  void set(USVString name, USVString value);
+  undefined set(USVString name, USVString value);
 
   [Throws]
-  void sort();
+  undefined sort();
 
   iterable<USVString, USVString>;
   stringifier;

--- a/crates/web-sys/webidls/enabled/VRDisplay.webidl
+++ b/crates/web-sys/webidls/enabled/VRDisplay.webidl
@@ -258,7 +258,7 @@ interface VRDisplay : EventTarget {
    * updated when calling resetPose(). This should be called in only
    * sitting-space experiences.
    */
-  void resetPose();
+  undefined resetPose();
 
   /**
    * z-depth defining the near plane of the eye view frustum
@@ -289,18 +289,18 @@ interface VRDisplay : EventTarget {
    * Passing the value returned by `requestAnimationFrame` to
    * `cancelAnimationFrame` will unregister the callback.
    */
-  [Throws] void cancelAnimationFrame(long handle);
+  [Throws] undefined cancelAnimationFrame(long handle);
 
   /**
    * Begin presenting to the VRDisplay. Must be called in response to a user gesture.
    * Repeat calls while already presenting will update the VRLayers being displayed.
    */
-  [Throws, NeedsCallerType] Promise<void> requestPresent(sequence<VRLayer> layers);
+  [Throws, NeedsCallerType] Promise<undefined> requestPresent(sequence<VRLayer> layers);
 
   /**
    * Stops presenting to the VRDisplay.
    */
-  [Throws] Promise<void> exitPresent();
+  [Throws] Promise<undefined> exitPresent();
 
   /**
    * Get the layers currently being presented.
@@ -313,5 +313,5 @@ interface VRDisplay : EventTarget {
    * canvas as any other operation that uses its source image, and canvases
    * created without preserveDrawingBuffer set to true will be cleared.
    */
-  void submitFrame();
+  undefined submitFrame();
 };

--- a/crates/web-sys/webidls/enabled/VRServiceTest.webidl
+++ b/crates/web-sys/webidls/enabled/VRServiceTest.webidl
@@ -8,23 +8,23 @@
 [Pref="dom.vr.test.enabled",
  HeaderFile="mozilla/dom/VRServiceTest.h"]
 interface VRMockDisplay {
-  void setEyeResolution(unsigned long aRenderWidth, unsigned long aRenderHeight);
-  void setEyeParameter(VREye eye, double offsetX, double offsetY, double offsetZ,
+  undefined setEyeResolution(unsigned long aRenderWidth, unsigned long aRenderHeight);
+  undefined setEyeParameter(VREye eye, double offsetX, double offsetY, double offsetZ,
                        double upDegree, double rightDegree,
                        double downDegree, double leftDegree);
-  void setPose(Float32Array? position, Float32Array? linearVelocity,
+  undefined setPose(Float32Array? position, Float32Array? linearVelocity,
                Float32Array? linearAcceleration, Float32Array? orientation,
                Float32Array? angularVelocity, Float32Array? angularAcceleration);
-  void setMountState(boolean isMounted);
-  void update();
+  undefined setMountState(boolean isMounted);
+  undefined update();
 };
 
 [Pref="dom.vr.test.enabled",
  HeaderFile="mozilla/dom/VRServiceTest.h"]
 interface VRMockController {
-  void newButtonEvent(unsigned long button, boolean pressed);
-  void newAxisMoveEvent(unsigned long axis, double value);
-  void newPoseMove(Float32Array? position, Float32Array? linearVelocity,
+  undefined newButtonEvent(unsigned long button, boolean pressed);
+  undefined newAxisMoveEvent(unsigned long axis, double value);
+  undefined newPoseMove(Float32Array? position, Float32Array? linearVelocity,
                    Float32Array? linearAcceleration, Float32Array? orientation,
                    Float32Array? angularVelocity, Float32Array? angularAcceleration);
 };

--- a/crates/web-sys/webidls/enabled/VideoStreamTrack.webidl
+++ b/crates/web-sys/webidls/enabled/VideoStreamTrack.webidl
@@ -13,7 +13,7 @@
 // [Constructor(optional MediaTrackConstraints videoConstraints)]
 interface VideoStreamTrack : MediaStreamTrack {
 //    static sequence<DOMString> getSourceIds ();
-//    void                       takePhoto ();
+//    undefined                       takePhoto ();
 //                attribute EventHandler onphoto;
 //                attribute EventHandler onphotoerror;
 };

--- a/crates/web-sys/webidls/enabled/WebComponents.webidl
+++ b/crates/web-sys/webidls/enabled/WebComponents.webidl
@@ -10,11 +10,11 @@
  * liability, trademark and document use rules apply.
  */
 
-callback LifecycleConnectedCallback = void();
-callback LifecycleDisconnectedCallback = void();
-callback LifecycleAdoptedCallback = void(Document? oldDocument,
+callback LifecycleConnectedCallback = undefined();
+callback LifecycleDisconnectedCallback = undefined();
+callback LifecycleAdoptedCallback = undefined(Document? oldDocument,
                                          Document? newDocment);
-callback LifecycleAttributeChangedCallback = void(DOMString attrName,
+callback LifecycleAttributeChangedCallback = undefined(DOMString attrName,
                                                   DOMString? oldValue,
                                                   DOMString? newValue,
                                                   DOMString? namespaceURI);

--- a/crates/web-sys/webidls/enabled/WebGL2RenderingContext.webidl
+++ b/crates/web-sys/webidls/enabled/WebGL2RenderingContext.webidl
@@ -304,237 +304,237 @@ interface mixin WebGL2RenderingContextBase
 
     /* Buffer objects */
     // WebGL1:
-    void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-    void bufferData(GLenum target, ArrayBuffer? srcData, GLenum usage);
-    void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage);
-    void bufferSubData(GLenum target, GLintptr offset, ArrayBuffer srcData);
-    void bufferSubData(GLenum target, GLintptr offset, ArrayBufferView srcData);
+    undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
+    undefined bufferData(GLenum target, ArrayBuffer? srcData, GLenum usage);
+    undefined bufferData(GLenum target, ArrayBufferView srcData, GLenum usage);
+    undefined bufferSubData(GLenum target, GLintptr offset, ArrayBuffer srcData);
+    undefined bufferSubData(GLenum target, GLintptr offset, ArrayBufferView srcData);
     // WebGL2:
-    void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage,
+    undefined bufferData(GLenum target, ArrayBufferView srcData, GLenum usage,
                     GLuint srcOffset, optional GLuint length = 0);
-    void bufferSubData(GLenum target, GLintptr dstByteOffset, ArrayBufferView srcData,
+    undefined bufferSubData(GLenum target, GLintptr dstByteOffset, ArrayBufferView srcData,
                        GLuint srcOffset, optional GLuint length = 0);
 
-    void copyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
+    undefined copyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
                            GLintptr writeOffset, GLsizeiptr size);
     // MapBufferRange, in particular its read-only and write-only modes,
     // can not be exposed safely to JavaScript. GetBufferSubData
     // replaces it for the purpose of fetching data back from the GPU.
-    void getBufferSubData(GLenum target, GLintptr srcByteOffset, ArrayBufferView dstData,
+    undefined getBufferSubData(GLenum target, GLintptr srcByteOffset, ArrayBufferView dstData,
                           optional GLuint dstOffset = 0, optional GLuint length = 0);
 
     /* Framebuffer objects */
-    void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
+    undefined blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
                          GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-    void framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
+    undefined framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level,
                                  GLint layer);
 
     [Throws]
-    void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
+    undefined invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
 
     [Throws]
-    void invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
+    undefined invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
                                   GLint x, GLint y, GLsizei width, GLsizei height);
 
-    void readBuffer(GLenum src);
+    undefined readBuffer(GLenum src);
 
     /* Renderbuffer objects */
     [Throws]
     any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
-    void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat,
+    undefined renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat,
                                         GLsizei width, GLsizei height);
 
     /* Texture objects */
-    void texStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    undefined texStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
                       GLsizei height);
-    void texStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
+    undefined texStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width,
                       GLsizei height, GLsizei depth);
 
     // WebGL1 legacy entrypoints:
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
                     GLenum type, ArrayBufferView? pixels);
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, HTMLCanvasElement source); // May throw DOMException
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, HTMLImageElement source); // May throw DOMException
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, HTMLVideoElement source); // May throw DOMException
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, ImageBitmap source);
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, ImageData source);
 
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLsizei width, GLsizei height,
                        GLenum format, GLenum type, ArrayBufferView? pixels);
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLCanvasElement source); // May throw DOMException
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLImageElement source); // May throw DOMException
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLVideoElement source); // May throw DOMException
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, ImageBitmap source);
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, ImageData source);
 
     // WebGL2 entrypoints:
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type, GLintptr pboOffset);
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
                     HTMLCanvasElement source); // May throw DOMException
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
                     HTMLImageElement source); // May throw DOMException
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
                     HTMLVideoElement source); // May throw DOMException
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
                     ImageBitmap source);
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type,
                     ImageData source);
     [Throws] // Another overhead throws.
-    void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLint border, GLenum format, GLenum type, ArrayBufferView srcData,
                     GLuint srcOffset);
 
     [Throws] // Another overhead throws.
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type, GLintptr pboOffset);
     [Throws]
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
                     HTMLCanvasElement source); // May throw DOMException
     [Throws]
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
                     HTMLImageElement source); // May throw DOMException
     [Throws]
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
                     HTMLVideoElement source); // May throw DOMException
     [Throws] // Another overhead throws.
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
                     ImageBitmap source);
     [Throws] // Another overhead throws.
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type,
                     ImageData source);
     [Throws] // Another overhead throws.
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView? srcData);
     [Throws] // Another overhead throws.
-    void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                     GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView srcData,
                     GLuint srcOffset);
 
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type, GLintptr pboOffset);
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type,
                        HTMLCanvasElement source); // May throw DOMException
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type,
                        HTMLImageElement source); // May throw DOMException
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type,
                        HTMLVideoElement source); // May throw DOMException
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type,
                        ImageBitmap source);
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type,
                        ImageData source);
     [Throws] // Another overhead throws.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                        GLsizei height, GLenum format, GLenum type, ArrayBufferView srcData,
                        GLuint srcOffset);
 
     [Throws] // Another overhead throws.
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        GLintptr pboOffset);
     [Throws]
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        HTMLCanvasElement source); // May throw DOMException
     [Throws]
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        HTMLImageElement source); // May throw DOMException
     [Throws]
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        HTMLVideoElement source); // May throw DOMException
     [Throws] // Another overhead throws.
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        ImageBitmap source);
     [Throws] // Another overhead throws.
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        ImageData source);
     [Throws] // Another overhead throws.
-    void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                        GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
                        ArrayBufferView? srcData, optional GLuint srcOffset = 0);
 
-    void copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
+    undefined copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                            GLint x, GLint y, GLsizei width, GLsizei height);
 
-    void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                               GLsizei height, GLint border, GLsizei imageSize,  GLintptr offset);
-    void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                               GLsizei height, GLint border, ArrayBufferView srcData,
                               optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
-    void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                               GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, GLintptr offset);
-    void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
+    undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                               GLsizei height, GLsizei depth, GLint border, ArrayBufferView srcData,
                               optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
-    void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                  GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, GLintptr offset);
-    void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                  GLsizei width, GLsizei height, GLenum format,
                                  ArrayBufferView srcData,
                                  optional GLuint srcOffset = 0,
                                  optional GLuint srcLengthOverride = 0);
 
-    void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                  GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                  GLenum format, GLsizei imageSize, GLintptr offset);
-    void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                  GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                  GLenum format, ArrayBufferView srcData,
                                  optional GLuint srcOffset = 0,
@@ -544,139 +544,139 @@ interface mixin WebGL2RenderingContextBase
     [WebGLHandlesContextLoss] GLint getFragDataLocation(WebGLProgram program, DOMString name);
 
     /* Uniforms */
-    void uniform1ui(WebGLUniformLocation? location, GLuint v0);
-    void uniform2ui(WebGLUniformLocation? location, GLuint v0, GLuint v1);
-    void uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
-    void uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
+    undefined uniform1ui(WebGLUniformLocation? location, GLuint v0);
+    undefined uniform2ui(WebGLUniformLocation? location, GLuint v0, GLuint v1);
+    undefined uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
+    undefined uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
 
-    void uniform1fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+    undefined uniform1fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
-    void uniform2fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+    undefined uniform2fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
-    void uniform3fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+    undefined uniform3fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
-    void uniform4fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
-                    optional GLuint srcLength = 0);
-
-    void uniform1iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-                    optional GLuint srcLength = 0);
-    void uniform2iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-                    optional GLuint srcLength = 0);
-    void uniform3iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
-                    optional GLuint srcLength = 0);
-    void uniform4iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+    undefined uniform4fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
 
-    void uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+    undefined uniform1iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
-    void uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+    undefined uniform2iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
-    void uniform3uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+    undefined uniform3iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
-    void uniform4uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+    undefined uniform4iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
                     optional GLuint srcLength = 0);
 
-    void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    undefined uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    undefined uniform3uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+    undefined uniform4uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+                    optional GLuint srcLength = 0);
+
+    undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                           optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    void uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    void uniformMatrix4x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix4x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
 
-    void uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                           optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    void uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
 
-    void uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    void uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
-    void uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
+    undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
                           optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
 
     /* Vertex attribs */
-    void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
-    void vertexAttribI4iv(GLuint index, Int32List values);
-    void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
-    void vertexAttribI4uiv(GLuint index, Uint32List values);
-    void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
+    undefined vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
+    undefined vertexAttribI4iv(GLuint index, Int32List values);
+    undefined vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
+    undefined vertexAttribI4uiv(GLuint index, Uint32List values);
+    undefined vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
 
     /* Writing to the drawing buffer */
-    void vertexAttribDivisor(GLuint index, GLuint divisor);
-    void drawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount);
-    void drawElementsInstanced(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei instanceCount);
-    void drawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, GLintptr offset);
+    undefined vertexAttribDivisor(GLuint index, GLuint divisor);
+    undefined drawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount);
+    undefined drawElementsInstanced(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei instanceCount);
+    undefined drawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, GLintptr offset);
 
     /* Reading back pixels */
     // WebGL1:
     [Throws, NeedsCallerType] // Throws on readback in a write-only context.
-    void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
                     ArrayBufferView? dstData);
     // WebGL2:
     [Throws, NeedsCallerType] // Throws on readback in a write-only context.
-    void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
                     GLintptr offset);
     [Throws, NeedsCallerType] // Throws on readback in a write-only context.
-    void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
+    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
                     ArrayBufferView dstData, GLuint dstOffset);
 
     /* Multiple Render Targets */
-    void drawBuffers(sequence<GLenum> buffers);
+    undefined drawBuffers(sequence<GLenum> buffers);
 
-    void clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
+    undefined clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
                        optional GLuint srcOffset = 0);
-    void clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values,
+    undefined clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values,
                        optional GLuint srcOffset = 0);
-    void clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values,
+    undefined clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values,
                         optional GLuint srcOffset = 0);
 
-    void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
+    undefined clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
 
     /* Query Objects */
     WebGLQuery? createQuery();
-    void deleteQuery(WebGLQuery? query);
+    undefined deleteQuery(WebGLQuery? query);
     [WebGLHandlesContextLoss] GLboolean isQuery(WebGLQuery? query);
-    void beginQuery(GLenum target, WebGLQuery query);
-    void endQuery(GLenum target);
+    undefined beginQuery(GLenum target, WebGLQuery query);
+    undefined endQuery(GLenum target);
     any getQuery(GLenum target, GLenum pname);
     any getQueryParameter(WebGLQuery query, GLenum pname);
 
     /* Sampler Objects */
     WebGLSampler? createSampler();
-    void deleteSampler(WebGLSampler? sampler);
+    undefined deleteSampler(WebGLSampler? sampler);
     [WebGLHandlesContextLoss] GLboolean isSampler(WebGLSampler? sampler);
-    void bindSampler(GLuint unit, WebGLSampler? sampler);
-    void samplerParameteri(WebGLSampler sampler, GLenum pname, GLint param);
-    void samplerParameterf(WebGLSampler sampler, GLenum pname, GLfloat param);
+    undefined bindSampler(GLuint unit, WebGLSampler? sampler);
+    undefined samplerParameteri(WebGLSampler sampler, GLenum pname, GLint param);
+    undefined samplerParameterf(WebGLSampler sampler, GLenum pname, GLfloat param);
     any getSamplerParameter(WebGLSampler sampler, GLenum pname);
 
     /* Sync objects */
     WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
     [WebGLHandlesContextLoss] GLboolean isSync(WebGLSync? sync);
-    void deleteSync(WebGLSync? sync);
+    undefined deleteSync(WebGLSync? sync);
     GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout);
-    void waitSync(WebGLSync sync, GLbitfield flags, GLint64 timeout);
+    undefined waitSync(WebGLSync sync, GLbitfield flags, GLint64 timeout);
     any getSyncParameter(WebGLSync sync, GLenum pname);
 
     /* Transform Feedback */
     WebGLTransformFeedback? createTransformFeedback();
-    void deleteTransformFeedback(WebGLTransformFeedback? tf);
+    undefined deleteTransformFeedback(WebGLTransformFeedback? tf);
     [WebGLHandlesContextLoss] GLboolean isTransformFeedback(WebGLTransformFeedback? tf);
-    void bindTransformFeedback(GLenum target, WebGLTransformFeedback? tf);
-    void beginTransformFeedback(GLenum primitiveMode);
-    void endTransformFeedback();
-    void transformFeedbackVaryings(WebGLProgram program, sequence<DOMString> varyings, GLenum bufferMode);
+    undefined bindTransformFeedback(GLenum target, WebGLTransformFeedback? tf);
+    undefined beginTransformFeedback(GLenum primitiveMode);
+    undefined endTransformFeedback();
+    undefined transformFeedbackVaryings(WebGLProgram program, sequence<DOMString> varyings, GLenum bufferMode);
     [NewObject]
     WebGLActiveInfo? getTransformFeedbackVarying(WebGLProgram program, GLuint index);
-    void pauseTransformFeedback();
-    void resumeTransformFeedback();
+    undefined pauseTransformFeedback();
+    undefined resumeTransformFeedback();
 
     /* Uniform Buffer Objects and Transform Feedback Buffers */
-    void bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer);
-    void bindBufferRange(GLenum target, GLuint index, WebGLBuffer? buffer, GLintptr offset, GLsizeiptr size);
+    undefined bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer);
+    undefined bindBufferRange(GLenum target, GLuint index, WebGLBuffer? buffer, GLintptr offset, GLsizeiptr size);
     [Throws] // GetOrCreateDOMReflector can fail.
     any getIndexedParameter(GLenum target, GLuint index);
     sequence<GLuint>? getUniformIndices(WebGLProgram program, sequence<DOMString> uniformNames);
@@ -685,13 +685,13 @@ interface mixin WebGL2RenderingContextBase
     [Throws] // Creating a Uint32Array can fail.
     any getActiveUniformBlockParameter(WebGLProgram program, GLuint uniformBlockIndex, GLenum pname);
     DOMString? getActiveUniformBlockName(WebGLProgram program, GLuint uniformBlockIndex);
-    void uniformBlockBinding(WebGLProgram program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
+    undefined uniformBlockBinding(WebGLProgram program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
 
     /* Vertex Array Objects */
     WebGLVertexArrayObject? createVertexArray();
-    void deleteVertexArray(WebGLVertexArrayObject? vertexArray);
+    undefined deleteVertexArray(WebGLVertexArrayObject? vertexArray);
     [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
-    void bindVertexArray(WebGLVertexArrayObject? array);
+    undefined bindVertexArray(WebGLVertexArrayObject? array);
 };
 
 WebGL2RenderingContextBase includes WebGLRenderingContextBase;

--- a/crates/web-sys/webidls/enabled/WebGLRenderingContext.webidl
+++ b/crates/web-sys/webidls/enabled/WebGLRenderingContext.webidl
@@ -545,32 +545,32 @@ interface mixin WebGLRenderingContextBase {
     [Throws, NeedsCallerType]
     object? getExtension(DOMString name);
 
-    void activeTexture(GLenum texture);
-    void attachShader(WebGLProgram program, WebGLShader shader);
-    void bindAttribLocation(WebGLProgram program, GLuint index, DOMString name);
-    void bindBuffer(GLenum target, WebGLBuffer? buffer);
-    void bindFramebuffer(GLenum target, WebGLFramebuffer? framebuffer);
-    void bindRenderbuffer(GLenum target, WebGLRenderbuffer? renderbuffer);
-    void bindTexture(GLenum target, WebGLTexture? texture);
-    void blendColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
-    void blendEquation(GLenum mode);
-    void blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha);
-    void blendFunc(GLenum sfactor, GLenum dfactor);
-    void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB,
+    undefined activeTexture(GLenum texture);
+    undefined attachShader(WebGLProgram program, WebGLShader shader);
+    undefined bindAttribLocation(WebGLProgram program, GLuint index, DOMString name);
+    undefined bindBuffer(GLenum target, WebGLBuffer? buffer);
+    undefined bindFramebuffer(GLenum target, WebGLFramebuffer? framebuffer);
+    undefined bindRenderbuffer(GLenum target, WebGLRenderbuffer? renderbuffer);
+    undefined bindTexture(GLenum target, WebGLTexture? texture);
+    undefined blendColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+    undefined blendEquation(GLenum mode);
+    undefined blendEquationSeparate(GLenum modeRGB, GLenum modeAlpha);
+    undefined blendFunc(GLenum sfactor, GLenum dfactor);
+    undefined blendFuncSeparate(GLenum srcRGB, GLenum dstRGB,
                            GLenum srcAlpha, GLenum dstAlpha);
 
     [WebGLHandlesContextLoss] GLenum checkFramebufferStatus(GLenum target);
-    void clear(GLbitfield mask);
-    void clearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
-    void clearDepth(GLclampf depth);
-    void clearStencil(GLint s);
-    void colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
-    void compileShader(WebGLShader shader);
+    undefined clear(GLbitfield mask);
+    undefined clearColor(GLfloat red, GLfloat green, GLfloat blue, GLfloat alpha);
+    undefined clearDepth(GLclampf depth);
+    undefined clearStencil(GLint s);
+    undefined colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
+    undefined compileShader(WebGLShader shader);
 
-    void copyTexImage2D(GLenum target, GLint level, GLenum internalformat,
+    undefined copyTexImage2D(GLenum target, GLint level, GLenum internalformat,
                         GLint x, GLint y, GLsizei width, GLsizei height,
                         GLint border);
-    void copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                            GLint x, GLint y, GLsizei width, GLsizei height);
 
     WebGLBuffer? createBuffer();
@@ -580,36 +580,36 @@ interface mixin WebGLRenderingContextBase {
     WebGLShader? createShader(GLenum type);
     WebGLTexture? createTexture();
 
-    void cullFace(GLenum mode);
+    undefined cullFace(GLenum mode);
 
-    void deleteBuffer(WebGLBuffer? buffer);
-    void deleteFramebuffer(WebGLFramebuffer? framebuffer);
-    void deleteProgram(WebGLProgram? program);
-    void deleteRenderbuffer(WebGLRenderbuffer? renderbuffer);
-    void deleteShader(WebGLShader? shader);
-    void deleteTexture(WebGLTexture? texture);
+    undefined deleteBuffer(WebGLBuffer? buffer);
+    undefined deleteFramebuffer(WebGLFramebuffer? framebuffer);
+    undefined deleteProgram(WebGLProgram? program);
+    undefined deleteRenderbuffer(WebGLRenderbuffer? renderbuffer);
+    undefined deleteShader(WebGLShader? shader);
+    undefined deleteTexture(WebGLTexture? texture);
 
-    void depthFunc(GLenum func);
-    void depthMask(GLboolean flag);
-    void depthRange(GLclampf zNear, GLclampf zFar);
-    void detachShader(WebGLProgram program, WebGLShader shader);
-    void disable(GLenum cap);
-    void disableVertexAttribArray(GLuint index);
-    void drawArrays(GLenum mode, GLint first, GLsizei count);
-    void drawElements(GLenum mode, GLsizei count, GLenum type, GLintptr offset);
+    undefined depthFunc(GLenum func);
+    undefined depthMask(GLboolean flag);
+    undefined depthRange(GLclampf zNear, GLclampf zFar);
+    undefined detachShader(WebGLProgram program, WebGLShader shader);
+    undefined disable(GLenum cap);
+    undefined disableVertexAttribArray(GLuint index);
+    undefined drawArrays(GLenum mode, GLint first, GLsizei count);
+    undefined drawElements(GLenum mode, GLsizei count, GLenum type, GLintptr offset);
 
-    void enable(GLenum cap);
-    void enableVertexAttribArray(GLuint index);
-    void finish();
-    void flush();
-    void framebufferRenderbuffer(GLenum target, GLenum attachment,
+    undefined enable(GLenum cap);
+    undefined enableVertexAttribArray(GLuint index);
+    undefined finish();
+    undefined flush();
+    undefined framebufferRenderbuffer(GLenum target, GLenum attachment,
                                  GLenum renderbuffertarget,
                                  WebGLRenderbuffer? renderbuffer);
-    void framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget,
+    undefined framebufferTexture2D(GLenum target, GLenum attachment, GLenum textarget,
                               WebGLTexture? texture, GLint level);
-    void frontFace(GLenum mode);
+    undefined frontFace(GLenum mode);
 
-    void generateMipmap(GLenum target);
+    undefined generateMipmap(GLenum target);
 
     [NewObject]
     WebGLActiveInfo? getActiveAttrib(WebGLProgram program, GLuint index);
@@ -653,7 +653,7 @@ interface mixin WebGLRenderingContextBase {
 
     [WebGLHandlesContextLoss] GLintptr getVertexAttribOffset(GLuint index, GLenum pname);
 
-    void hint(GLenum target, GLenum mode);
+    undefined hint(GLenum target, GLenum mode);
     [WebGLHandlesContextLoss] GLboolean isBuffer(WebGLBuffer? buffer);
     [WebGLHandlesContextLoss] GLboolean isEnabled(GLenum cap);
     [WebGLHandlesContextLoss] GLboolean isFramebuffer(WebGLFramebuffer? framebuffer);
@@ -661,144 +661,144 @@ interface mixin WebGLRenderingContextBase {
     [WebGLHandlesContextLoss] GLboolean isRenderbuffer(WebGLRenderbuffer? renderbuffer);
     [WebGLHandlesContextLoss] GLboolean isShader(WebGLShader? shader);
     [WebGLHandlesContextLoss] GLboolean isTexture(WebGLTexture? texture);
-    void lineWidth(GLfloat width);
-    void linkProgram(WebGLProgram program);
-    void pixelStorei(GLenum pname, GLint param);
-    void polygonOffset(GLfloat factor, GLfloat units);
+    undefined lineWidth(GLfloat width);
+    undefined linkProgram(WebGLProgram program);
+    undefined pixelStorei(GLenum pname, GLint param);
+    undefined polygonOffset(GLfloat factor, GLfloat units);
 
-    void renderbufferStorage(GLenum target, GLenum internalformat,
+    undefined renderbufferStorage(GLenum target, GLenum internalformat,
                              GLsizei width, GLsizei height);
-    void sampleCoverage(GLclampf value, GLboolean invert);
-    void scissor(GLint x, GLint y, GLsizei width, GLsizei height);
+    undefined sampleCoverage(GLclampf value, GLboolean invert);
+    undefined scissor(GLint x, GLint y, GLsizei width, GLsizei height);
 
-    void shaderSource(WebGLShader shader, DOMString source);
+    undefined shaderSource(WebGLShader shader, DOMString source);
 
-    void stencilFunc(GLenum func, GLint ref, GLuint mask);
-    void stencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask);
-    void stencilMask(GLuint mask);
-    void stencilMaskSeparate(GLenum face, GLuint mask);
-    void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
-    void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass);
+    undefined stencilFunc(GLenum func, GLint ref, GLuint mask);
+    undefined stencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask);
+    undefined stencilMask(GLuint mask);
+    undefined stencilMaskSeparate(GLenum face, GLuint mask);
+    undefined stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
+    undefined stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass);
 
-    void texParameterf(GLenum target, GLenum pname, GLfloat param);
-    void texParameteri(GLenum target, GLenum pname, GLint param);
+    undefined texParameterf(GLenum target, GLenum pname, GLfloat param);
+    undefined texParameteri(GLenum target, GLenum pname, GLint param);
 
-    void uniform1f(WebGLUniformLocation? location, GLfloat x);
-    void uniform2f(WebGLUniformLocation? location, GLfloat x, GLfloat y);
-    void uniform3f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z);
-    void uniform4f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+    undefined uniform1f(WebGLUniformLocation? location, GLfloat x);
+    undefined uniform2f(WebGLUniformLocation? location, GLfloat x, GLfloat y);
+    undefined uniform3f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z);
+    undefined uniform4f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
 
-    void uniform1i(WebGLUniformLocation? location, GLint x);
-    void uniform2i(WebGLUniformLocation? location, GLint x, GLint y);
-    void uniform3i(WebGLUniformLocation? location, GLint x, GLint y, GLint z);
-    void uniform4i(WebGLUniformLocation? location, GLint x, GLint y, GLint z, GLint w);
+    undefined uniform1i(WebGLUniformLocation? location, GLint x);
+    undefined uniform2i(WebGLUniformLocation? location, GLint x, GLint y);
+    undefined uniform3i(WebGLUniformLocation? location, GLint x, GLint y, GLint z);
+    undefined uniform4i(WebGLUniformLocation? location, GLint x, GLint y, GLint z, GLint w);
 
-    void useProgram(WebGLProgram? program);
-    void validateProgram(WebGLProgram program);
+    undefined useProgram(WebGLProgram? program);
+    undefined validateProgram(WebGLProgram program);
 
-    void vertexAttrib1f(GLuint indx, GLfloat x);
-    void vertexAttrib1fv(GLuint indx, Float32List values);
-    void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
-    void vertexAttrib2fv(GLuint indx, Float32List values);
-    void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
-    void vertexAttrib3fv(GLuint indx, Float32List values);
-    void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
-    void vertexAttrib4fv(GLuint indx, Float32List values);
-    void vertexAttribPointer(GLuint indx, GLint size, GLenum type,
+    undefined vertexAttrib1f(GLuint indx, GLfloat x);
+    undefined vertexAttrib1fv(GLuint indx, Float32List values);
+    undefined vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
+    undefined vertexAttrib2fv(GLuint indx, Float32List values);
+    undefined vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
+    undefined vertexAttrib3fv(GLuint indx, Float32List values);
+    undefined vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+    undefined vertexAttrib4fv(GLuint indx, Float32List values);
+    undefined vertexAttribPointer(GLuint indx, GLint size, GLenum type,
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 
-    void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
+    undefined viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 };
 
 [Exposed=(Window,Worker),
  Func="mozilla::dom::OffscreenCanvas::PrefEnabledOnWorkerThread"]
 interface WebGLRenderingContext {
     // bufferData has WebGL2 overloads.
-    void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-    void bufferData(GLenum target, ArrayBuffer? data, GLenum usage);
-    void bufferData(GLenum target, ArrayBufferView data, GLenum usage);
+    undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
+    undefined bufferData(GLenum target, ArrayBuffer? data, GLenum usage);
+    undefined bufferData(GLenum target, ArrayBufferView data, GLenum usage);
     // bufferSubData has WebGL2 overloads.
-    void bufferSubData(GLenum target, GLintptr offset, ArrayBuffer data);
-    void bufferSubData(GLenum target, GLintptr offset, ArrayBufferView data);
+    undefined bufferSubData(GLenum target, GLintptr offset, ArrayBuffer data);
+    undefined bufferSubData(GLenum target, GLintptr offset, ArrayBufferView data);
 
     // compressedTexImage2D has WebGL2 overloads.
-    void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
+    undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                               GLsizei width, GLsizei height, GLint border,
                               ArrayBufferView data);
     // compressedTexSubImage2D has WebGL2 overloads.
-    void compressedTexSubImage2D(GLenum target, GLint level,
+    undefined compressedTexSubImage2D(GLenum target, GLint level,
                                  GLint xoffset, GLint yoffset,
                                  GLsizei width, GLsizei height, GLenum format,
                                  ArrayBufferView data);
 
     // readPixels has WebGL2 overloads.
     [Throws, NeedsCallerType]
-    void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
+    undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
                     GLenum format, GLenum type, ArrayBufferView? pixels);
 
     // texImage2D has WebGL2 overloads.
     // Overloads must share [Throws].
     [Throws] // Can't actually throw.
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
                     GLenum type, ArrayBufferView? pixels);
     [Throws] // Can't actually throw.
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, ImageBitmap pixels);
     [Throws] // Can't actually throw.
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, ImageData pixels);
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, HTMLImageElement image); // May throw DOMException
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, HTMLCanvasElement canvas); // May throw DOMException
     [Throws]
-    void texImage2D(GLenum target, GLint level, GLint internalformat,
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, HTMLVideoElement video); // May throw DOMException
 
     // texSubImage2D has WebGL2 overloads.
     [Throws] // Can't actually throw.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLsizei width, GLsizei height,
                        GLenum format, GLenum type, ArrayBufferView? pixels);
     [Throws] // Can't actually throw.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, ImageBitmap pixels);
     [Throws] // Can't actually throw.
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, ImageData pixels);
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLImageElement image); // May throw DOMException
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLCanvasElement canvas); // May throw DOMException
     [Throws]
-    void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, HTMLVideoElement video); // May throw DOMException
 
     // uniform*fv have WebGL2 overloads, or rather extensions, that are not
     // distinguishable from the WebGL1 versions when called with two arguments.
-    void uniform1fv(WebGLUniformLocation? location, Float32List data);
-    void uniform2fv(WebGLUniformLocation? location, Float32List data);
-    void uniform3fv(WebGLUniformLocation? location, Float32List data);
-    void uniform4fv(WebGLUniformLocation? location, Float32List data);
+    undefined uniform1fv(WebGLUniformLocation? location, Float32List data);
+    undefined uniform2fv(WebGLUniformLocation? location, Float32List data);
+    undefined uniform3fv(WebGLUniformLocation? location, Float32List data);
+    undefined uniform4fv(WebGLUniformLocation? location, Float32List data);
 
     // uniform*iv have WebGL2 overloads, or rather extensions, that are not
     // distinguishable from the WebGL1 versions when called with two arguments.
-    void uniform1iv(WebGLUniformLocation? location, Int32List data);
-    void uniform2iv(WebGLUniformLocation? location, Int32List data);
-    void uniform3iv(WebGLUniformLocation? location, Int32List data);
-    void uniform4iv(WebGLUniformLocation? location, Int32List data);
+    undefined uniform1iv(WebGLUniformLocation? location, Int32List data);
+    undefined uniform2iv(WebGLUniformLocation? location, Int32List data);
+    undefined uniform3iv(WebGLUniformLocation? location, Int32List data);
+    undefined uniform4iv(WebGLUniformLocation? location, Int32List data);
 
     // uniformMatrix*fv have WebGL2 overloads, or rather extensions, that are
     // not distinguishable from the WebGL1 versions when called with two
     // arguments.
-    void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data);
-    void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data);
-    void uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data);
+    undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data);
+    undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data);
+    undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data);
 };
 
 WebGLRenderingContext includes WebGLRenderingContextBase;
@@ -808,7 +808,7 @@ WebGLRenderingContext includes WebGLRenderingContextBase;
 [Exposed=(Window,Worker)]
 partial interface WebGLRenderingContext {
     [Func="mozilla::dom::DOMPrefs::OffscreenCanvasEnabled"]
-    void commit();
+    undefined commit();
 };
 
 ////////////////////////////////////////
@@ -938,8 +938,8 @@ interface EXT_frag_depth
 
 [NoInterfaceObject]
 interface WEBGL_lose_context {
-    void loseContext();
-    void restoreContext();
+    undefined loseContext();
+    undefined restoreContext();
 };
 
 [NoInterfaceObject]
@@ -1007,7 +1007,7 @@ interface WEBGL_draw_buffers {
     const GLenum MAX_COLOR_ATTACHMENTS_WEBGL = 0x8CDF;
     const GLenum MAX_DRAW_BUFFERS_WEBGL      = 0x8824;
 
-    void drawBuffersWEBGL(sequence<GLenum> buffers);
+    undefined drawBuffersWEBGL(sequence<GLenum> buffers);
 };
 
 [NoInterfaceObject]
@@ -1054,18 +1054,18 @@ interface OES_vertex_array_object {
     const GLenum VERTEX_ARRAY_BINDING_OES = 0x85B5;
 
     WebGLVertexArrayObject? createVertexArrayOES();
-    void deleteVertexArrayOES(WebGLVertexArrayObject? arrayObject);
+    undefined deleteVertexArrayOES(WebGLVertexArrayObject? arrayObject);
     [WebGLHandlesContextLoss] GLboolean isVertexArrayOES(WebGLVertexArrayObject? arrayObject);
-    void bindVertexArrayOES(WebGLVertexArrayObject? arrayObject);
+    undefined bindVertexArrayOES(WebGLVertexArrayObject? arrayObject);
 };
 
 [NoInterfaceObject]
 interface ANGLE_instanced_arrays {
     const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
 
-    void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
-    void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
-    void vertexAttribDivisorANGLE(GLuint index, GLuint divisor);
+    undefined drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
+    undefined drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
+    undefined vertexAttribDivisorANGLE(GLuint index, GLuint divisor);
 };
 
 [NoInterfaceObject]
@@ -1088,11 +1088,11 @@ interface EXT_disjoint_timer_query {
     const GLenum GPU_DISJOINT_EXT = 0x8FBB;
 
     WebGLQuery? createQueryEXT();
-    void deleteQueryEXT(WebGLQuery? query);
+    undefined deleteQueryEXT(WebGLQuery? query);
     [WebGLHandlesContextLoss] boolean isQueryEXT(WebGLQuery? query);
-    void beginQueryEXT(GLenum target, WebGLQuery query);
-    void endQueryEXT(GLenum target);
-    void queryCounterEXT(WebGLQuery query, GLenum target);
+    undefined beginQueryEXT(GLenum target, WebGLQuery query);
+    undefined endQueryEXT(GLenum target);
+    undefined queryCounterEXT(WebGLQuery query, GLenum target);
     any getQueryEXT(GLenum target, GLenum pname);
     any getQueryObjectEXT(WebGLQuery query, GLenum pname);
 };

--- a/crates/web-sys/webidls/enabled/WebSocket.webidl
+++ b/crates/web-sys/webidls/enabled/WebSocket.webidl
@@ -43,7 +43,7 @@ interface WebSocket : EventTarget {
   readonly attribute DOMString protocol;
 
   [Throws]
-  void close([Clamp] optional unsigned short code, optional DOMString reason);
+  undefined close([Clamp] optional unsigned short code, optional DOMString reason);
 
   // messaging
 
@@ -52,16 +52,16 @@ interface WebSocket : EventTarget {
   attribute BinaryType binaryType;
 
   [Throws]
-  void send(DOMString data);
+  undefined send(DOMString data);
 
   [Throws]
-  void send(Blob data);
+  undefined send(Blob data);
 
   [Throws]
-  void send(ArrayBuffer data);
+  undefined send(ArrayBuffer data);
 
   [Throws]
-  void send(ArrayBufferView data);
+  undefined send(ArrayBufferView data);
 };
 
 // Support for creating server-side chrome-only WebSocket. Used in

--- a/crates/web-sys/webidls/enabled/WebrtcGlobalInformation.webidl
+++ b/crates/web-sys/webidls/enabled/WebrtcGlobalInformation.webidl
@@ -8,23 +8,23 @@ dictionary WebrtcGlobalStatisticsReport {
   sequence<RTCStatsReportInternal> reports;
 };
 
-callback WebrtcGlobalStatisticsCallback = void (WebrtcGlobalStatisticsReport reports);
-callback WebrtcGlobalLoggingCallback = void (sequence<DOMString> logMessages);
+callback WebrtcGlobalStatisticsCallback = undefined (WebrtcGlobalStatisticsReport reports);
+callback WebrtcGlobalLoggingCallback = undefined (sequence<DOMString> logMessages);
 
 [ChromeOnly]
 interface WebrtcGlobalInformation {
 
   [Throws]
-  static void getAllStats(WebrtcGlobalStatisticsCallback callback,
+  static undefined getAllStats(WebrtcGlobalStatisticsCallback callback,
                           optional DOMString pcIdFilter);
 
-  static void clearAllStats();
+  static undefined clearAllStats();
 
   [Throws]
-  static void getLogging(DOMString pattern,
+  static undefined getLogging(DOMString pattern,
                          WebrtcGlobalLoggingCallback callback);
 
-  static void clearLogging();
+  static undefined clearLogging();
 
   // NSPR WebRTC Trace debug level (0 - 65535)
   //

--- a/crates/web-sys/webidls/enabled/Window.webidl
+++ b/crates/web-sys/webidls/enabled/Window.webidl
@@ -48,11 +48,11 @@
   [Replaceable, Throws] readonly attribute BarProp statusbar;
   [Replaceable, Throws] readonly attribute BarProp toolbar;
   [Throws] attribute DOMString status;
-  [Throws, CrossOriginCallable] void close();
+  [Throws, CrossOriginCallable] undefined close();
   [Throws, CrossOriginReadable] readonly attribute boolean closed;
-  [Throws] void stop();
-  [Throws, CrossOriginCallable] void focus();
-  [Throws, CrossOriginCallable] void blur();
+  [Throws] undefined stop();
+  [Throws, CrossOriginCallable] undefined focus();
+  [Throws, CrossOriginCallable] undefined blur();
   [Replaceable] readonly attribute any event;
 
   // other browsing contexts
@@ -76,15 +76,15 @@
   [Throws, Pref="browser.cache.offline.enable", Func="nsGlobalWindowInner::OfflineCacheAllowedForContext"] readonly attribute ApplicationCache applicationCache;
 
   // user prompts
-  [Throws, NeedsSubjectPrincipal] void alert();
-  [Throws, NeedsSubjectPrincipal] void alert(DOMString message);
+  [Throws, NeedsSubjectPrincipal] undefined alert();
+  [Throws, NeedsSubjectPrincipal] undefined alert(DOMString message);
   [Throws, NeedsSubjectPrincipal] boolean confirm(optional DOMString message = "");
   [Throws, NeedsSubjectPrincipal] DOMString? prompt(optional DOMString message = "", optional DOMString default = "");
   [Throws, Func="nsGlobalWindowInner::IsWindowPrintEnabled"]
-  void print();
+  undefined print();
 
   [Throws, CrossOriginCallable, NeedsSubjectPrincipal]
-  void postMessage(any message, DOMString targetOrigin, optional sequence<object> transfer = []);
+  undefined postMessage(any message, DOMString targetOrigin, optional sequence<object> transfer = []);
 
   // also has obsolete members
 };
@@ -112,8 +112,8 @@ Window includes WindowLocalStorage;
 
 // http://www.whatwg.org/specs/web-apps/current-work/
 partial interface Window {
-  void captureEvents();
-  void releaseEvents();
+  undefined captureEvents();
+  undefined releaseEvents();
 };
 
 // https://dvcs.w3.org/hg/editing/raw-file/tip/editing.html
@@ -149,14 +149,14 @@ partial interface Window {
   [Replaceable, Throws] readonly attribute Screen screen;
 
   // browsing context
-  //[Throws] void moveTo(double x, double y);
-  //[Throws] void moveBy(double x, double y);
-  //[Throws] void resizeTo(double x, double y);
-  //[Throws] void resizeBy(double x, double y);
-  [Throws, NeedsCallerType] void moveTo(long x, long y);
-  [Throws, NeedsCallerType] void moveBy(long x, long y);
-  [Throws, NeedsCallerType] void resizeTo(long x, long y);
-  [Throws, NeedsCallerType] void resizeBy(long x, long y);
+  //[Throws] undefined moveTo(double x, double y);
+  //[Throws] undefined moveBy(double x, double y);
+  //[Throws] undefined resizeTo(double x, double y);
+  //[Throws] undefined resizeBy(double x, double y);
+  [Throws, NeedsCallerType] undefined moveTo(long x, long y);
+  [Throws, NeedsCallerType] undefined moveBy(long x, long y);
+  [Throws, NeedsCallerType] undefined resizeTo(long x, long y);
+  [Throws, NeedsCallerType] undefined resizeBy(long x, long y);
 
   // viewport
   // These are writable because we allow chrome to write them.  And they need
@@ -168,12 +168,12 @@ partial interface Window {
   [Throws, NeedsCallerType] attribute any innerHeight;
 
   // viewport scrolling
-  void scroll(unrestricted double x, unrestricted double y);
-  void scroll(optional ScrollToOptions options);
-  void scrollTo(unrestricted double x, unrestricted double y);
-  void scrollTo(optional ScrollToOptions options);
-  void scrollBy(unrestricted double x, unrestricted double y);
-  void scrollBy(optional ScrollToOptions options);
+  undefined scroll(unrestricted double x, unrestricted double y);
+  undefined scroll(optional ScrollToOptions options);
+  undefined scrollTo(unrestricted double x, unrestricted double y);
+  undefined scrollTo(optional ScrollToOptions options);
+  undefined scrollBy(unrestricted double x, unrestricted double y);
+  undefined scrollBy(optional ScrollToOptions options);
   // The four properties below are double per spec at the moment, but whether
   // that will continue is unclear.
   [Replaceable, Throws] readonly attribute double scrollX;
@@ -199,9 +199,9 @@ partial interface Window {
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html
 partial interface Window {
   [Throws] long requestAnimationFrame(FrameRequestCallback callback);
-  [Throws] void cancelAnimationFrame(long handle);
+  [Throws] undefined cancelAnimationFrame(long handle);
 };
-callback FrameRequestCallback = void (DOMHighResTimeStamp time);
+callback FrameRequestCallback = undefined (DOMHighResTimeStamp time);
 
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html
 partial interface Window {
@@ -264,11 +264,11 @@ partial interface Window {
   unsigned long requestIdleCallback(IdleRequestCallback callback,
                                     optional IdleRequestOptions options);
   [Func="nsGlobalWindowInner::IsRequestIdleCallbackEnabled"]
-  void          cancelIdleCallback(unsigned long handle);
+  undefined          cancelIdleCallback(unsigned long handle);
 };
 
 dictionary IdleRequestOptions {
   unsigned long timeout;
 };
 
-callback IdleRequestCallback = void (IdleDeadline deadline);
+callback IdleRequestCallback = undefined (IdleDeadline deadline);

--- a/crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl
@@ -28,12 +28,12 @@ interface mixin WindowOrWorkerGlobalScope {
   long setTimeout(Function handler, optional long timeout = 0, any... arguments);
   [Throws]
   long setTimeout(DOMString handler, optional long timeout = 0, any... unused);
-  void clearTimeout(optional long handle = 0);
+  undefined clearTimeout(optional long handle = 0);
   [Throws]
   long setInterval(Function handler, optional long timeout = 0, any... arguments);
   [Throws]
   long setInterval(DOMString handler, optional long timeout = 0, any... unused);
-  void clearInterval(optional long handle = 0);
+  undefined clearInterval(optional long handle = 0);
 
   // ImageBitmap
   [Throws]

--- a/crates/web-sys/webidls/enabled/Worker.webidl
+++ b/crates/web-sys/webidls/enabled/Worker.webidl
@@ -15,10 +15,10 @@
 [Constructor(USVString scriptURL, optional WorkerOptions options),
  Exposed=(Window,DedicatedWorker,SharedWorker,System)]
 interface Worker : EventTarget {
-  void terminate();
+  undefined terminate();
 
   [Throws]
-  void postMessage(any message, optional sequence<object> transfer = []);
+  undefined postMessage(any message, optional sequence<object> transfer = []);
 
   attribute EventHandler onmessage;
   attribute EventHandler onmessageerror;

--- a/crates/web-sys/webidls/enabled/WorkerDebuggerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/WorkerDebuggerGlobalScope.webidl
@@ -12,29 +12,29 @@ interface WorkerDebuggerGlobalScope : EventTarget {
   object createSandbox(DOMString name, object prototype);
 
   [Throws]
-  void loadSubScript(DOMString url, optional object sandbox);
+  undefined loadSubScript(DOMString url, optional object sandbox);
 
-  void enterEventLoop();
+  undefined enterEventLoop();
 
-  void leaveEventLoop();
+  undefined leaveEventLoop();
 
-  void postMessage(DOMString message);
+  undefined postMessage(DOMString message);
 
   attribute EventHandler onmessage;
 
   [Throws]
-  void setImmediate(Function handler);
+  undefined setImmediate(Function handler);
 
-  void reportError(DOMString message);
+  undefined reportError(DOMString message);
 
   [Throws]
   sequence<any> retrieveConsoleEvents();
 
   [Throws]
-  void setConsoleEventHandler(AnyCallback? handler);
+  undefined setConsoleEventHandler(AnyCallback? handler);
 };
 
 // So you can debug while you debug
 partial interface WorkerDebuggerGlobalScope {
-  void dump(optional DOMString string);
+  undefined dump(optional DOMString string);
 };

--- a/crates/web-sys/webidls/enabled/WorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/WorkerGlobalScope.webidl
@@ -20,7 +20,7 @@ interface WorkerGlobalScope : EventTarget {
   readonly attribute WorkerNavigator navigator;
 
   [Throws]
-  void importScripts(DOMString... urls);
+  undefined importScripts(DOMString... urls);
 
   attribute OnErrorEventHandler onerror;
 

--- a/crates/web-sys/webidls/enabled/Worklet.webidl
+++ b/crates/web-sys/webidls/enabled/Worklet.webidl
@@ -11,7 +11,7 @@
  Exposed=Window]
 interface Worklet {
   [NewObject, Throws, NeedsCallerType]
-  Promise<void> addModule(USVString moduleURL, optional WorkletOptions options = {});
+  Promise<undefined> addModule(USVString moduleURL, optional WorkletOptions options = {});
 };
 
 dictionary WorkletOptions {

--- a/crates/web-sys/webidls/enabled/XMLHttpRequest.webidl
+++ b/crates/web-sys/webidls/enabled/XMLHttpRequest.webidl
@@ -45,12 +45,12 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
 
   // request
   [Throws]
-  void open(ByteString method, USVString url);
+  undefined open(ByteString method, USVString url);
   [Throws]
-  void open(ByteString method, USVString url, boolean async,
+  undefined open(ByteString method, USVString url, boolean async,
             optional USVString? user=null, optional USVString? password=null);
   [Throws]
-  void setRequestHeader(ByteString header, ByteString value);
+  undefined setRequestHeader(ByteString header, ByteString value);
 
   [SetterThrows]
   attribute unsigned long timeout;
@@ -62,10 +62,10 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   readonly attribute XMLHttpRequestUpload upload;
 
   [Throws]
-  void send(optional (Document or BodyInit)? body = null);
+  undefined send(optional (Document or BodyInit)? body = null);
 
   [Throws]
-  void abort();
+  undefined abort();
 
   // response
   readonly attribute USVString responseURL;
@@ -83,7 +83,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
   ByteString getAllResponseHeaders();
 
   [Throws]
-  void overrideMimeType(DOMString mime);
+  undefined overrideMimeType(DOMString mime);
 
   [SetterThrows]
   attribute XMLHttpRequestResponseType responseType;

--- a/crates/web-sys/webidls/enabled/XSLTProcessor.webidl
+++ b/crates/web-sys/webidls/enabled/XSLTProcessor.webidl
@@ -20,7 +20,7 @@ interface XSLTProcessor {
      *              stylesheet.
      */
     [Throws]
-    void importStylesheet(Node style);
+    undefined importStylesheet(Node style);
 
     /**
      * Transforms the node source applying the stylesheet given by
@@ -55,7 +55,7 @@ interface XSLTProcessor {
      * @param value        The new value of the XSLT parameter
      */
     [Throws]
-    void setParameter([TreatNullAs=EmptyString] DOMString namespaceURI,
+    undefined setParameter([TreatNullAs=EmptyString] DOMString namespaceURI,
                       DOMString localName,
                       any value);
 
@@ -78,7 +78,7 @@ interface XSLTProcessor {
      * @param localName    The local name of the XSLT parameter
      */
     [Throws]
-    void removeParameter([TreatNullAs=EmptyString] DOMString namespaceURI,
+    undefined removeParameter([TreatNullAs=EmptyString] DOMString namespaceURI,
                          DOMString localName);
 
     /**
@@ -86,12 +86,12 @@ interface XSLTProcessor {
      * the processor use the default-value for all parameters as specified in
      * the stylesheet.
      */
-    void clearParameters();
+    undefined clearParameters();
 
     /**
      * Remove all parameters and stylesheets from this XSLTProcessor.
      */
-    void reset();
+    undefined reset();
 
     /**
     * Disables all loading of external documents, such as from

--- a/crates/web-sys/webidls/unavailable_option_primitive/PaymentRequest.webidl
+++ b/crates/web-sys/webidls/unavailable_option_primitive/PaymentRequest.webidl
@@ -97,7 +97,7 @@ interface PaymentRequest : EventTarget {
   [NewObject]
   Promise<PaymentResponse> show(optional Promise<PaymentDetailsUpdate> detailsPromise);
   [NewObject]
-  Promise<void>            abort();
+  Promise<undefined>            abort();
   [NewObject]
   Promise<boolean>         canMakePayment();
 

--- a/crates/web-sys/webidls/unstable/Bluetooth.webidl
+++ b/crates/web-sys/webidls/unstable/Bluetooth.webidl
@@ -75,7 +75,7 @@ interface BluetoothDevice : EventTarget {
   readonly attribute DOMString? name;
   readonly attribute BluetoothRemoteGATTServer? gatt;
 
-  Promise<void> watchAdvertisements(
+  Promise<undefined> watchAdvertisements(
       optional WatchAdvertisementsOptions options = {});
   readonly attribute boolean watchingAdvertisements;
 };
@@ -130,7 +130,7 @@ interface BluetoothRemoteGATTServer {
   readonly attribute BluetoothDevice device;
   readonly attribute boolean connected;
   Promise<BluetoothRemoteGATTServer> connect();
-  void disconnect();
+  undefined disconnect();
   Promise<BluetoothRemoteGATTService> getPrimaryService(BluetoothServiceUUID service);
   Promise<sequence<BluetoothRemoteGATTService>>
     getPrimaryServices(optional BluetoothServiceUUID service);
@@ -165,9 +165,9 @@ interface BluetoothRemoteGATTCharacteristic : EventTarget {
   Promise<sequence<BluetoothRemoteGATTDescriptor>>
     getDescriptors(optional BluetoothDescriptorUUID descriptor);
   Promise<DataView> readValue();
-  Promise<void> writeValue(BufferSource value);
-  Promise<void> writeValueWithResponse(BufferSource value);
-  Promise<void> writeValueWithoutResponse(BufferSource value);
+  Promise<undefined> writeValue(BufferSource value);
+  Promise<undefined> writeValueWithResponse(BufferSource value);
+  Promise<undefined> writeValueWithoutResponse(BufferSource value);
   Promise<BluetoothRemoteGATTCharacteristic> startNotifications();
   Promise<BluetoothRemoteGATTCharacteristic> stopNotifications();
 };
@@ -193,7 +193,7 @@ interface BluetoothRemoteGATTDescriptor {
   readonly attribute UUID uuid;
   readonly attribute DataView? value;
   Promise<DataView> readValue();
-  Promise<void> writeValue(BufferSource value);
+  Promise<undefined> writeValue(BufferSource value);
 };
 
 [SecureContext]

--- a/crates/web-sys/webidls/unstable/Clipboard.webidl
+++ b/crates/web-sys/webidls/unstable/Clipboard.webidl
@@ -24,8 +24,8 @@ typedef sequence<ClipboardItem> ClipboardItems;
 [SecureContext, Exposed=Window] interface Clipboard : EventTarget {
   Promise<ClipboardItems> read();
   Promise<DOMString> readText();
-  Promise<void> write(ClipboardItems data);
-  Promise<void> writeText(DOMString data);
+  Promise<undefined> write(ClipboardItems data);
+  Promise<undefined> writeText(DOMString data);
 };
 
 typedef (DOMString or Blob) ClipboardItemDataType;

--- a/crates/web-sys/webidls/unstable/WebGPU.webidl
+++ b/crates/web-sys/webidls/unstable/WebGPU.webidl
@@ -100,11 +100,11 @@ GPUDevice includes GPUObjectBase;
 
 [Serializable]
 interface GPUBuffer {
-    Promise<void> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
+    Promise<undefined> mapAsync(GPUMapModeFlags mode, optional GPUSize64 offset = 0, optional GPUSize64 size);
     ArrayBuffer getMappedRange(optional GPUSize64 offset = 0, optional GPUSize64 size);
-    void unmap();
+    undefined unmap();
 
-    void destroy();
+    undefined destroy();
 };
 GPUBuffer includes GPUObjectBase;
 
@@ -138,7 +138,7 @@ interface GPUMapMode {
 interface GPUTexture {
     GPUTextureView createView(optional GPUTextureViewDescriptor descriptor = {});
 
-    void destroy();
+    undefined destroy();
 };
 GPUTexture includes GPUObjectBase;
 
@@ -659,35 +659,35 @@ interface GPUCommandEncoder {
     GPURenderPassEncoder beginRenderPass(GPURenderPassDescriptor descriptor);
     GPUComputePassEncoder beginComputePass(optional GPUComputePassDescriptor descriptor = {});
 
-    void copyBufferToBuffer(
+    undefined copyBufferToBuffer(
         GPUBuffer source,
         GPUSize64 sourceOffset,
         GPUBuffer destination,
         GPUSize64 destinationOffset,
         GPUSize64 size);
 
-    void copyBufferToTexture(
+    undefined copyBufferToTexture(
         GPUBufferCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void copyTextureToBuffer(
+    undefined copyTextureToBuffer(
         GPUTextureCopyView source,
         GPUBufferCopyView destination,
         GPUExtent3D copySize);
 
-    void copyTextureToTexture(
+    undefined copyTextureToTexture(
         GPUTextureCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
 
-    void pushDebugGroup(USVString groupLabel);
-    void popDebugGroup();
-    void insertDebugMarker(USVString markerLabel);
+    undefined pushDebugGroup(USVString groupLabel);
+    undefined popDebugGroup();
+    undefined insertDebugMarker(USVString markerLabel);
 
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
-    void resolveQuerySet(
+    undefined resolveQuerySet(
         GPUQuerySet querySet,
         GPUSize32 firstQuery,
         GPUSize32 queryCount,
@@ -727,30 +727,30 @@ dictionary GPUImageBitmapCopyView {
 };
 
 interface mixin GPUProgrammablePassEncoder {
-    void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+    undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       optional sequence<GPUBufferDynamicOffset> dynamicOffsets = []);
 
-    void setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
+    undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,
                       Uint32Array dynamicOffsetsData,
                       GPUSize64 dynamicOffsetsDataStart,
                       GPUSize32 dynamicOffsetsDataLength);
 
-    void pushDebugGroup(USVString groupLabel);
-    void popDebugGroup();
-    void insertDebugMarker(USVString markerLabel);
+    undefined pushDebugGroup(USVString groupLabel);
+    undefined popDebugGroup();
+    undefined insertDebugMarker(USVString markerLabel);
 };
 
 interface GPUComputePassEncoder {
-    void setPipeline(GPUComputePipeline pipeline);
-    void dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
-    void dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined setPipeline(GPUComputePipeline pipeline);
+    undefined dispatch(GPUSize32 x, optional GPUSize32 y = 1, optional GPUSize32 z = 1);
+    undefined dispatchIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 
-    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void endPipelineStatisticsQuery();
+    undefined beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined endPipelineStatisticsQuery();
 
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
-    void endPass();
+    undefined endPass();
 };
 GPUComputePassEncoder includes GPUObjectBase;
 GPUComputePassEncoder includes GPUProgrammablePassEncoder;
@@ -759,43 +759,43 @@ dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
 };
 
 interface mixin GPURenderEncoderBase {
-    void setPipeline(GPURenderPipeline pipeline);
+    undefined setPipeline(GPURenderPipeline pipeline);
 
-    void setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
-    void setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    undefined setIndexBuffer(GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
+    undefined setVertexBuffer(GPUIndex32 slot, GPUBuffer buffer, optional GPUSize64 offset = 0, optional GPUSize64 size = 0);
 
-    void draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
+    undefined draw(GPUSize32 vertexCount, optional GPUSize32 instanceCount = 1,
               optional GPUSize32 firstVertex = 0, optional GPUSize32 firstInstance = 0);
-    void drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,
+    undefined drawIndexed(GPUSize32 indexCount, optional GPUSize32 instanceCount = 1,
                      optional GPUSize32 firstIndex = 0,
                      optional GPUSignedOffset32 baseVertex = 0,
                      optional GPUSize32 firstInstance = 0);
 
-    void drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
-    void drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined drawIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
+    undefined drawIndexedIndirect(GPUBuffer indirectBuffer, GPUSize64 indirectOffset);
 };
 
 interface GPURenderPassEncoder {
-    void setViewport(float x, float y,
+    undefined setViewport(float x, float y,
                      float width, float height,
                      float minDepth, float maxDepth);
 
-    void setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
+    undefined setScissorRect(GPUIntegerCoordinate x, GPUIntegerCoordinate y,
                         GPUIntegerCoordinate width, GPUIntegerCoordinate height);
 
-    void setBlendColor(GPUColor color);
-    void setStencilReference(GPUStencilValue reference);
+    undefined setBlendColor(GPUColor color);
+    undefined setStencilReference(GPUStencilValue reference);
 
-    void beginOcclusionQuery(GPUSize32 queryIndex);
-    void endOcclusionQuery();
+    undefined beginOcclusionQuery(GPUSize32 queryIndex);
+    undefined endOcclusionQuery();
 
-    void beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
-    void endPipelineStatisticsQuery();
+    undefined beginPipelineStatisticsQuery(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined endPipelineStatisticsQuery();
 
-    void writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
+    undefined writeTimestamp(GPUQuerySet querySet, GPUSize32 queryIndex);
 
-    void executeBundles(sequence<GPURenderBundle> bundles);
-    void endPass();
+    undefined executeBundles(sequence<GPURenderBundle> bundles);
+    undefined endPass();
 };
 GPURenderPassEncoder includes GPUObjectBase;
 GPURenderPassEncoder includes GPUProgrammablePassEncoder;
@@ -857,25 +857,25 @@ dictionary GPURenderBundleEncoderDescriptor : GPUObjectDescriptorBase {
 };
 
 interface GPUQueue {
-    void submit(sequence<GPUCommandBuffer> commandBuffers);
+    undefined submit(sequence<GPUCommandBuffer> commandBuffers);
 
     GPUFence createFence(optional GPUFenceDescriptor descriptor = {});
-    void signal(GPUFence fence, GPUFenceValue signalValue);
+    undefined signal(GPUFence fence, GPUFenceValue signalValue);
 
-    void writeBuffer(
+    undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
         [AllowShared] BufferSource data,
         optional GPUSize64 dataOffset = 0,
         optional GPUSize64 size);
 
-    void writeTexture(
+    undefined writeTexture(
       GPUTextureCopyView destination,
       [AllowShared] BufferSource data,
       GPUTextureDataLayout dataLayout,
       GPUExtent3D size);
 
-    void copyImageBitmapToTexture(
+    undefined copyImageBitmapToTexture(
         GPUImageBitmapCopyView source,
         GPUTextureCopyView destination,
         GPUExtent3D copySize);
@@ -884,7 +884,7 @@ GPUQueue includes GPUObjectBase;
 
 interface GPUFence {
     GPUFenceValue getCompletedValue();
-    Promise<void> onCompletion(GPUFenceValue completionValue);
+    Promise<undefined> onCompletion(GPUFenceValue completionValue);
 };
 GPUFence includes GPUObjectBase;
 
@@ -893,7 +893,7 @@ dictionary GPUFenceDescriptor : GPUObjectDescriptorBase {
 };
 
 interface GPUQuerySet {
-    void destroy();
+    undefined destroy();
 };
 GPUQuerySet includes GPUObjectBase;
 
@@ -959,7 +959,7 @@ interface GPUValidationError {
 typedef (GPUOutOfMemoryError or GPUValidationError) GPUError;
 
 partial interface GPUDevice {
-    void pushErrorScope(GPUErrorFilter filter);
+    undefined pushErrorScope(GPUErrorFilter filter);
     Promise<GPUError?> popErrorScope();
 };
 

--- a/crates/web-sys/webidls/unstable/WebXRDevice.webidl
+++ b/crates/web-sys/webidls/unstable/WebXRDevice.webidl
@@ -42,13 +42,13 @@ enum XRVisibilityState {
   [SameObject] readonly attribute XRInputSourceArray inputSources;
 
   // Methods
-  void updateRenderState(optional XRRenderStateInit state = {});
+  undefined updateRenderState(optional XRRenderStateInit state = {});
   [NewObject] Promise<XRReferenceSpace> requestReferenceSpace(XRReferenceSpaceType type);
 
   long requestAnimationFrame(XRFrameRequestCallback callback);
-  void cancelAnimationFrame(long handle);
+  undefined cancelAnimationFrame(long handle);
 
-  Promise<void> end();
+  Promise<undefined> end();
 
   // Events
   attribute EventHandler onend;
@@ -73,7 +73,7 @@ dictionary XRRenderStateInit {
   readonly attribute XRWebGLLayer? baseLayer;
 };
 
-callback XRFrameRequestCallback = void (DOMHighResTimeStamp time, XRFrame frame);
+callback XRFrameRequestCallback = undefined (DOMHighResTimeStamp time, XRFrame frame);
 
 [SecureContext, Exposed=Window] interface XRFrame {
   [SameObject] readonly attribute XRSession session;
@@ -220,7 +220,7 @@ partial dictionary WebGLContextAttributes {
 };
 
 partial interface mixin WebGLRenderingContextBase {
-    Promise<void> makeXRCompatible();
+    Promise<undefined> makeXRCompatible();
 };
 
 [SecureContext, Exposed=Window]

--- a/crates/webidl-tests/webidls/enabled/array_buffer.webidl
+++ b/crates/webidl-tests/webidls/enabled/array_buffer.webidl
@@ -1,6 +1,6 @@
 [Constructor]
 interface ArrayBufferTest {
   ArrayBuffer getBuffer();
-  void setBuffer(ArrayBuffer? b);
+  undefined setBuffer(ArrayBuffer? b);
   DataView getDataView();
 };

--- a/crates/webidl-tests/webidls/enabled/callbacks.webidl
+++ b/crates/webidl-tests/webidls/enabled/callbacks.webidl
@@ -1,14 +1,14 @@
 callback interface CallbackInterface1 {
-  void foo();
+  undefined foo();
 };
 
 callback interface CallbackInterface2 {
-  void foo();
-  void bar();
+  undefined foo();
+  undefined bar();
 };
 
 [Constructor()]
 interface TakeCallbackInterface {
-  void a(CallbackInterface1 arg);
-  void b(CallbackInterface2 arg);
+  undefined a(CallbackInterface1 arg);
+  undefined b(CallbackInterface2 arg);
 };

--- a/crates/webidl-tests/webidls/enabled/no_interface.webidl
+++ b/crates/webidl-tests/webidls/enabled/no_interface.webidl
@@ -1,7 +1,7 @@
 [NoInterfaceObject]
 interface NoInterfaceObject {
   readonly attribute double number;
-  void foo();
+  undefined foo();
 };
 
 interface GetNoInterfaceObject {

--- a/crates/webidl-tests/webidls/enabled/simple.webidl
+++ b/crates/webidl-tests/webidls/enabled/simple.webidl
@@ -43,8 +43,8 @@ interface GlobalMethod {
 [Constructor()]
 interface Indexing {
   getter short (unsigned long index);
-  setter void (unsigned long index, short value);
-  deleter void (unsigned long index);
+  setter undefined (unsigned long index, short value);
+  deleter undefined (unsigned long index);
 };
 
 [Constructor()]
@@ -89,16 +89,16 @@ interface mixin MixinBar {
 };
 
 partial interface mixin MixinBar {
-  void addToBar(short other);
+  undefined addToBar(short other);
 };
 
 MixinFoo includes MixinBar;
 
 [Constructor()]
 interface Overloads {
-  void foo();
-  void foo(DOMString arg, optional long a);
-  void foo(DOMString arg, (float or short) b);
+  undefined foo();
+  undefined foo(DOMString arg, optional long a);
+  undefined foo(DOMString arg, (float or short) b);
 };
 
 callback MyCallback = any();
@@ -108,7 +108,7 @@ callback GetAnswer = long();
 
 [Constructor()]
 interface InvokeCallback {
-  void invoke(MyCallback callback);
+  undefined invoke(MyCallback callback);
   long callAdd(AddCallback callback);
   DOMString callRepeat(RepeatCallback callback);
 };

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '1.0', features = ['full'] }
 wasm-bindgen-backend = { version = "=0.2.69", path = "../backend" }
-weedle = "0.11"
+weedle = "0.12"
 lazy_static = "1.0.2"
 sourcefile = "0.1"
 structopt = "0.3.9"

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -503,6 +503,13 @@ impl<'src> FirstPass<'src, (&'src str, ApiStability)> for weedle::interface::Int
                 log::warn!("Unsupported WebIDL Setlike interface member: {:?}", self);
                 Ok(())
             }
+            InterfaceMember::AsyncIterable(_iterable) => {
+                log::warn!(
+                    "Unsupported WebIDL async iterable interface member: {:?}",
+                    self
+                );
+                Ok(())
+            }
         }
     }
 }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -83,7 +83,7 @@ pub(crate) enum IdlType<'a> {
     Union(Vec<IdlType<'a>>),
 
     Any,
-    Void,
+    Undefined,
 
     UnknownInterface(&'a str),
 }
@@ -298,7 +298,7 @@ impl<'a> ToIdlType<'a> for ConstType<'a> {
 impl<'a> ToIdlType<'a> for ReturnType<'a> {
     fn to_idl_type(&self, record: &FirstPassRecord<'a>) -> IdlType<'a> {
         match self {
-            ReturnType::Void(t) => t.to_idl_type(record),
+            ReturnType::Undefined(t) => t.to_idl_type(record),
             ReturnType::Type(t) => t.to_idl_type(record),
         }
     }
@@ -388,7 +388,7 @@ terms_to_idl_type! {
     Object => Object
     Octet => Octet
     Short => Short
-    Void => Void
+    Undefined => Undefined
     ArrayBuffer => ArrayBuffer
     DataView => DataView
     Error => Error
@@ -490,7 +490,7 @@ impl<'a> IdlType<'a> {
             }
 
             IdlType::Any => dst.push_str("any"),
-            IdlType::Void => dst.push_str("void"),
+            IdlType::Undefined => dst.push_str("undefined"),
         }
     }
 
@@ -642,7 +642,7 @@ impl<'a> IdlType<'a> {
             }
 
             IdlType::Any => Ok(js_value),
-            IdlType::Void => Ok(None),
+            IdlType::Undefined => Ok(None),
             IdlType::Callback => Ok(js_sys("Function")),
             IdlType::UnknownInterface(_) => Err(TypeError::CannotConvert),
         }


### PR DESCRIPTION
We updated weedle to use `undefined` instead of `void` in rustwasm/weedle#43, so now the plan is to update all WebIDL too.

The changes here are split into two commits for reviewing. The first commit updates all of the WebIDL and the second commit updates how the tokens are used from weedle.

Overall the changes seem to be fine because the generated bindings don't show any differences.