### PR TITLE
Implement Default for JS types

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1098,12 +1098,6 @@ extern "C" {
     pub fn to_string(this: &Error) -> JsString;
 }
 
-impl Default for Error {
-    fn default() -> Self {
-        Self::new("")
-    }
-}
-
 // EvalError
 #[wasm_bindgen]
 extern "C" {
@@ -1118,12 +1112,6 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError)
     #[wasm_bindgen(constructor)]
     pub fn new(message: &str) -> EvalError;
-}
-
-impl Default for EvalError {
-    fn default() -> Self {
-        Self::new("")
-    }
 }
 
 // Function
@@ -2464,12 +2452,6 @@ extern "C" {
     pub fn value_of(this: &Date) -> f64;
 }
 
-impl Default for Date {
-    fn default() -> Self {
-        Self::new_0()
-    }
-}
-
 // Object.
 #[wasm_bindgen]
 extern "C" {
@@ -2786,12 +2768,6 @@ extern "C" {
     pub fn new(message: &str) -> RangeError;
 }
 
-impl Default for RangeError {
-    fn default() -> Self {
-        Self::new("")
-    }
-}
-
 // ReferenceError
 #[wasm_bindgen]
 extern "C" {
@@ -2809,12 +2785,6 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError)
     #[wasm_bindgen(constructor)]
     pub fn new(message: &str) -> ReferenceError;
-}
-
-impl Default for ReferenceError {
-    fn default() -> Self {
-        Self::new("")
-    }
 }
 
 #[allow(non_snake_case)]
@@ -3282,12 +3252,6 @@ extern "C" {
     pub fn new(message: &str) -> SyntaxError;
 }
 
-impl Default for SyntaxError {
-    fn default() -> Self {
-        Self::new("")
-    }
-}
-
 // TypeError
 #[wasm_bindgen]
 extern "C" {
@@ -3307,12 +3271,6 @@ extern "C" {
     pub fn new(message: &str) -> TypeError;
 }
 
-impl Default for TypeError {
-    fn default() -> Self {
-        Self::new("")
-    }
-}
-
 // URIError
 #[wasm_bindgen]
 extern "C" {
@@ -3330,12 +3288,6 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError)
     #[wasm_bindgen(constructor, js_class = "URIError")]
     pub fn new(message: &str) -> UriError;
-}
-
-impl Default for UriError {
-    fn default() -> Self {
-        Self::new("")
-    }
 }
 
 // WeakMap
@@ -3497,12 +3449,6 @@ pub mod WebAssembly {
         pub fn new(message: &str) -> CompileError;
     }
 
-    impl Default for CompileError {
-        fn default() -> Self {
-            Self::new("")
-        }
-    }
-
     // WebAssembly.Instance
     #[wasm_bindgen]
     extern "C" {
@@ -3556,12 +3502,6 @@ pub mod WebAssembly {
         pub fn new(message: &str) -> LinkError;
     }
 
-    impl Default for LinkError {
-        fn default() -> Self {
-            Self::new("")
-        }
-    }
-
     // WebAssembly.RuntimeError
     #[wasm_bindgen]
     extern "C" {
@@ -3581,12 +3521,6 @@ pub mod WebAssembly {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError)
         #[wasm_bindgen(constructor, js_namespace = WebAssembly)]
         pub fn new(message: &str) -> RuntimeError;
-    }
-
-    impl Default for RuntimeError {
-        fn default() -> Self {
-            Self::new("")
-        }
     }
 
     // WebAssembly.Module

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -500,6 +500,12 @@ where
     }
 }
 
+impl Default for Array {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ArrayBuffer
 #[wasm_bindgen]
 extern "C" {
@@ -815,6 +821,12 @@ impl fmt::Debug for Boolean {
     }
 }
 
+impl Default for Boolean {
+    fn default() -> Self {
+        Self::from(bool::default())
+    }
+}
+
 // DataView
 #[wasm_bindgen]
 extern "C" {
@@ -1086,6 +1098,12 @@ extern "C" {
     pub fn to_string(this: &Error) -> JsString;
 }
 
+impl Default for Error {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
 // EvalError
 #[wasm_bindgen]
 extern "C" {
@@ -1100,6 +1118,12 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError)
     #[wasm_bindgen(constructor)]
     pub fn new(message: &str) -> EvalError;
+}
+
+impl Default for EvalError {
+    fn default() -> Self {
+        Self::new("")
+    }
 }
 
 // Function
@@ -1251,6 +1275,12 @@ impl Function {
     }
 }
 
+impl Default for Function {
+    fn default() -> Self {
+        Self::new_no_args("")
+    }
+}
+
 // Generator
 #[wasm_bindgen]
 extern "C" {
@@ -1346,6 +1376,12 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size)
     #[wasm_bindgen(method, getter, structural)]
     pub fn size(this: &Map) -> u32;
+}
+
+impl Default for Map {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // Map Iterator
@@ -1980,6 +2016,12 @@ impl fmt::Debug for Number {
     }
 }
 
+impl Default for Number {
+    fn default() -> Self {
+        Self::from(f64::default())
+    }
+}
+
 // Date.
 #[wasm_bindgen]
 extern "C" {
@@ -2422,6 +2464,12 @@ extern "C" {
     pub fn value_of(this: &Date) -> f64;
 }
 
+impl Default for Date {
+    fn default() -> Self {
+        Self::new_0()
+    }
+}
+
 // Object.
 #[wasm_bindgen]
 extern "C" {
@@ -2690,6 +2738,12 @@ impl PartialEq for Object {
 
 impl Eq for Object {}
 
+impl Default for Object {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Proxy
 #[wasm_bindgen]
 extern "C" {
@@ -2732,6 +2786,12 @@ extern "C" {
     pub fn new(message: &str) -> RangeError;
 }
 
+impl Default for RangeError {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
 // ReferenceError
 #[wasm_bindgen]
 extern "C" {
@@ -2749,6 +2809,12 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError)
     #[wasm_bindgen(constructor)]
     pub fn new(message: &str) -> ReferenceError;
+}
+
+impl Default for ReferenceError {
+    fn default() -> Self {
+        Self::new("")
+    }
 }
 
 #[allow(non_snake_case)]
@@ -3160,6 +3226,12 @@ extern "C" {
     pub fn size(this: &Set) -> u32;
 }
 
+impl Default for Set {
+    fn default() -> Self {
+        Self::new(&JsValue::UNDEFINED)
+    }
+}
+
 // SetIterator
 #[wasm_bindgen]
 extern "C" {
@@ -3210,6 +3282,12 @@ extern "C" {
     pub fn new(message: &str) -> SyntaxError;
 }
 
+impl Default for SyntaxError {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
 // TypeError
 #[wasm_bindgen]
 extern "C" {
@@ -3229,6 +3307,12 @@ extern "C" {
     pub fn new(message: &str) -> TypeError;
 }
 
+impl Default for TypeError {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
 // URIError
 #[wasm_bindgen]
 extern "C" {
@@ -3246,6 +3330,12 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError)
     #[wasm_bindgen(constructor, js_class = "URIError")]
     pub fn new(message: &str) -> UriError;
+}
+
+impl Default for UriError {
+    fn default() -> Self {
+        Self::new("")
+    }
 }
 
 // WeakMap
@@ -3292,6 +3382,12 @@ extern "C" {
     pub fn delete(this: &WeakMap, key: &Object) -> bool;
 }
 
+impl Default for WeakMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // WeakSet
 #[wasm_bindgen]
 extern "C" {
@@ -3324,6 +3420,12 @@ extern "C" {
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete)
     #[wasm_bindgen(method)]
     pub fn delete(this: &WeakSet, value: &Object) -> bool;
+}
+
+impl Default for WeakSet {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[allow(non_snake_case)]
@@ -3395,6 +3497,12 @@ pub mod WebAssembly {
         pub fn new(message: &str) -> CompileError;
     }
 
+    impl Default for CompileError {
+        fn default() -> Self {
+            Self::new("")
+        }
+    }
+
     // WebAssembly.Instance
     #[wasm_bindgen]
     extern "C" {
@@ -3448,6 +3556,12 @@ pub mod WebAssembly {
         pub fn new(message: &str) -> LinkError;
     }
 
+    impl Default for LinkError {
+        fn default() -> Self {
+            Self::new("")
+        }
+    }
+
     // WebAssembly.RuntimeError
     #[wasm_bindgen]
     extern "C" {
@@ -3467,6 +3581,12 @@ pub mod WebAssembly {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError)
         #[wasm_bindgen(constructor, js_namespace = WebAssembly)]
         pub fn new(message: &str) -> RuntimeError;
+    }
+
+    impl Default for RuntimeError {
+        fn default() -> Self {
+            Self::new("")
+        }
     }
 
     // WebAssembly.Module
@@ -4493,6 +4613,15 @@ pub mod Intl {
         pub fn supported_locales_of(locales: &Array, options: &Object) -> Array;
     }
 
+    impl Default for Collator {
+        fn default() -> Self {
+            Self::new(
+                &JsValue::UNDEFINED.unchecked_into(),
+                &JsValue::UNDEFINED.unchecked_into(),
+            )
+        }
+    }
+
     // Intl.DateTimeFormat
     #[wasm_bindgen]
     extern "C" {
@@ -4542,6 +4671,15 @@ pub mod Intl {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/supportedLocalesOf)
         #[wasm_bindgen(static_method_of = DateTimeFormat, js_namespace = Intl, js_name = supportedLocalesOf)]
         pub fn supported_locales_of(locales: &Array, options: &Object) -> Array;
+    }
+
+    impl Default for DateTimeFormat {
+        fn default() -> Self {
+            Self::new(
+                &JsValue::UNDEFINED.unchecked_into(),
+                &JsValue::UNDEFINED.unchecked_into(),
+            )
+        }
     }
 
     // Intl.NumberFormat
@@ -4594,6 +4732,15 @@ pub mod Intl {
         pub fn supported_locales_of(locales: &Array, options: &Object) -> Array;
     }
 
+    impl Default for NumberFormat {
+        fn default() -> Self {
+            Self::new(
+                &JsValue::UNDEFINED.unchecked_into(),
+                &JsValue::UNDEFINED.unchecked_into(),
+            )
+        }
+    }
+
     // Intl.PluralRules
     #[wasm_bindgen]
     extern "C" {
@@ -4634,6 +4781,15 @@ pub mod Intl {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules/supportedLocalesOf)
         #[wasm_bindgen(static_method_of = PluralRules, js_namespace = Intl, js_name = supportedLocalesOf)]
         pub fn supported_locales_of(locales: &Array, options: &Object) -> Array;
+    }
+
+    impl Default for PluralRules {
+        fn default() -> Self {
+            Self::new(
+                &JsValue::UNDEFINED.unchecked_into(),
+                &JsValue::UNDEFINED.unchecked_into(),
+            )
+        }
     }
 }
 
@@ -5044,6 +5200,12 @@ macro_rules! arrays {
             fn from(slice: &'a [$ty]) -> $name {
                 // This is safe because the `new` function makes a copy if its argument is a TypedArray
                 unsafe { $name::new(&$name::view(slice)) }
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new(&JsValue::UNDEFINED.unchecked_into())
             }
         }
     )*);

--- a/crates/web-sys/src/features/gen_AddEventListenerOptions.rs
+++ b/crates/web-sys/src/features/gen_AddEventListenerOptions.rs
@@ -67,3 +67,8 @@ impl AddEventListenerOptions {
         self
     }
 }
+impl Default for AddEventListenerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AnalyserOptions.rs
+++ b/crates/web-sys/src/features/gen_AnalyserOptions.rs
@@ -141,3 +141,8 @@ impl AnalyserOptions {
         self
     }
 }
+impl Default for AnalyserOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AnimationEventInit.rs
+++ b/crates/web-sys/src/features/gen_AnimationEventInit.rs
@@ -122,3 +122,8 @@ impl AnimationEventInit {
         self
     }
 }
+impl Default for AnimationEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AnimationPlaybackEventInit.rs
+++ b/crates/web-sys/src/features/gen_AnimationPlaybackEventInit.rs
@@ -105,3 +105,8 @@ impl AnimationPlaybackEventInit {
         self
     }
 }
+impl Default for AnimationPlaybackEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AssignedNodesOptions.rs
+++ b/crates/web-sys/src/features/gen_AssignedNodesOptions.rs
@@ -37,3 +37,8 @@ impl AssignedNodesOptions {
         self
     }
 }
+impl Default for AssignedNodesOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AudioBufferSourceOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioBufferSourceOptions.rs
@@ -113,3 +113,8 @@ impl AudioBufferSourceOptions {
         self
     }
 }
+impl Default for AudioBufferSourceOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AudioConfiguration.rs
+++ b/crates/web-sys/src/features/gen_AudioConfiguration.rs
@@ -88,3 +88,8 @@ impl AudioConfiguration {
         self
     }
 }
+impl Default for AudioConfiguration {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AudioContextOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioContextOptions.rs
@@ -37,3 +37,8 @@ impl AudioContextOptions {
         self
     }
 }
+impl Default for AudioContextOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AudioNodeOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioNodeOptions.rs
@@ -73,3 +73,8 @@ impl AudioNodeOptions {
         self
     }
 }
+impl Default for AudioNodeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AudioWorkletNodeOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioWorkletNodeOptions.rs
@@ -141,3 +141,8 @@ impl AudioWorkletNodeOptions {
         self
     }
 }
+impl Default for AudioWorkletNodeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AuthenticationExtensionsClientInputs.rs
+++ b/crates/web-sys/src/features/gen_AuthenticationExtensionsClientInputs.rs
@@ -33,3 +33,8 @@ impl AuthenticationExtensionsClientInputs {
         self
     }
 }
+impl Default for AuthenticationExtensionsClientInputs {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AuthenticationExtensionsClientOutputs.rs
+++ b/crates/web-sys/src/features/gen_AuthenticationExtensionsClientOutputs.rs
@@ -33,3 +33,8 @@ impl AuthenticationExtensionsClientOutputs {
         self
     }
 }
+impl Default for AuthenticationExtensionsClientOutputs {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AuthenticatorSelectionCriteria.rs
+++ b/crates/web-sys/src/features/gen_AuthenticatorSelectionCriteria.rs
@@ -73,3 +73,8 @@ impl AuthenticatorSelectionCriteria {
         self
     }
 }
+impl Default for AuthenticatorSelectionCriteria {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_AutocompleteInfo.rs
+++ b/crates/web-sys/src/features/gen_AutocompleteInfo.rs
@@ -88,3 +88,8 @@ impl AutocompleteInfo {
         self
     }
 }
+impl Default for AutocompleteInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BaseComputedKeyframe.rs
+++ b/crates/web-sys/src/features/gen_BaseComputedKeyframe.rs
@@ -100,3 +100,8 @@ impl BaseComputedKeyframe {
         self
     }
 }
+impl Default for BaseComputedKeyframe {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BaseKeyframe.rs
+++ b/crates/web-sys/src/features/gen_BaseKeyframe.rs
@@ -83,3 +83,8 @@ impl BaseKeyframe {
         self
     }
 }
+impl Default for BaseKeyframe {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BasePropertyIndexedKeyframe.rs
+++ b/crates/web-sys/src/features/gen_BasePropertyIndexedKeyframe.rs
@@ -65,3 +65,8 @@ impl BasePropertyIndexedKeyframe {
         self
     }
 }
+impl Default for BasePropertyIndexedKeyframe {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BasicCardRequest.rs
+++ b/crates/web-sys/src/features/gen_BasicCardRequest.rs
@@ -54,3 +54,8 @@ impl BasicCardRequest {
         self
     }
 }
+impl Default for BasicCardRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BiquadFilterOptions.rs
+++ b/crates/web-sys/src/features/gen_BiquadFilterOptions.rs
@@ -144,3 +144,8 @@ impl BiquadFilterOptions {
         self
     }
 }
+impl Default for BiquadFilterOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BlobEventInit.rs
+++ b/crates/web-sys/src/features/gen_BlobEventInit.rs
@@ -85,3 +85,8 @@ impl BlobEventInit {
         self
     }
 }
+impl Default for BlobEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BlobPropertyBag.rs
+++ b/crates/web-sys/src/features/gen_BlobPropertyBag.rs
@@ -51,3 +51,8 @@ impl BlobPropertyBag {
         self
     }
 }
+impl Default for BlobPropertyBag {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BlockParsingOptions.rs
+++ b/crates/web-sys/src/features/gen_BlockParsingOptions.rs
@@ -37,3 +37,8 @@ impl BlockParsingOptions {
         self
     }
 }
+impl Default for BlockParsingOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BluetoothDataFilterInit.rs
+++ b/crates/web-sys/src/features/gen_BluetoothDataFilterInit.rs
@@ -66,3 +66,9 @@ impl BluetoothDataFilterInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for BluetoothDataFilterInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BluetoothLeScanFilterInit.rs
+++ b/crates/web-sys/src/features/gen_BluetoothLeScanFilterInit.rs
@@ -129,3 +129,9 @@ impl BluetoothLeScanFilterInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for BluetoothLeScanFilterInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BoxQuadOptions.rs
+++ b/crates/web-sys/src/features/gen_BoxQuadOptions.rs
@@ -51,3 +51,8 @@ impl BoxQuadOptions {
         self
     }
 }
+impl Default for BoxQuadOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BrowserElementDownloadOptions.rs
+++ b/crates/web-sys/src/features/gen_BrowserElementDownloadOptions.rs
@@ -54,3 +54,8 @@ impl BrowserElementDownloadOptions {
         self
     }
 }
+impl Default for BrowserElementDownloadOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_BrowserElementExecuteScriptOptions.rs
+++ b/crates/web-sys/src/features/gen_BrowserElementExecuteScriptOptions.rs
@@ -47,3 +47,8 @@ impl BrowserElementExecuteScriptOptions {
         self
     }
 }
+impl Default for BrowserElementExecuteScriptOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CacheBatchOperation.rs
+++ b/crates/web-sys/src/features/gen_CacheBatchOperation.rs
@@ -87,3 +87,8 @@ impl CacheBatchOperation {
         self
     }
 }
+impl Default for CacheBatchOperation {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CacheQueryOptions.rs
+++ b/crates/web-sys/src/features/gen_CacheQueryOptions.rs
@@ -88,3 +88,8 @@ impl CacheQueryOptions {
         self
     }
 }
+impl Default for CacheQueryOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CaretStateChangedEventInit.rs
+++ b/crates/web-sys/src/features/gen_CaretStateChangedEventInit.rs
@@ -206,3 +206,8 @@ impl CaretStateChangedEventInit {
         self
     }
 }
+impl Default for CaretStateChangedEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ChannelMergerOptions.rs
+++ b/crates/web-sys/src/features/gen_ChannelMergerOptions.rs
@@ -90,3 +90,8 @@ impl ChannelMergerOptions {
         self
     }
 }
+impl Default for ChannelMergerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ChannelSplitterOptions.rs
+++ b/crates/web-sys/src/features/gen_ChannelSplitterOptions.rs
@@ -90,3 +90,8 @@ impl ChannelSplitterOptions {
         self
     }
 }
+impl Default for ChannelSplitterOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CheckerboardReport.rs
+++ b/crates/web-sys/src/features/gen_CheckerboardReport.rs
@@ -82,3 +82,8 @@ impl CheckerboardReport {
         self
     }
 }
+impl Default for CheckerboardReport {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ChromeFilePropertyBag.rs
+++ b/crates/web-sys/src/features/gen_ChromeFilePropertyBag.rs
@@ -80,3 +80,8 @@ impl ChromeFilePropertyBag {
         self
     }
 }
+impl Default for ChromeFilePropertyBag {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ClientQueryOptions.rs
+++ b/crates/web-sys/src/features/gen_ClientQueryOptions.rs
@@ -51,3 +51,8 @@ impl ClientQueryOptions {
         self
     }
 }
+impl Default for ClientQueryOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ClipboardEventInit.rs
+++ b/crates/web-sys/src/features/gen_ClipboardEventInit.rs
@@ -113,3 +113,9 @@ impl ClipboardEventInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for ClipboardEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ClipboardItemOptions.rs
+++ b/crates/web-sys/src/features/gen_ClipboardItemOptions.rs
@@ -50,3 +50,9 @@ impl ClipboardItemOptions {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for ClipboardItemOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CloseEventInit.rs
+++ b/crates/web-sys/src/features/gen_CloseEventInit.rs
@@ -115,3 +115,8 @@ impl CloseEventInit {
         self
     }
 }
+impl Default for CloseEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CompositionEventInit.rs
+++ b/crates/web-sys/src/features/gen_CompositionEventInit.rs
@@ -112,3 +112,8 @@ impl CompositionEventInit {
         self
     }
 }
+impl Default for CompositionEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ComputedEffectTiming.rs
+++ b/crates/web-sys/src/features/gen_ComputedEffectTiming.rs
@@ -232,3 +232,8 @@ impl ComputedEffectTiming {
         self
     }
 }
+impl Default for ComputedEffectTiming {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConnStatusDict.rs
+++ b/crates/web-sys/src/features/gen_ConnStatusDict.rs
@@ -34,3 +34,8 @@ impl ConnStatusDict {
         self
     }
 }
+impl Default for ConnStatusDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleCounter.rs
+++ b/crates/web-sys/src/features/gen_ConsoleCounter.rs
@@ -46,3 +46,8 @@ impl ConsoleCounter {
         self
     }
 }
+impl Default for ConsoleCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleCounterError.rs
+++ b/crates/web-sys/src/features/gen_ConsoleCounterError.rs
@@ -46,3 +46,8 @@ impl ConsoleCounterError {
         self
     }
 }
+impl Default for ConsoleCounterError {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleEvent.rs
+++ b/crates/web-sys/src/features/gen_ConsoleEvent.rs
@@ -291,3 +291,8 @@ impl ConsoleEvent {
         self
     }
 }
+impl Default for ConsoleEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleInstanceOptions.rs
+++ b/crates/web-sys/src/features/gen_ConsoleInstanceOptions.rs
@@ -116,3 +116,8 @@ impl ConsoleInstanceOptions {
         self
     }
 }
+impl Default for ConsoleInstanceOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleProfileEvent.rs
+++ b/crates/web-sys/src/features/gen_ConsoleProfileEvent.rs
@@ -51,3 +51,8 @@ impl ConsoleProfileEvent {
         self
     }
 }
+impl Default for ConsoleProfileEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleStackEntry.rs
+++ b/crates/web-sys/src/features/gen_ConsoleStackEntry.rs
@@ -105,3 +105,8 @@ impl ConsoleStackEntry {
         self
     }
 }
+impl Default for ConsoleStackEntry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleTimerError.rs
+++ b/crates/web-sys/src/features/gen_ConsoleTimerError.rs
@@ -46,3 +46,8 @@ impl ConsoleTimerError {
         self
     }
 }
+impl Default for ConsoleTimerError {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleTimerLogOrEnd.rs
+++ b/crates/web-sys/src/features/gen_ConsoleTimerLogOrEnd.rs
@@ -50,3 +50,8 @@ impl ConsoleTimerLogOrEnd {
         self
     }
 }
+impl Default for ConsoleTimerLogOrEnd {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConsoleTimerStart.rs
+++ b/crates/web-sys/src/features/gen_ConsoleTimerStart.rs
@@ -33,3 +33,8 @@ impl ConsoleTimerStart {
         self
     }
 }
+impl Default for ConsoleTimerStart {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConstantSourceOptions.rs
+++ b/crates/web-sys/src/features/gen_ConstantSourceOptions.rs
@@ -34,3 +34,8 @@ impl ConstantSourceOptions {
         self
     }
 }
+impl Default for ConstantSourceOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConstrainBooleanParameters.rs
+++ b/crates/web-sys/src/features/gen_ConstrainBooleanParameters.rs
@@ -46,3 +46,8 @@ impl ConstrainBooleanParameters {
         self
     }
 }
+impl Default for ConstrainBooleanParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConstrainDomStringParameters.rs
+++ b/crates/web-sys/src/features/gen_ConstrainDomStringParameters.rs
@@ -46,3 +46,8 @@ impl ConstrainDomStringParameters {
         self
     }
 }
+impl Default for ConstrainDomStringParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConstrainDoubleRange.rs
+++ b/crates/web-sys/src/features/gen_ConstrainDoubleRange.rs
@@ -72,3 +72,8 @@ impl ConstrainDoubleRange {
         self
     }
 }
+impl Default for ConstrainDoubleRange {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConstrainLongRange.rs
+++ b/crates/web-sys/src/features/gen_ConstrainLongRange.rs
@@ -72,3 +72,8 @@ impl ConstrainLongRange {
         self
     }
 }
+impl Default for ConstrainLongRange {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ContextAttributes2d.rs
+++ b/crates/web-sys/src/features/gen_ContextAttributes2d.rs
@@ -50,3 +50,8 @@ impl ContextAttributes2d {
         self
     }
 }
+impl Default for ContextAttributes2d {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConvertCoordinateOptions.rs
+++ b/crates/web-sys/src/features/gen_ConvertCoordinateOptions.rs
@@ -52,3 +52,8 @@ impl ConvertCoordinateOptions {
         self
     }
 }
+impl Default for ConvertCoordinateOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ConvolverOptions.rs
+++ b/crates/web-sys/src/features/gen_ConvolverOptions.rs
@@ -105,3 +105,8 @@ impl ConvolverOptions {
         self
     }
 }
+impl Default for ConvolverOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CredentialCreationOptions.rs
+++ b/crates/web-sys/src/features/gen_CredentialCreationOptions.rs
@@ -53,3 +53,8 @@ impl CredentialCreationOptions {
         self
     }
 }
+impl Default for CredentialCreationOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CredentialRequestOptions.rs
+++ b/crates/web-sys/src/features/gen_CredentialRequestOptions.rs
@@ -53,3 +53,8 @@ impl CredentialRequestOptions {
         self
     }
 }
+impl Default for CredentialRequestOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_Csp.rs
+++ b/crates/web-sys/src/features/gen_Csp.rs
@@ -394,3 +394,8 @@ impl Csp {
         self
     }
 }
+impl Default for Csp {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CspPolicies.rs
+++ b/crates/web-sys/src/features/gen_CspPolicies.rs
@@ -37,3 +37,8 @@ impl CspPolicies {
         self
     }
 }
+impl Default for CspPolicies {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CspReport.rs
+++ b/crates/web-sys/src/features/gen_CspReport.rs
@@ -38,3 +38,8 @@ impl CspReport {
         self
     }
 }
+impl Default for CspReport {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CspReportProperties.rs
+++ b/crates/web-sys/src/features/gen_CspReportProperties.rs
@@ -173,3 +173,8 @@ impl CspReportProperties {
         self
     }
 }
+impl Default for CspReportProperties {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_CustomEventInit.rs
+++ b/crates/web-sys/src/features/gen_CustomEventInit.rs
@@ -85,3 +85,8 @@ impl CustomEventInit {
         self
     }
 }
+impl Default for CustomEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DateTimeValue.rs
+++ b/crates/web-sys/src/features/gen_DateTimeValue.rs
@@ -86,3 +86,8 @@ impl DateTimeValue {
         self
     }
 }
+impl Default for DateTimeValue {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DelayOptions.rs
+++ b/crates/web-sys/src/features/gen_DelayOptions.rs
@@ -107,3 +107,8 @@ impl DelayOptions {
         self
     }
 }
+impl Default for DelayOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DeviceAccelerationInit.rs
+++ b/crates/web-sys/src/features/gen_DeviceAccelerationInit.rs
@@ -59,3 +59,8 @@ impl DeviceAccelerationInit {
         self
     }
 }
+impl Default for DeviceAccelerationInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DeviceLightEventInit.rs
+++ b/crates/web-sys/src/features/gen_DeviceLightEventInit.rs
@@ -84,3 +84,8 @@ impl DeviceLightEventInit {
         self
     }
 }
+impl Default for DeviceLightEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DeviceMotionEventInit.rs
+++ b/crates/web-sys/src/features/gen_DeviceMotionEventInit.rs
@@ -142,3 +142,8 @@ impl DeviceMotionEventInit {
         self
     }
 }
+impl Default for DeviceMotionEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DeviceOrientationEventInit.rs
+++ b/crates/web-sys/src/features/gen_DeviceOrientationEventInit.rs
@@ -127,3 +127,8 @@ impl DeviceOrientationEventInit {
         self
     }
 }
+impl Default for DeviceOrientationEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DeviceProximityEventInit.rs
+++ b/crates/web-sys/src/features/gen_DeviceProximityEventInit.rs
@@ -110,3 +110,8 @@ impl DeviceProximityEventInit {
         self
     }
 }
+impl Default for DeviceProximityEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DeviceRotationRateInit.rs
+++ b/crates/web-sys/src/features/gen_DeviceRotationRateInit.rs
@@ -59,3 +59,8 @@ impl DeviceRotationRateInit {
         self
     }
 }
+impl Default for DeviceRotationRateInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DisplayMediaStreamConstraints.rs
+++ b/crates/web-sys/src/features/gen_DisplayMediaStreamConstraints.rs
@@ -46,3 +46,8 @@ impl DisplayMediaStreamConstraints {
         self
     }
 }
+impl Default for DisplayMediaStreamConstraints {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DisplayNameOptions.rs
+++ b/crates/web-sys/src/features/gen_DisplayNameOptions.rs
@@ -46,3 +46,8 @@ impl DisplayNameOptions {
         self
     }
 }
+impl Default for DisplayNameOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DisplayNameResult.rs
+++ b/crates/web-sys/src/features/gen_DisplayNameResult.rs
@@ -47,3 +47,8 @@ impl DisplayNameResult {
         self
     }
 }
+impl Default for DisplayNameResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DnsCacheDict.rs
+++ b/crates/web-sys/src/features/gen_DnsCacheDict.rs
@@ -37,3 +37,8 @@ impl DnsCacheDict {
         self
     }
 }
+impl Default for DnsCacheDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DnsCacheEntry.rs
+++ b/crates/web-sys/src/features/gen_DnsCacheEntry.rs
@@ -98,3 +98,8 @@ impl DnsCacheEntry {
         self
     }
 }
+impl Default for DnsCacheEntry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DnsLookupDict.rs
+++ b/crates/web-sys/src/features/gen_DnsLookupDict.rs
@@ -64,3 +64,8 @@ impl DnsLookupDict {
         self
     }
 }
+impl Default for DnsLookupDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DocumentTimelineOptions.rs
+++ b/crates/web-sys/src/features/gen_DocumentTimelineOptions.rs
@@ -37,3 +37,8 @@ impl DocumentTimelineOptions {
         self
     }
 }
+impl Default for DocumentTimelineOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DomPointInit.rs
+++ b/crates/web-sys/src/features/gen_DomPointInit.rs
@@ -72,3 +72,8 @@ impl DomPointInit {
         self
     }
 }
+impl Default for DomPointInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DomQuadInit.rs
+++ b/crates/web-sys/src/features/gen_DomQuadInit.rs
@@ -76,3 +76,8 @@ impl DomQuadInit {
         self
     }
 }
+impl Default for DomQuadInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DomQuadJson.rs
+++ b/crates/web-sys/src/features/gen_DomQuadJson.rs
@@ -76,3 +76,8 @@ impl DomQuadJson {
         self
     }
 }
+impl Default for DomQuadJson {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DomRectInit.rs
+++ b/crates/web-sys/src/features/gen_DomRectInit.rs
@@ -73,3 +73,8 @@ impl DomRectInit {
         self
     }
 }
+impl Default for DomRectInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DomWindowResizeEventDetail.rs
+++ b/crates/web-sys/src/features/gen_DomWindowResizeEventDetail.rs
@@ -47,3 +47,8 @@ impl DomWindowResizeEventDetail {
         self
     }
 }
+impl Default for DomWindowResizeEventDetail {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DragEventInit.rs
+++ b/crates/web-sys/src/features/gen_DragEventInit.rs
@@ -486,3 +486,8 @@ impl DragEventInit {
         self
     }
 }
+impl Default for DragEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_DynamicsCompressorOptions.rs
+++ b/crates/web-sys/src/features/gen_DynamicsCompressorOptions.rs
@@ -147,3 +147,8 @@ impl DynamicsCompressorOptions {
         self
     }
 }
+impl Default for DynamicsCompressorOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_EffectTiming.rs
+++ b/crates/web-sys/src/features/gen_EffectTiming.rs
@@ -147,3 +147,8 @@ impl EffectTiming {
         self
     }
 }
+impl Default for EffectTiming {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ElementCreationOptions.rs
+++ b/crates/web-sys/src/features/gen_ElementCreationOptions.rs
@@ -47,3 +47,8 @@ impl ElementCreationOptions {
         self
     }
 }
+impl Default for ElementCreationOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ElementDefinitionOptions.rs
+++ b/crates/web-sys/src/features/gen_ElementDefinitionOptions.rs
@@ -37,3 +37,8 @@ impl ElementDefinitionOptions {
         self
     }
 }
+impl Default for ElementDefinitionOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ErrorCallback.rs
+++ b/crates/web-sys/src/features/gen_ErrorCallback.rs
@@ -37,3 +37,8 @@ impl ErrorCallback {
         self
     }
 }
+impl Default for ErrorCallback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_ErrorEventInit.rs
@@ -145,3 +145,8 @@ impl ErrorEventInit {
         self
     }
 }
+impl Default for ErrorEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_EventInit.rs
+++ b/crates/web-sys/src/features/gen_EventInit.rs
@@ -71,3 +71,8 @@ impl EventInit {
         self
     }
 }
+impl Default for EventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_EventListener.rs
+++ b/crates/web-sys/src/features/gen_EventListener.rs
@@ -37,3 +37,8 @@ impl EventListener {
         self
     }
 }
+impl Default for EventListener {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_EventListenerOptions.rs
+++ b/crates/web-sys/src/features/gen_EventListenerOptions.rs
@@ -37,3 +37,8 @@ impl EventListenerOptions {
         self
     }
 }
+impl Default for EventListenerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_EventModifierInit.rs
+++ b/crates/web-sys/src/features/gen_EventModifierInit.rs
@@ -317,3 +317,8 @@ impl EventModifierInit {
         self
     }
 }
+impl Default for EventModifierInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_EventSourceInit.rs
+++ b/crates/web-sys/src/features/gen_EventSourceInit.rs
@@ -37,3 +37,8 @@ impl EventSourceInit {
         self
     }
 }
+impl Default for EventSourceInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ExtendableEventInit.rs
+++ b/crates/web-sys/src/features/gen_ExtendableEventInit.rs
@@ -71,3 +71,8 @@ impl ExtendableEventInit {
         self
     }
 }
+impl Default for ExtendableEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ExtendableMessageEventInit.rs
+++ b/crates/web-sys/src/features/gen_ExtendableMessageEventInit.rs
@@ -142,3 +142,8 @@ impl ExtendableMessageEventInit {
         self
     }
 }
+impl Default for ExtendableMessageEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FetchReadableStreamReadDataArray.rs
+++ b/crates/web-sys/src/features/gen_FetchReadableStreamReadDataArray.rs
@@ -20,3 +20,8 @@ impl FetchReadableStreamReadDataArray {
         ret
     }
 }
+impl Default for FetchReadableStreamReadDataArray {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FetchReadableStreamReadDataDone.rs
+++ b/crates/web-sys/src/features/gen_FetchReadableStreamReadDataDone.rs
@@ -33,3 +33,8 @@ impl FetchReadableStreamReadDataDone {
         self
     }
 }
+impl Default for FetchReadableStreamReadDataDone {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FileCallback.rs
+++ b/crates/web-sys/src/features/gen_FileCallback.rs
@@ -37,3 +37,8 @@ impl FileCallback {
         self
     }
 }
+impl Default for FileCallback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FilePropertyBag.rs
+++ b/crates/web-sys/src/features/gen_FilePropertyBag.rs
@@ -50,3 +50,8 @@ impl FilePropertyBag {
         self
     }
 }
+impl Default for FilePropertyBag {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FileSystemEntriesCallback.rs
+++ b/crates/web-sys/src/features/gen_FileSystemEntriesCallback.rs
@@ -37,3 +37,8 @@ impl FileSystemEntriesCallback {
         self
     }
 }
+impl Default for FileSystemEntriesCallback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FileSystemEntryCallback.rs
+++ b/crates/web-sys/src/features/gen_FileSystemEntryCallback.rs
@@ -37,3 +37,8 @@ impl FileSystemEntryCallback {
         self
     }
 }
+impl Default for FileSystemEntryCallback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FileSystemFlags.rs
+++ b/crates/web-sys/src/features/gen_FileSystemFlags.rs
@@ -51,3 +51,8 @@ impl FileSystemFlags {
         self
     }
 }
+impl Default for FileSystemFlags {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FocusEventInit.rs
+++ b/crates/web-sys/src/features/gen_FocusEventInit.rs
@@ -117,3 +117,8 @@ impl FocusEventInit {
         self
     }
 }
+impl Default for FocusEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FontFaceDescriptors.rs
+++ b/crates/web-sys/src/features/gen_FontFaceDescriptors.rs
@@ -149,3 +149,8 @@ impl FontFaceDescriptors {
         self
     }
 }
+impl Default for FontFaceDescriptors {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_FontFaceSetLoadEventInit.rs
+++ b/crates/web-sys/src/features/gen_FontFaceSetLoadEventInit.rs
@@ -88,3 +88,8 @@ impl FontFaceSetLoadEventInit {
         self
     }
 }
+impl Default for FontFaceSetLoadEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GainOptions.rs
+++ b/crates/web-sys/src/features/gen_GainOptions.rs
@@ -86,3 +86,8 @@ impl GainOptions {
         self
     }
 }
+impl Default for GainOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GamepadAxisMoveEventInit.rs
+++ b/crates/web-sys/src/features/gen_GamepadAxisMoveEventInit.rs
@@ -115,3 +115,8 @@ impl GamepadAxisMoveEventInit {
         self
     }
 }
+impl Default for GamepadAxisMoveEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GamepadButtonEventInit.rs
+++ b/crates/web-sys/src/features/gen_GamepadButtonEventInit.rs
@@ -103,3 +103,8 @@ impl GamepadButtonEventInit {
         self
     }
 }
+impl Default for GamepadButtonEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GamepadEventInit.rs
+++ b/crates/web-sys/src/features/gen_GamepadEventInit.rs
@@ -89,3 +89,8 @@ impl GamepadEventInit {
         self
     }
 }
+impl Default for GamepadEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GetNotificationOptions.rs
+++ b/crates/web-sys/src/features/gen_GetNotificationOptions.rs
@@ -33,3 +33,8 @@ impl GetNotificationOptions {
         self
     }
 }
+impl Default for GetNotificationOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GetRootNodeOptions.rs
+++ b/crates/web-sys/src/features/gen_GetRootNodeOptions.rs
@@ -37,3 +37,8 @@ impl GetRootNodeOptions {
         self
     }
 }
+impl Default for GetRootNodeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuBlendComponent.rs
+++ b/crates/web-sys/src/features/gen_GpuBlendComponent.rs
@@ -94,3 +94,9 @@ impl GpuBlendComponent {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuBlendComponent {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuBufferBindingLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuBufferBindingLayout.rs
@@ -88,3 +88,9 @@ impl GpuBufferBindingLayout {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuBufferBindingLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuCommandBufferDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuCommandBufferDescriptor.rs
@@ -45,3 +45,9 @@ impl GpuCommandBufferDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuCommandBufferDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuCommandEncoderDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuCommandEncoderDescriptor.rs
@@ -66,3 +66,9 @@ impl GpuCommandEncoderDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuCommandEncoderDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuComputePassDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuComputePassDescriptor.rs
@@ -45,3 +45,9 @@ impl GpuComputePassDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuComputePassDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuDeviceDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuDeviceDescriptor.rs
@@ -66,3 +66,9 @@ impl GpuDeviceDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuDeviceDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuExternalTextureBindingLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuExternalTextureBindingLayout.rs
@@ -28,3 +28,9 @@ impl GpuExternalTextureBindingLayout {
         ret
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuExternalTextureBindingLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuImageDataLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuImageDataLayout.rs
@@ -88,3 +88,9 @@ impl GpuImageDataLayout {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuImageDataLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuMultisampleState.rs
+++ b/crates/web-sys/src/features/gen_GpuMultisampleState.rs
@@ -83,3 +83,9 @@ impl GpuMultisampleState {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuMultisampleState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuObjectDescriptorBase.rs
+++ b/crates/web-sys/src/features/gen_GpuObjectDescriptorBase.rs
@@ -45,3 +45,9 @@ impl GpuObjectDescriptorBase {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuObjectDescriptorBase {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuOrigin2dDict.rs
+++ b/crates/web-sys/src/features/gen_GpuOrigin2dDict.rs
@@ -62,3 +62,9 @@ impl GpuOrigin2dDict {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuOrigin2dDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuOrigin3dDict.rs
+++ b/crates/web-sys/src/features/gen_GpuOrigin3dDict.rs
@@ -79,3 +79,9 @@ impl GpuOrigin3dDict {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuOrigin3dDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuPipelineDescriptorBase.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineDescriptorBase.rs
@@ -64,3 +64,9 @@ impl GpuPipelineDescriptorBase {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuPipelineDescriptorBase {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuPrimitiveState.rs
+++ b/crates/web-sys/src/features/gen_GpuPrimitiveState.rs
@@ -137,3 +137,9 @@ impl GpuPrimitiveState {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuPrimitiveState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuRenderBundleDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderBundleDescriptor.rs
@@ -45,3 +45,9 @@ impl GpuRenderBundleDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuRenderBundleDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuRequestAdapterOptions.rs
+++ b/crates/web-sys/src/features/gen_GpuRequestAdapterOptions.rs
@@ -71,3 +71,9 @@ impl GpuRequestAdapterOptions {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuRequestAdapterOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuSamplerBindingLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuSamplerBindingLayout.rs
@@ -46,3 +46,9 @@ impl GpuSamplerBindingLayout {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuSamplerBindingLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuSamplerDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuSamplerDescriptor.rs
@@ -262,3 +262,9 @@ impl GpuSamplerDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuSamplerDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuStencilFaceState.rs
+++ b/crates/web-sys/src/features/gen_GpuStencilFaceState.rs
@@ -110,3 +110,9 @@ impl GpuStencilFaceState {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuStencilFaceState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuTextureBindingLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureBindingLayout.rs
@@ -93,3 +93,9 @@ impl GpuTextureBindingLayout {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuTextureBindingLayout {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GpuTextureViewDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureViewDescriptor.rs
@@ -189,3 +189,9 @@ impl GpuTextureViewDescriptor {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for GpuTextureViewDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_GroupedHistoryEventInit.rs
+++ b/crates/web-sys/src/features/gen_GroupedHistoryEventInit.rs
@@ -89,3 +89,8 @@ impl GroupedHistoryEventInit {
         self
     }
 }
+impl Default for GroupedHistoryEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HalfOpenInfoDict.rs
+++ b/crates/web-sys/src/features/gen_HalfOpenInfoDict.rs
@@ -37,3 +37,8 @@ impl HalfOpenInfoDict {
         self
     }
 }
+impl Default for HalfOpenInfoDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HashChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_HashChangeEventInit.rs
@@ -99,3 +99,8 @@ impl HashChangeEventInit {
         self
     }
 }
+impl Default for HashChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HidCollectionInfo.rs
+++ b/crates/web-sys/src/features/gen_HidCollectionInfo.rs
@@ -167,3 +167,9 @@ impl HidCollectionInfo {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for HidCollectionInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HidDeviceFilter.rs
+++ b/crates/web-sys/src/features/gen_HidDeviceFilter.rs
@@ -108,3 +108,9 @@ impl HidDeviceFilter {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for HidDeviceFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HidReportInfo.rs
+++ b/crates/web-sys/src/features/gen_HidReportInfo.rs
@@ -66,3 +66,9 @@ impl HidReportInfo {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for HidReportInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HidReportItem.rs
+++ b/crates/web-sys/src/features/gen_HidReportItem.rs
@@ -610,3 +610,9 @@ impl HidReportItem {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for HidReportItem {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HiddenPluginEventInit.rs
+++ b/crates/web-sys/src/features/gen_HiddenPluginEventInit.rs
@@ -71,3 +71,8 @@ impl HiddenPluginEventInit {
         self
     }
 }
+impl Default for HiddenPluginEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HitRegionOptions.rs
+++ b/crates/web-sys/src/features/gen_HitRegionOptions.rs
@@ -65,3 +65,8 @@ impl HitRegionOptions {
         self
     }
 }
+impl Default for HitRegionOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HttpConnDict.rs
+++ b/crates/web-sys/src/features/gen_HttpConnDict.rs
@@ -37,3 +37,8 @@ impl HttpConnDict {
         self
     }
 }
+impl Default for HttpConnDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HttpConnInfo.rs
+++ b/crates/web-sys/src/features/gen_HttpConnInfo.rs
@@ -63,3 +63,8 @@ impl HttpConnInfo {
         self
     }
 }
+impl Default for HttpConnInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_HttpConnectionElement.rs
+++ b/crates/web-sys/src/features/gen_HttpConnectionElement.rs
@@ -116,3 +116,8 @@ impl HttpConnectionElement {
         self
     }
 }
+impl Default for HttpConnectionElement {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IdbFileMetadataParameters.rs
+++ b/crates/web-sys/src/features/gen_IdbFileMetadataParameters.rs
@@ -50,3 +50,8 @@ impl IdbFileMetadataParameters {
         self
     }
 }
+impl Default for IdbFileMetadataParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IdbIndexParameters.rs
+++ b/crates/web-sys/src/features/gen_IdbIndexParameters.rs
@@ -65,3 +65,8 @@ impl IdbIndexParameters {
         self
     }
 }
+impl Default for IdbIndexParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IdbObjectStoreParameters.rs
+++ b/crates/web-sys/src/features/gen_IdbObjectStoreParameters.rs
@@ -54,3 +54,8 @@ impl IdbObjectStoreParameters {
         self
     }
 }
+impl Default for IdbObjectStoreParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IdbOpenDbOptions.rs
+++ b/crates/web-sys/src/features/gen_IdbOpenDbOptions.rs
@@ -55,3 +55,8 @@ impl IdbOpenDbOptions {
         self
     }
 }
+impl Default for IdbOpenDbOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IdbVersionChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_IdbVersionChangeEventInit.rs
@@ -105,3 +105,8 @@ impl IdbVersionChangeEventInit {
         self
     }
 }
+impl Default for IdbVersionChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IdleRequestOptions.rs
+++ b/crates/web-sys/src/features/gen_IdleRequestOptions.rs
@@ -37,3 +37,8 @@ impl IdleRequestOptions {
         self
     }
 }
+impl Default for IdleRequestOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ImageCaptureErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_ImageCaptureErrorEventInit.rs
@@ -89,3 +89,8 @@ impl ImageCaptureErrorEventInit {
         self
     }
 }
+impl Default for ImageCaptureErrorEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_InputEventInit.rs
+++ b/crates/web-sys/src/features/gen_InputEventInit.rs
@@ -181,3 +181,8 @@ impl InputEventInit {
         self
     }
 }
+impl Default for InputEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_InstallTriggerData.rs
+++ b/crates/web-sys/src/features/gen_InstallTriggerData.rs
@@ -63,3 +63,8 @@ impl InstallTriggerData {
         self
     }
 }
+impl Default for InstallTriggerData {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IntersectionObserverInit.rs
+++ b/crates/web-sys/src/features/gen_IntersectionObserverInit.rs
@@ -68,3 +68,8 @@ impl IntersectionObserverInit {
         self
     }
 }
+impl Default for IntersectionObserverInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IterableKeyAndValueResult.rs
+++ b/crates/web-sys/src/features/gen_IterableKeyAndValueResult.rs
@@ -46,3 +46,8 @@ impl IterableKeyAndValueResult {
         self
     }
 }
+impl Default for IterableKeyAndValueResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_IterableKeyOrValueResult.rs
+++ b/crates/web-sys/src/features/gen_IterableKeyOrValueResult.rs
@@ -46,3 +46,8 @@ impl IterableKeyOrValueResult {
         self
     }
 }
+impl Default for IterableKeyOrValueResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_KeyboardEventInit.rs
+++ b/crates/web-sys/src/features/gen_KeyboardEventInit.rs
@@ -438,3 +438,8 @@ impl KeyboardEventInit {
         self
     }
 }
+impl Default for KeyboardEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_KeyframeEffectOptions.rs
+++ b/crates/web-sys/src/features/gen_KeyframeEffectOptions.rs
@@ -183,3 +183,8 @@ impl KeyframeEffectOptions {
         self
     }
 }
+impl Default for KeyframeEffectOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_L10nValue.rs
+++ b/crates/web-sys/src/features/gen_L10nValue.rs
@@ -50,3 +50,8 @@ impl L10nValue {
         self
     }
 }
+impl Default for L10nValue {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_LifecycleCallbacks.rs
+++ b/crates/web-sys/src/features/gen_LifecycleCallbacks.rs
@@ -88,3 +88,8 @@ impl LifecycleCallbacks {
         self
     }
 }
+impl Default for LifecycleCallbacks {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_LocaleInfo.rs
+++ b/crates/web-sys/src/features/gen_LocaleInfo.rs
@@ -51,3 +51,8 @@ impl LocaleInfo {
         self
     }
 }
+impl Default for LocaleInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaConfiguration.rs
+++ b/crates/web-sys/src/features/gen_MediaConfiguration.rs
@@ -48,3 +48,8 @@ impl MediaConfiguration {
         self
     }
 }
+impl Default for MediaConfiguration {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaKeyNeededEventInit.rs
+++ b/crates/web-sys/src/features/gen_MediaKeyNeededEventInit.rs
@@ -105,3 +105,8 @@ impl MediaKeyNeededEventInit {
         self
     }
 }
+impl Default for MediaKeyNeededEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaKeySystemConfiguration.rs
+++ b/crates/web-sys/src/features/gen_MediaKeySystemConfiguration.rs
@@ -137,3 +137,8 @@ impl MediaKeySystemConfiguration {
         self
     }
 }
+impl Default for MediaKeySystemConfiguration {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaKeySystemMediaCapability.rs
+++ b/crates/web-sys/src/features/gen_MediaKeySystemMediaCapability.rs
@@ -54,3 +54,8 @@ impl MediaKeySystemMediaCapability {
         self
     }
 }
+impl Default for MediaKeySystemMediaCapability {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaKeysPolicy.rs
+++ b/crates/web-sys/src/features/gen_MediaKeysPolicy.rs
@@ -37,3 +37,8 @@ impl MediaKeysPolicy {
         self
     }
 }
+impl Default for MediaKeysPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaQueryListEventInit.rs
+++ b/crates/web-sys/src/features/gen_MediaQueryListEventInit.rs
@@ -101,3 +101,8 @@ impl MediaQueryListEventInit {
         self
     }
 }
+impl Default for MediaQueryListEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaRecorderOptions.rs
+++ b/crates/web-sys/src/features/gen_MediaRecorderOptions.rs
@@ -88,3 +88,8 @@ impl MediaRecorderOptions {
         self
     }
 }
+impl Default for MediaRecorderOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaStreamConstraints.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamConstraints.rs
@@ -93,3 +93,8 @@ impl MediaStreamConstraints {
         self
     }
 }
+impl Default for MediaStreamConstraints {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaStreamEventInit.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamEventInit.rs
@@ -86,3 +86,8 @@ impl MediaStreamEventInit {
         self
     }
 }
+impl Default for MediaStreamEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaTrackConstraintSet.rs
+++ b/crates/web-sys/src/features/gen_MediaTrackConstraintSet.rs
@@ -285,3 +285,8 @@ impl MediaTrackConstraintSet {
         self
     }
 }
+impl Default for MediaTrackConstraintSet {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaTrackConstraints.rs
+++ b/crates/web-sys/src/features/gen_MediaTrackConstraints.rs
@@ -302,3 +302,8 @@ impl MediaTrackConstraints {
         self
     }
 }
+impl Default for MediaTrackConstraints {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaTrackSettings.rs
+++ b/crates/web-sys/src/features/gen_MediaTrackSettings.rs
@@ -166,3 +166,8 @@ impl MediaTrackSettings {
         self
     }
 }
+impl Default for MediaTrackSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MediaTrackSupportedConstraints.rs
+++ b/crates/web-sys/src/features/gen_MediaTrackSupportedConstraints.rs
@@ -265,3 +265,8 @@ impl MediaTrackSupportedConstraints {
         self
     }
 }
+impl Default for MediaTrackSupportedConstraints {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MessageEventInit.rs
+++ b/crates/web-sys/src/features/gen_MessageEventInit.rs
@@ -142,3 +142,8 @@ impl MessageEventInit {
         self
     }
 }
+impl Default for MessageEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MidiConnectionEventInit.rs
+++ b/crates/web-sys/src/features/gen_MidiConnectionEventInit.rs
@@ -85,3 +85,8 @@ impl MidiConnectionEventInit {
         self
     }
 }
+impl Default for MidiConnectionEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MidiMessageEventInit.rs
+++ b/crates/web-sys/src/features/gen_MidiMessageEventInit.rs
@@ -71,3 +71,8 @@ impl MidiMessageEventInit {
         self
     }
 }
+impl Default for MidiMessageEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MidiOptions.rs
+++ b/crates/web-sys/src/features/gen_MidiOptions.rs
@@ -50,3 +50,8 @@ impl MidiOptions {
         self
     }
 }
+impl Default for MidiOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MouseEventInit.rs
+++ b/crates/web-sys/src/features/gen_MouseEventInit.rs
@@ -468,3 +468,8 @@ impl MouseEventInit {
         self
     }
 }
+impl Default for MouseEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MutationObserverInit.rs
+++ b/crates/web-sys/src/features/gen_MutationObserverInit.rs
@@ -173,3 +173,8 @@ impl MutationObserverInit {
         self
     }
 }
+impl Default for MutationObserverInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_MutationObservingInfo.rs
+++ b/crates/web-sys/src/features/gen_MutationObservingInfo.rs
@@ -191,3 +191,8 @@ impl MutationObservingInfo {
         self
     }
 }
+impl Default for MutationObservingInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NativeOsFileReadOptions.rs
+++ b/crates/web-sys/src/features/gen_NativeOsFileReadOptions.rs
@@ -50,3 +50,8 @@ impl NativeOsFileReadOptions {
         self
     }
 }
+impl Default for NativeOsFileReadOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NativeOsFileWriteAtomicOptions.rs
+++ b/crates/web-sys/src/features/gen_NativeOsFileWriteAtomicOptions.rs
@@ -97,3 +97,8 @@ impl NativeOsFileWriteAtomicOptions {
         self
     }
 }
+impl Default for NativeOsFileWriteAtomicOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NetworkCommandOptions.rs
+++ b/crates/web-sys/src/features/gen_NetworkCommandOptions.rs
@@ -681,3 +681,8 @@ impl NetworkCommandOptions {
         self
     }
 }
+impl Default for NetworkCommandOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NetworkResultOptions.rs
+++ b/crates/web-sys/src/features/gen_NetworkResultOptions.rs
@@ -549,3 +549,8 @@ impl NetworkResultOptions {
         self
     }
 }
+impl Default for NetworkResultOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NodeFilter.rs
+++ b/crates/web-sys/src/features/gen_NodeFilter.rs
@@ -37,3 +37,8 @@ impl NodeFilter {
         self
     }
 }
+impl Default for NodeFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NotificationBehavior.rs
+++ b/crates/web-sys/src/features/gen_NotificationBehavior.rs
@@ -105,3 +105,8 @@ impl NotificationBehavior {
         self
     }
 }
+impl Default for NotificationBehavior {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_NotificationOptions.rs
+++ b/crates/web-sys/src/features/gen_NotificationOptions.rs
@@ -116,3 +116,8 @@ impl NotificationOptions {
         self
     }
 }
+impl Default for NotificationOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ObserverCallback.rs
+++ b/crates/web-sys/src/features/gen_ObserverCallback.rs
@@ -37,3 +37,8 @@ impl ObserverCallback {
         self
     }
 }
+impl Default for ObserverCallback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_OpenWindowEventDetail.rs
+++ b/crates/web-sys/src/features/gen_OpenWindowEventDetail.rs
@@ -81,3 +81,8 @@ impl OpenWindowEventDetail {
         self
     }
 }
+impl Default for OpenWindowEventDetail {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_OptionalEffectTiming.rs
+++ b/crates/web-sys/src/features/gen_OptionalEffectTiming.rs
@@ -147,3 +147,8 @@ impl OptionalEffectTiming {
         self
     }
 }
+impl Default for OptionalEffectTiming {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_OscillatorOptions.rs
+++ b/crates/web-sys/src/features/gen_OscillatorOptions.rs
@@ -136,3 +136,8 @@ impl OscillatorOptions {
         self
     }
 }
+impl Default for OscillatorOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PageTransitionEventInit.rs
+++ b/crates/web-sys/src/features/gen_PageTransitionEventInit.rs
@@ -105,3 +105,8 @@ impl PageTransitionEventInit {
         self
     }
 }
+impl Default for PageTransitionEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PannerOptions.rs
+++ b/crates/web-sys/src/features/gen_PannerOptions.rs
@@ -313,3 +313,8 @@ impl PannerOptions {
         self
     }
 }
+impl Default for PannerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PaymentRequestUpdateEventInit.rs
+++ b/crates/web-sys/src/features/gen_PaymentRequestUpdateEventInit.rs
@@ -71,3 +71,8 @@ impl PaymentRequestUpdateEventInit {
         self
     }
 }
+impl Default for PaymentRequestUpdateEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PerformanceEntryEventInit.rs
+++ b/crates/web-sys/src/features/gen_PerformanceEntryEventInit.rs
@@ -162,3 +162,8 @@ impl PerformanceEntryEventInit {
         self
     }
 }
+impl Default for PerformanceEntryEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PerformanceEntryFilterOptions.rs
+++ b/crates/web-sys/src/features/gen_PerformanceEntryFilterOptions.rs
@@ -67,3 +67,8 @@ impl PerformanceEntryFilterOptions {
         self
     }
 }
+impl Default for PerformanceEntryFilterOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PeriodicWaveConstraints.rs
+++ b/crates/web-sys/src/features/gen_PeriodicWaveConstraints.rs
@@ -37,3 +37,8 @@ impl PeriodicWaveConstraints {
         self
     }
 }
+impl Default for PeriodicWaveConstraints {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PeriodicWaveOptions.rs
+++ b/crates/web-sys/src/features/gen_PeriodicWaveOptions.rs
@@ -63,3 +63,8 @@ impl PeriodicWaveOptions {
         self
     }
 }
+impl Default for PeriodicWaveOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PluginCrashedEventInit.rs
+++ b/crates/web-sys/src/features/gen_PluginCrashedEventInit.rs
@@ -190,3 +190,8 @@ impl PluginCrashedEventInit {
         self
     }
 }
+impl Default for PluginCrashedEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PointerEventInit.rs
+++ b/crates/web-sys/src/features/gen_PointerEventInit.rs
@@ -636,3 +636,8 @@ impl PointerEventInit {
         self
     }
 }
+impl Default for PointerEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PopStateEventInit.rs
+++ b/crates/web-sys/src/features/gen_PopStateEventInit.rs
@@ -84,3 +84,8 @@ impl PopStateEventInit {
         self
     }
 }
+impl Default for PopStateEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PopupBlockedEventInit.rs
+++ b/crates/web-sys/src/features/gen_PopupBlockedEventInit.rs
@@ -123,3 +123,8 @@ impl PopupBlockedEventInit {
         self
     }
 }
+impl Default for PopupBlockedEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PositionOptions.rs
+++ b/crates/web-sys/src/features/gen_PositionOptions.rs
@@ -71,3 +71,8 @@ impl PositionOptions {
         self
     }
 }
+impl Default for PositionOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ProfileTimelineLayerRect.rs
+++ b/crates/web-sys/src/features/gen_ProfileTimelineLayerRect.rs
@@ -73,3 +73,8 @@ impl ProfileTimelineLayerRect {
         self
     }
 }
+impl Default for ProfileTimelineLayerRect {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ProfileTimelineMarker.rs
+++ b/crates/web-sys/src/features/gen_ProfileTimelineMarker.rs
@@ -260,3 +260,8 @@ impl ProfileTimelineMarker {
         self
     }
 }
+impl Default for ProfileTimelineMarker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ProfileTimelineStackFrame.rs
+++ b/crates/web-sys/src/features/gen_ProfileTimelineStackFrame.rs
@@ -126,3 +126,8 @@ impl ProfileTimelineStackFrame {
         self
     }
 }
+impl Default for ProfileTimelineStackFrame {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ProgressEventInit.rs
+++ b/crates/web-sys/src/features/gen_ProgressEventInit.rs
@@ -115,3 +115,8 @@ impl ProgressEventInit {
         self
     }
 }
+impl Default for ProgressEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PushEventInit.rs
+++ b/crates/web-sys/src/features/gen_PushEventInit.rs
@@ -84,3 +84,8 @@ impl PushEventInit {
         self
     }
 }
+impl Default for PushEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PushSubscriptionJson.rs
+++ b/crates/web-sys/src/features/gen_PushSubscriptionJson.rs
@@ -51,3 +51,8 @@ impl PushSubscriptionJson {
         self
     }
 }
+impl Default for PushSubscriptionJson {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PushSubscriptionKeys.rs
+++ b/crates/web-sys/src/features/gen_PushSubscriptionKeys.rs
@@ -47,3 +47,8 @@ impl PushSubscriptionKeys {
         self
     }
 }
+impl Default for PushSubscriptionKeys {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_PushSubscriptionOptionsInit.rs
+++ b/crates/web-sys/src/features/gen_PushSubscriptionOptionsInit.rs
@@ -54,3 +54,8 @@ impl PushSubscriptionOptionsInit {
         self
     }
 }
+impl Default for PushSubscriptionOptionsInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_QueuingStrategy.rs
+++ b/crates/web-sys/src/features/gen_QueuingStrategy.rs
@@ -66,3 +66,9 @@ impl QueuingStrategy {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for QueuingStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RcwnPerfStats.rs
+++ b/crates/web-sys/src/features/gen_RcwnPerfStats.rs
@@ -71,3 +71,8 @@ impl RcwnPerfStats {
         self
     }
 }
+impl Default for RcwnPerfStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RcwnStatus.rs
+++ b/crates/web-sys/src/features/gen_RcwnStatus.rs
@@ -122,3 +122,8 @@ impl RcwnStatus {
         self
     }
 }
+impl Default for RcwnStatus {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ReadableStreamByobReadResult.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamByobReadResult.rs
@@ -62,3 +62,9 @@ impl ReadableStreamByobReadResult {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for ReadableStreamByobReadResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ReadableStreamDefaultReadResult.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamDefaultReadResult.rs
@@ -62,3 +62,9 @@ impl ReadableStreamDefaultReadResult {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for ReadableStreamDefaultReadResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ReadableStreamGetReaderOptions.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamGetReaderOptions.rs
@@ -34,3 +34,8 @@ impl ReadableStreamGetReaderOptions {
         self
     }
 }
+impl Default for ReadableStreamGetReaderOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ReadableStreamIteratorOptions.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamIteratorOptions.rs
@@ -37,3 +37,8 @@ impl ReadableStreamIteratorOptions {
         self
     }
 }
+impl Default for ReadableStreamIteratorOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RegisterRequest.rs
+++ b/crates/web-sys/src/features/gen_RegisterRequest.rs
@@ -54,3 +54,8 @@ impl RegisterRequest {
         self
     }
 }
+impl Default for RegisterRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RegisterResponse.rs
+++ b/crates/web-sys/src/features/gen_RegisterResponse.rs
@@ -105,3 +105,8 @@ impl RegisterResponse {
         self
     }
 }
+impl Default for RegisterResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RegisteredKey.rs
+++ b/crates/web-sys/src/features/gen_RegisteredKey.rs
@@ -84,3 +84,8 @@ impl RegisteredKey {
         self
     }
 }
+impl Default for RegisteredKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RegistrationOptions.rs
+++ b/crates/web-sys/src/features/gen_RegistrationOptions.rs
@@ -51,3 +51,8 @@ impl RegistrationOptions {
         self
     }
 }
+impl Default for RegistrationOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RequestDeviceOptions.rs
+++ b/crates/web-sys/src/features/gen_RequestDeviceOptions.rs
@@ -91,3 +91,9 @@ impl RequestDeviceOptions {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for RequestDeviceOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RequestInit.rs
+++ b/crates/web-sys/src/features/gen_RequestInit.rs
@@ -213,3 +213,8 @@ impl RequestInit {
         self
     }
 }
+impl Default for RequestInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ResponseInit.rs
+++ b/crates/web-sys/src/features/gen_ResponseInit.rs
@@ -68,3 +68,8 @@ impl ResponseInit {
         self
     }
 }
+impl Default for ResponseInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcAnswerOptions.rs
+++ b/crates/web-sys/src/features/gen_RtcAnswerOptions.rs
@@ -20,3 +20,8 @@ impl RtcAnswerOptions {
         ret
     }
 }
+impl Default for RtcAnswerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcCertificateExpiration.rs
+++ b/crates/web-sys/src/features/gen_RtcCertificateExpiration.rs
@@ -37,3 +37,8 @@ impl RtcCertificateExpiration {
         self
     }
 }
+impl Default for RtcCertificateExpiration {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcCodecStats.rs
+++ b/crates/web-sys/src/features/gen_RtcCodecStats.rs
@@ -145,3 +145,8 @@ impl RtcCodecStats {
         self
     }
 }
+impl Default for RtcCodecStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcConfiguration.rs
+++ b/crates/web-sys/src/features/gen_RtcConfiguration.rs
@@ -107,3 +107,8 @@ impl RtcConfiguration {
         self
     }
 }
+impl Default for RtcConfiguration {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcDataChannelInit.rs
+++ b/crates/web-sys/src/features/gen_RtcDataChannelInit.rs
@@ -135,3 +135,8 @@ impl RtcDataChannelInit {
         self
     }
 }
+impl Default for RtcDataChannelInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcFecParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcFecParameters.rs
@@ -33,3 +33,8 @@ impl RtcFecParameters {
         self
     }
 }
+impl Default for RtcFecParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcIceCandidatePairStats.rs
+++ b/crates/web-sys/src/features/gen_RtcIceCandidatePairStats.rs
@@ -299,3 +299,8 @@ impl RtcIceCandidatePairStats {
         self
     }
 }
+impl Default for RtcIceCandidatePairStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcIceCandidateStats.rs
+++ b/crates/web-sys/src/features/gen_RtcIceCandidateStats.rs
@@ -167,3 +167,8 @@ impl RtcIceCandidateStats {
         self
     }
 }
+impl Default for RtcIceCandidateStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcIceComponentStats.rs
+++ b/crates/web-sys/src/features/gen_RtcIceComponentStats.rs
@@ -149,3 +149,8 @@ impl RtcIceComponentStats {
         self
     }
 }
+impl Default for RtcIceComponentStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcIceServer.rs
+++ b/crates/web-sys/src/features/gen_RtcIceServer.rs
@@ -98,3 +98,8 @@ impl RtcIceServer {
         self
     }
 }
+impl Default for RtcIceServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcIdentityAssertion.rs
+++ b/crates/web-sys/src/features/gen_RtcIdentityAssertion.rs
@@ -46,3 +46,8 @@ impl RtcIdentityAssertion {
         self
     }
 }
+impl Default for RtcIdentityAssertion {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcIdentityProviderOptions.rs
+++ b/crates/web-sys/src/features/gen_RtcIdentityProviderOptions.rs
@@ -71,3 +71,8 @@ impl RtcIdentityProviderOptions {
         self
     }
 }
+impl Default for RtcIdentityProviderOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcInboundRtpStreamStats.rs
+++ b/crates/web-sys/src/features/gen_RtcInboundRtpStreamStats.rs
@@ -414,3 +414,8 @@ impl RtcInboundRtpStreamStats {
         self
     }
 }
+impl Default for RtcInboundRtpStreamStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcMediaStreamStats.rs
+++ b/crates/web-sys/src/features/gen_RtcMediaStreamStats.rs
@@ -98,3 +98,8 @@ impl RtcMediaStreamStats {
         self
     }
 }
+impl Default for RtcMediaStreamStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcMediaStreamTrackStats.rs
+++ b/crates/web-sys/src/features/gen_RtcMediaStreamTrackStats.rs
@@ -302,3 +302,8 @@ impl RtcMediaStreamTrackStats {
         self
     }
 }
+impl Default for RtcMediaStreamTrackStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcOfferAnswerOptions.rs
+++ b/crates/web-sys/src/features/gen_RtcOfferAnswerOptions.rs
@@ -20,3 +20,8 @@ impl RtcOfferAnswerOptions {
         ret
     }
 }
+impl Default for RtcOfferAnswerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcOfferOptions.rs
+++ b/crates/web-sys/src/features/gen_RtcOfferOptions.rs
@@ -71,3 +71,8 @@ impl RtcOfferOptions {
         self
     }
 }
+impl Default for RtcOfferOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcOutboundRtpStreamStats.rs
+++ b/crates/web-sys/src/features/gen_RtcOutboundRtpStreamStats.rs
@@ -383,3 +383,8 @@ impl RtcOutboundRtpStreamStats {
         self
     }
 }
+impl Default for RtcOutboundRtpStreamStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcPeerConnectionIceEventInit.rs
+++ b/crates/web-sys/src/features/gen_RtcPeerConnectionIceEventInit.rs
@@ -89,3 +89,8 @@ impl RtcPeerConnectionIceEventInit {
         self
     }
 }
+impl Default for RtcPeerConnectionIceEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtcpParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcRtcpParameters.rs
@@ -50,3 +50,8 @@ impl RtcRtcpParameters {
         self
     }
 }
+impl Default for RtcRtcpParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtpCodecParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpCodecParameters.rs
@@ -105,3 +105,8 @@ impl RtcRtpCodecParameters {
         self
     }
 }
+impl Default for RtcRtpCodecParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtpEncodingParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpEncodingParameters.rs
@@ -158,3 +158,8 @@ impl RtcRtpEncodingParameters {
         self
     }
 }
+impl Default for RtcRtpEncodingParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtpHeaderExtensionParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpHeaderExtensionParameters.rs
@@ -63,3 +63,8 @@ impl RtcRtpHeaderExtensionParameters {
         self
     }
 }
+impl Default for RtcRtpHeaderExtensionParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtpParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpParameters.rs
@@ -82,3 +82,8 @@ impl RtcRtpParameters {
         self
     }
 }
+impl Default for RtcRtpParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtpTransceiverInit.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpTransceiverInit.rs
@@ -55,3 +55,8 @@ impl RtcRtpTransceiverInit {
         self
     }
 }
+impl Default for RtcRtpTransceiverInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcRtxParameters.rs
+++ b/crates/web-sys/src/features/gen_RtcRtxParameters.rs
@@ -33,3 +33,8 @@ impl RtcRtxParameters {
         self
     }
 }
+impl Default for RtcRtxParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcStats.rs
+++ b/crates/web-sys/src/features/gen_RtcStats.rs
@@ -64,3 +64,8 @@ impl RtcStats {
         self
     }
 }
+impl Default for RtcStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcStatsReportInternal.rs
+++ b/crates/web-sys/src/features/gen_RtcStatsReportInternal.rs
@@ -370,3 +370,8 @@ impl RtcStatsReportInternal {
         self
     }
 }
+impl Default for RtcStatsReportInternal {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcTransportStats.rs
+++ b/crates/web-sys/src/features/gen_RtcTransportStats.rs
@@ -98,3 +98,8 @@ impl RtcTransportStats {
         self
     }
 }
+impl Default for RtcTransportStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcdtmfToneChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_RtcdtmfToneChangeEventInit.rs
@@ -84,3 +84,8 @@ impl RtcdtmfToneChangeEventInit {
         self
     }
 }
+impl Default for RtcdtmfToneChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcrtpContributingSourceStats.rs
+++ b/crates/web-sys/src/features/gen_RtcrtpContributingSourceStats.rs
@@ -98,3 +98,8 @@ impl RtcrtpContributingSourceStats {
         self
     }
 }
+impl Default for RtcrtpContributingSourceStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_RtcrtpStreamStats.rs
+++ b/crates/web-sys/src/features/gen_RtcrtpStreamStats.rs
@@ -298,3 +298,8 @@ impl RtcrtpStreamStats {
         self
     }
 }
+impl Default for RtcrtpStreamStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ScrollIntoViewOptions.rs
+++ b/crates/web-sys/src/features/gen_ScrollIntoViewOptions.rs
@@ -67,3 +67,8 @@ impl ScrollIntoViewOptions {
         self
     }
 }
+impl Default for ScrollIntoViewOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ScrollOptions.rs
+++ b/crates/web-sys/src/features/gen_ScrollOptions.rs
@@ -38,3 +38,8 @@ impl ScrollOptions {
         self
     }
 }
+impl Default for ScrollOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ScrollToOptions.rs
+++ b/crates/web-sys/src/features/gen_ScrollToOptions.rs
@@ -64,3 +64,8 @@ impl ScrollToOptions {
         self
     }
 }
+impl Default for ScrollToOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ScrollViewChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_ScrollViewChangeEventInit.rs
@@ -85,3 +85,8 @@ impl ScrollViewChangeEventInit {
         self
     }
 }
+impl Default for ScrollViewChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SecurityPolicyViolationEventInit.rs
+++ b/crates/web-sys/src/features/gen_SecurityPolicyViolationEventInit.rs
@@ -273,3 +273,8 @@ impl SecurityPolicyViolationEventInit {
         self
     }
 }
+impl Default for SecurityPolicyViolationEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ServerSocketOptions.rs
+++ b/crates/web-sys/src/features/gen_ServerSocketOptions.rs
@@ -38,3 +38,8 @@ impl ServerSocketOptions {
         self
     }
 }
+impl Default for ServerSocketOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SignResponse.rs
+++ b/crates/web-sys/src/features/gen_SignResponse.rs
@@ -105,3 +105,8 @@ impl SignResponse {
         self
     }
 }
+impl Default for SignResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SocketElement.rs
+++ b/crates/web-sys/src/features/gen_SocketElement.rs
@@ -103,3 +103,8 @@ impl SocketElement {
         self
     }
 }
+impl Default for SocketElement {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SocketOptions.rs
+++ b/crates/web-sys/src/features/gen_SocketOptions.rs
@@ -55,3 +55,8 @@ impl SocketOptions {
         self
     }
 }
+impl Default for SocketOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SocketsDict.rs
+++ b/crates/web-sys/src/features/gen_SocketsDict.rs
@@ -67,3 +67,8 @@ impl SocketsDict {
         self
     }
 }
+impl Default for SocketsDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SpeechRecognitionErrorInit.rs
+++ b/crates/web-sys/src/features/gen_SpeechRecognitionErrorInit.rs
@@ -102,3 +102,8 @@ impl SpeechRecognitionErrorInit {
         self
     }
 }
+impl Default for SpeechRecognitionErrorInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SpeechRecognitionEventInit.rs
+++ b/crates/web-sys/src/features/gen_SpeechRecognitionEventInit.rs
@@ -137,3 +137,8 @@ impl SpeechRecognitionEventInit {
         self
     }
 }
+impl Default for SpeechRecognitionEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StereoPannerOptions.rs
+++ b/crates/web-sys/src/features/gen_StereoPannerOptions.rs
@@ -86,3 +86,8 @@ impl StereoPannerOptions {
         self
     }
 }
+impl Default for StereoPannerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StorageEstimate.rs
+++ b/crates/web-sys/src/features/gen_StorageEstimate.rs
@@ -46,3 +46,8 @@ impl StorageEstimate {
         self
     }
 }
+impl Default for StorageEstimate {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StorageEventInit.rs
+++ b/crates/web-sys/src/features/gen_StorageEventInit.rs
@@ -149,3 +149,8 @@ impl StorageEventInit {
         self
     }
 }
+impl Default for StorageEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StreamPipeOptions.rs
+++ b/crates/web-sys/src/features/gen_StreamPipeOptions.rs
@@ -86,3 +86,8 @@ impl StreamPipeOptions {
         self
     }
 }
+impl Default for StreamPipeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StyleRuleChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_StyleRuleChangeEventInit.rs
@@ -103,3 +103,8 @@ impl StyleRuleChangeEventInit {
         self
     }
 }
+impl Default for StyleRuleChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StyleSheetApplicableStateChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_StyleSheetApplicableStateChangeEventInit.rs
@@ -106,3 +106,8 @@ impl StyleSheetApplicableStateChangeEventInit {
         self
     }
 }
+impl Default for StyleSheetApplicableStateChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_StyleSheetChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_StyleSheetChangeEventInit.rs
@@ -106,3 +106,8 @@ impl StyleSheetChangeEventInit {
         self
     }
 }
+impl Default for StyleSheetChangeEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_SvgBoundingBoxOptions.rs
+++ b/crates/web-sys/src/features/gen_SvgBoundingBoxOptions.rs
@@ -81,3 +81,8 @@ impl SvgBoundingBoxOptions {
         self
     }
 }
+impl Default for SvgBoundingBoxOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TcpServerSocketEventInit.rs
+++ b/crates/web-sys/src/features/gen_TcpServerSocketEventInit.rs
@@ -86,3 +86,8 @@ impl TcpServerSocketEventInit {
         self
     }
 }
+impl Default for TcpServerSocketEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TcpSocketErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_TcpSocketErrorEventInit.rs
@@ -101,3 +101,8 @@ impl TcpSocketErrorEventInit {
         self
     }
 }
+impl Default for TcpSocketErrorEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TcpSocketEventInit.rs
+++ b/crates/web-sys/src/features/gen_TcpSocketEventInit.rs
@@ -84,3 +84,8 @@ impl TcpSocketEventInit {
         self
     }
 }
+impl Default for TcpSocketEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TextDecodeOptions.rs
+++ b/crates/web-sys/src/features/gen_TextDecodeOptions.rs
@@ -34,3 +34,8 @@ impl TextDecodeOptions {
         self
     }
 }
+impl Default for TextDecodeOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TextDecoderOptions.rs
+++ b/crates/web-sys/src/features/gen_TextDecoderOptions.rs
@@ -33,3 +33,8 @@ impl TextDecoderOptions {
         self
     }
 }
+impl Default for TextDecoderOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TouchEventInit.rs
+++ b/crates/web-sys/src/features/gen_TouchEventInit.rs
@@ -368,3 +368,8 @@ impl TouchEventInit {
         self
     }
 }
+impl Default for TouchEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TrackEventInit.rs
+++ b/crates/web-sys/src/features/gen_TrackEventInit.rs
@@ -84,3 +84,8 @@ impl TrackEventInit {
         self
     }
 }
+impl Default for TrackEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TransitionEventInit.rs
+++ b/crates/web-sys/src/features/gen_TransitionEventInit.rs
@@ -122,3 +122,8 @@ impl TransitionEventInit {
         self
     }
 }
+impl Default for TransitionEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_TreeCellInfo.rs
+++ b/crates/web-sys/src/features/gen_TreeCellInfo.rs
@@ -50,3 +50,8 @@ impl TreeCellInfo {
         self
     }
 }
+impl Default for TreeCellInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_U2fClientData.rs
+++ b/crates/web-sys/src/features/gen_U2fClientData.rs
@@ -64,3 +64,8 @@ impl U2fClientData {
         self
     }
 }
+impl Default for U2fClientData {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_UdpMessageEventInit.rs
+++ b/crates/web-sys/src/features/gen_UdpMessageEventInit.rs
@@ -118,3 +118,8 @@ impl UdpMessageEventInit {
         self
     }
 }
+impl Default for UdpMessageEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_UdpOptions.rs
+++ b/crates/web-sys/src/features/gen_UdpOptions.rs
@@ -122,3 +122,8 @@ impl UdpOptions {
         self
     }
 }
+impl Default for UdpOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_UiEventInit.rs
+++ b/crates/web-sys/src/features/gen_UiEventInit.rs
@@ -99,3 +99,8 @@ impl UiEventInit {
         self
     }
 }
+impl Default for UiEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_UsbDeviceFilter.rs
+++ b/crates/web-sys/src/features/gen_UsbDeviceFilter.rs
@@ -154,3 +154,9 @@ impl UsbDeviceFilter {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for UsbDeviceFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_UsbPermissionStorage.rs
+++ b/crates/web-sys/src/features/gen_UsbPermissionStorage.rs
@@ -49,3 +49,9 @@ impl UsbPermissionStorage {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for UsbPermissionStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_UserProximityEventInit.rs
+++ b/crates/web-sys/src/features/gen_UserProximityEventInit.rs
@@ -84,3 +84,8 @@ impl UserProximityEventInit {
         self
     }
 }
+impl Default for UserProximityEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_ValueEventInit.rs
+++ b/crates/web-sys/src/features/gen_ValueEventInit.rs
@@ -108,3 +108,9 @@ impl ValueEventInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for ValueEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_VideoConfiguration.rs
+++ b/crates/web-sys/src/features/gen_VideoConfiguration.rs
@@ -98,3 +98,8 @@ impl VideoConfiguration {
         self
     }
 }
+impl Default for VideoConfiguration {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_VoidCallback.rs
+++ b/crates/web-sys/src/features/gen_VoidCallback.rs
@@ -37,3 +37,8 @@ impl VoidCallback {
         self
     }
 }
+impl Default for VoidCallback {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_VrLayer.rs
+++ b/crates/web-sys/src/features/gen_VrLayer.rs
@@ -69,3 +69,8 @@ impl VrLayer {
         self
     }
 }
+impl Default for VrLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WatchAdvertisementsOptions.rs
+++ b/crates/web-sys/src/features/gen_WatchAdvertisementsOptions.rs
@@ -47,3 +47,9 @@ impl WatchAdvertisementsOptions {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for WatchAdvertisementsOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WaveShaperOptions.rs
+++ b/crates/web-sys/src/features/gen_WaveShaperOptions.rs
@@ -104,3 +104,8 @@ impl WaveShaperOptions {
         self
     }
 }
+impl Default for WaveShaperOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WebGlContextAttributes.rs
+++ b/crates/web-sys/src/features/gen_WebGlContextAttributes.rs
@@ -166,3 +166,8 @@ impl WebGlContextAttributes {
         self
     }
 }
+impl Default for WebGlContextAttributes {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WebGlContextEventInit.rs
+++ b/crates/web-sys/src/features/gen_WebGlContextEventInit.rs
@@ -88,3 +88,8 @@ impl WebGlContextEventInit {
         self
     }
 }
+impl Default for WebGlContextEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WebSocketDict.rs
+++ b/crates/web-sys/src/features/gen_WebSocketDict.rs
@@ -37,3 +37,8 @@ impl WebSocketDict {
         self
     }
 }
+impl Default for WebSocketDict {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WebSocketElement.rs
+++ b/crates/web-sys/src/features/gen_WebSocketElement.rs
@@ -122,3 +122,8 @@ impl WebSocketElement {
         self
     }
 }
+impl Default for WebSocketElement {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WebrtcGlobalStatisticsReport.rs
+++ b/crates/web-sys/src/features/gen_WebrtcGlobalStatisticsReport.rs
@@ -37,3 +37,8 @@ impl WebrtcGlobalStatisticsReport {
         self
     }
 }
+impl Default for WebrtcGlobalStatisticsReport {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WheelEventInit.rs
+++ b/crates/web-sys/src/features/gen_WheelEventInit.rs
@@ -527,3 +527,8 @@ impl WheelEventInit {
         self
     }
 }
+impl Default for WheelEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WorkerOptions.rs
+++ b/crates/web-sys/src/features/gen_WorkerOptions.rs
@@ -33,3 +33,8 @@ impl WorkerOptions {
         self
     }
 }
+impl Default for WorkerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_WorkletOptions.rs
+++ b/crates/web-sys/src/features/gen_WorkletOptions.rs
@@ -38,3 +38,8 @@ impl WorkletOptions {
         self
     }
 }
+impl Default for WorkletOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_XPathNsResolver.rs
+++ b/crates/web-sys/src/features/gen_XPathNsResolver.rs
@@ -37,3 +37,8 @@ impl XPathNsResolver {
         self
     }
 }
+impl Default for XPathNsResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_XrRenderStateInit.rs
+++ b/crates/web-sys/src/features/gen_XrRenderStateInit.rs
@@ -113,3 +113,9 @@ impl XrRenderStateInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for XrRenderStateInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_XrSessionInit.rs
+++ b/crates/web-sys/src/features/gen_XrSessionInit.rs
@@ -70,3 +70,9 @@ impl XrSessionInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for XrSessionInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/gen_XrWebGlLayerInit.rs
+++ b/crates/web-sys/src/features/gen_XrWebGlLayerInit.rs
@@ -146,3 +146,9 @@ impl XrWebGlLayerInit {
         self
     }
 }
+#[cfg(web_sys_unstable_apis)]
+impl Default for XrWebGlLayerInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -739,7 +739,7 @@ impl Dictionary {
             .map(|field| field.generate_rust(options, name.to_string()))
             .collect::<Vec<_>>();
 
-        quote! {
+        let mut base_stream = quote! {
             #![allow(unused_imports)]
             use super::*;
             use wasm_bindgen::prelude::*;
@@ -770,7 +770,22 @@ impl Dictionary {
 
                 #(#fields)*
             }
+        };
+
+        if required_args.is_empty() {
+            let default_impl = quote! {
+                #unstable_attr
+                impl Default for #name {
+                    fn default() -> Self {
+                        Self::new()
+                    }
+                }
+            };
+
+            base_stream.extend(default_impl.into_iter());
         }
+
+        base_stream
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,6 +570,12 @@ impl Drop for JsValue {
     }
 }
 
+impl Default for JsValue {
+    fn default() -> Self {
+        Self::UNDEFINED
+    }
+}
+
 /// Wrapper type for imported statics.
 ///
 /// This type is used whenever a `static` is imported from a JS module, for


### PR DESCRIPTION
- Implement the `Default` trait for types in `js-sys` where it makes sense
- Generate a `Default` impl for WebIDL types with zero-argument constructors 