### PR TITLE
Adjust attributes for linters in generated code

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -58,7 +58,12 @@ impl TryToTokens for ast::Program {
                                 continue;
                             }
                         };
-                        (quote! { impl #ns { #kind } }).to_tokens(tokens);
+                        (quote! {
+                            #[automatically_derived]
+                            #[allow(clippy::nursery)]
+                            impl #ns { #kind }
+                        })
+                        .to_tokens(tokens);
                         continue;
                     }
                 }
@@ -119,11 +124,11 @@ impl TryToTokens for ast::Program {
         });
 
         (quote! {
-            #[allow(non_upper_case_globals)]
             #[cfg(target_arch = "wasm32")]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #[link_section = "__wasm_bindgen_unstable"]
             #[doc(hidden)]
-            #[allow(clippy::all)]
             pub static #generated_static_name: [u8; #generated_static_length] = {
                 static _INCLUDED_FILES: &[&str] = &[#(#file_dependencies),*];
 
@@ -146,7 +151,8 @@ impl ToTokens for ast::Struct {
         let new_fn = Ident::new(&shared::new_function(&name_str), Span::call_site());
         let free_fn = Ident::new(&shared::free_function(&name_str), Span::call_site());
         (quote! {
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::describe::WasmDescribe for #name {
                 fn describe() {
                     use wasm_bindgen::__wbindgen_if_not_std;
@@ -163,7 +169,8 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::IntoWasmAbi for #name {
                 type Abi = u32;
 
@@ -174,7 +181,8 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::FromWasmAbi for #name {
                 type Abi = u32;
 
@@ -190,7 +198,8 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::__rt::core::convert::From<#name> for
                 wasm_bindgen::JsValue
             {
@@ -216,14 +225,16 @@ impl ToTokens for ast::Struct {
             }
 
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #[no_mangle]
             #[doc(hidden)]
-            #[allow(clippy::all)]
             pub unsafe extern "C" fn #free_fn(ptr: u32) {
                 drop(<#name as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr));
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::RefFromWasmAbi for #name {
                 type Abi = u32;
                 type Anchor = wasm_bindgen::__rt::Ref<'static, #name>;
@@ -235,7 +246,8 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::RefMutFromWasmAbi for #name {
                 type Abi = u32;
                 type Anchor = wasm_bindgen::__rt::RefMut<'static, #name>;
@@ -247,16 +259,19 @@ impl ToTokens for ast::Struct {
                 }
             }
 
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionIntoWasmAbi for #name {
                 #[inline]
                 fn none() -> Self::Abi { 0 }
             }
 
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionFromWasmAbi for #name {
                 #[inline]
                 fn is_none(abi: &Self::Abi) -> bool { *abi == 0 }
             }
-
         })
         .to_tokens(tokens);
 
@@ -288,9 +303,10 @@ impl ToTokens for ast::StructField {
         };
 
         (quote! {
-            #[doc(hidden)]
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #[cfg_attr(all(target_arch = "wasm32", not(target_os = "emscripten")), no_mangle)]
+            #[doc(hidden)]
             pub unsafe extern "C" fn #getter(js: u32)
                 -> <#ty as wasm_bindgen::convert::IntoWasmAbi>::Abi
             {
@@ -322,10 +338,11 @@ impl ToTokens for ast::StructField {
         }
 
         (quote! {
+            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #[no_mangle]
             #[doc(hidden)]
-            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            #[allow(clippy::all)]
             pub unsafe extern "C" fn #setter(
                 js: u32,
                 val: <#ty as wasm_bindgen::convert::FromWasmAbi>::Abi,
@@ -507,13 +524,13 @@ impl TryToTokens for ast::Export {
         };
 
         (quote! {
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #(#attrs)*
-            #[allow(non_snake_case)]
             #[cfg_attr(
                 all(target_arch = "wasm32", not(target_os = "emscripten")),
                 export_name = #export_name,
             )]
-            #[allow(clippy::all)]
             pub extern "C" fn #generated_name(#(#args),*) -> #projection::Abi {
                 #start_check
                 // Scope all local variables to be destroyed after we call the
@@ -625,17 +642,17 @@ impl ToTokens for ast::ImportType {
         let no_deref = self.no_deref;
 
         (quote! {
-            #[allow(bad_style)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #(#attrs)*
             #[doc = #doc_comment]
             #[repr(transparent)]
-            #[allow(clippy::all)]
             #vis struct #rust_name {
                 obj: #internal_obj
             }
 
-            #[allow(bad_style)]
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             const #const_name: () = {
                 use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
                 use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
@@ -778,7 +795,8 @@ impl ToTokens for ast::ImportType {
 
         if !no_deref {
             (quote! {
-                #[allow(clippy::all)]
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 impl core::ops::Deref for #rust_name {
                     type Target = #internal_obj;
 
@@ -793,7 +811,8 @@ impl ToTokens for ast::ImportType {
 
         for superclass in self.extends.iter() {
             (quote! {
-                #[allow(clippy::all)]
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 impl From<#rust_name> for #superclass {
                     #[inline]
                     fn from(obj: #rust_name) -> #superclass {
@@ -802,7 +821,8 @@ impl ToTokens for ast::ImportType {
                     }
                 }
 
-                #[allow(clippy::all)]
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 impl AsRef<#superclass> for #rust_name {
                     #[inline]
                     fn as_ref(&self) -> &#superclass {
@@ -849,16 +869,17 @@ impl ToTokens for ast::ImportEnum {
         let variant_paths_ref = &variant_paths;
 
         (quote! {
-            #[allow(bad_style)]
             #(#attrs)*
-            #[allow(clippy::all)]
             #vis enum #name {
                 #(#variants = #variant_indexes_ref,)*
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 #[doc(hidden)]
                 __Nonexhaustive,
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl #name {
                 fn from_str(s: &str) -> Option<#name> {
                     match s {
@@ -880,14 +901,16 @@ impl ToTokens for ast::ImportEnum {
             }
 
             // It should really be using &str for all of these, but that requires some major changes to cli-support
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::describe::WasmDescribe for #name {
                 fn describe() {
                     <wasm_bindgen::JsValue as wasm_bindgen::describe::WasmDescribe>::describe()
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::IntoWasmAbi for #name {
                 type Abi = <wasm_bindgen::JsValue as wasm_bindgen::convert::IntoWasmAbi>::Abi;
 
@@ -897,7 +920,8 @@ impl ToTokens for ast::ImportEnum {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::FromWasmAbi for #name {
                 type Abi = <wasm_bindgen::JsValue as wasm_bindgen::convert::FromWasmAbi>::Abi;
 
@@ -907,19 +931,22 @@ impl ToTokens for ast::ImportEnum {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionIntoWasmAbi for #name {
                 #[inline]
                 fn none() -> Self::Abi { <::js_sys::Object as wasm_bindgen::convert::OptionIntoWasmAbi>::none() }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionFromWasmAbi for #name {
                 #[inline]
                 fn is_none(abi: &Self::Abi) -> bool { <::js_sys::Object as wasm_bindgen::convert::OptionFromWasmAbi>::is_none(abi) }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl From<#name> for wasm_bindgen::JsValue {
                 fn from(obj: #name) -> wasm_bindgen::JsValue {
                     wasm_bindgen::JsValue::from(obj.to_str())
@@ -1088,13 +1115,17 @@ impl TryToTokens for ast::ImportFunction {
         // the best we can in the meantime.
         let extern_fn = respan(
             quote! {
+                #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 #(#attrs)*
                 #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
                 extern "C" {
                     fn #import_name(#(#abi_arguments),*) -> #abi_ret;
                 }
                 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 unsafe fn #import_name(#(#abi_arguments),*) -> #abi_ret {
                     #(
                         drop(#abi_argument_names);
@@ -1112,10 +1143,10 @@ impl TryToTokens for ast::ImportFunction {
             None
         };
         let invocation = quote! {
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #(#attrs)*
-            #[allow(bad_style)]
             #[doc = #doc_comment]
-            #[allow(clippy::all)]
             #vis #maybe_async fn #rust_name(#me #(#arguments),*) #ret {
                 #extern_fn
 
@@ -1132,6 +1163,8 @@ impl TryToTokens for ast::ImportFunction {
 
         if let Some(class) = class_ty {
             (quote! {
+                #[automatically_derived]
+                #[allow(clippy::nursery)]
                 impl #class {
                     #invocation
                 }
@@ -1196,7 +1229,8 @@ impl ToTokens for ast::Enum {
             }
         });
         (quote! {
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::IntoWasmAbi for #enum_name {
                 type Abi = u32;
 
@@ -1206,7 +1240,8 @@ impl ToTokens for ast::Enum {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::FromWasmAbi for #enum_name {
                 type Abi = u32;
 
@@ -1218,19 +1253,22 @@ impl ToTokens for ast::Enum {
                 }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionFromWasmAbi for #enum_name {
                 #[inline]
                 fn is_none(val: &u32) -> bool { *val == #hole }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionIntoWasmAbi for #enum_name {
                 #[inline]
                 fn none() -> Self::Abi { #hole }
             }
 
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             impl wasm_bindgen::describe::WasmDescribe for #enum_name {
                 fn describe() {
                     use wasm_bindgen::describe::*;
@@ -1250,8 +1288,8 @@ impl ToTokens for ast::ImportStatic {
         let shim_name = &self.shim;
         let vis = &self.vis;
         (quote! {
-            #[allow(bad_style)]
-            #[allow(clippy::all)]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #vis static #name: wasm_bindgen::JsStatic<#ty> = {
                 fn init() -> #ty {
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
@@ -1323,12 +1361,12 @@ impl<'a, T: ToTokens> ToTokens for Descriptor<'a, T> {
         let inner = &self.inner;
         let attrs = &self.attrs;
         (quote! {
+            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+            #[automatically_derived]
+            #[allow(clippy::nursery)]
             #(#attrs)*
             #[no_mangle]
-            #[allow(non_snake_case)]
             #[doc(hidden)]
-            #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
-            #[allow(clippy::all)]
             pub extern "C" fn #name() {
                 use wasm_bindgen::describe::*;
                 // See definition of `link_mem_intrinsics` for what this is doing

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -60,7 +60,6 @@ impl TryToTokens for ast::Program {
                         };
                         (quote! {
                             #[automatically_derived]
-                            #[allow(clippy::nursery)]
                             impl #ns { #kind }
                         })
                         .to_tokens(tokens);
@@ -126,7 +125,6 @@ impl TryToTokens for ast::Program {
         (quote! {
             #[cfg(target_arch = "wasm32")]
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #[link_section = "__wasm_bindgen_unstable"]
             #[doc(hidden)]
             pub static #generated_static_name: [u8; #generated_static_length] = {
@@ -152,7 +150,6 @@ impl ToTokens for ast::Struct {
         let free_fn = Ident::new(&shared::free_function(&name_str), Span::call_site());
         (quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::describe::WasmDescribe for #name {
                 fn describe() {
                     use wasm_bindgen::__wbindgen_if_not_std;
@@ -170,7 +167,6 @@ impl ToTokens for ast::Struct {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::IntoWasmAbi for #name {
                 type Abi = u32;
 
@@ -182,7 +178,6 @@ impl ToTokens for ast::Struct {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::FromWasmAbi for #name {
                 type Abi = u32;
 
@@ -199,7 +194,6 @@ impl ToTokens for ast::Struct {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::__rt::core::convert::From<#name> for
                 wasm_bindgen::JsValue
             {
@@ -226,7 +220,6 @@ impl ToTokens for ast::Struct {
 
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #[no_mangle]
             #[doc(hidden)]
             pub unsafe extern "C" fn #free_fn(ptr: u32) {
@@ -234,7 +227,6 @@ impl ToTokens for ast::Struct {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::RefFromWasmAbi for #name {
                 type Abi = u32;
                 type Anchor = wasm_bindgen::__rt::Ref<'static, #name>;
@@ -247,7 +239,6 @@ impl ToTokens for ast::Struct {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::RefMutFromWasmAbi for #name {
                 type Abi = u32;
                 type Anchor = wasm_bindgen::__rt::RefMut<'static, #name>;
@@ -260,14 +251,12 @@ impl ToTokens for ast::Struct {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionIntoWasmAbi for #name {
                 #[inline]
                 fn none() -> Self::Abi { 0 }
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionFromWasmAbi for #name {
                 #[inline]
                 fn is_none(abi: &Self::Abi) -> bool { *abi == 0 }
@@ -304,7 +293,6 @@ impl ToTokens for ast::StructField {
 
         (quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #[cfg_attr(all(target_arch = "wasm32", not(target_os = "emscripten")), no_mangle)]
             #[doc(hidden)]
             pub unsafe extern "C" fn #getter(js: u32)
@@ -340,7 +328,6 @@ impl ToTokens for ast::StructField {
         (quote! {
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #[no_mangle]
             #[doc(hidden)]
             pub unsafe extern "C" fn #setter(
@@ -525,7 +512,6 @@ impl TryToTokens for ast::Export {
 
         (quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #(#attrs)*
             #[cfg_attr(
                 all(target_arch = "wasm32", not(target_os = "emscripten")),
@@ -643,7 +629,6 @@ impl ToTokens for ast::ImportType {
 
         (quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #(#attrs)*
             #[doc = #doc_comment]
             #[repr(transparent)]
@@ -652,7 +637,6 @@ impl ToTokens for ast::ImportType {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             const #const_name: () = {
                 use wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
                 use wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
@@ -796,7 +780,6 @@ impl ToTokens for ast::ImportType {
         if !no_deref {
             (quote! {
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 impl core::ops::Deref for #rust_name {
                     type Target = #internal_obj;
 
@@ -812,7 +795,6 @@ impl ToTokens for ast::ImportType {
         for superclass in self.extends.iter() {
             (quote! {
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 impl From<#rust_name> for #superclass {
                     #[inline]
                     fn from(obj: #rust_name) -> #superclass {
@@ -822,7 +804,6 @@ impl ToTokens for ast::ImportType {
                 }
 
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 impl AsRef<#superclass> for #rust_name {
                     #[inline]
                     fn as_ref(&self) -> &#superclass {
@@ -873,13 +854,11 @@ impl ToTokens for ast::ImportEnum {
             #vis enum #name {
                 #(#variants = #variant_indexes_ref,)*
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 #[doc(hidden)]
                 __Nonexhaustive,
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl #name {
                 fn from_str(s: &str) -> Option<#name> {
                     match s {
@@ -902,7 +881,6 @@ impl ToTokens for ast::ImportEnum {
 
             // It should really be using &str for all of these, but that requires some major changes to cli-support
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::describe::WasmDescribe for #name {
                 fn describe() {
                     <wasm_bindgen::JsValue as wasm_bindgen::describe::WasmDescribe>::describe()
@@ -910,7 +888,6 @@ impl ToTokens for ast::ImportEnum {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::IntoWasmAbi for #name {
                 type Abi = <wasm_bindgen::JsValue as wasm_bindgen::convert::IntoWasmAbi>::Abi;
 
@@ -921,7 +898,6 @@ impl ToTokens for ast::ImportEnum {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::FromWasmAbi for #name {
                 type Abi = <wasm_bindgen::JsValue as wasm_bindgen::convert::FromWasmAbi>::Abi;
 
@@ -932,21 +908,18 @@ impl ToTokens for ast::ImportEnum {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionIntoWasmAbi for #name {
                 #[inline]
                 fn none() -> Self::Abi { <::js_sys::Object as wasm_bindgen::convert::OptionIntoWasmAbi>::none() }
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionFromWasmAbi for #name {
                 #[inline]
                 fn is_none(abi: &Self::Abi) -> bool { <::js_sys::Object as wasm_bindgen::convert::OptionFromWasmAbi>::is_none(abi) }
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl From<#name> for wasm_bindgen::JsValue {
                 fn from(obj: #name) -> wasm_bindgen::JsValue {
                     wasm_bindgen::JsValue::from(obj.to_str())
@@ -1117,7 +1090,6 @@ impl TryToTokens for ast::ImportFunction {
             quote! {
                 #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 #(#attrs)*
                 #[link(wasm_import_module = "__wbindgen_placeholder__")]
                 extern "C" {
@@ -1125,7 +1097,6 @@ impl TryToTokens for ast::ImportFunction {
                 }
                 #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 unsafe fn #import_name(#(#abi_arguments),*) -> #abi_ret {
                     #(
                         drop(#abi_argument_names);
@@ -1144,7 +1115,6 @@ impl TryToTokens for ast::ImportFunction {
         };
         let invocation = quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #(#attrs)*
             #[doc = #doc_comment]
             #vis #maybe_async fn #rust_name(#me #(#arguments),*) #ret {
@@ -1164,7 +1134,6 @@ impl TryToTokens for ast::ImportFunction {
         if let Some(class) = class_ty {
             (quote! {
                 #[automatically_derived]
-                #[allow(clippy::nursery)]
                 impl #class {
                     #invocation
                 }
@@ -1230,7 +1199,6 @@ impl ToTokens for ast::Enum {
         });
         (quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::IntoWasmAbi for #enum_name {
                 type Abi = u32;
 
@@ -1241,7 +1209,6 @@ impl ToTokens for ast::Enum {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::FromWasmAbi for #enum_name {
                 type Abi = u32;
 
@@ -1254,21 +1221,18 @@ impl ToTokens for ast::Enum {
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionFromWasmAbi for #enum_name {
                 #[inline]
                 fn is_none(val: &u32) -> bool { *val == #hole }
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::convert::OptionIntoWasmAbi for #enum_name {
                 #[inline]
                 fn none() -> Self::Abi { #hole }
             }
 
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             impl wasm_bindgen::describe::WasmDescribe for #enum_name {
                 fn describe() {
                     use wasm_bindgen::describe::*;
@@ -1289,7 +1253,6 @@ impl ToTokens for ast::ImportStatic {
         let vis = &self.vis;
         (quote! {
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #vis static #name: wasm_bindgen::JsStatic<#ty> = {
                 fn init() -> #ty {
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
@@ -1363,7 +1326,6 @@ impl<'a, T: ToTokens> ToTokens for Descriptor<'a, T> {
         (quote! {
             #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
             #[automatically_derived]
-            #[allow(clippy::nursery)]
             #(#attrs)*
             #[no_mangle]
             #[doc(hidden)]


### PR DESCRIPTION
This PR replaces `#[allow(clippy::all)]` usage in the generated code with `#[automatically_derived]` ~~+ `#[allow(clippy::nursery)]`~~.

## Motivation

If the project using `wasm-bindgen` hardens its rustc and Clippy lints having `#[allow(clippy::all)]` in the generated code is not enough and linter complains about many stuff, which cannot be supressed from the user code.

## Solution

`#[automatically_derived]` attribute allows rustc and Clippy to omit linting items with stylish lints and is intended exactly for that purpose.

~~Additionally, `#[allow(clippy::nursery)]` is used, because some lints from that group don't consider `#[automatically_derived]` attribute well in some edge cases, as are kinda unstable.~~   
UPD:  Considered to omit this.