### PR TITLE
Documentation link update

### DIFF
--- a/src/cast.rs
+++ b/src/cast.rs
@@ -11,7 +11,7 @@ use crate::{describe::WasmDescribe, JsValue};
 /// This trait is automatically implemented for any type imported in a
 /// `#[wasm_bindgen]` `extern` block.
 ///
-/// [rfc]: https://github.com/rustwasm/rfcs/pull/2
+/// [rfc]: https://github.com/rustwasm/rfcs/blob/master/text/002-wasm-bindgen-inheritance-casting.md
 pub trait JsCast
 where
     Self: AsRef<JsValue> + Into<JsValue>,


### PR DESCRIPTION
Previously the link in the docs went to a github pull request which then linked to https://github.com/rustwasm/rfcs/blob/master/text/000-wasm-bindgen-inheritance-casting.md when the working link was https://github.com/rustwasm/rfcs/blob/master/text/002-wasm-bindgen-inheritance-casting.md