### PR TITLE
Pass-through file urls to Deno.readFile

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -326,11 +326,7 @@ impl<'a> Context<'a> {
             let wasmCode = '';
             switch (wasm_url.protocol) {{
                 case 'file:':
-                    let wasm_pathname = wasm_url.pathname;
-                    if (Deno.build.os === 'windows' && wasm_pathname.startsWith('/')) {{
-                        wasm_pathname = wasm_pathname.substr(1);
-                    }}
-                    wasmCode = await Deno.readFile(wasm_pathname);
+                    wasmCode = await Deno.readFile(wasm_url);
                     break
                 case 'https:':
                 case 'http:':


### PR DESCRIPTION
This removes the conversion from URL to string and just passes through the file urls directly to `Deno.readFile`.
We support taking URLs as an overload in the runtime and when you have one resolved from import.meta, it's better to just pass it through.

See https://github.com/rustwasm/wasm-bindgen/issues/2296