### PR TITLE
fix: load internal node modules without string raw

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -537,7 +537,11 @@ impl<'a> Context<'a> {
                             imports.push_str(other)
                         }
                     }
-                    imports.push_str(" } = require(String.raw`");
+                    if module.starts_with(".") || PathBuf::from(module).is_absolute() {
+                        imports.push_str(" } = require(String.raw`");
+                    } else {
+                        imports.push_str(" } = require(`");
+                    }
                     imports.push_str(module);
                     imports.push_str("`);\n");
                 }


### PR DESCRIPTION
I'm not sure if there is a more elegant way to check for internal Node modules, but I think this should catch them all.

resolves #2605