### PR TITLE
Added library to wasm-bindgen-cli

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -46,7 +46,7 @@ Options:
 ";
 
 #[derive(Debug, Deserialize)]
-struct Args {
+pub struct Args {
     flag_nodejs: bool,
     flag_browser: bool,
     flag_web: bool,
@@ -71,7 +71,7 @@ struct Args {
     arg_input: Option<PathBuf>,
 }
 
-fn main() {
+pub fn main() {
     env_logger::init();
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
@@ -89,7 +89,7 @@ fn main() {
     process::exit(1);
 }
 
-fn rmain(args: &Args) -> Result<(), Error> {
+pub fn rmain(args: &Args) -> Result<(), Error> {
     let input = match args.arg_input {
         Some(ref s) => s,
         None => bail!("input file expected"),

--- a/crates/cli/src/bin/wasm2es6js.rs
+++ b/crates/cli/src/bin/wasm2es6js.rs
@@ -38,7 +38,7 @@ struct Args {
     arg_input: PathBuf,
 }
 
-fn main() -> anyhow::Result<()> {
+pub fn main() -> anyhow::Result<()> {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,0 +1,16 @@
+//! wasm-bindgen cli
+
+pub mod bin {
+    #[cfg(not(feature = "wasm2es6js"))]
+    #[path = "wasm-bindgen.rs"]
+    pub mod wasm_bindgen;
+
+    #[cfg(feature = "wasm2es6js")]
+    pub mod wasm2es6js;
+}
+
+#[cfg(not(feature = "wasm2es6js"))]
+pub use bin::wasm_bindgen::main;
+
+#[cfg(feature = "wasm2es6js")]
+pub use bin::wasm2es6js::main;


### PR DESCRIPTION
This may come off as an odd PR but would be something very beneficial to [bazelbuild/rules_rust::wasm_bindgen](https://github.com/bazelbuild/rules_rust/tree/0.3.0/wasm_bindgen) which are tools which use `wasm-bindgen` in the [Bazel](https://bazel.build/) build system. The functionality currently tries to recompile of the `wasm-bindgen-cli` crate but in order to achieve this, a ton of complexity was added to solve for issues where binary-only crates do not show up in `cargo metadata` outputs (https://github.com/google/cargo-raze/issues/218 has some good details on this issue). To avoid needing to maintain this complicated behavior, it would be very helpful to have `wasm-bindgen-cli` also contain a library target, which would allow it to appear in `cargo metadata` output. My hope is that this change has no noticeable impact to existing Cargo users but would be very helpful to Bazel users.