### PR TITLE
Fix incorrect link to `--target no-modules` example

### DIFF
--- a/examples/without-a-bundler-no-modules/README.md
+++ b/examples/without-a-bundler-no-modules/README.md
@@ -2,7 +2,7 @@
 
 [View documentation for this example online][dox]
 
-[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html
+[dox]: https://rustwasm.github.io/docs/wasm-bindgen/examples/without-a-bundler.html#using-the-older---target-no-modules
 
 You can build the example locally with:
 

--- a/guide/src/examples/without-a-bundler.md
+++ b/guide/src/examples/without-a-bundler.md
@@ -29,9 +29,9 @@ what it means to deploy without a bundler.
 
 ## Using the older `--target no-modules`
 
-[View full source code][code]
+[View full source code][code-no-modules]
 
-[code]: https://github.com/rustwasm/wasm-bindgen/tree/master/examples/without-a-bundler-no-modules
+[code-no-modules]: https://github.com/rustwasm/wasm-bindgen/tree/master/examples/without-a-bundler-no-modules
 
 The older version of using `wasm-bindgen` without a bundler is to use the
 `--target no-modules` flag to the `wasm-bindgen` CLI.


### PR DESCRIPTION
Fixes #2500

I also changed the link in `--target no-modules` example README to jump directly to the corresponding section.