### PR TITLE
Remove usage of non-standard inner_html in docs

### DIFF
--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -11,7 +11,7 @@ pub fn run() -> Result<(), JsValue> {
 
     // Manufacture the element we're gonna append
     let val = document.create_element("p")?;
-    val.set_inner_html("Hello from Rust!");
+    val.set_text_content("Hello from Rust!");
 
     body.append_child(&val)?;
 


### PR DESCRIPTION
Part of https://github.com/rustwasm/wasm-bindgen/issues/2461.

The documentation for web-sys showed an example in Rust calling out to a non-standard web API whose spec is not finished.

This seemed to have happened slipped passed unintentionally.
This PR removes it's usage from the docs in favor of the standardized text_content accessor.