### PR TITLE
Support browser preload in both chrome and safari

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -777,7 +777,7 @@ impl<'a> Context<'a> {
                     {imports_init}
 
                     if (typeof input === 'string' || (typeof Request === 'function' && input instanceof Request) || (typeof URL === 'function' && input instanceof URL)) {{
-                        input = fetch(input);
+                        input = fetch(input, {method: 'GET', credentials: 'include',  mode: 'no-cors'});
                     }}
 
                     {init_memory}


### PR DESCRIPTION
To allow the following html tag to work in more browsers
```<link rel="preload" href="app.wasm" as="fetch" type="application/wasm">```

See issue at https://stackoverflow.com/questions/52635660/can-link-rel-preload-be-made-to-work-with-fetch