### PR TITLE
raytrace-parallel: use rust nightly explicitly

### DIFF
--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -13,7 +13,7 @@ set -ex
 #   shared memory, passive segments, etc.
 
 RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' \
-  cargo build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort
+  cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort
 
 # Note the usage of `--target no-modules` here which is required for passing
 # the memory import to each wasm module.


### PR DESCRIPTION
Hey Rust Wasm peeps,

I cannot get over how awesome this project is. I have learned so much rust and wasm going through all the documentation, and would never have been able to get close to using webassembly without this project. Thanks so much for your efforts!

Ok so this is just a cheeky little PR to get my feet wet. I _think_ it makes sense, since at the moment I believe you can't use the `-Z` flag in stable Rust.

What do you think?