### PR TITLE
Add `#[wasm_bindgen(getter_with_clone)]` attribute

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -343,6 +343,8 @@ pub struct StructField {
     pub comments: Vec<String>,
     /// Whether to generate a typescript definition for this field
     pub generate_typescript: bool,
+    /// Whether to use .clone() in the auto-generated getter for this field
+    pub getter_with_clone: bool,
 }
 
 /// Information about an Enum being exported

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -59,6 +59,7 @@ macro_rules! attrgen {
             (start, Start(Span)),
             (skip, Skip(Span)),
             (typescript_type, TypeScriptType(Span, String, Span)),
+            (getter_with_clone, GetterWithClone(Span)),
 
             // For testing purposes only.
             (assert_no_shim, AssertNoShim(Span)),
@@ -374,6 +375,7 @@ impl<'a> ConvertToAst<BindgenAttrs> for &'a mut syn::ItemStruct {
             .map(|s| s.0.to_string())
             .unwrap_or(self.ident.to_string());
         let is_inspectable = attrs.inspectable().is_some();
+        let getter_with_clone = attrs.getter_with_clone().is_some();
         for (i, field) in self.fields.iter_mut().enumerate() {
             match field.vis {
                 syn::Visibility::Public(..) => {}
@@ -410,6 +412,7 @@ impl<'a> ConvertToAst<BindgenAttrs> for &'a mut syn::ItemStruct {
                 setter: Ident::new(&setter, Span::call_site()),
                 comments,
                 generate_typescript: attrs.skip_typescript().is_none(),
+                getter_with_clone: getter_with_clone || attrs.getter_with_clone().is_some(),
             });
             attrs.check_used()?;
         }

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -87,6 +87,7 @@
       - [`inspectable`](./reference/attributes/on-rust-exports/inspectable.md)
       - [`skip_typescript`](./reference/attributes/on-rust-exports/skip_typescript.md)
       - [`typescript_type`](./reference/attributes/on-rust-exports/typescript_type.md)
+      - [`getter_with_clone`](./reference/attributes/on-rust-exports/getter_with_clone.md)
 
 - [`web-sys`](./web-sys/index.md)
   - [Using `web-sys`](./web-sys/using-web-sys.md)

--- a/guide/src/reference/attributes/on-rust-exports/getter_with_clone.md
+++ b/guide/src/reference/attributes/on-rust-exports/getter_with_clone.md
@@ -1,0 +1,17 @@
+# `getter_with_clone`
+
+By default, Rust exports exposed to JavaScript will generate getters that require fields to implement `Copy`. The `getter_with_clone` attribute can be used to generate getters that require `Clone` instead. This attribute can be applied per struct or per field. For example:
+
+```rust
+#[wasm_bindgen]
+pub struct Foo {
+    #[wasm_bindgen(getter_with_clone)]
+    pub bar: String,
+}
+
+#[wasm_bindgen(getter_with_clone)]
+pub struct Foo {
+    pub bar: String,
+    pub baz: String,
+}
+```

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -112,6 +112,18 @@ exports.js_public_fields = () => {
     assert.strictEqual(a.skipped, undefined);
 };
 
+exports.js_getter_with_clone = () => {
+    const a = wasm.GetterWithCloneStruct.new();
+    assert.strictEqual(a.a, '');
+    a.a = 'foo';
+    assert.strictEqual(a.a, 'foo');
+
+    const b = wasm.GetterWithCloneStructField.new();
+    assert.strictEqual(b.a, '');
+    b.a = 'foo';
+    assert.strictEqual(b.a, 'foo');
+};
+
 exports.js_using_self = () => {
     wasm.UseSelf.new().free();
 };

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -16,6 +16,7 @@ extern "C" {
     fn js_constructors();
     fn js_empty_structs();
     fn js_public_fields();
+    fn js_getter_with_clone();
     fn js_using_self();
     fn js_readonly_fields();
     fn js_double_consume();
@@ -285,6 +286,38 @@ pub struct PublicFields {
 impl PublicFields {
     pub fn new() -> PublicFields {
         PublicFields::default()
+    }
+}
+
+#[wasm_bindgen_test]
+fn getter_with_clone() {
+    js_getter_with_clone();
+}
+
+#[wasm_bindgen(getter_with_clone)]
+#[derive(Default)]
+pub struct GetterWithCloneStruct {
+    pub a: String,
+}
+
+#[wasm_bindgen]
+impl GetterWithCloneStruct {
+    pub fn new() -> GetterWithCloneStruct {
+        GetterWithCloneStruct::default()
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Default)]
+pub struct GetterWithCloneStructField {
+    #[wasm_bindgen(getter_with_clone)]
+    pub a: String,
+}
+
+#[wasm_bindgen]
+impl GetterWithCloneStructField {
+    pub fn new() -> GetterWithCloneStructField {
+        GetterWithCloneStructField::default()
     }
 }
 


### PR DESCRIPTION
https://github.com/rustwasm/wasm-bindgen/issues/1775#issuecomment-534144161 :

>it'd be a neat feature to do something like `#[wasm_bindgen(getter_setter_with_clone)]` or something like that so the boilerplate could be drastically reduced

```rust
// doesn't work: "the trait bound std::string::String: std::marker::Copy is not satisfied"
#[wasm_bindgen]
struct Data {
    pub id: String,
}

// now does work
#[wasm_bindgen(getter_with_clone)]
struct Data {
    pub id: String,
}
```
