### PR TITLE
Add `no_deref` attribute to opt out of generating `deref` impls for imported types

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -261,6 +261,8 @@ pub struct ImportType {
     pub extends: Vec<syn::Path>,
     /// A custom prefix to add and attempt to fall back to, if the type isn't found
     pub vendor_prefixes: Vec<Ident>,
+    /// If present, don't generate a `Deref` impl
+    pub no_deref: bool,
 }
 
 /// The metadata for an Enum being imported

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -52,6 +52,7 @@ macro_rules! attrgen {
             (inspectable, Inspectable(Span)),
             (is_type_of, IsTypeOf(Span, syn::Expr)),
             (extends, Extends(Span, syn::Path)),
+            (no_deref, NoDeref(Span)),
             (vendor_prefix, VendorPrefix(Span, Ident)),
             (variadic, Variadic(Span)),
             (typescript_custom_section, TypescriptCustomSection(Span)),
@@ -612,6 +613,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ForeignItemType {
         let shim = format!("__wbg_instanceof_{}_{}", self.ident, ShortHash(&self.ident));
         let mut extends = Vec::new();
         let mut vendor_prefixes = Vec::new();
+        let no_deref = attrs.no_deref().is_some();
         for (used, attr) in attrs.attrs.iter() {
             match attr {
                 BindgenAttr::Extends(_, e) => {
@@ -637,6 +639,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ForeignItemType {
             js_name,
             extends,
             vendor_prefixes,
+            no_deref,
         }))
     }
 }

--- a/guide/src/reference/attributes/on-js-imports/no_deref.md
+++ b/guide/src/reference/attributes/on-js-imports/no_deref.md
@@ -1,0 +1,24 @@
+# `no_deref`
+
+The `no_deref` attribute can be used to say that no `Deref` impl should be
+generated for an imported type. If this attribute is not present, a `Deref` impl
+will be generated with a `Target` of the type's first `extends` attribute, or
+`Target = JsValue` if there are no `extends` attributes.
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    type Foo;
+
+    #[wasm_bindgen(method)]
+    fn baz(this: &Foo)
+
+    #[wasm_bindgen(extends = Foo, no_deref)]
+    type Bar;
+}
+
+fn do_stuff(bar: &Bar) {
+    bar.baz() // Does not compile
+}
+
+```


### PR DESCRIPTION
This allows:
1. An imported type to extend another type with more restricted visibility
2. Custom `Deref` impls for imported types