### PR TITLE
Work around for building with webpack5

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1765,7 +1765,7 @@ impl<'a> Context<'a> {
                     "\
                     function handleError(f, args) {{
                         try {{
-                            return f.apply(this, arguments);
+                            return f.apply(this, args);
                         }} catch (e) {{
                             wasm.{}(addHeapObject(e));
                         }}

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2403,9 +2403,15 @@ impl<'a> Context<'a> {
             }
             Kind::Import(core) => {
                 let code = if catch {
-                    format!("function() {{ return handleError(function {}, arguments) }}", code)
+                    format!(
+                        "function() {{ return handleError(function {}, arguments) }}",
+                        code
+                    )
                 } else if log_error {
-                    format!("function() {{ return logError(function {}, arguments) }}", code)
+                    format!(
+                        "function() {{ return logError(function {}, arguments) }}",
+                        code
+                    )
                 } else {
                     format!("function{}", code)
                 };

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2403,9 +2403,9 @@ impl<'a> Context<'a> {
             }
             Kind::Import(core) => {
                 let code = if catch {
-                    format!("function() {{ handleError(function {}, arguments) }}", code)
+                    format!("function() {{ return handleError(function {}, arguments) }}", code)
                 } else if log_error {
-                    format!("function() {{ logError(function {}, arguments) }}", code)
+                    format!("function() {{ return logError(function {}, arguments) }}", code)
                 } else {
                     format!("function{}", code)
                 };

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -431,7 +431,7 @@ impl<'a> Context<'a> {
                         footer.push_str(" = ");
                         footer.push_str(js.trim());
                         footer.push_str(";\n");
-                    }       
+                    }
                 }
                 if needs_manual_start {
                     start = Some("\nwasm.__wbindgen_start();\n".to_string());
@@ -1746,7 +1746,7 @@ impl<'a> Context<'a> {
             (Some(table), Some(alloc)) => {
                 let add = self.expose_add_to_externref_table(table, alloc)?;
                 self.global(&format!(
-                    "
+                    "\
                     function handleError(f, args) {{                       
                         try {{
                             return f.apply(this, args);
@@ -1762,7 +1762,7 @@ impl<'a> Context<'a> {
             _ => {
                 self.expose_add_heap_object();
                 self.global(&format!(
-                    "
+                    "\
                     function handleError(f, args) {{
                         try {{
                             return f.apply(this, arguments);
@@ -2403,7 +2403,7 @@ impl<'a> Context<'a> {
             }
             Kind::Import(core) => {
                 let code = if catch {
-                    format!("function() {{ handleError(function {}, arguments )}}", code)
+                    format!("function() {{ handleError(function {}, arguments) }}", code)
                 } else if log_error {
                     format!("function() {{ logError(function {}, arguments) }}", code)
                 } else {

--- a/crates/cli/tests/reference/anyref-empty.js
+++ b/crates/cli/tests/reference/anyref-empty.js
@@ -1,6 +1,6 @@
 import * as wasm from './reference_test_bg.wasm';
 
-export const __wbindgen_init_externref_table = function() {
+export function __wbindgen_init_externref_table() {
     const table = wasm.__wbindgen_export_0;
     const offset = table.grow(4);
     table.set(0, undefined);

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -38,9 +38,9 @@ export function exported() {
     wasm.exported();
 }
 
-export function __wbg_foo_8d66ddef0ff279d6() { handleError(function () {
+export function __wbg_foo_8d66ddef0ff279d6() { return handleError(function () {
     foo();
-}, arguments )};
+}, arguments) };
 
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -24,16 +24,13 @@ function addToExternrefTable0(obj) {
     return idx;
 }
 
-function handleError(f) {
-    return function () {
-        try {
-            return f.apply(this, arguments);
-
-        } catch (e) {
-            const idx = addToExternrefTable0(e);
-            wasm.__wbindgen_exn_store(idx);
-        }
-    };
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        const idx = addToExternrefTable0(e);
+        wasm.__wbindgen_exn_store(idx);
+    }
 }
 /**
 */
@@ -41,19 +38,19 @@ export function exported() {
     wasm.exported();
 }
 
-export const __wbg_foo_8d66ddef0ff279d6 = handleError(function() {
+export function __wbg_foo_8d66ddef0ff279d6() { handleError(function () {
     foo();
-});
+}, arguments )};
 
-export const __wbindgen_throw = function(arg0, arg1) {
+export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
 };
 
-export const __wbindgen_rethrow = function(arg0) {
+export function __wbindgen_rethrow(arg0) {
     throw arg0;
 };
 
-export const __wbindgen_init_externref_table = function() {
+export function __wbindgen_init_externref_table() {
     const table = wasm.__wbindgen_export_0;
     const offset = table.grow(4);
     table.set(0, undefined);

--- a/crates/cli/tests/reference/anyref-nop.js
+++ b/crates/cli/tests/reference/anyref-nop.js
@@ -6,7 +6,7 @@ export function foo() {
     wasm.foo();
 }
 
-export const __wbindgen_init_externref_table = function() {
+export function __wbindgen_init_externref_table() {
     const table = wasm.__wbindgen_export_0;
     const offset = table.grow(4);
     table.set(0, undefined);

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -29,15 +29,12 @@ function addHeapObject(obj) {
     return idx;
 }
 
-function handleError(f) {
-    return function () {
-        try {
-            return f.apply(this, arguments);
-
-        } catch (e) {
-            wasm.__wbindgen_exn_store(addHeapObject(e));
-        }
-    };
+function handleError(f, args) {
+    try {
+        return f.apply(this, arguments);
+    } catch (e) {
+        wasm.__wbindgen_exn_store(addHeapObject(e));
+    }
 }
 /**
 */
@@ -45,11 +42,11 @@ export function exported() {
     wasm.exported();
 }
 
-export const __wbg_foo_8d66ddef0ff279d6 = handleError(function() {
+export function __wbg_foo_8d66ddef0ff279d6() { handleError(function () {
     foo();
-});
+}, arguments )};
 
-export const __wbindgen_rethrow = function(arg0) {
+export function __wbindgen_rethrow(arg0) {
     throw takeObject(arg0);
 };
 

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -31,7 +31,7 @@ function addHeapObject(obj) {
 
 function handleError(f, args) {
     try {
-        return f.apply(this, arguments);
+        return f.apply(this, args);
     } catch (e) {
         wasm.__wbindgen_exn_store(addHeapObject(e));
     }

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -42,9 +42,9 @@ export function exported() {
     wasm.exported();
 }
 
-export function __wbg_foo_8d66ddef0ff279d6() { handleError(function () {
+export function __wbg_foo_8d66ddef0ff279d6() { return handleError(function () {
     foo();
-}, arguments )};
+}, arguments) };
 
 export function __wbindgen_rethrow(arg0) {
     throw takeObject(arg0);

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -83,7 +83,7 @@ export function foo(a) {
     wasm.foo(ptr0, len0);
 }
 
-export const __wbindgen_throw = function(arg0, arg1) {
+export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
 };
 


### PR DESCRIPTION
This pr will be solution to #2343.
In this PR, binding functions are declared with "function" instead of "const".

[Hansihe showed](https://github.com/rustwasm/wasm-bindgen/issues/2343#issuecomment-766363602):

```js
((module, __webpack_exports__, __webpack_require__) => {
    module.exports = async () => {
        [...]
        __webpack_require__.d(__webpack_exports__, {
            [...],
            "__wbindgen_throw": () => __wbindgen_throw,
        });
        [...]

        var _my_rust_bg_wasm__WEBPACK_IMPORTED_MODULE = __webpack_require__(119);
        _my_rust_bg_wasm__WEBPACK_IMPORTED_MODULE = await Promise.resolve(_my_rust_bg_wasm__WEBPACK_IMPORTED_MODULE);

        [...]

        const __wbindgen_throw = function([..]) { [..] };

        [...]
        return __webpack_exports__;
    }();
})
```

Webpack tries to export "__wbindgen_throw", but "__wbindgen_throw" is undefined because "__wbindgen_throw" is declared below with "const" and undefined will be exported.

```js
        __webpack_require__.d(__webpack_exports__, {
            [...],
            "__wbindgen_throw": () => __wbindgen_throw,
        });
```

Now webpack start to load .wasm, but imported object "__wbindgen_throw" is undefined, which leads silent promise rejection.

```js
        var _my_rust_bg_wasm__WEBPACK_IMPORTED_MODULE = __webpack_require__(119);
```

"__wbindgen_throw" will be hoisted and it is not "undefined" when webpack exports "__wbindgen_throw".

```js
        __webpack_require__.d(__webpack_exports__, {
            [...],
            "__wbindgen_throw": () => __wbindgen_throw,
        });
        [...]
        function __wbindgen_throw([..]) { [..] };
```