### PR TITLE
Generate TypeScript return types for `async` functions

### DIFF
--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -205,6 +205,7 @@ fn shared_function<'a>(func: &'a ast::Function, _intern: &'a Interner) -> Functi
         .collect::<Vec<_>>();
     Function {
         arg_names,
+        asyncness: func.r#async,
         name: &func.name,
         generate_typescript: func.generate_typescript,
     }

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -76,6 +76,7 @@ pub struct Function {
     pub arguments: Vec<Descriptor>,
     pub shim_idx: u32,
     pub ret: Descriptor,
+    pub inner_ret: Option<Descriptor>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -237,6 +238,7 @@ impl Function {
             arguments,
             shim_idx,
             ret: Descriptor::_decode(data, false),
+            inner_ret: Some(Descriptor::_decode(data, false)),
         }
     }
 }

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -45,6 +45,7 @@ macro_rules! intrinsics {
                                 shim_idx: 0,
                                 arguments: vec![$($arg),*],
                                 ret: $ret,
+                                inner_ret: None
                             }
                         }
                     )*

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2325,9 +2325,11 @@ impl<'a> Context<'a> {
         });
         builder.catch(catch);
         let mut arg_names = &None;
+        let mut asyncness = false;
         match kind {
             Kind::Export(export) => {
                 arg_names = &export.arg_names;
+                asyncness = export.asyncness;
                 match &export.kind {
                     AuxExportKind::Function(_) => {}
                     AuxExportKind::StaticFunction { .. } => {}
@@ -2352,7 +2354,7 @@ impl<'a> Context<'a> {
             catch,
             log_error,
         } = builder
-            .process(&adapter, instrs, arg_names)
+            .process(&adapter, instrs, arg_names, asyncness)
             .with_context(|| match kind {
                 Kind::Export(e) => format!("failed to generate bindings for `{}`", e.debug_name),
                 Kind::Import(i) => {

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -71,6 +71,8 @@ pub struct AuxExport {
     /// Argument names in Rust forwarded here to configure the names that show
     /// up in TypeScript bindings.
     pub arg_names: Option<Vec<String>>,
+    /// Whether this is an async function, to configure the TypeScript return value.
+    pub asyncness: bool,
     /// What kind of function this is and where it shows up
     pub kind: AuxExportKind,
     /// Whether typescript bindings should be generated for this export.

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -26,6 +26,7 @@ pub struct Adapter {
     pub id: AdapterId,
     pub params: Vec<AdapterType>,
     pub results: Vec<AdapterType>,
+    pub inner_results: Vec<AdapterType>,
     pub kind: AdapterKind,
 }
 
@@ -368,6 +369,7 @@ impl NonstandardWitSection {
         &mut self,
         params: Vec<AdapterType>,
         results: Vec<AdapterType>,
+        inner_results: Vec<AdapterType>,
         kind: AdapterKind,
     ) -> AdapterId {
         let id = AdapterId(self.adapters.len());
@@ -377,6 +379,7 @@ impl NonstandardWitSection {
                 id,
                 params,
                 results,
+                inner_results,
                 kind,
             },
         );

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -115,6 +115,7 @@ macro_rules! shared_api {
 
         struct Function<'a> {
             arg_names: Vec<String>,
+            asyncness: bool,
             name: &'a str,
             generate_typescript: bool,
         }

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -53,6 +53,7 @@ macro_rules! stack_closures {
                 inform($cnt);
                 $(<$var as WasmDescribe>::describe();)*
                 <R as WasmDescribe>::describe();
+                <R as WasmDescribe>::describe();
             }
         }
 
@@ -100,6 +101,7 @@ macro_rules! stack_closures {
                 inform($invoke_mut::<$($var,)* R> as u32);
                 inform($cnt);
                 $(<$var as WasmDescribe>::describe();)*
+                <R as WasmDescribe>::describe();
                 <R as WasmDescribe>::describe();
             }
         }
@@ -166,6 +168,7 @@ where
         inform(1);
         <&A as WasmDescribe>::describe();
         <R as WasmDescribe>::describe();
+        <R as WasmDescribe>::describe();
     }
 }
 
@@ -216,6 +219,7 @@ where
         inform(invoke1_mut_ref::<A, R> as u32);
         inform(1);
         <&A as WasmDescribe>::describe();
+        <R as WasmDescribe>::describe();
         <R as WasmDescribe>::describe();
     }
 }


### PR DESCRIPTION
Threads through an `asyncness` value and an "inner" type descriptor for functions, then generates `Promise<...>` return types for `async` functions.

Fixes #2394