### PR TITLE
Remove unnecessary async import in hello world example

### DIFF
--- a/examples/hello_world/index.js
+++ b/examples/hello_world/index.js
@@ -1,8 +1,3 @@
-// Note that a dynamic `import` statement here is required due to
-// webpack/webpack#6615, but in theory `import { greet } from './pkg';`
-// will work here one day as well!
-const rust = import('./pkg');
+import { greet } from './pkg';
 
-rust
-  .then(m => m.greet('World!'))
-  .catch(console.error);
+greet('World');


### PR DESCRIPTION
In Webpack 5, wasm-based imports are now supported, and can be imported directly