### PR TITLE
cli-support: Make default_module_path optional

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -632,15 +632,16 @@ impl<'a> Context<'a> {
             }
         }
 
-        let default_module_path = match self.config.mode {
-            OutputMode::Web => format!(
-                "\
+        let default_module_path = if !self.config.omit_default_module_path {
+            match self.config.mode {
+                OutputMode::Web => format!(
+                    "\
                     if (typeof input === 'undefined') {{
                         input = new URL('{stem}_bg.wasm', import.meta.url);
                     }}",
-                stem = self.config.stem()?
-            ),
-            OutputMode::NoModules { .. } => "\
+                    stem = self.config.stem()?
+                ),
+                OutputMode::NoModules { .. } => "\
                     if (typeof input === 'undefined') {
                         let src;
                         if (typeof document === 'undefined') {
@@ -650,11 +651,17 @@ impl<'a> Context<'a> {
                         }
                         input = src.replace(/\\.js$/, '_bg.wasm');
                     }"
-            .to_string(),
-            _ => "".to_string(),
+                .to_string(),
+                _ => "".to_string(),
+            }
+        } else {
+            String::from("")
         };
 
-        let ts = self.ts_for_init_fn(has_memory, !default_module_path.is_empty())?;
+        let ts = self.ts_for_init_fn(
+            has_memory,
+            !self.config.omit_default_module_path && !default_module_path.is_empty(),
+        )?;
 
         // Initialize the `imports` object for all import definitions that we're
         // directed to wire up.

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -33,6 +33,7 @@ pub struct Bindgen {
     keep_debug: bool,
     remove_name_section: bool,
     remove_producers_section: bool,
+    omit_default_module_path: bool,
     emit_start: bool,
     // Experimental support for weakrefs, an upcoming ECMAScript feature.
     // Currently only enable-able through an env var.
@@ -115,6 +116,7 @@ impl Bindgen {
             multi_value: multi_value || wasm_interface_types,
             wasm_interface_types,
             encode_into: EncodeInto::Test,
+            omit_default_module_path: true,
         }
     }
 
@@ -279,6 +281,11 @@ impl Bindgen {
 
     pub fn encode_into(&mut self, mode: EncodeInto) -> &mut Bindgen {
         self.encode_into = mode;
+        self
+    }
+
+    pub fn omit_default_module_path(&mut self, omit_default_module_path: bool) -> &mut Bindgen {
+        self.omit_default_module_path = omit_default_module_path;
         self
     }
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -34,6 +34,7 @@ Options:
     --keep-debug                 Keep debug sections in wasm files
     --remove-name-section        Remove the debugging `name` section of the file
     --remove-producers-section   Remove the telemetry `producers` section
+    --omit-default-module-path   Don't add WebAssembly fallback imports in generated JavaScript
     --encode-into MODE           Whether or not to use TextEncoder#encodeInto,
                                  valid values are [test, always, never]
     --nodejs                     Deprecated, use `--target nodejs`
@@ -66,6 +67,7 @@ struct Args {
     flag_keep_debug: bool,
     flag_encode_into: Option<String>,
     flag_target: Option<String>,
+    flag_omit_default_module_path: bool,
     arg_input: Option<PathBuf>,
 }
 
@@ -117,7 +119,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .remove_name_section(args.flag_remove_name_section)
         .remove_producers_section(args.flag_remove_producers_section)
         .typescript(typescript)
-        .omit_imports(args.flag_omit_imports);
+        .omit_imports(args.flag_omit_imports)
+        .omit_default_module_path(args.flag_omit_default_module_path);
     if let Some(true) = args.flag_weak_refs {
         b.weak_refs(true);
     }

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -227,6 +227,93 @@ fn bin_crate_works() {
 }
 
 #[test]
+fn default_module_path_target_web() {
+    let (mut cmd, out_dir) = Project::new("default_module_path_target_web")
+        .file(
+            "src/lib.rs",
+            r#"
+            "#,
+        )
+        .wasm_bindgen("--target web");
+    cmd.assert().success();
+    let contents = fs::read_to_string(out_dir.join("default_module_path_target_web.js")).unwrap();
+    assert!(contents.contains(
+        "\
+async function init(input) {
+    if (typeof input === 'undefined') {
+        input = new URL('default_module_path_target_web_bg.wasm', import.meta.url);
+    }",
+    ));
+}
+
+#[test]
+fn default_module_path_target_no_modules() {
+    let (mut cmd, out_dir) = Project::new("default_module_path_target_no_modules")
+        .file(
+            "src/lib.rs",
+            r#"
+            "#,
+        )
+        .wasm_bindgen("--target no-modules");
+    cmd.assert().success();
+    let contents =
+        fs::read_to_string(out_dir.join("default_module_path_target_no_modules.js")).unwrap();
+    assert!(contents.contains(
+        "\
+    async function init(input) {
+        if (typeof input === 'undefined') {
+            let src;
+            if (typeof document === 'undefined') {
+                src = location.href;
+            } else {
+                src = document.currentScript.src;
+            }
+            input = src.replace(/\\.js$/, '_bg.wasm');
+        }",
+    ));
+}
+
+#[test]
+fn omit_default_module_path_target_web() {
+    let (mut cmd, out_dir) = Project::new("omit_default_module_path_target_web")
+        .file(
+            "src/lib.rs",
+            r#"
+            "#,
+        )
+        .wasm_bindgen("--target web --omit-default-module-path");
+    cmd.assert().success();
+    let contents =
+        fs::read_to_string(out_dir.join("omit_default_module_path_target_web.js")).unwrap();
+    assert!(contents.contains(
+        "\
+async function init(input) {
+
+    const imports = {};",
+    ));
+}
+
+#[test]
+fn omit_default_module_path_target_no_modules() {
+    let (mut cmd, out_dir) = Project::new("omit_default_module_path_target_no_modules")
+        .file(
+            "src/lib.rs",
+            r#"
+            "#,
+        )
+        .wasm_bindgen("--target no-modules --omit-default-module-path");
+    cmd.assert().success();
+    let contents =
+        fs::read_to_string(out_dir.join("omit_default_module_path_target_no_modules.js")).unwrap();
+    assert!(contents.contains(
+        "\
+    async function init(input) {
+
+        const imports = {};",
+    ));
+}
+
+#[test]
 fn empty_interface_types() {
     let (mut cmd, _out_dir) = Project::new("empty_interface_types")
         .file(

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -118,3 +118,7 @@ proposal](https://github.com/webassembly/reference-types) proposal, meaning that
 the WebAssembly binary will use `externref` when importing and exporting
 functions that work with `JsValue`. For more information see the [documentation
 about reference types](./reference-types.md).
+
+### `--omit-default-module-path`
+
+Don't add WebAssembly fallback imports in generated JavaScript.


### PR DESCRIPTION
Adds a new CLI flag `--omit-default-module-path`, to control the `default_module_path` generated JavaScript code.

The `default_module_path` generated JavaScript code is **enabled** by default, users need to explicitly disable it by setting the `--omit-default-module-path` CLI flag

```sh
$ wasm-bindgen --omit-default-module-path
```

Documentation

```txt
$ wasm-bindgen --help

Options:

...

--omit-default-module-path       Don't add WebAssembly fallback imports in generated JavaScript
```

Affected JavaScript code

`$ wasm-bindgen --target web`

```js
async function init(input) {
    if (typeof input === 'undefined') {
        input = import.meta.url.replace(/\.js$/, '_bg.wasm');
    }
    ...
```

`$ wasm-bindgen --target no-modules`

```js
async function init(input) {
    if (typeof input === 'undefined') {
        let src;
        if (typeof document === 'undefined') {
            src = location.href;
        } else {
            src = document.currentScript.src;
        }
        input = src.replace(/\\.js$/, '_bg.wasm');
    }
    ...
```