### PR TITLE
Correctly consume tokens when parsing `js_namespace`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
     steps:
       - template: ci/azure-install-rust.yml
         parameters:
-          toolchain: nightly-2021-01-23
+          toolchain: nightly-2021-03-28
       - template: ci/azure-install-node.yml
       - script: cargo test --target wasm32-unknown-unknown --features nightly --test wasm
 

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -17,7 +17,7 @@ extra-traits = ["syn/extra-traits"]
 strict-macro = []
 
 [dependencies]
-syn = { version = '1.0.27', features = ['visit', 'full'] }
+syn = { version = '1.0.67', features = ['visit', 'full'] }
 quote = '1.0'
 proc-macro2 = "1.0"
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.72" }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -299,7 +299,6 @@ impl Parse for BindgenAttr {
 
             (@parser $variant:ident(Span, Vec<String>, Vec<Span>)) => ({
                 input.parse::<Token![=]>()?;
-                let input_before_parse = input.fork();
                 let (vals, spans) = match input.parse::<syn::ExprArray>() {
                     Ok(exprs) => {
                         let mut vals = vec![];
@@ -320,7 +319,7 @@ impl Parse for BindgenAttr {
                         (vals, spans)
                     },
                     Err(_) => {
-                        let ident = input_before_parse.parse::<AnyIdent>()?.0;
+                        let ident = input.parse::<AnyIdent>()?.0;
                         (vec![ident.to_string()], vec![ident.span()])
                     }
                 };


### PR DESCRIPTION
`syn` < 1.0.66 would consume the `AnyIdent` anyway while trying to parse the `ExprArray`.

Now due to a refactoring they did, they (correctly) leave the `ParseBuffer` untouched if the input is not a valid `ExprArray`, so we should avoid forking the input buffer and just use the same for both tries, otherwise the unwanted tokens left in there would make `Punctuated` break soon after.

Fixes #2508 

