### PR TITLE
Fix missing wasm_bindgen attribute

### DIFF
--- a/guide/src/contributing/design/exporting-rust-struct.md
+++ b/guide/src/contributing/design/exporting-rust-struct.md
@@ -17,6 +17,7 @@ pub struct Foo {
 
 #[wasm_bindgen]
 impl Foo {
+    #[wasm_bindgen(constructor)]
     pub fn new(val: i32) -> Foo {
         Foo { internal: val }
     }


### PR DESCRIPTION
The generated JS code in the following code snippet has a constructor. The corresponding Rust code did not have the attribute marking the `new` as the constructor.