### PR TITLE
Update the Windows Documentation

### DIFF
--- a/guide/src/contributing/web-sys/supporting-more-web-apis.md
+++ b/guide/src/contributing/web-sys/supporting-more-web-apis.md
@@ -35,5 +35,8 @@
    cd crates/web-sys
    cargo run --release --package wasm-bindgen-webidl webidls src/features
    ```
+   
+   If you are on Windows, you need to use the following command:
+   ```cargo run --release --package wasm-bindgen-webidl -- webidls src/features```
 
    You can then use `git diff` to ensure the bindings look correct.


### PR DESCRIPTION
I am currently trying to get my webIDL changes done, but cannot get GitAhead to work with my 2FA, so I am reverting to windows to the Github Desktop because they don't have a Linux version.