### PR TITLE
Enable additional TextMetrics properties

### DIFF
--- a/crates/web-sys/src/features/gen_TextMetrics.rs
+++ b/crates/web-sys/src/features/gen_TextMetrics.rs
@@ -18,4 +18,46 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
     pub fn width(this: &TextMetrics) -> f64;
+    # [wasm_bindgen (structural , method , getter , js_class = "TextMetrics" , js_name = actualBoundingBoxLeft)]
+    #[doc = "Getter for the `actualBoundingBoxLeft` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/actualBoundingBoxLeft)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
+    pub fn actual_bounding_box_left(this: &TextMetrics) -> f64;
+    # [wasm_bindgen (structural , method , getter , js_class = "TextMetrics" , js_name = actualBoundingBoxRight)]
+    #[doc = "Getter for the `actualBoundingBoxRight` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/actualBoundingBoxRight)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
+    pub fn actual_bounding_box_right(this: &TextMetrics) -> f64;
+    # [wasm_bindgen (structural , method , getter , js_class = "TextMetrics" , js_name = fontBoundingBoxAscent)]
+    #[doc = "Getter for the `fontBoundingBoxAscent` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/fontBoundingBoxAscent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
+    pub fn font_bounding_box_ascent(this: &TextMetrics) -> f64;
+    # [wasm_bindgen (structural , method , getter , js_class = "TextMetrics" , js_name = fontBoundingBoxDescent)]
+    #[doc = "Getter for the `fontBoundingBoxDescent` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/fontBoundingBoxDescent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
+    pub fn font_bounding_box_descent(this: &TextMetrics) -> f64;
+    # [wasm_bindgen (structural , method , getter , js_class = "TextMetrics" , js_name = actualBoundingBoxAscent)]
+    #[doc = "Getter for the `actualBoundingBoxAscent` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/actualBoundingBoxAscent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
+    pub fn actual_bounding_box_ascent(this: &TextMetrics) -> f64;
+    # [wasm_bindgen (structural , method , getter , js_class = "TextMetrics" , js_name = actualBoundingBoxDescent)]
+    #[doc = "Getter for the `actualBoundingBoxDescent` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/actualBoundingBoxDescent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `TextMetrics`*"]
+    pub fn actual_bounding_box_descent(this: &TextMetrics) -> f64;
 }

--- a/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
@@ -339,17 +339,19 @@ interface TextMetrics {
   // x-direction
   readonly attribute double width; // advance width
 
-  /*
-   * NOT IMPLEMENTED YET
-
   readonly attribute double actualBoundingBoxLeft;
   readonly attribute double actualBoundingBoxRight;
 
-  // y-direction
   readonly attribute double fontBoundingBoxAscent;
   readonly attribute double fontBoundingBoxDescent;
+
+  // y-direction
   readonly attribute double actualBoundingBoxAscent;
   readonly attribute double actualBoundingBoxDescent;
+
+  /*
+   * NOT IMPLEMENTED YET
+  
   readonly attribute double emHeightAscent;
   readonly attribute double emHeightDescent;
   readonly attribute double hangingBaseline;


### PR DESCRIPTION
When the webidl for `TextMetrics` was originally created, no properties except `width` had widespread browser support. Today, a number of additional metrics have reached widespread browser support ([caniuse link](https://caniuse.com/?search=TextMetrics)).

This PR enables the additional properties that have widespread browser support. I leave `emHeight{Ascent,Descent}` and `{hanging,alphabetic,ideographic}Baseline` commented as they currently have only Safari support.