### PR TITLE
Make navigator.clipboard fallible

### DIFF
--- a/crates/web-sys/src/features/gen_ClipboardEvent.rs
+++ b/crates/web-sys/src/features/gen_ClipboardEvent.rs
@@ -27,30 +27,4 @@ extern "C" {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clipboard_data(this: &ClipboardEvent) -> Option<DataTransfer>;
-    #[cfg(web_sys_unstable_apis)]
-    #[wasm_bindgen(catch, constructor, js_class = "ClipboardEvent")]
-    #[doc = "The `new ClipboardEvent(..)` constructor, creating a new instance of `ClipboardEvent`."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ClipboardEvent`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn new(type_: &str) -> Result<ClipboardEvent, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
-    #[cfg(feature = "ClipboardEventInit")]
-    #[wasm_bindgen(catch, constructor, js_class = "ClipboardEvent")]
-    #[doc = "The `new ClipboardEvent(..)` constructor, creating a new instance of `ClipboardEvent`."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ClipboardEvent`, `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn new_with_event_init_dict(
-        type_: &str,
-        event_init_dict: &ClipboardEventInit,
-    ) -> Result<ClipboardEvent, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_Navigator.rs
+++ b/crates/web-sys/src/features/gen_Navigator.rs
@@ -127,7 +127,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn clipboard(this: &Navigator) -> Clipboard;
+    pub fn clipboard(this: &Navigator) -> Option<Clipboard>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "WakeLock")]
     # [wasm_bindgen (structural , method , getter , js_class = "Navigator" , js_name = wakeLock)]

--- a/crates/web-sys/webidls/unstable/Clipboard.webidl
+++ b/crates/web-sys/webidls/unstable/Clipboard.webidl
@@ -1,22 +1,23 @@
 /* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /*
  * Clipboard API and events
- * W3C Working Draft, 5 June 2019
+ * W3C Working Draft, 4 June 2021
  * The origin of this IDL file is:
- * https://www.w3.org/TR/2019/WD-clipboard-apis-20190605/
+ * https://www.w3.org/TR/2021/WD-clipboard-apis-20210604/
  */
 
 dictionary ClipboardEventInit : EventInit {
   DataTransfer? clipboardData = null;
 };
 
-[Constructor(DOMString type, optional ClipboardEventInit eventInitDict), Exposed=Window]
+[Exposed=Window]
 interface ClipboardEvent : Event {
+  constructor(DOMString type, optional ClipboardEventInit eventInitDict = {});
   readonly attribute DataTransfer? clipboardData;
 };
 
 partial interface Navigator {
-  [SecureContext, SameObject] readonly attribute Clipboard clipboard;
+  [SecureContext, SameObject] readonly attribute Clipboard? clipboard;
 };
 
 typedef sequence<ClipboardItem> ClipboardItems;
@@ -33,12 +34,12 @@ typedef Promise<ClipboardItemDataType> ClipboardItemData;
 
 callback ClipboardItemDelayedCallback = ClipboardItemData ();
 
-[Constructor(record<DOMString, ClipboardItemData> items,
-    optional ClipboardItemOptions options),
- Exposed=Window] interface ClipboardItem {
+[Exposed=Window] interface ClipboardItem {
+  constructor(record<DOMString, ClipboardItemData> items,
+    optional ClipboardItemOptions options = {});
   static ClipboardItem createDelayed(
       record<DOMString, ClipboardItemDelayedCallback> items,
-      optional ClipboardItemOptions options);
+      optional ClipboardItemOptions options = {});
 
   readonly attribute PresentationStyle presentationStyle;
   readonly attribute long long lastModified;


### PR DESCRIPTION
`navigator.clipboard` is currently, in line with the [official IDL](https://www.w3.org/TR/2021/WD-clipboard-apis-20210604/#idl-index), infallible:

https://github.com/rustwasm/wasm-bindgen/blob/b2caf8370fa16a69fc405e667d6936247e14b64d/crates/web-sys/webidls/unstable/Clipboard.webidl#L18-L20

In practise though it is fallible, at least in firefox and edge it's undefined on non-HTTPS sites.

I went ahead and made this PR to change to `Clipboard? clipboard`, while also bumping the IDL used from [5 June 2019's](https://www.w3.org/TR/2019/WD-clipboard-apis-20190605/#idl-index) spec to [4 June 2021's](https://www.w3.org/TR/2021/WD-clipboard-apis-20210604/#idl-index).

Let me know if there's a better approach to resolving this! Also if someone could confirm the removal of `ClipboardEvent::{new,new_with_event_init_dict}` are expected?