### PR TITLE
Add `XrInputSource::gamepad`

### DIFF
--- a/crates/web-sys/src/features/gen_XrInputSource.rs
+++ b/crates/web-sys/src/features/gen_XrInputSource.rs
@@ -16,6 +16,18 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type XrInputSource;
     #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "Gamepad")]
+    # [wasm_bindgen (structural , method , getter , js_class = "XRInputSource" , js_name = gamepad)]
+    #[doc = "Getter for the `gamepad` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource/gamepad)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Gamepad`, `XrInputSource`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn gamepad(this: &XrInputSource) -> Option<Gamepad>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "XrHandedness")]
     # [wasm_bindgen (structural , method , getter , js_class = "XRInputSource" , js_name = handedness)]
     #[doc = "Getter for the `handedness` field of this object."]

--- a/crates/web-sys/webidls/unstable/WebXRDevice.webidl
+++ b/crates/web-sys/webidls/unstable/WebXRDevice.webidl
@@ -163,6 +163,7 @@ enum XRTargetRayMode {
 
 [SecureContext, Exposed=Window]
 interface XRInputSource {
+  readonly attribute Gamepad? gamepad;
   readonly attribute XRHandedness handedness;
   readonly attribute XRTargetRayMode targetRayMode;
   [SameObject] readonly attribute XRSpace targetRaySpace;


### PR DESCRIPTION
XRInputSource has a gamepad property which is not exposed by web-sys, this adds it.

Closes #2800