### PR TITLE
doc(jsvalue) Fix documentation of the `in` operator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ impl JsValue {
 
     /// Applies the binary `in` JS operator on the two `JsValue`s.
     ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof)
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in)
     #[inline]
     pub fn js_in(&self, obj: &JsValue) -> bool {
         unsafe { __wbindgen_in(self.idx, obj.idx) == 1 }


### PR DESCRIPTION
It was a copy-paste error from the `typeof` operator.