### PR TITLE
Make `Closure::new` work on stable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,18 +91,6 @@ jobs:
   #       WBINDGEN_I_PROMISE_JS_SYNTAX_WORKS_IN_NODE: 1
   #   - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features "Node Window Document"
 
-  test_wasm_bindgen_nightly:
-    name: "Run wasm-bindgen crate tests (nightly)"
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - run: rustup default nightly-2021-09-02
-    - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-    - run: cargo test --target wasm32-unknown-unknown --features nightly --test wasm
-
   test_native:
     name: Run native tests
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -318,7 +318,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: rustup update nightly && rustup default nightly
-    - run: cargo doc --no-deps --features 'nightly serde-serialize'
+    - run: cargo doc --no-deps --features 'serde-serialize'
     - run: cargo doc --no-deps --manifest-path crates/js-sys/Cargo.toml
     - run: cargo doc --no-deps --manifest-path crates/web-sys/Cargo.toml --all-features
       env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ default = ["spans", "std"]
 spans = ["wasm-bindgen-macro/spans"]
 std = []
 serde-serialize = ["serde", "serde_json", "std"]
-nightly = []
 enable-interning = ["std"]
 
 # Whether or not the `#[wasm_bindgen]` macro is strict and generates an error on

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![no_std]
 #![allow(coherence_leak_check)]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
-#![cfg_attr(feature = "nightly", feature(unsize))]
 
 use core::convert::TryFrom;
 use core::fmt;

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "nightly")]
-
 use js_sys::Number;
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -224,7 +224,6 @@ fn dead_imports_not_generated() {
 }
 
 #[wasm_bindgen_test]
-#[cfg(feature = "nightly")]
 fn import_inside_function_works() {
     #[wasm_bindgen(module = "tests/wasm/imports.js")]
     extern "C" {
@@ -234,12 +233,10 @@ fn import_inside_function_works() {
 }
 
 #[wasm_bindgen_test]
-#[cfg(feature = "nightly")]
 fn private_module_imports_work() {
     private::foo();
 }
 
-#[cfg(feature = "nightly")]
 mod private {
     use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
I've removed the nightly requirement by replacing `Unsize<T>` with a custom `IntoWasmClosure<T>` trait, implemented for `Fn` and `FnMut`.

I don't think this is a breaking change, since I don't think any stability guarantees are provided for nightly.

One thing I'm not sure about is whether `Closure::wrap` should be deprecated. It could still be kinda useful if you've already got a `Box<dyn Fn[Mut]>` and don't want to double-box it, but that seems like a rare case.