### PR TITLE
Upgrade the webpack-based examples' npm dependencies (move to webpack 5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
   "examples/wasm-in-wasm-imports",
   "examples/wasm-in-web-worker",
   "examples/wasm2js",
+  "examples/weather_report",
   "examples/webaudio",
   "examples/webgl",
   "examples/webrtc_datachannel",

--- a/_package.json
+++ b/_package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
-    "build": "webpack -p",
-    "serve": "webpack-dev-server -p"
+    "build": "webpack",
+    "serve": "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
-    "html-webpack-plugin": "^3.2.0",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
+    "html-webpack-plugin": "^5.3.2",
     "text-encoding": "^0.7.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/add/package.json
+++ b/examples/add/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
-    "build": "webpack -p",
-    "serve": "webpack-dev-server -p"
+    "build": "webpack",
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
-    "html-webpack-plugin": "^3.2.0",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
+    "html-webpack-plugin": "^5.3.2",
     "text-encoding": "^0.7.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/add/webpack.config.js
+++ b/examples/add/webpack.config.js
@@ -21,5 +21,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/canvas/webpack.config.js
+++ b/examples/canvas/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/char/package.json
+++ b/examples/char/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/char/webpack.config.js
+++ b/examples/char/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/closures/package.json
+++ b/examples/closures/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/closures/webpack.config.js
+++ b/examples/closures/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/console_log/package.json
+++ b/examples/console_log/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/console_log/webpack.config.js
+++ b/examples/console_log/webpack.config.js
@@ -21,5 +21,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/dom/package.json
+++ b/examples/dom/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/dom/webpack.config.js
+++ b/examples/dom/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/duck-typed-interfaces/package.json
+++ b/examples/duck-typed-interfaces/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/duck-typed-interfaces/webpack.config.js
+++ b/examples/duck-typed-interfaces/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/fetch/webpack.config.js
+++ b/examples/fetch/webpack.config.js
@@ -21,5 +21,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/guide-supported-types-examples/package.json
+++ b/examples/guide-supported-types-examples/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/guide-supported-types-examples/webpack.config.js
+++ b/examples/guide-supported-types-examples/webpack.config.js
@@ -21,5 +21,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/hello_world/package.json
+++ b/examples/hello_world/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/hello_world/webpack.config.js
+++ b/examples/hello_world/webpack.config.js
@@ -21,5 +21,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/import_js/package.json
+++ b/examples/import_js/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/import_js/webpack.config.js
+++ b/examples/import_js/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/julia_set/package.json
+++ b/examples/julia_set/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/julia_set/webpack.config.js
+++ b/examples/julia_set/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/paint/package.json
+++ b/examples/paint/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/paint/webpack.config.js
+++ b/examples/paint/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/performance/package.json
+++ b/examples/performance/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/performance/webpack.config.js
+++ b/examples/performance/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/request-animation-frame/package.json
+++ b/examples/request-animation-frame/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/request-animation-frame/webpack.config.js
+++ b/examples/request-animation-frame/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/wasm-in-wasm-imports/package.json
+++ b/examples/wasm-in-wasm-imports/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/wasm-in-wasm-imports/webpack.config.js
+++ b/examples/wasm-in-wasm-imports/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/wasm-in-wasm/package.json
+++ b/examples/wasm-in-wasm/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/wasm-in-wasm/webpack.config.js
+++ b/examples/wasm-in-wasm/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/weather_report/package.json
+++ b/examples/weather_report/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/weather_report/src/lib.rs
+++ b/examples/weather_report/src/lib.rs
@@ -169,7 +169,7 @@ pub fn run() -> Result<(), JsValue> {
                 ".png'>",
                 "  ",
             ]
-                .concat();
+            .concat();
             let temp = ((&parsed["main"]["temp"]).to_owned().as_f64().unwrap() - 273.15) as i64;
 
             let content = [src, temp.to_string()].concat();

--- a/examples/weather_report/webpack.config.js
+++ b/examples/weather_report/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
             TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        syncWebAssembly: true
+   }
 };

--- a/examples/webaudio/package.json
+++ b/examples/webaudio/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/webaudio/webpack.config.js
+++ b/examples/webaudio/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/webgl/package.json
+++ b/examples/webgl/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/webgl/webpack.config.js
+++ b/examples/webgl/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/webrtc_datachannel/package.json
+++ b/examples/webrtc_datachannel/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/webrtc_datachannel/webpack.config.js
+++ b/examples/webrtc_datachannel/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/webxr/package.json
+++ b/examples/webxr/package.json
@@ -1,17 +1,17 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve": "webpack-dev-server"
+    "serve" : "webpack serve"
   },
   "dependencies": {
     "webxr": "./pkg"
   },
   "devDependencies": {
-    "@wasm-tool/wasm-pack-plugin": "1.0.1",
+    "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "text-encoding": "^0.7.0",
-    "html-webpack-plugin": "^3.2.0",
-    "webpack": "^4.29.4",
-    "webpack-cli": "^3.1.1",
-    "webpack-dev-server": "^3.1.0"
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.49.0",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^3.11.2"
   }
 }

--- a/examples/webxr/webpack.config.js
+++ b/examples/webxr/webpack.config.js
@@ -23,5 +23,8 @@ module.exports = {
           TextEncoder: ['text-encoding', 'TextEncoder']
         })
     ],
-    mode: 'development'
+    mode: 'development',
+    experiments: {
+        asyncWebAssembly: true
+   }
 };

--- a/examples/webxr/webxr.js
+++ b/examples/webxr/webxr.js
@@ -1,4 +1,4 @@
-import * as wasm from "webxr";
+import * as wasm from "./pkg";
 
 var xrApp = new wasm.XrApp();
 xrApp.init()


### PR DESCRIPTION
This is mostly:
```
$ fd webpack.config.js examples/ | xargs sed "s/mode: 'development'/mode: 'development',\n    experiments: {\n        asyncWebAssembly: true\n   }/" -i

$ fd package.json examples/ | xargs sed 's/serve": "webpack-dev-server/serve" : "webpack serve/' -i
```
And in each folder touched by the above:
```
$ ncu -u && npm update && npm update --dev
```
The `weather_report` and the `webxr` examples needed minor adjustments, but besides that everything seems to 

The examples seem to work, except `ducktype` and `guide-supported-types` which build, but I could not really see anything in the browser.
This was the same for me before this change, please let me know if this is not expected.