### PR TITLE
Catch syntax errors in constructors of `js_sys::Function`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1117,8 +1117,8 @@ extern "C" {
     /// habits and allowing for more efficient code minification.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-    #[wasm_bindgen(constructor)]
-    pub fn new_with_args(args: &str, body: &str) -> Function;
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new_with_args(args: &str, body: &str) -> Result<Function, JsValue>;
 
     /// The `Function` constructor creates a new `Function` object. Calling the
     /// constructor directly can create functions dynamically, but suffers from
@@ -1128,8 +1128,8 @@ extern "C" {
     /// habits and allowing for more efficient code minification.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
-    #[wasm_bindgen(constructor)]
-    pub fn new_no_args(body: &str) -> Function;
+    #[wasm_bindgen(constructor, catch)]
+    pub fn new_no_args(body: &str) -> Result<Function, JsValue>;
 
     /// The `apply()` method calls a function with a given this value, and arguments provided as an array
     /// (or an array-like object).
@@ -4780,6 +4780,7 @@ pub fn global() -> Object {
         // global object in a sort of roundabout way that should hopefully work in
         // all contexts like ESM, node, browsers, etc.
         let this = Function::new_no_args("return this")
+            .unwrap()
             .call0(&JsValue::undefined())
             .ok();
 

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -68,7 +68,7 @@ fn stringify() {
 
 #[wasm_bindgen_test]
 fn stringify_error() {
-    let func = Function::new_no_args("throw new Error(\"rust really rocks\")");
+    let func = Function::new_no_args("throw new Error(\"rust really rocks\")").unwrap();
     let obj = Object::new();
     Reflect::set(obj.as_ref(), &JsValue::from("toJSON"), func.as_ref()).unwrap();
 
@@ -101,7 +101,8 @@ fn stringify_with_replacer() {
     assert_eq!(output1, "{\"hello\":\"world\"}");
 
     let replacer_func =
-        Function::new_with_args("key, value", "return key === 'hello' ? undefined : value");
+        Function::new_with_args("key, value", "return key === 'hello' ? undefined : value")
+        .unwrap();
     let output2: String =
         JSON::stringify_with_replacer(&JsValue::from(obj), &JsValue::from(replacer_func))
             .unwrap()
@@ -116,7 +117,7 @@ fn stringify_with_replacer_error() {
     arr.push(&JsValue::from(true));
     arr.push(&JsValue::from("hello"));
 
-    let replacer = Function::new_no_args("throw new Error(\"rust really rocks\")");
+    let replacer = Function::new_no_args("throw new Error(\"rust really rocks\")").unwrap();
 
     let result = JSON::stringify_with_replacer(&JsValue::from(arr), &JsValue::from(replacer));
     assert!(result.is_err());
@@ -164,7 +165,7 @@ fn stringify_with_replacer_and_space() {
     assert_eq!(output2, "{\n    \"hello\": \"world\"\n}");
 
     let replacer_func =
-        Function::new_with_args("key, value", "return key === 'hello' ? undefined : value");
+        Function::new_with_args("key, value", "return key === 'hello' ? undefined : value").unwrap();
     let output3: String = JSON::stringify_with_replacer_and_space(
         &JsValue::from(obj),
         &JsValue::from(replacer_func),
@@ -182,7 +183,7 @@ fn stringify_with_replacer_and_space_error() {
     arr.push(&JsValue::from(true));
     arr.push(&JsValue::from("hello"));
 
-    let replacer = Function::new_no_args("throw new Error(\"rust really rocks\")");
+    let replacer = Function::new_no_args("throw new Error(\"rust really rocks\")").unwrap();
 
     let result = JSON::stringify_with_replacer_and_space(
         &JsValue::from(arr),


### PR DESCRIPTION
This is a potential solution to issue #2496.

The constructors `new_with_args` and `new_no_args` will catch exceptions that are caused by syntax errors or similar problem.

This change would require to add an explicit `unwrap` in all places where the constructors are already used.