### PR TITLE
Implement `Extend<A> for Array where A: AsRef<JsValue>`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -657,13 +657,23 @@ where
     where
         T: IntoIterator<Item = A>,
     {
-        let out = Array::new();
-
-        for value in iter {
-            out.push(value.as_ref());
-        }
-
+        let mut out = Array::new();
+        out.extend(iter);
         out
+    }
+}
+
+impl<A> std::iter::Extend<A> for Array
+where
+    A: AsRef<JsValue>,
+{
+    fn extend<T>(&mut self, iter: T)
+    where
+        T: IntoIterator<Item = A>,
+    {
+        for value in iter {
+            self.push(value.as_ref());
+        }
     }
 }
 

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -82,6 +82,13 @@ fn from_iter() {
 }
 
 #[wasm_bindgen_test]
+fn extend() {
+    let mut array = array!["a", "b"];
+    array.extend(vec![JsValue::from("c"), JsValue::from("d")]);
+    assert_eq!(array, array!["a", "b", "c", "d"]);
+}
+
+#[wasm_bindgen_test]
 fn to_vec() {
     let array = vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]
         .into_iter()


### PR DESCRIPTION
Collections are conventionally expected to implement both `FromInterator` and `Extend` traits. More specifically, I need `Array` to implement `Extend` in order to build one with [`futures::StreamExt::collect()`](https://docs.rs/futures/0.3.17/futures/stream/trait.StreamExt.html#method.collect)