### PR TITLE
Fix js_sys::Intl::DateTimeFormat::format

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -4488,8 +4488,8 @@ pub mod Intl {
         /// Intl.DateTimeFormat object.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/format)
-        #[wasm_bindgen(method, getter, js_class = "Intl.DateTimeFormat")]
-        pub fn format(this: &DateTimeFormat) -> Function;
+        #[wasm_bindgen(method, js_class = "Intl.DateTimeFormat")]
+        pub fn format(this: &DateTimeFormat, date: &Date) -> JsString;
 
         /// The `Intl.DateTimeFormat.prototype.formatToParts()` method allows locale-aware
         /// formatting of strings produced by DateTimeFormat formatters.

--- a/crates/js-sys/tests/wasm/Intl.rs
+++ b/crates/js-sys/tests/wasm/Intl.rs
@@ -55,7 +55,7 @@ fn date_time_format() {
     let epoch = Date::new(&JsValue::from(0));
 
     let c = Intl::DateTimeFormat::new(&locales, &opts);
-    assert!(c.format().is_instance_of::<Function>());
+    assert!(c.format(&epoch).is_string());
     assert!(c.format_to_parts(&epoch).is_instance_of::<Array>());
     assert!(c.resolved_options().is_instance_of::<Object>());
 


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format) 'Intl.DateTimeFormat.format' takes a `Date` and returns a `String`.

I'm not sure why the current binding was made as it is, but the fact that there's a test for it that checks that it does the wrong thing makes it look deliberate. This was originally added in #691, but I see no rationale for it there either. Perhaps there's some obscure historical reason for it. I do see several similar mistakes in the `Intl` namespace however, but figured I'd start with something small and simple to make sure I'm not misunderstanding something.

Also, the value returned apparently isn't an instance of `JsString`, but `is_string()` still returns `true` so I'm hoping that's fine.