### PR TITLE
Fix cast in `performance` API example

### DIFF
--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -31,6 +31,6 @@ pub fn run() {
 
 fn perf_to_system(amt: f64) -> SystemTime {
     let secs = (amt as u64) / 1_000;
-    let nanos = ((amt as u32) % 1_000) * 1_000_000;
+    let nanos = (((amt as u64) % 1_000) as u32) * 1_000_000;
     UNIX_EPOCH + Duration::new(secs, nanos)
 }


### PR DESCRIPTION
Rust 1.45 [defines](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#fixing-unsoundness-in-casts) `(f64 as u32)` as a saturating cast.
The millis was incorrectly always 295 (`u32::MAX % 1000`).

[Affected example](https://rustwasm.github.io/wasm-bindgen/examples/performance.html)