### PR TITLE
Add TypedArray::copy_from

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4997,7 +4997,7 @@ macro_rules! arrays {
             ///
             /// This function will panic if this typed array's length is
             /// different than the length of the provided `src` array.
-            pub fn copy_from(&mut self, src: &[$ty]) {
+            pub fn copy_from(&self, src: &[$ty]) {
                 assert_eq!(self.length() as usize, src.len());
                 unsafe { self.set(&$name::view(src), 0) }
             }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4999,6 +4999,7 @@ macro_rules! arrays {
             /// different than the length of the provided `src` array.
             pub fn copy_from(&self, src: &[$ty]) {
                 assert_eq!(self.length() as usize, src.len());
+                // This is safe because the `set` function copies from its TypedArray argument
                 unsafe { self.set(&$name::view(src), 0) }
             }
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4987,6 +4987,21 @@ macro_rules! arrays {
                 self.raw_copy_to(dst);
             }
 
+            /// Copy the contents of the source Rust slice into this
+            /// JS typed array.
+            ///
+            /// This function will efficiently copy the memory from within
+            /// the wasm module's own linear memory to this typed array.
+            ///
+            /// # Panics
+            ///
+            /// This function will panic if this typed array's length is
+            /// different than the length of the provided `src` array.
+            pub fn copy_from(&mut self, src: &[$ty]) {
+                assert_eq!(self.length() as usize, src.len());
+                unsafe { self.set(&$name::view(src), 0) }
+            }
+
             /// Efficiently copies the contents of this JS typed array into a new Vec.
             pub fn to_vec(&self) -> Vec<$ty> {
                 let mut output = vec![$ty::default(); self.length() as usize];

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -146,6 +146,16 @@ fn copy_to() {
 }
 
 #[wasm_bindgen_test]
+fn copy_from() {
+    let x = [1, 2, 3];
+    let mut array = Int32Array::new(&3.into());
+    array.copy_from(&x);
+    array.for_each(&mut |x, i, _| {
+        assert_eq!(x, (i + 1) as i32);
+    });
+}
+
+#[wasm_bindgen_test]
 fn to_vec() {
     let array = Int32Array::new(&10.into());
     array.fill(5, 0, 10);

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -148,7 +148,7 @@ fn copy_to() {
 #[wasm_bindgen_test]
 fn copy_from() {
     let x = [1, 2, 3];
-    let mut array = Int32Array::new(&3.into());
+    let array = Int32Array::new(&3.into());
     array.copy_from(&x);
     array.for_each(&mut |x, i, _| {
         assert_eq!(x, (i + 1) as i32);


### PR DESCRIPTION
This introduces `TypedArray::copy_from(src)`, as the dual of `TypedArray::copy_to(dst)`.

While this *can* already be achieved today with `TypedArray::set()`, it requires either unsafe code or an additional allocation:
```rust
let x = [1, 2, 3];
let mut array = Int32Array::new(&3.into());

unsafe { array.set(Int32Array::view(&x), 0); } // view() is unsafe
// or
array.set(Int32Array::from(&x), 0); // from() allocates a new Uint8Array to copy the contents of x
```
The new helper method provides a safe interface to perform this copy:
```rust
let x = [1, 2, 3];
let mut array = Int32Array::new(&3.into());
array.copy_from(&x);
```
Internally, it uses the unsafe implementation listed above. We know that this is safe, because:
* the `TypedArray` view on the Rust slice lives only for the duration of the `copy_from()` call
* `set()` does not grow the WebAssembly linear memory, so it cannot invalidate the created view