### PR TITLE
replace the dead echo service

### DIFF
--- a/examples/websockets/src/lib.rs
+++ b/examples/websockets/src/lib.rs
@@ -15,7 +15,7 @@ extern "C" {
 #[wasm_bindgen(start)]
 pub fn start_websocket() -> Result<(), JsValue> {
     // Connect to an echo server
-    let ws = WebSocket::new("wss://echo.websocket.org")?;
+    let ws = WebSocket::new("wss://echo.websocket.events")?;
     // For small binary messages, like CBOR, Arraybuffer is more efficient than Blob handling
     ws.set_binary_type(web_sys::BinaryType::Arraybuffer);
     // create callback


### PR DESCRIPTION
as I am playing with the example, the echo server seems dead.

according to https://www.lob.com/blog/websocket-org-is-down-here-is-an-alternative , I replaced it with echo.websocket.events and it worked

![image](https://user-images.githubusercontent.com/29735669/151687226-e0f8bf9b-0ede-412a-9616-1e1f7e830ce6.png)
