### PR TITLE
Add 5 WebGPU feature name

### DIFF
--- a/crates/web-sys/src/features/gen_GpuFeatureName.rs
+++ b/crates/web-sys/src/features/gen_GpuFeatureName.rs
@@ -15,5 +15,10 @@ pub enum GpuFeatureName {
     Depth32floatStencil8 = "depth32float-stencil8",
     PipelineStatisticsQuery = "pipeline-statistics-query",
     TextureCompressionBc = "texture-compression-bc",
+    TextureCompressionEtc2 = "texture-compression-etc2",
+    TextureCompressionAstc = "texture-compression-astc",
     TimestampQuery = "timestamp-query",
+    IndirectFirstInstance = "indirect-first-instance",
+    ShaderF16 = "shader-f16",
+    Bgra8unormStorage = "bgra8unorm-storage",
 }


### PR DESCRIPTION
WebGPU spec: https://gpuweb.github.io/gpuweb/#texture-compression-etc

Since `PipelineStatisticsQuery` is only temporarily removed from the spec, it is more appropriate to keep it.