### PR TITLE
feat(jsvalue) Add `JsValue.ptr` to retrieve internal `idx` value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,11 @@ impl JsValue {
         }
     }
 
+    /// Returns the internal pointer value of this `JsValue`.
+    pub fn ptr(&self) -> u32 {
+        self.idx
+    }
+
     /// Creates a new JS value which is a string.
     ///
     /// The utf-8 string provided is copied to the JS heap and the string will


### PR DESCRIPTION
I'm trying to solve https://github.com/rustwasm/wasm-bindgen/issues/2231, and the first immediate step is to make `JsValue.idx` visible to the world. There is nothing particularly dangerous to allow that.