### PR TITLE
Update IndexedDB IDL to latest version from gecko

### DIFF
--- a/crates/web-sys/src/features/gen_IdbCursor.rs
+++ b/crates/web-sys/src/features/gen_IdbCursor.rs
@@ -40,6 +40,14 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `IdbCursor`*"]
     pub fn primary_key(this: &IdbCursor) -> Result<::wasm_bindgen::JsValue, JsValue>;
+    #[cfg(feature = "IdbRequest")]
+    # [wasm_bindgen (structural , method , getter , js_class = "IDBCursor" , js_name = request)]
+    #[doc = "Getter for the `request` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/IDBCursor/request)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `IdbCursor`, `IdbRequest`*"]
+    pub fn request(this: &IdbCursor) -> IdbRequest;
     # [wasm_bindgen (catch , method , structural , js_class = "IDBCursor" , js_name = advance)]
     #[doc = "The `advance()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_IdbTransaction.rs
+++ b/crates/web-sys/src/features/gen_IdbTransaction.rs
@@ -92,6 +92,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `IdbTransaction`*"]
     pub fn abort(this: &IdbTransaction) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "IDBTransaction" , js_name = commit)]
+    #[doc = "The `commit()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/IDBTransaction/commit)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `IdbTransaction`*"]
+    pub fn commit(this: &IdbTransaction) -> Result<(), JsValue>;
     #[cfg(feature = "IdbObjectStore")]
     # [wasm_bindgen (catch , method , structural , js_class = "IDBTransaction" , js_name = objectStore)]
     #[doc = "The `objectStore()` method."]

--- a/crates/web-sys/webidls/enabled/IDBCursor.webidl
+++ b/crates/web-sys/webidls/enabled/IDBCursor.webidl
@@ -14,10 +14,11 @@ enum IDBCursorDirection {
     "prevunique"
 };
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBCursor {
     readonly    attribute (IDBObjectStore or IDBIndex) source;
 
+    [BinaryName="getDirection"]
     readonly    attribute IDBCursorDirection           direction;
 
     [Throws]
@@ -25,6 +26,8 @@ interface IDBCursor {
 
     [Throws]
     readonly    attribute any                          primaryKey;
+
+    readonly    attribute IDBRequest                   request;
 
     [Throws]
     IDBRequest update (any value);
@@ -42,7 +45,7 @@ interface IDBCursor {
     IDBRequest delete ();
 };
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBCursorWithValue : IDBCursor {
     [Throws]
     readonly    attribute any value;

--- a/crates/web-sys/webidls/enabled/IDBDatabase.webidl
+++ b/crates/web-sys/webidls/enabled/IDBDatabase.webidl
@@ -10,7 +10,7 @@
  * liability, trademark and document use rules apply.
  */
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBDatabase : EventTarget {
     readonly    attribute DOMString          name;
     readonly    attribute unsigned long long version;
@@ -18,7 +18,7 @@ interface IDBDatabase : EventTarget {
     readonly    attribute DOMStringList      objectStoreNames;
 
     [Throws]
-    IDBObjectStore createObjectStore (DOMString name, optional IDBObjectStoreParameters optionalParameters);
+    IDBObjectStore createObjectStore (DOMString name, optional IDBObjectStoreParameters optionalParameters = {});
 
     [Throws]
     undefined           deleteObjectStore (DOMString name);
@@ -39,6 +39,6 @@ partial interface IDBDatabase {
     [Func="mozilla::dom::IndexedDatabaseManager::ExperimentalFeaturesEnabled"]
     readonly    attribute StorageType        storage;
 
-    [Exposed=Window, Throws, UseCounter]
+    [Exposed=Window, Throws, Deprecated="IDBDatabaseCreateMutableFile"]
     IDBRequest createMutableFile (DOMString name, optional DOMString type);
 };

--- a/crates/web-sys/webidls/enabled/IDBFactory.webidl
+++ b/crates/web-sys/webidls/enabled/IDBFactory.webidl
@@ -24,7 +24,7 @@ dictionary IDBOpenDBOptions
  * http://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#idl-def-IDBFactory
  * for more information.
  */
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBFactory {
   [Throws, NeedsCallerType]
   IDBOpenDBRequest
@@ -34,12 +34,12 @@ interface IDBFactory {
   [Throws, NeedsCallerType]
   IDBOpenDBRequest
   open(DOMString name,
-       optional IDBOpenDBOptions options);
+       optional IDBOpenDBOptions options = {});
 
   [Throws, NeedsCallerType]
   IDBOpenDBRequest
   deleteDatabase(DOMString name,
-                 optional IDBOpenDBOptions options);
+                 optional IDBOpenDBOptions options = {});
 
   [Throws]
   short
@@ -56,11 +56,11 @@ interface IDBFactory {
   IDBOpenDBRequest
   openForPrincipal(Principal principal,
                    DOMString name,
-                   optional IDBOpenDBOptions options);
+                   optional IDBOpenDBOptions options = {});
 
   [Throws, ChromeOnly, NeedsCallerType]
   IDBOpenDBRequest
   deleteForPrincipal(Principal principal,
                      DOMString name,
-                     optional IDBOpenDBOptions options);
+                     optional IDBOpenDBOptions options = {});
 };

--- a/crates/web-sys/webidls/enabled/IDBFileHandle.webidl
+++ b/crates/web-sys/webidls/enabled/IDBFileHandle.webidl
@@ -8,7 +8,7 @@ dictionary IDBFileMetadataParameters
   boolean lastModified = true;
 };
 
-[Exposed=(Window,System)]
+[Exposed=Window]
 interface IDBFileHandle : EventTarget
 {
   readonly attribute IDBMutableFile? mutableFile;
@@ -19,7 +19,7 @@ interface IDBFileHandle : EventTarget
   attribute unsigned long long? location;
 
   [Throws]
-  IDBFileRequest? getMetadata(optional IDBFileMetadataParameters parameters);
+  IDBFileRequest? getMetadata(optional IDBFileMetadataParameters parameters = {});
   [Throws]
   IDBFileRequest? readAsArrayBuffer(unsigned long long size);
   [Throws]

--- a/crates/web-sys/webidls/enabled/IDBFileRequest.webidl
+++ b/crates/web-sys/webidls/enabled/IDBFileRequest.webidl
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-[Exposed=(Window,System)]
+[Exposed=Window]
 interface IDBFileRequest : DOMRequest {
   readonly attribute IDBFileHandle? fileHandle;
   // this is deprecated due to renaming in the spec

--- a/crates/web-sys/webidls/enabled/IDBIndex.webidl
+++ b/crates/web-sys/webidls/enabled/IDBIndex.webidl
@@ -18,7 +18,7 @@ dictionary IDBIndexParameters {
     DOMString? locale = null;
 };
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBIndex {
     [SetterThrows]
     attribute DOMString name;
@@ -58,8 +58,8 @@ interface IDBIndex {
 
 partial interface IDBIndex {
     [Throws]
-    IDBRequest getAll (optional any key, [EnforceRange] optional unsigned long limit);
+    IDBRequest getAll (optional any key, optional [EnforceRange] unsigned long limit);
 
     [Throws]
-    IDBRequest getAllKeys (optional any key, [EnforceRange] optional unsigned long limit);
+    IDBRequest getAllKeys (optional any key, optional [EnforceRange] unsigned long limit);
 };

--- a/crates/web-sys/webidls/enabled/IDBKeyRange.webidl
+++ b/crates/web-sys/webidls/enabled/IDBKeyRange.webidl
@@ -9,7 +9,7 @@
  * liability, trademark and document use rules apply.
  */
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBKeyRange {
   [Throws]
   readonly attribute any     lower;
@@ -33,7 +33,7 @@ interface IDBKeyRange {
   static IDBKeyRange bound (any lower, any upper, optional boolean lowerOpen = false, optional boolean upperOpen = false);
 };
 
-[Exposed=(Window,Worker,System),
+[Exposed=(Window,Worker),
  Func="mozilla::dom::IndexedDatabaseManager::ExperimentalFeaturesEnabled"]
 interface IDBLocaleAwareKeyRange : IDBKeyRange {
   [NewObject, Throws]

--- a/crates/web-sys/webidls/enabled/IDBMutableFile.webidl
+++ b/crates/web-sys/webidls/enabled/IDBMutableFile.webidl
@@ -3,14 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-[Exposed=(Window,System)]
+[Exposed=Window]
 interface IDBMutableFile : EventTarget {
   readonly attribute DOMString name;
   readonly attribute DOMString type;
 
   readonly attribute IDBDatabase database;
 
-  [Throws, UseCounter]
+  [Throws, Deprecated="IDBMutableFileOpen"]
   IDBFileHandle open(optional FileMode mode = "readonly");
 
   [Throws, UseCounter]

--- a/crates/web-sys/webidls/enabled/IDBObjectStore.webidl
+++ b/crates/web-sys/webidls/enabled/IDBObjectStore.webidl
@@ -12,7 +12,7 @@ dictionary IDBObjectStoreParameters {
     boolean                             autoIncrement = false;
 };
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBObjectStore {
     [SetterThrows]
     attribute DOMString name;
@@ -46,7 +46,7 @@ interface IDBObjectStore {
     IDBRequest openCursor (optional any range, optional IDBCursorDirection direction = "next");
 
     [Throws]
-    IDBIndex   createIndex (DOMString name, (DOMString or sequence<DOMString>) keyPath, optional IDBIndexParameters optionalParameters);
+    IDBIndex   createIndex (DOMString name, (DOMString or sequence<DOMString>) keyPath, optional IDBIndexParameters optionalParameters = {});
 
     [Throws]
     IDBIndex   index (DOMString name);
@@ -60,10 +60,10 @@ interface IDBObjectStore {
 
 partial interface IDBObjectStore {
     [Throws]
-    IDBRequest getAll (optional any key, [EnforceRange] optional unsigned long limit);
+    IDBRequest getAll (optional any key, optional [EnforceRange] unsigned long limit);
 
     [Throws]
-    IDBRequest getAllKeys (optional any key, [EnforceRange] optional unsigned long limit);
+    IDBRequest getAllKeys (optional any key, optional [EnforceRange] unsigned long limit);
 
     [Throws]
     IDBRequest openKeyCursor (optional any range, optional IDBCursorDirection direction = "next");

--- a/crates/web-sys/webidls/enabled/IDBOpenDBRequest.webidl
+++ b/crates/web-sys/webidls/enabled/IDBOpenDBRequest.webidl
@@ -7,7 +7,7 @@
  * https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html#idl-def-IDBOpenDBRequest
  */
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBOpenDBRequest : IDBRequest {
                 attribute EventHandler onblocked;
 

--- a/crates/web-sys/webidls/enabled/IDBRequest.webidl
+++ b/crates/web-sys/webidls/enabled/IDBRequest.webidl
@@ -13,7 +13,7 @@ enum IDBRequestReadyState {
     "done"
 };
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBRequest : EventTarget {
     [Throws]
     readonly    attribute any                  result;

--- a/crates/web-sys/webidls/enabled/IDBTransaction.webidl
+++ b/crates/web-sys/webidls/enabled/IDBTransaction.webidl
@@ -19,7 +19,7 @@ enum IDBTransactionMode {
     "versionchange"
 };
 
-[Exposed=(Window,Worker,System)]
+[Exposed=(Window,Worker)]
 interface IDBTransaction : EventTarget {
     [Throws]
     readonly    attribute IDBTransactionMode mode;
@@ -29,6 +29,9 @@ interface IDBTransaction : EventTarget {
 
     [Throws]
     IDBObjectStore objectStore (DOMString name);
+
+    [Throws]
+    undefined           commit();
 
     [Throws]
     undefined           abort();

--- a/crates/web-sys/webidls/enabled/IDBVersionChangeEvent.webidl
+++ b/crates/web-sys/webidls/enabled/IDBVersionChangeEvent.webidl
@@ -16,9 +16,11 @@ dictionary IDBVersionChangeEventInit : EventInit {
 };
 
 [Constructor(DOMString type, optional IDBVersionChangeEventInit eventInitDict),
- Exposed=(Window,Worker,System)]
+ Exposed=(Window,Worker)]
 interface IDBVersionChangeEvent : Event {
+    constructor(DOMString type,
+                optional IDBVersionChangeEventInit eventInitDict = {});
+
     readonly    attribute unsigned long long  oldVersion;
     readonly    attribute unsigned long long? newVersion;
 };
-


### PR DESCRIPTION
Updated IndexedDB IDL files. It adds following new APIs:

- `request` getter for `IdbCursor`
- `commit` for `IdbTransaction`

Fixes https://github.com/rustwasm/wasm-bindgen/issues/2810.