### PR TITLE
#2806 bugfix: Added checks for JS keywords in signatures.

### DIFF
--- a/tests/wasm/js_keywords.js
+++ b/tests/wasm/js_keywords.js
@@ -1,0 +1,24 @@
+const wasm = require("wasm-bindgen-test.js");
+const assert = require("assert");
+
+exports.js_keywords_compile = () => {
+  assert.strictEqual(wasm._throw(1), 1);
+  assert.strictEqual(wasm._class(1, 2), false);
+  assert.strictEqual(wasm.classy(3), 3);
+  let obj = new wasm.Class("class");
+  assert.strictEqual(wasm.Class.void("string"), "string");
+  assert.strictEqual(obj.catch, "class");
+  assert.strictEqual(obj.instanceof("Class"), "class is instance of Class");
+};
+
+exports.test_keyword_1_as_fn_name = (x) => {
+  return wasm._throw(x);
+};
+
+exports.test_keyword_2_as_fn_name = (x, y) => {
+  return wasm._class(x, y);
+};
+
+exports.test_keyword_as_fn_arg = (x) => {
+  return wasm.classy(x);
+};

--- a/tests/wasm/js_keywords.rs
+++ b/tests/wasm/js_keywords.rs
@@ -1,0 +1,55 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/js_keywords.js")]
+extern "C" {
+    fn js_keywords_compile();
+    fn test_keyword_1_as_fn_name(x: u8) -> u8;
+    fn test_keyword_2_as_fn_name(x: u8, y: u8) -> bool;
+    fn test_keyword_as_fn_arg(x: u8) -> u8;
+}
+
+#[wasm_bindgen]
+pub fn throw(class: u8) -> u8 {
+    class
+}
+
+#[wasm_bindgen(js_name = class)]
+pub fn fn_parsed_to_keyword(instanceof: u8, catch: u8) -> bool {
+    instanceof > catch
+}
+
+#[wasm_bindgen(js_name = classy)]
+pub fn arg_is_keyword(class: u8) -> u8 {
+    class
+}
+
+#[wasm_bindgen]
+struct Class {
+    name: String,
+}
+#[wasm_bindgen]
+impl Class {
+    #[wasm_bindgen(constructor)]
+    pub fn new(void: String) -> Self {
+        Class { name: void }
+    }
+    pub fn instanceof(&self, class: String) -> String {
+        format!("{} is instance of {}", self.name.clone(), class)
+    }
+    #[wasm_bindgen(getter)]
+    pub fn catch(&self) -> String {
+        self.name.clone()
+    }
+    pub fn void(void: String) -> String {
+        void
+    }
+}
+
+#[wasm_bindgen_test]
+fn compile() {
+    js_keywords_compile();
+    assert_eq!(test_keyword_1_as_fn_name(1), 1);
+    assert_eq!(test_keyword_2_as_fn_name(1, 2), false);
+    assert_eq!(test_keyword_as_fn_arg(1), 1);
+}

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -27,6 +27,7 @@ pub mod futures;
 pub mod getters_and_setters;
 pub mod import_class;
 pub mod imports;
+pub mod js_keywords;
 pub mod js_objects;
 pub mod jscast;
 pub mod math;


### PR DESCRIPTION
Added checks in macro crate for those cases downstream crate uses idents, which would result in invalid JS code generation.