### PR TITLE
Identify missing environment variables

### DIFF
--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -48,11 +48,15 @@ struct LocalFile {
 
 impl Interner {
     fn new() -> Interner {
+        let root = env::var_os("CARGO_MANIFEST_DIR")
+            .expect("should have CARGO_MANIFEST_DIR env var")
+            .into();
+        let crate_name = env::var("CARGO_PKG_NAME").expect("should have CARGO_PKG_NAME env var");
         Interner {
             bump: bumpalo::Bump::new(),
             files: RefCell::new(HashMap::new()),
-            root: env::var_os("CARGO_MANIFEST_DIR").unwrap().into(),
-            crate_name: env::var("CARGO_PKG_NAME").unwrap(),
+            root,
+            crate_name,
             has_package_json: Cell::new(false),
         }
     }


### PR DESCRIPTION
Matches the strategy used in `crates/backend/src/util.rs:145`.