### PR TITLE
shared: support runtime variable for schema lookup

### DIFF
--- a/crates/shared/build.rs
+++ b/crates/shared/build.rs
@@ -1,4 +1,5 @@
 use std::collections::hash_map::DefaultHasher;
+use std::env;
 use std::hash::Hasher;
 use std::path::PathBuf;
 use std::process::Command;
@@ -21,7 +22,10 @@ fn main() {
 }
 
 fn set_schema_version_env_var() {
-    let schema_file = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lib.rs"));
+    let cargo_manifest_dir = env::var("CARGO_MANIFEST_DIR").expect(
+        "The `CARGO_MANIFEST_DIR` environment variable is needed to locate the schema file",
+    );
+    let schema_file = PathBuf::from(cargo_manifest_dir).join("src/lib.rs");
     let schema_file = std::fs::read(schema_file).unwrap();
 
     let mut hasher = DefaultHasher::new();


### PR DESCRIPTION
This change fixes a regression in being able to use version `0.2.75` for the [Bazel wasm_bindgen rules](https://github.com/bazelbuild/rules_rust/tree/0346cc492318d791fa6e47da4116c6e52c32ec74/wasm_bindgen). Bazel builds each crate in a separate sandbox and as a result, the `CARGO_MANIFEST_DIR` path is not consistent between use at runtime and compilation. To work around this, I'm looking for some way to control the lookup of the schema file when the `build.rs` script is run.

The change here allows for the `wasm_bindgen_shared` crate's `build.rs` script to allow `CARGO_MANIFEST_DIR` to be set at runtime to determine the location of the schema file. 