### PR TITLE
Fix build of raytrace example on nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2021-03-28
+          toolchain: nightly-2021-05-09
       - template: ci/azure-install-node.yml
       - script: cargo test --target wasm32-unknown-unknown --features nightly --test wasm
 
@@ -204,7 +204,7 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2020-08-27
+          toolchain: nightly-2021-05-09
       - script: rustup component add rust-src
         displayName: "install rust-src"
       - script: |

--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -113,7 +113,6 @@ impl Config {
         mem.maximum = Some(cmp::max(self.maximum_memory / PAGE_SIZE, prev_max));
         assert!(mem.data_segments.is_empty());
 
-        delete_synthetic_func(module, "__wasm_init_memory")?;
         let tls = Tls {
             init: delete_synthetic_func(module, "__wasm_init_tls")?,
             size: delete_synthetic_global(module, "__tls_size")?,

--- a/examples/raytrace-parallel/build.sh
+++ b/examples/raytrace-parallel/build.sh
@@ -12,7 +12,7 @@ set -ex
 #   features enabled, ensuring that LLVM will generate atomic instructions,
 #   shared memory, passive segments, etc.
 
-RUSTFLAGS='-C target-feature=+atomics,+bulk-memory' \
+RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
   cargo build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort
 
 # Note the usage of `--target no-modules` here which is required for passing


### PR DESCRIPTION
The `__wasm_init_memory` function is no longer exported and we also need
to build with `+mutable-globals`.

Closes #2487