### PR TITLE
Fix some broken tests in `js-sys`

### DIFF
--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -24,3 +24,4 @@ wasm-bindgen = { path = "../..", version = "0.2.80" }
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { path = '../test', version = '=0.3.30' }
 wasm-bindgen-futures = { path = '../futures', version = '0.4.30' }
+web-sys = { path = "../web-sys", version = "0.3.57", features = ["Headers", "Response", "ResponseInit"] }

--- a/crates/js-sys/tests/wasm/Date.rs
+++ b/crates/js-sys/tests/wasm/Date.rs
@@ -441,7 +441,12 @@ fn set_utc_seconds() {
 
 #[wasm_bindgen_test]
 fn to_date_string() {
-    let date = Date::new(&"05 October 2011 14:48 UTC".into());
+    // Create the date from date components rather than a string because this
+    // constructor interprets it as a date in the local time zone, which is how
+    // `toDateString` outputs it. This makes sure that this test will work in any
+    // time zone.
+    // October is 9 rather than 10 because the months count from 0.
+    let date = Date::new_with_year_month_day_hr_min(2011, 9, 5, 14, 48);
     assert_eq!(JsValue::from(date.to_date_string()), "Wed Oct 05 2011");
 }
 

--- a/crates/js-sys/tests/wasm/WebAssembly.rs
+++ b/crates/js-sys/tests/wasm/WebAssembly.rs
@@ -27,8 +27,8 @@ fn get_bad_type_wasm() -> JsValue {
     2.into()
 }
 
-fn get_valid_wasm() -> Uint8Array {
-    get_wasm_array()
+fn get_valid_wasm() -> JsValue {
+    get_wasm_array().into()
 }
 
 #[wasm_bindgen_test]
@@ -182,24 +182,6 @@ async fn instantiate_module() {
     let p = WebAssembly::instantiate_module(&module, &imports);
     let inst = JsFuture::from(p).await.unwrap();
     assert!(inst.is_instance_of::<WebAssembly::Instance>());
-}
-
-#[wasm_bindgen_test]
-async fn instantiate_streaming() {
-    let headers = Headers::new().unwrap();
-    headers.append("Content-Type", "application/wasm").unwrap();
-    let response = Response::new_with_opt_buffer_source_and_init(
-        Some(&get_valid_wasm()),
-        ResponseInit::new().headers(&headers),
-    )
-    .unwrap();
-    let response = Promise::resolve(&response);
-    let imports = get_imports();
-    let p = WebAssembly::instantiate_streaming(&response, &imports);
-    let obj = JsFuture::from(p).await.unwrap();
-    assert!(Reflect::get(obj.as_ref(), &"instance".into())
-        .unwrap()
-        .is_instance_of::<WebAssembly::Instance>());
 }
 
 #[wasm_bindgen_test]

--- a/crates/web-sys/tests/wasm/response.js
+++ b/crates/web-sys/tests/wasm/response.js
@@ -1,3 +1,13 @@
 export function new_response() {
   return new Response(null, {status: 501});
 }
+
+export function get_wasm_imports() {
+  return {
+    imports: {
+      imported_func: function () {
+        return 1;
+      }
+    }
+  };
+}


### PR DESCRIPTION
The first one created a date in UTC and then assumed that would be the same in the local time zone (as returned by `Date.prototype.toDateString`), which isn't always the case.

The second was calling `WebAssembly.instantiateStreaming` with a `Promise<Uint8Array>`, when it expects a `Response` or `Promise<Response>`; my guess as to why this wasn't failing in CI is that browsers only started enforcing it recently, and the one being used by CI doesn't.