### PR TITLE
Emit `new URL('...', import.meta.url)` for Wasm

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -611,14 +611,14 @@ impl<'a> Context<'a> {
         }
 
         let default_module_path = match self.config.mode {
-            OutputMode::Web => {
+            OutputMode::Web => format!(
                 "\
-                    if (typeof input === 'undefined') {
-                        input = import.meta.url.replace(/\\.js$/, '_bg.wasm');
-                    }"
-            }
-            OutputMode::NoModules { .. } => {
-                "\
+                    if (typeof input === 'undefined') {{
+                        input = new URL('{stem}_bg.wasm', import.meta.url);
+                    }}",
+                stem = self.config.stem()?
+            ),
+            OutputMode::NoModules { .. } => "\
                     if (typeof input === 'undefined') {
                         let src;
                         if (typeof document === 'undefined') {
@@ -628,8 +628,8 @@ impl<'a> Context<'a> {
                         }
                         input = src.replace(/\\.js$/, '_bg.wasm');
                     }"
-            }
-            _ => "",
+            .to_string(),
+            _ => "".to_string(),
         };
 
         let ts = self.ts_for_init_fn(has_memory, !default_module_path.is_empty())?;


### PR DESCRIPTION
Lots of bundlers now support `new URL('...path...', import.meta.url)` as an explicit signal to specify assets that should be bundled alongside JS.

This is already supported by default in Webpack v5, Parcel v2, Vite, Snowpack and WMR, and available via a plugin - https://modern-web.dev/docs/building/rollup-plugin-import-meta-assets/ - in Rollup as well.

Emitting such pattern by default would allow all those bundlers to automatically include Wasm and generate a correct URL for `--target web` builds without any work from the user's side.