### PR TITLE
Implement To/FromWasmAbi for arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ test = false
 [features]
 default = ["spans", "std"]
 spans = ["wasm-bindgen-macro/spans"]
-std = []
+std = ["array-init"]
 serde-serialize = ["serde", "serde_json", "std"]
 nightly = []
 enable-interning = ["std"]
@@ -40,6 +40,7 @@ wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.75" }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 cfg-if = "1.0.0"
+array-init = { version = "2.0.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 js-sys = { path = 'crates/js-sys', version = '0.3.52' }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -155,6 +155,12 @@ if_std! {
             <Box<[T]>>::describe();
         }
     }
+
+    impl<T, const N: usize> WasmDescribe for [T; N] where Box<[T]>: WasmDescribe {
+        fn describe() {
+            <Box<[T]>>::describe();
+        }
+    }
 }
 
 impl<T: WasmDescribe> WasmDescribe for Option<T> {


### PR DESCRIPTION
Allows using Rust arrays as arguments and return values for `wasm-bindgen` functions.