### PR TITLE
Fixes small type error in DOM example project

### DIFF
--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -11,7 +11,7 @@ pub fn run() -> Result<(), JsValue> {
 
     // Manufacture the element we're gonna append
     let val = document.create_element("p")?;
-    val.set_text_content("Hello from Rust!");
+    val.set_text_content(Some("Hello from Rust!"));
 
     body.append_child(&val)?;
 


### PR DESCRIPTION
Example project wasn't building, call to `.set_text_content` now takes an `Option<&str>` instead of `&str`.