### PR TITLE
Avoid errors if vendor-prefixed APIs do not exist (fix #2437)

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2095,10 +2095,6 @@ impl<'a> Context<'a> {
                 self.imports_post.push_str(";\n");
 
                 fn switch(dst: &mut String, name: &str, prefix: &str, left: &[String]) {
-                    if left.len() == 0 {
-                        dst.push_str(prefix);
-                        return dst.push_str(name);
-                    }
                     dst.push_str("(typeof ");
                     dst.push_str(prefix);
                     dst.push_str(name);
@@ -2106,7 +2102,11 @@ impl<'a> Context<'a> {
                     dst.push_str(prefix);
                     dst.push_str(name);
                     dst.push_str(" : ");
-                    switch(dst, name, &left[0], &left[1..]);
+                    if left.is_empty() {
+                        dst.push_str("undefined");
+                    } else {
+                        switch(dst, name, &left[0], &left[1..]);
+                    }
                     dst.push_str(")");
                 }
                 format!("l{}", name)

--- a/tests/wasm/vendor_prefix.rs
+++ b/tests/wasm/vendor_prefix.rs
@@ -28,6 +28,13 @@ extern "C" {
     fn new() -> MySpecialApi3;
     #[wasm_bindgen(method)]
     fn foo(this: &MySpecialApi3) -> u32;
+
+    // This API does not exist at all;
+    // test that Rust gets a chance to catch the error (#2437)
+    #[wasm_bindgen(vendor_prefix = a, vendor_prefix = b)]
+    type MyMissingApi;
+    #[wasm_bindgen(constructor, catch)]
+    fn new() -> Result<MyMissingApi, JsValue>;
 }
 
 #[wasm_bindgen_test]
@@ -37,4 +44,5 @@ pub fn polyfill_works() {
     assert_eq!(MySpecialApi::new().foo(), 123);
     assert_eq!(MySpecialApi2::new().foo(), 124);
     assert_eq!(MySpecialApi3::new().foo(), 125);
+    assert!(MyMissingApi::new().is_err());
 }


### PR DESCRIPTION
Avoid errors in the generated vendor-prefix code if neither the
standard API nor the vendor-prefixed API exists. Instead, fall back
to undefined, which will give the Rust module a chance to run and
handle the error when it tries to use the API.

Fixes #2437.