### PR TITLE
Fix derive for `no_std` environments

### DIFF
--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -62,7 +62,7 @@ pub fn wasm_bindgen_test(
         (quote! {
             #[no_mangle]
             pub extern "C" fn #name(cx: &::wasm_bindgen_test::__rt::Context) {
-                let test_name = ::std::concat!(::std::module_path!(), "::", ::std::stringify!(#ident));
+                let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
                 #test_body
             }
         })


### PR DESCRIPTION
The derive macro is assuming that `std` is defined, which is not always
the case. Switching the macro to use `core` instead should fix this
issue.