### PR TITLE
Fix weak-ref by-value function parameter UAF 

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -641,8 +641,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.assert_class(&val, &class);
             js.assert_not_moved(&val);
             let i = js.tmp();
-            js.prelude(&format!("var ptr{} = {}.ptr;", i, val));
-            js.prelude(&format!("{}.ptr = 0;", val));
+            js.prelude(&format!("var ptr{} = {}.__destroy_into_raw();", i, val));
             js.push(format!("ptr{}", i));
         }
 
@@ -661,8 +660,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.prelude(&format!("if (!isLikeNone({0})) {{", val));
             js.assert_class(&val, class);
             js.assert_not_moved(&val);
-            js.prelude(&format!("ptr{} = {}.ptr;", i, val));
-            js.prelude(&format!("{}.ptr = 0;", val));
+            js.prelude(&format!("ptr{} = {}.__destroy_into_raw();", i, val));
             js.prelude("}");
             js.push(format!("ptr{}", i));
         }


### PR DESCRIPTION
The <https://github.com/rustwasm/wasm-bindgen/issues/2447> not considered the by-value function parameter case. This MR try fix that. 

All `xxx.ptr = 0;` will now called by `__destroy_into_raw` and unregister the finalizer.