### PR TITLE
Fix deno lint warnings

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -453,14 +453,14 @@ impl<'a, 'b> JsBuilder<'a, 'b> {
             None => String::new(),
         };
         self.prelude(&format!(
-            "var ptr{i} = {f}({0}, wasm.{malloc}{realloc});",
+            "const ptr{i} = {f}({0}, wasm.{malloc}{realloc});",
             val,
             i = i,
             f = pass,
             malloc = malloc,
             realloc = realloc,
         ));
-        self.prelude(&format!("var len{} = WASM_VECTOR_LEN;", i));
+        self.prelude(&format!("const len{} = WASM_VECTOR_LEN;", i));
         self.push(format!("ptr{}", i));
         self.push(format!("len{}", i));
         Ok(())
@@ -507,7 +507,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
                 (true, _) => panic!("deferred calls must have no results"),
                 (false, 0) => js.prelude(&format!("{};", call)),
                 (false, n) => {
-                    js.prelude(&format!("var ret = {};", call));
+                    js.prelude(&format!("const ret = {};", call));
                     if n == 1 {
                         js.push("ret".to_string());
                     } else {
@@ -776,13 +776,13 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             let malloc = js.cx.export_name_of(*malloc);
             let i = js.tmp();
             js.prelude(&format!(
-                "var ptr{i} = {f}({0}, wasm.{malloc});",
+                "const ptr{i} = {f}({0}, wasm.{malloc});",
                 val,
                 i = i,
                 f = func,
                 malloc = malloc,
             ));
-            js.prelude(&format!("var len{} = WASM_VECTOR_LEN;", i));
+            js.prelude(&format!("const len{} = WASM_VECTOR_LEN;", i));
             js.push(format!("ptr{}", i));
             js.push(format!("len{}", i));
         }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1359,7 +1359,7 @@ impl<'a> Context<'a> {
             | OutputMode::Web
             | OutputMode::NoModules { .. }
             | OutputMode::Bundler { browser_only: true } => {
-                self.global(&format!("let cached{0} = new {0}{1};", s, args))
+                self.global(&format!("const cached{0} = new {0}{1};", s, args))
             }
         };
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -334,7 +334,6 @@ impl<'a> Context<'a> {
                     break
                 default:
                     throw new Error(`Unsupported protocol: ${{wasm_url.protocol}}`);
-                    break
             }}
 
             const wasmInstance = (await WebAssembly.instantiate(wasmCode, imports)).instance;

--- a/crates/cli/tests/reference/add.js
+++ b/crates/cli/tests/reference/add.js
@@ -6,7 +6,7 @@ import * as wasm from './reference_test_bg.wasm';
 * @returns {number}
 */
 export function add_u32(a, b) {
-    var ret = wasm.add_u32(a, b);
+    const ret = wasm.add_u32(a, b);
     return ret >>> 0;
 }
 
@@ -16,7 +16,7 @@ export function add_u32(a, b) {
 * @returns {number}
 */
 export function add_i32(a, b) {
-    var ret = wasm.add_i32(a, b);
+    const ret = wasm.add_i32(a, b);
     return ret;
 }
 

--- a/crates/cli/tests/reference/result-string.js
+++ b/crates/cli/tests/reference/result-string.js
@@ -79,7 +79,7 @@ export function exported() {
 }
 
 export function __wbindgen_number_new(arg0) {
-    var ret = arg0;
+    const ret = arg0;
     return addHeapObject(ret);
 };
 

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -78,8 +78,8 @@ function passStringToWasm0(arg, malloc, realloc) {
 * @param {string} a
 */
 export function foo(a) {
-    var ptr0 = passStringToWasm0(a, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
-    var len0 = WASM_VECTOR_LEN;
+    const ptr0 = passStringToWasm0(a, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+    const len0 = WASM_VECTOR_LEN;
     wasm.foo(ptr0, len0);
 }
 


### PR DESCRIPTION
This PR modifies the JS snippets generated by `wasm-bindgen` to satisfy a linting check with `deno lint`.

Please note that I only adjusted code snippets which were actually in use in my projects, there are more candidates in the source files. I want to see if you would be interested in merging these changes before putting in more effort than necessary for my current needs.

I also did not check if those changes are compatible with targets other than Deno, though I expect this should be fine as `const` is already in use in other parts of the bindings generation. I did run the tests for the crate, though.