### PR TITLE
Makes slice argument of `web_sys::AudioBuffer::copy_to_channel*` non mutable (#2434)

### DIFF
--- a/crates/web-sys/src/features/gen_AudioBuffer.rs
+++ b/crates/web-sys/src/features/gen_AudioBuffer.rs
@@ -78,7 +78,7 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `AudioBuffer`*"]
     pub fn copy_to_channel(
         this: &AudioBuffer,
-        source: &mut [f32],
+        source: &[f32],
         channel_number: i32,
     ) -> Result<(), JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "AudioBuffer" , js_name = copyToChannel)]
@@ -89,7 +89,7 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `AudioBuffer`*"]
     pub fn copy_to_channel_with_start_in_channel(
         this: &AudioBuffer,
-        source: &mut [f32],
+        source: &[f32],
         channel_number: i32,
         start_in_channel: u32,
     ) -> Result<(), JsValue>;

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -88,6 +88,8 @@ lazy_static! {
         "setBindGroup",
         "writeBuffer",
         "writeTexture",
+        // AudioBuffer
+        "copyToChannel"
         // TODO: Add another type's functions here. Leave a comment header with the type name
     ]);
 }


### PR DESCRIPTION
Hopefully fixes #2434