### PR TITLE
Fix wasm2js example

### DIFF
--- a/examples/wasm2js/build.sh
+++ b/examples/wasm2js/build.sh
@@ -3,12 +3,13 @@
 set -ex
 
 # Compile our wasm module and run `wasm-bindgen`
-wasm-pack build --target web
+wasm-pack build
 
 # Run the `wasm2js` tool from `binaryen`
-wasm2js pkg/wasm2js_bg.wasm -o pkg/wasm2js_bg.js
+wasm2js pkg/wasm2js_bg.wasm -o pkg/wasm2js_bg.wasm.js
 
 # Update our JS shim to require the JS file instead
-sed -i 's/wasm2js_bg.wasm/wasm2js_bg.js/' pkg/wasm2js.js
+sed -i 's/wasm2js_bg.wasm/wasm2js_bg.wasm.js/' pkg/wasm2js.js
+sed -i 's/wasm2js_bg.wasm/wasm2js_bg.wasm.js/' pkg/wasm2js_bg.js
 
 http

--- a/examples/wasm2js/index.js
+++ b/examples/wasm2js/index.js
@@ -1,4 +1,4 @@
-// Import our JS shim and initialize it, executing the start function when it's
-// ready.
-import init from './pkg/wasm2js.js';
-init();
+// Import our JS shim; will initialize by itself
+import { run } from './pkg/wasm2js.js';
+// Run the function a second time
+run();


### PR DESCRIPTION
Removing the `--target web` and fixing up the imports fixes the wasm2js example.

Note that we don't need to run `init` any longer since it's already run by `wasm2js.js`

Fixes #2735