### PR TITLE
Update browser support caveats

### DIFF
--- a/guide/src/reference/browser-support.md
+++ b/guide/src/reference/browser-support.md
@@ -19,6 +19,45 @@ also like to be aware of it!
   an example of doing this too](../examples/wasm2js.html)). Note
   that at this time no bundler will do this by default, but we'd love to
   document plugins which do this if you are aware of one!
+  
+* **Edge before 79+** - the `TextEncoder` and `TextDecoder` APIs where not
+  available in Edge which `wasm-bindgen` uses to encode/decode strings between
+  JS and Rust. You can polyfill this with at least one of two strategies:
+
+  1. If using a bundler, you can likely configure the bundler to polyfill these
+     types by default. For example if you're using Webpack you can use the
+     [`ProvidePlugin` interface][wpp] like so after also adding
+     [`text-encoding`] to your `package.json`
+
+     ```js
+     const webpack = require('webpack');
+     module.exports = {
+         plugins: [
+             new webpack.ProvidePlugin({
+               TextDecoder: ['text-encoding', 'TextDecoder'],
+               TextEncoder: ['text-encoding', 'TextEncoder']
+             })
+         ]
+         // ... other configuration options
+     };
+     ```
+
+     **Warning:** doing this implies the polyfill will always be used,
+     even if native APIs are available. This has a very significant
+     performance impact (the polyfill was measured to be 100x slower in Chromium)!
+
+  2. If you're not using a bundler you can also include support manually by
+     adding a `<script>` tag which defines the `TextEncoder` and `TextDecoder`
+     globals. [This StackOverflow question][soq] has some example usage and MDN
+     has a [`TextEncoder` polyfill implementation][mdntepi] to get you started
+     as well.
+
+* **BigInt and `u64`** - currently the WebAssembly specification for the web
+  forbids the usage of 64-bit integers (Rust types `i64` and `u64`) in
+  exported/imported functions. When using `wasm-bindgen`, however, `u64` is
+  allowed! The reason for this is that it's translated to the `BigInt` type in
+  JS. The `BigInt` class is supported by all major browsers starting in the 
+  following versions: Chrome 67+, Firefox 68+, Edge 79+, and Safari 14+.
 
 
 If you find other incompatibilities please report them to us! We'd love to
@@ -26,3 +65,7 @@ either keep this list up-to-date or fix the underlying bugs :)
 
 [report it]: https://github.com/rustwasm/wasm-bindgen/issues/new
 [w2js]: https://github.com/WebAssembly/binaryen
+[wpp]: https://webpack.js.org/plugins/provide-plugin/
+[`text-encoding`]: https://www.npmjs.com/package/text-encoding
+[soq]: https://stackoverflow.com/questions/40662142/polyfill-for-textdecoder/46549188#46549188
+[mdntepi]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#Polyfill

--- a/guide/src/reference/browser-support.md
+++ b/guide/src/reference/browser-support.md
@@ -20,56 +20,9 @@ also like to be aware of it!
   that at this time no bundler will do this by default, but we'd love to
   document plugins which do this if you are aware of one!
 
-* **Edge** - the `TextEncoder` and `TextDecoder` APIs are not currently
-  available in Edge which `wasm-bindgen` uses to encode/decode strings between
-  JS and Rust. You can polyfill this with at least one of two strategies:
-
-  1. If using a bundler, you can likely configure the bundler to polyfill these
-     types by default. For example if you're using Webpack you can use the
-     [`ProvidePlugin` interface][wpp] like so after also adding
-     [`text-encoding`] to your `package.json`
-
-     ```js
-     const webpack = require('webpack');
-
-     module.exports = {
-         plugins: [
-             new webpack.ProvidePlugin({
-               TextDecoder: ['text-encoding', 'TextDecoder'],
-               TextEncoder: ['text-encoding', 'TextEncoder']
-             })
-         ]
-
-         // ... other configuration options
-     };
-     ```
-
-     **Warning:** doing this implies the polyfill will always be used,
-     even if native APIs are available. This has a very significant
-     performance impact (the polyfill was measured to be 100x slower in Chromium)!
-
-  2. If you're not using a bundler you can also include support manually by
-     adding a `<script>` tag which defines the `TextEncoder` and `TextDecoder`
-     globals. [This StackOverflow question][soq] has some example usage and MDN
-     has a [`TextEncoder` polyfill implementation][mdntepi] to get you started
-     as well.
-
-* **BigInt and `u64`** - currently the WebAssembly specification for the web
-  forbids the usage of 64-bit integers (Rust types `i64` and `u64`) in
-  exported/imported functions. When using `wasm-bindgen`, however, `u64` is
-  allowed! The reason for this is that it's translated to the `BigInt` type in
-  JS. The `BigInt` class, however, is only currently supported in Chrome 67+ and
-  Firefox 68+ (as of the time of this writing) and isn't supported in Edge or
-  Safari, for example. For more, up-to-date details, see [`BigInt` on Can I
-  use...][ciu_bigint].
 
 If you find other incompatibilities please report them to us! We'd love to
 either keep this list up-to-date or fix the underlying bugs :)
 
 [report it]: https://github.com/rustwasm/wasm-bindgen/issues/new
 [w2js]: https://github.com/WebAssembly/binaryen
-[wpp]: https://webpack.js.org/plugins/provide-plugin/
-[`text-encoding`]: https://www.npmjs.com/package/text-encoding
-[soq]: https://stackoverflow.com/questions/40662142/polyfill-for-textdecoder/46549188#46549188
-[mdntepi]: https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#Polyfill
-[ciu_bigint]: https://caniuse.com/#feat=bigint


### PR DESCRIPTION
Most of the caveats can be removed:
- Edge 79+ supports TextEncoder and TextDecoder APIs  (https://caniuse.com/textencoder)
- Edge 79+ and Safari 14+ supports BigInt (https://caniuse.com/bigint)