### PR TITLE
Add TSDoc for the `imports`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -203,6 +203,7 @@ impl<'a> Context<'a> {
 
         let mut shim = String::new();
 
+        shim.push_str("/** @type {WebAssembly.Imports} */\n");
         shim.push_str("let imports = {};\n");
 
         if self.config.mode.nodejs_experimental_modules() {


### PR DESCRIPTION
Fixes:

```node
 error TS2345: Argument of type '{}' is not assignable to parameter of type 'Imports'.
  Index signature is missing in type '{}'.
```

Here is the repro:
https://github.com/umidbekk/prettier-plugin-prisma/runs/2845989557?check_suite_focus=true