### PR TITLE
test-runner: Run tests isolated by default in headless mode

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ edition = '2018'
 default-run = 'wasm-bindgen'
 
 [dependencies]
+rayon = "1.5"
 curl = "0.4.13"
 docopt = "1.0"
 env_logger = "0.8"
@@ -33,7 +34,6 @@ wasm-bindgen-shared = { path = "../shared", version = "=0.2.79" }
 assert_cmd = "1.0"
 diff = "0.1"
 predicates = "1.0.0"
-rayon = "1.0"
 tempfile = "3.0"
 wit-printer = "0.2"
 wit-text = "0.8"

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/browser.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/browser.rs
@@ -1,0 +1,151 @@
+use anyhow::Context;
+use rayon::prelude::*;
+use std::env;
+use std::ffi::OsString;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::headless::{tab, TestResult};
+
+pub fn execute(
+    shell: crate::shell::Shell,
+    module: &str,
+    tmpdir: &Path,
+    args: &[OsString],
+    tests: Vec<String>,
+) -> anyhow::Result<()> {
+    let isolated = env::var("NO_ISOLATED").is_err();
+    let headless = env::var("NO_HEADLESS").is_err();
+    let debug = env::var("WASM_BINDGEN_DEBUG").is_ok();
+    let timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
+        .map(|timeout| {
+            timeout
+                .parse()
+                .expect("Could not parse 'WASM_BINDGEN_TEST_TIMEOUT'")
+        })
+        .unwrap_or(20);
+    if debug {
+        println!("Set timeout to {} seconds...", timeout);
+    }
+    let shell = Arc::new(shell);
+
+    let addr = if headless {
+        "127.0.0.1:0"
+    } else {
+        "127.0.0.1:8000"
+    };
+    let spawn_server = |tests| {
+        let srv = crate::server::spawn(
+            &addr.parse().unwrap(),
+            headless,
+            &module,
+            &tmpdir,
+            &args,
+            tests,
+        )
+        .context("failed to spawn server")?;
+        let addr = srv.server_addr();
+        Ok::<_, anyhow::Error>((srv, addr))
+    };
+    if headless && isolated && tests.len() > 1 {
+        // Here instead of spawning a server and driver running all tests
+        // we create a pair of server and driver per test and spawn them
+        // parallely. For parallel execution we use rayon so it can automatically
+        // take care of limiting the resources. After all tests finish, we aggregate
+        // their results and present them to the user.
+        println!("\nrunning {} tests", tests.len());
+        let tests = tests.into_iter().map(|t| vec![t]).collect::<Vec<_>>();
+        let results = tests
+            .par_iter()
+            .map(|test| {
+                let (srv, addr) = spawn_server(test)?;
+                let (handle, tx) = srv.stoppable();
+                let shell = shell.clone();
+                let (test_outcome, _) = rayon::join(
+                    move || {
+                        let res = crate::headless::run_isolated(&addr, shell, timeout, debug);
+                        tx.send(()).map_err(Into::into).and(res)
+                    },
+                    move || handle.join(),
+                );
+                Ok::<_, anyhow::Error>((test[0].as_str(), test_outcome?))
+            })
+            .collect::<Vec<_>>();
+        show_test_results(results)?;
+    } else if headless {
+        let (srv, addr) = spawn_server(&tests)?;
+        std::thread::spawn(|| srv.run());
+        crate::headless::run(&addr, shell, timeout, debug)?;
+    } else {
+        let (srv, addr) = spawn_server(&tests)?;
+
+        // TODO: eventually we should provide the ability to exit at some point
+        // (gracefully) here, but for now this just runs forever.
+        println!(
+            "Interactive browsers tests are now available at http://{}",
+            addr
+        );
+        println!("");
+        println!("Note that interactive mode is enabled because `NO_HEADLESS`");
+        println!("is specified in the environment of this process. Once you're");
+        println!("done with testing you'll need to kill this server with");
+        println!("Ctrl-C.");
+        return Ok(srv.run());
+    }
+    Ok(())
+}
+
+// Create a summary of ran tests counting passed, ignored and failed.
+// Combine informations about all failed test cases and print it before the final
+// summary.
+fn show_test_results(
+    results: Vec<Result<(&str, TestResult), anyhow::Error>>,
+) -> Result<(), anyhow::Error> {
+    let mut passed = 0;
+    let mut failed = 0;
+    let mut ignored = 0;
+    let mut all_details = String::new();
+    for result in results {
+        let (test_name, test_result) = result?;
+        match test_result {
+            TestResult::Passed => passed += 1,
+            TestResult::Ignored => ignored += 1,
+            TestResult::Failed { details } => {
+                failed += 1;
+                all_details += &details;
+                all_details.push('\n');
+            }
+            TestResult::Timeouted {
+                output,
+                errors,
+                logs,
+            } => {
+                failed += 1;
+                all_details += &format!(
+                    "Failed to detect {} as having been run. It might have timed out.\n",
+                    test_name
+                );
+                if !output.is_empty() {
+                    all_details += "output div contained:\n";
+                    all_details += &tab(&output);
+                }
+                if !logs.is_empty() {
+                    all_details += "logs div contained:\n";
+                    all_details += &tab(&logs);
+                }
+                if !errors.is_empty() {
+                    all_details += "errors div contained:\n";
+                    all_details += &tab(&errors);
+                }
+            }
+        }
+    }
+    println!();
+    if !all_details.is_empty() {
+        println!("failures:\n");
+        println!("{all_details}");
+    }
+    let result = if failed == 0 { "ok" } else { "FAILED" };
+    println!("test result: {result}. {passed} passed; {failed} failed; {ignored} ignored");
+    Ok(())
+}

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
@@ -36,6 +36,6 @@
 
      window.__wbg_test_invoke = f => f();
     </script>
-    <script src='run.js' type=module></script>
+    <script src='%%SCRIPT_NAME%%' type=module></script>
   </body>
 </html>


### PR DESCRIPTION
Hi. I wanted to propose some changes to the wasm test runner. I'm currently working on some internal projects that are using `yew` frontend framework and I came across some problems with the current state of test runner. I'm trying to address those by this PR but please notice that I'm only focusing on running frontend tests in headless browser. I may be missing some points about other forms of testing that this tool has to offer as I simply haven't used it in other ways. I tried to not modify the behavior of any other forms of testing. If you think that this proposal could be expanded also to `deno` / `node` tests, I can try to handle this either in scope of this PR or in a future one.

# Problem

Currently running a binary containing `wasm_bindgen_test`s results in creating a js script that executes all tests sequentially one after another in a headless browser. This doesn't introduce any isolation of environment in which tests are run, that means that each test is impacting all tests that are executed after it. Consider this simple example:
Assume we are testing some website which has such content:

```html
<a id="login" href="/login">Log in</a>
<a id="signup" href="/signup">Sign up</a>
```
And some tests (pseudocode warning):
```rust
#[wasm_bindgen_test]
fn webpage_should_allow_user_to_sign_up_or_log_in() {
    somehow_render(MyComponent);
    assert!(body().get_element_by_id("login").is_some());
    assert!(body().get_element_by_id("signup").is_some());
}

#[wasm_bindgen_test]
fn login_button_should_redirect_to_login_page() {
    somehow_render(MyComponent);
    let login: HtmlElement = body().get_element_by_id("login").unwrap().unchecked_into();
    login.click();
    assert!(body().inner_html().contains("Please provide password");
}
```
Those test cases looks pretty deterministic, however the test results will not be. We possibly already redirected to some other page and we rendered `MyComponent` second time, so depending on the implementation of `somehow_render` it may lead to some hidden complications.

# Solution

Of course being aware of this behavior we can try to include some forms of cleanup in tests. In this (and possibly other) simple cases this can not be a problem. Eg. redirect back, remove inserted elements and so on. However restoring DOM to original state with all default listeners is not that simple, and restoring JavaScript state seems pretty impossible. We can have some `Promises` running in the void, some mutated global state etc.

With this in mind, I thought that the only possible way to make running such tests deterministic is to run a clean webdriver session for each test case. This seems to be the simplest (and only?) solution that delivers.

# Problems of solution :)

Running a new webdriver session is a huge time overhead. When tests are run sequentially, it is often orders of magnitude slower than just executing test and we pay for it with each running testcase. The obvious solution for this is to make all tests execute in parallel. I've implemented this and it seems to be doing a good job shortening the time the tests are ran.

The implementation is probably not the smartest one, as I don't only run a webdriver for each of test cases but also a separated rouille server. This doesn't seem to be that heavy overhead but it is definitely also not the lightest in terms of resources. I know that this could be handled by only spawning the server once and modifying the requests that we make to the server, however I decided to go with the simplest thing right now. Implementation uses rayon to manage resources as I didn't want to bother with manual calculations of how many threads to spawn depending on available cores and so on. Rayon handles all of this by itself.

In my opinion the resources during testing is not that much of a problem this days as the tests execution time, so I consider this as a reasonable tradeoff.

# Environment configuration

In this proposal, I've included running headless tests isolated by default. It can be controlled by `NO_ISOLATED` flag. I think that this should be a default behavior, as it makes tests deterministic. Also I've limited the output printed by `wasm-bindgen-test-runner` by hiding most of it's prints not directly related to ran tests behind the debugging flag. I renamed it from `WASM_BINDGEN_NO_DEBUG` to `WASM_BINDGEN_DEBUG` and it means that debug will be off by default. I think this is a reasonable to print only an absolute minimum when everything goes well.

# Breaking API

I consider this changes as breaking api so I think if this is merged we should release a new version of wasm-bindgen with a note about those changes. Those are also worth documenting in official book or wherever you think they should however I haven't bothered in providing anything yet as I'm not sure what kind of response this will get.

# Testing done

I've tested this PR on my project containing a handful of wasm tests, where I've driven some testcases to either fail or timeout and everything was working smoothly. I tried running tests of wasm-bindgen-cli itself and it seems to pass some tests and then hang somewhere unless I pass `NO_ISOLATED=1`. I haven't investigated it yet but I'll try to take care of this in the near future.