### PR TITLE
WiP: Fix wasm2js example

### DIFF
--- a/examples/wasm2js/build.sh
+++ b/examples/wasm2js/build.sh
@@ -8,7 +8,9 @@ wasm-pack build --target web
 # Run the `wasm2js` tool from `binaryen`
 wasm2js pkg/wasm2js_bg.wasm -o pkg/wasm2js_bg.js
 
-# Update our JS shim to require the JS file instead
-sed -i 's/wasm2js_bg.wasm/wasm2js_bg.js/' pkg/wasm2js.js
+# Update our JS shim to import the JS file instead
+sed -i "s,^let wasm;\$,import * as wasm from './wasm2js_bg.js';," pkg/wasm2js.js
+# Update the wasm2js js to import from the shim
+sed -i "s,from 'wbg';\$,from \'./wasm2js.js\';," pkg/wasm2js_bg.js
 
 http

--- a/examples/wasm2js/index.js
+++ b/examples/wasm2js/index.js
@@ -1,4 +1,10 @@
 // Import our JS shim and initialize it, executing the start function when it's
 // ready.
 import init from './pkg/wasm2js.js';
-init();
+import {run} from './pkg/wasm2js.js';
+
+// Will print "Hello World" because run() has "wasm_bindgen(start)"
+// call init with input='js' so that it doesn't try to load the wasm
+init('js');
+// manually call run again to print another Hello World
+run();


### PR DESCRIPTION
Proposal fix for #2735

Maybe we should distinguish between builds that are meant to be used with wasm2js and normal web-wasm builds?

This is just a proof of concept and might break lots of things.