### PR TITLE
Fix recursive impl of `From<js_sys::Number> for f64`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2447,7 +2447,7 @@ impl From<&Number> for f64 {
 impl From<Number> for f64 {
     #[inline]
     fn from(n: Number) -> f64 {
-        n.into()
+        <f64 as From<&'_ Number>>::from(&n)
     }
 }
 


### PR DESCRIPTION
The current code, I assume, attempted to hand over such implementation to that of `From<&Number> for f64`, but not only did it use the ambiguous `.` dot method syntax, it also forgot to take a reference to `n`, resulting in `<Number as Into<f64>>::into` being called, whose implementation comes from the blanket `From -> Into` impl, effectively resulting in a recursive definition.