### PR TITLE
Fix typo wasm_bidngen to wasm_bindgen

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1097,7 +1097,7 @@ fn import_enum(enum_: syn::ItemEnum, program: &mut ast::Program) -> Result<(), D
             }
             expr => bail_span!(
                 expr,
-                "enums with #[wasm_bidngen] cannot mix string and non-string values",
+                "enums with #[wasm_bindgen] cannot mix string and non-string values",
             ),
         }
     }
@@ -1191,7 +1191,7 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
                         },
                         expr => bail_span!(
                             expr,
-                            "enums with #[wasm_bidngen] may only have \
+                            "enums with #[wasm_bindgen] may only have \
                              number literal values",
                         ),
                     },

--- a/crates/macro/ui-tests/invalid-enums.stderr
+++ b/crates/macro/ui-tests/invalid-enums.stderr
@@ -10,7 +10,7 @@ error: only C-Style enums allowed with #[wasm_bindgen]
 8 |     D(u32),
   |      ^^^^^
 
-error: enums with #[wasm_bidngen] may only have number literal values
+error: enums with #[wasm_bindgen] may only have number literal values
   --> $DIR/invalid-enums.rs:13:9
    |
 13 |     X = 1 + 3,


### PR DESCRIPTION
Fixes a couple of macro error messages which have `wasm_bidngen` instead of `wasm_bindgen`.