### PR TITLE
Add list of current unstable APIs to docs

### DIFF
--- a/guide/src/web-sys/unstable-apis.md
+++ b/guide/src/web-sys/unstable-apis.md
@@ -29,3 +29,21 @@ to do this. For example:
 ```bash
 RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run
 ```
+
+## List of Current Unstable APIs
+- `Bluetooth`
+- `Clipboard`
+- `ImageCapture`
+- `QueuingStrategy`
+- `ReadableStreamBYOBReader`
+- `ReadableStreamDefaultReader`
+- `ReadableStreamGenericReader`
+- `ResizeObserver`
+- `ScreenWakeLock`
+- `TransformStream`
+- `WebGPU`
+- `WebHID`
+- `WebUSB`
+- `WebXRDevice`
+- `WritableStream`
+- `WritableStreamDefaultWriter`


### PR DESCRIPTION
The motivation behind making this change is to increase the discoverability of unstable APIs.
The current list has been populated using the contents of `wasm-bindgen/crates/web-sys/webidls/unstable/`.
Going forward, MRs that add or remove unstable APIs will need to update this list accordingly.