### PR TITLE
Document support for Option<RustStruct>

### DIFF
--- a/examples/guide-supported-types-examples/exported_types.js
+++ b/examples/guide-supported-types-examples/exported_types.js
@@ -4,6 +4,8 @@ import {
   named_struct_by_shared_ref,
   named_struct_by_exclusive_ref,
   return_named_struct,
+  named_struct_by_optional_value,
+  return_optional_named_struct,
 
   ExportedTupleStruct,
   return_tuple_struct
@@ -13,9 +15,12 @@ let namedStruct = return_named_struct(42);
 console.log(namedStruct instanceof ExportedNamedStruct); // true
 console.log(namedStruct.inner); // 42
 
-named_struct_by_value(namedStruct);
 named_struct_by_shared_ref(namedStruct);
 named_struct_by_exclusive_ref(namedStruct);
+named_struct_by_value(namedStruct);
+
+let optionalNamedStruct = return_optional_named_struct(42);
+named_struct_by_optional_value(optionalNamedStruct);
 
 let tupleStruct = return_tuple_struct(10, 20);
 console.log(tupleStruct instanceof ExportedTupleStruct); // true

--- a/examples/guide-supported-types-examples/src/exported_types.rs
+++ b/examples/guide-supported-types-examples/src/exported_types.rs
@@ -20,6 +20,14 @@ pub fn return_named_struct(inner: u32) -> ExportedNamedStruct {
 }
 
 #[wasm_bindgen]
+pub fn named_struct_by_optional_value(x: Option<ExportedNamedStruct>) {}
+
+#[wasm_bindgen]
+pub fn return_optional_named_struct(inner: u32) -> Option<ExportedNamedStruct> {
+    Some(ExportedNamedStruct { inner })
+}
+
+#[wasm_bindgen]
 pub struct ExportedTupleStruct(pub u32, pub u32);
 
 #[wasm_bindgen]

--- a/guide/src/reference/types/exported-rust-types.md
+++ b/guide/src/reference/types/exported-rust-types.md
@@ -2,7 +2,7 @@
 
 | `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value | `Option<T>` parameter | `Option<T>` return value | JavaScript representation |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Yes | Yes | Yes | Yes | No | No | Instances of a `wasm-bindgen`-generated JavaScript `class Whatever { ... }` |
+| Yes | Yes | Yes | Yes | Yes | Yes | Instances of a `wasm-bindgen`-generated JavaScript `class Whatever { ... }` |
 
 ## Example Rust Usage
 


### PR DESCRIPTION
While working on a project of my own I intuitively attempted to return an `Option<MyRustType>` from a `#[wasm_bindgen]` annotated function and it worked as expected.

I later realized that support for that is not currently documented in the docs.
[The relevant page on the official website](https://rustwasm.github.io/docs/wasm-bindgen/reference/types/exported-rust-types.html) even appear to explicitly say that it is not supported:
![image](https://user-images.githubusercontent.com/2079561/155880300-662bc0bb-0f6b-4f52-9729-cbac15a207db.png)

I then found out about PR https://github.com/rustwasm/wasm-bindgen/pull/1275 which seems to implement both `OptionIntoWasmAbi` and `OptionFromWasmAbi` for any `#[wasm_bindgen]` annotated rust struct. If I'm understanding everything correctly, then those two columns should be switched to `Yes`. 

This PR adjusts the markdown to reflect the support for `Option<RustStruct>` in both parameter and return type position while also adding some use cases in the relevant rust and javascript examples.