### PR TITLE
js-sys: fix `typescript_type` for `AsyncIterator`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1872,7 +1872,7 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)
     #[derive(Clone, Debug)]
-    #[wasm_bindgen(is_type_of = Iterator::looks_like_iterator, typescript_type = "Iterator<Promise<any>>")]
+    #[wasm_bindgen(is_type_of = Iterator::looks_like_iterator, typescript_type = "AsyncIterator<any>")]
     pub type AsyncIterator;
 
     /// The `next()` method always has to return a Promise which resolves to an object


### PR DESCRIPTION
`AsyncIterator` is different from an `Iterator<Promise>`. The method signature is correct (`.next()` returns a `Promise<IteratorResult>`, not an `IteratorResult<Promise>`), it's just the generated type file that's incorrect.