### PR TITLE
Namespace const

### DIFF
--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '1.0', features = ['full'] }
 wasm-bindgen-backend = { version = "=0.2.80", path = "../backend" }
-weedle = "0.12"
+weedle = { git = "https://github.com/rustwasm/weedle.git" }
 lazy_static = "1.0.2"
 sourcefile = "0.1"
 structopt = "0.3.9"

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -15,6 +15,7 @@ use weedle::argument::Argument;
 use weedle::attribute::*;
 use weedle::interface::*;
 use weedle::mixin::*;
+use weedle::namespace::*;
 use weedle::CallbackInterfaceDefinition;
 use weedle::{DictionaryDefinition, PartialDictionaryDefinition};
 
@@ -80,6 +81,8 @@ pub(crate) struct MixinData<'src> {
 #[derive(Default)]
 pub(crate) struct NamespaceData<'src> {
     pub(crate) operations: BTreeMap<OperationId<'src>, OperationData<'src>>,
+    pub(crate) consts: Vec<&'src ConstNamespaceMember<'src>>,
+    pub(crate) stability: ApiStability,
 }
 
 #[derive(Default)]
@@ -173,8 +176,8 @@ impl<'src> FirstPass<'src, ApiStability> for weedle::Definition<'src> {
             PartialInterface(interface) => interface.first_pass(record, stability),
             InterfaceMixin(mixin) => mixin.first_pass(record, stability),
             PartialInterfaceMixin(mixin) => mixin.first_pass(record, stability),
-            Namespace(namespace) => namespace.first_pass(record, ()),
-            PartialNamespace(namespace) => namespace.first_pass(record, ()),
+            Namespace(namespace) => namespace.first_pass(record, stability),
+            PartialNamespace(namespace) => namespace.first_pass(record, stability),
             Typedef(typedef) => typedef.first_pass(record, ()),
             Callback(callback) => callback.first_pass(record, ()),
             CallbackInterface(iface) => iface.first_pass(record, ()),
@@ -750,13 +753,14 @@ impl<'src> FirstPass<'src, ()> for weedle::TypedefDefinition<'src> {
     }
 }
 
-impl<'src> FirstPass<'src, ()> for weedle::NamespaceDefinition<'src> {
-    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, (): ()) -> Result<()> {
+impl<'src> FirstPass<'src, ApiStability> for weedle::NamespaceDefinition<'src> {
+    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, stability: ApiStability) -> Result<()> {
         if util::is_chrome_only(&self.attributes) {
             return Ok(());
         }
 
-        record.namespaces.entry(self.identifier.0).or_default();
+        let namespace = record.namespaces.entry(self.identifier.0).or_default();
+        namespace.stability = stability;
 
         for member in &self.members.body {
             member.first_pass(record, self.identifier.0)?;
@@ -766,13 +770,14 @@ impl<'src> FirstPass<'src, ()> for weedle::NamespaceDefinition<'src> {
     }
 }
 
-impl<'src> FirstPass<'src, ()> for weedle::PartialNamespaceDefinition<'src> {
-    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, (): ()) -> Result<()> {
+impl<'src> FirstPass<'src, ApiStability> for weedle::PartialNamespaceDefinition<'src> {
+    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, stability: ApiStability) -> Result<()> {
         if util::is_chrome_only(&self.attributes) {
             return Ok(());
         }
 
-        record.namespaces.entry(self.identifier.0).or_default();
+        let namespace = record.namespaces.entry(self.identifier.0).or_default();
+        namespace.stability = stability;
 
         for member in &self.members.body {
             member.first_pass(record, self.identifier.0)?;
@@ -786,9 +791,18 @@ impl<'src> FirstPass<'src, &'src str> for weedle::namespace::NamespaceMember<'sr
     fn first_pass(
         &'src self,
         record: &mut FirstPassRecord<'src>,
-        self_name: &'src str,
+        self_name: &'src str
     ) -> Result<()> {
         match self {
+            weedle::namespace::NamespaceMember::Const(const_) => {
+                record
+                    .namespaces
+                    .get_mut(self_name)
+                    .unwrap()
+                    .consts
+                    .push(const_);
+                Ok(())
+            },
             weedle::namespace::NamespaceMember::Operation(op) => op.first_pass(record, self_name),
             _ => Ok(()),
         }

--- a/crates/webidl/src/first_pass.rs
+++ b/crates/webidl/src/first_pass.rs
@@ -754,7 +754,11 @@ impl<'src> FirstPass<'src, ()> for weedle::TypedefDefinition<'src> {
 }
 
 impl<'src> FirstPass<'src, ApiStability> for weedle::NamespaceDefinition<'src> {
-    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, stability: ApiStability) -> Result<()> {
+    fn first_pass(
+        &'src self,
+        record: &mut FirstPassRecord<'src>,
+        stability: ApiStability,
+    ) -> Result<()> {
         if util::is_chrome_only(&self.attributes) {
             return Ok(());
         }
@@ -771,7 +775,11 @@ impl<'src> FirstPass<'src, ApiStability> for weedle::NamespaceDefinition<'src> {
 }
 
 impl<'src> FirstPass<'src, ApiStability> for weedle::PartialNamespaceDefinition<'src> {
-    fn first_pass(&'src self, record: &mut FirstPassRecord<'src>, stability: ApiStability) -> Result<()> {
+    fn first_pass(
+        &'src self,
+        record: &mut FirstPassRecord<'src>,
+        stability: ApiStability,
+    ) -> Result<()> {
         if util::is_chrome_only(&self.attributes) {
             return Ok(());
         }
@@ -791,7 +799,7 @@ impl<'src> FirstPass<'src, &'src str> for weedle::namespace::NamespaceMember<'sr
     fn first_pass(
         &'src self,
         record: &mut FirstPassRecord<'src>,
-        self_name: &'src str
+        self_name: &'src str,
     ) -> Result<()> {
         match self {
             weedle::namespace::NamespaceMember::Const(const_) => {
@@ -802,7 +810,7 @@ impl<'src> FirstPass<'src, &'src str> for weedle::namespace::NamespaceMember<'sr
                     .consts
                     .push(const_);
                 Ok(())
-            },
+            }
             weedle::namespace::NamespaceMember::Operation(op) => op.first_pass(record, self_name),
             _ => Ok(()),
         }

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -895,7 +895,7 @@ impl Namespace {
             js_name,
             consts,
             functions,
-            unstable
+            unstable,
         } = self;
 
         let unstable_attr = maybe_unstable_attr(*unstable);

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -138,6 +138,82 @@ impl Enum {
     }
 }
 
+pub enum ConstValue {
+    BooleanLiteral(bool),
+    FloatLiteral(f64),
+    SignedIntegerLiteral(i64),
+    UnsignedIntegerLiteral(u64),
+}
+
+impl ConstValue {
+    fn generate(&self) -> TokenStream {
+        use ConstValue::*;
+
+        match self {
+            BooleanLiteral(false) => quote!(false),
+            BooleanLiteral(true) => quote!(true),
+            // the actual type is unknown because of typedefs
+            // so we cannot use std::fxx::INFINITY
+            // but we can use type inference
+            FloatLiteral(f) if f.is_infinite() && f.is_sign_positive() => quote!(1.0 / 0.0),
+            FloatLiteral(f) if f.is_infinite() && f.is_sign_negative() => quote!(-1.0 / 0.0),
+            FloatLiteral(f) if f.is_nan() => quote!(0.0 / 0.0),
+            // again no suffix
+            // panics on +-inf, nan
+            FloatLiteral(f) => {
+                let f = Literal::f64_suffixed(*f);
+                quote!(#f)
+            }
+            SignedIntegerLiteral(i) => {
+                let i = Literal::i64_suffixed(*i);
+                quote!(#i)
+            }
+            UnsignedIntegerLiteral(i) => {
+                let i = Literal::u64_suffixed(*i);
+                quote!(#i)
+            }
+        }
+    }
+}
+
+pub struct Const {
+    pub name: Ident,
+    pub js_name: String,
+    pub ty: syn::Type,
+    pub value: ConstValue,
+    pub unstable: bool,
+}
+
+impl Const {
+    fn generate(
+        &self,
+        options: &Options,
+        parent_name: &Ident,
+        parent_js_name: &str,
+    ) -> TokenStream {
+        let name = &self.name;
+        let ty = &self.ty;
+        let js_name = &self.js_name;
+        let value = self.value.generate();
+        let unstable = self.unstable;
+
+        let unstable_attr = maybe_unstable_attr(unstable);
+        let unstable_docs = maybe_unstable_docs(unstable);
+
+        let doc_comment = comment(
+            format!("The `{}.{}` const.", parent_js_name, js_name),
+            &get_features_doc(options, parent_name.to_string()),
+        );
+
+        quote! {
+            #unstable_attr
+            #doc_comment
+            #unstable_docs
+            pub const #name: #ty = #value as #ty;
+        }
+    }
+}
+
 pub enum InterfaceAttributeKind {
     Getter,
     Setter,
@@ -429,89 +505,13 @@ impl InterfaceMethod {
     }
 }
 
-pub enum InterfaceConstValue {
-    BooleanLiteral(bool),
-    FloatLiteral(f64),
-    SignedIntegerLiteral(i64),
-    UnsignedIntegerLiteral(u64),
-}
-
-impl InterfaceConstValue {
-    fn generate(&self) -> TokenStream {
-        use InterfaceConstValue::*;
-
-        match self {
-            BooleanLiteral(false) => quote!(false),
-            BooleanLiteral(true) => quote!(true),
-            // the actual type is unknown because of typedefs
-            // so we cannot use std::fxx::INFINITY
-            // but we can use type inference
-            FloatLiteral(f) if f.is_infinite() && f.is_sign_positive() => quote!(1.0 / 0.0),
-            FloatLiteral(f) if f.is_infinite() && f.is_sign_negative() => quote!(-1.0 / 0.0),
-            FloatLiteral(f) if f.is_nan() => quote!(0.0 / 0.0),
-            // again no suffix
-            // panics on +-inf, nan
-            FloatLiteral(f) => {
-                let f = Literal::f64_suffixed(*f);
-                quote!(#f)
-            }
-            SignedIntegerLiteral(i) => {
-                let i = Literal::i64_suffixed(*i);
-                quote!(#i)
-            }
-            UnsignedIntegerLiteral(i) => {
-                let i = Literal::u64_suffixed(*i);
-                quote!(#i)
-            }
-        }
-    }
-}
-
-pub struct InterfaceConst {
-    pub name: Ident,
-    pub js_name: String,
-    pub ty: syn::Type,
-    pub value: InterfaceConstValue,
-    pub unstable: bool,
-}
-
-impl InterfaceConst {
-    fn generate(
-        &self,
-        options: &Options,
-        parent_name: &Ident,
-        parent_js_name: &str,
-    ) -> TokenStream {
-        let name = &self.name;
-        let ty = &self.ty;
-        let js_name = &self.js_name;
-        let value = self.value.generate();
-        let unstable = self.unstable;
-
-        let unstable_attr = maybe_unstable_attr(unstable);
-        let unstable_docs = maybe_unstable_docs(unstable);
-
-        let doc_comment = comment(
-            format!("The `{}.{}` const.", parent_js_name, js_name),
-            &get_features_doc(options, parent_name.to_string()),
-        );
-
-        quote! {
-            #unstable_attr
-            #doc_comment
-            #unstable_docs
-            pub const #name: #ty = #value as #ty;
-        }
-    }
-}
-
 pub struct Interface {
     pub name: Ident,
     pub js_name: String,
     pub deprecated: Option<String>,
     pub has_interface: bool,
     pub parents: Vec<Ident>,
-    pub consts: Vec<InterfaceConst>,
+    pub consts: Vec<Const>,
     pub attributes: Vec<InterfaceAttribute>,
     pub methods: Vec<InterfaceMethod>,
     pub unstable: bool,
@@ -883,7 +883,9 @@ impl Function {
 pub struct Namespace {
     pub name: Ident,
     pub js_name: String,
+    pub consts: Vec<Const>,
     pub functions: Vec<Function>,
+    pub unstable: bool,
 }
 
 impl Namespace {
@@ -891,24 +893,46 @@ impl Namespace {
         let Namespace {
             name,
             js_name,
+            consts,
             functions,
+            unstable
         } = self;
+
+        let unstable_attr = maybe_unstable_attr(*unstable);
+        let unstable_docs = maybe_unstable_docs(*unstable);
 
         let functions = functions
             .into_iter()
             .map(|x| x.generate(options, &name, js_name.to_string()))
             .collect::<Vec<_>>();
 
+        let functions = if functions.is_empty() {
+            None
+        } else {
+            Some(quote! {
+                #[wasm_bindgen]
+                extern "C" {
+                    #(#functions)*
+                }
+            })
+        };
+
+        let consts = consts
+            .into_iter()
+            .map(|x| x.generate(options, &name, js_name))
+            .collect::<Vec<_>>();
+
         quote! {
+            #unstable_attr
+            #unstable_docs
             pub mod #name {
                 #![allow(unused_imports)]
                 use super::super::*;
                 use wasm_bindgen::prelude::*;
 
-                #[wasm_bindgen]
-                extern "C" {
-                    #(#functions)*
-                }
+                #(#consts)*
+
+                #functions
             }
         }
     }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -263,12 +263,13 @@ impl<'a> ToIdlType<'a> for RecordType<'a> {
     }
 }
 
-impl<'a> ToIdlType<'a> for StringType {
+impl<'a> ToIdlType<'a> for RecordKeyType<'a> {
     fn to_idl_type(&self, record: &FirstPassRecord<'a>) -> IdlType<'a> {
         match self {
-            StringType::Byte(t) => t.to_idl_type(record),
-            StringType::DOM(t) => t.to_idl_type(record),
-            StringType::USV(t) => t.to_idl_type(record),
+            RecordKeyType::Byte(t) => t.to_idl_type(record),
+            RecordKeyType::DOM(t) => t.to_idl_type(record),
+            RecordKeyType::USV(t) => t.to_idl_type(record),
+            RecordKeyType::NonAny(t) => t.to_idl_type(record)
         }
     }
 }

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -269,7 +269,7 @@ impl<'a> ToIdlType<'a> for RecordKeyType<'a> {
             RecordKeyType::Byte(t) => t.to_idl_type(record),
             RecordKeyType::DOM(t) => t.to_idl_type(record),
             RecordKeyType::USV(t) => t.to_idl_type(record),
-            RecordKeyType::NonAny(t) => t.to_idl_type(record)
+            RecordKeyType::NonAny(t) => t.to_idl_type(record),
         }
     }
 }

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -19,8 +19,8 @@ mod util;
 use crate::first_pass::{CallbackInterfaceData, OperationData};
 use crate::first_pass::{FirstPass, FirstPassRecord, InterfaceData, OperationId};
 use crate::generator::{
-    Dictionary, DictionaryField, Enum, EnumVariant, Function, Interface, InterfaceAttribute,
-    InterfaceAttributeKind, Const, InterfaceMethod, Namespace,
+    Const, Dictionary, DictionaryField, Enum, EnumVariant, Function, Interface, InterfaceAttribute,
+    InterfaceAttributeKind, InterfaceMethod, Namespace,
 };
 use crate::idl_type::ToIdlType;
 use crate::traverse::TraverseType;
@@ -455,7 +455,7 @@ impl<'src> FirstPassRecord<'src> {
                 js_name,
                 consts,
                 functions,
-                unstable
+                unstable,
             }
             .generate(options)
             .to_tokens(&mut program.tokens);
@@ -466,7 +466,7 @@ impl<'src> FirstPassRecord<'src> {
         &self,
         consts: &mut Vec<Const>,
         member: &'src weedle::namespace::ConstNamespaceMember<'src>,
-        unstable: bool
+        unstable: bool,
     ) {
         let idl_type = member.const_type.to_idl_type(self);
         let ty = idl_type.to_syn_type(TypePosition::Return).unwrap().unwrap();

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -20,7 +20,7 @@ use crate::first_pass::{CallbackInterfaceData, OperationData};
 use crate::first_pass::{FirstPass, FirstPassRecord, InterfaceData, OperationId};
 use crate::generator::{
     Dictionary, DictionaryField, Enum, EnumVariant, Function, Interface, InterfaceAttribute,
-    InterfaceAttributeKind, InterfaceConst, InterfaceMethod, Namespace,
+    InterfaceAttributeKind, Const, InterfaceMethod, Namespace,
 };
 use crate::idl_type::ToIdlType;
 use crate::traverse::TraverseType;
@@ -436,24 +436,55 @@ impl<'src> FirstPassRecord<'src> {
         js_name: String,
         ns: &'src first_pass::NamespaceData<'src>,
     ) {
+        let unstable = ns.stability.is_unstable();
+
+        let mut consts = vec![];
         let mut functions = vec![];
 
-        for (id, data) in ns.operations.iter() {
-            self.append_ns_member(&mut functions, &js_name, id, data);
+        for member in ns.consts.iter() {
+            self.append_ns_const(&mut consts, member, unstable);
         }
 
-        if !functions.is_empty() {
+        for (id, data) in ns.operations.iter() {
+            self.append_ns_operation(&mut functions, &js_name, id, data);
+        }
+
+        if !consts.is_empty() || !functions.is_empty() {
             Namespace {
                 name,
                 js_name,
+                consts,
                 functions,
+                unstable
             }
             .generate(options)
             .to_tokens(&mut program.tokens);
         }
     }
 
-    fn append_ns_member(
+    fn append_ns_const(
+        &self,
+        consts: &mut Vec<Const>,
+        member: &'src weedle::namespace::ConstNamespaceMember<'src>,
+        unstable: bool
+    ) {
+        let idl_type = member.const_type.to_idl_type(self);
+        let ty = idl_type.to_syn_type(TypePosition::Return).unwrap().unwrap();
+
+        let js_name = member.identifier.0;
+        let name = rust_ident(shouty_snake_case_ident(js_name).as_str());
+        let value = webidl_const_v_to_backend_const_v(&member.const_value);
+
+        consts.push(Const {
+            name,
+            js_name: js_name.to_string(),
+            ty,
+            value,
+            unstable,
+        });
+    }
+
+    fn append_ns_operation(
         &self,
         functions: &mut Vec<Function>,
         js_name: &'src str,
@@ -486,9 +517,9 @@ impl<'src> FirstPassRecord<'src> {
         }
     }
 
-    fn append_const(
+    fn append_interface_const(
         &self,
-        consts: &mut Vec<InterfaceConst>,
+        consts: &mut Vec<Const>,
         member: &'src weedle::interface::ConstMember<'src>,
         unstable: bool,
     ) {
@@ -499,7 +530,7 @@ impl<'src> FirstPassRecord<'src> {
         let name = rust_ident(shouty_snake_case_ident(js_name).as_str());
         let value = webidl_const_v_to_backend_const_v(&member.const_value);
 
-        consts.push(InterfaceConst {
+        consts.push(Const {
             name,
             js_name: js_name.to_string(),
             ty,
@@ -536,7 +567,7 @@ impl<'src> FirstPassRecord<'src> {
         let mut methods = vec![];
 
         for member in data.consts.iter() {
-            self.append_const(&mut consts, member, unstable);
+            self.append_interface_const(&mut consts, member, unstable);
         }
 
         for member in data.attributes.iter() {
@@ -560,7 +591,7 @@ impl<'src> FirstPassRecord<'src> {
 
         for mixin_data in self.all_mixins(&js_name) {
             for member in &mixin_data.consts {
-                self.append_const(&mut consts, member, unstable);
+                self.append_interface_const(&mut consts, member, unstable);
             }
 
             for member in &mixin_data.attributes {

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -12,12 +12,12 @@ use wasm_bindgen_backend::util::{ident_ty, raw_ident, rust_ident};
 use weedle;
 use weedle::attribute::{ExtendedAttribute, ExtendedAttributeList, IdentifierOrString};
 use weedle::common::Identifier;
-use weedle::literal::{ConstValue, FloatLit, IntegerLit};
+use weedle::literal::{ConstValue as ConstValueLit, FloatLit, IntegerLit};
 use weedle::types::{NonAnyType, SingleType};
 
 use crate::constants::IMMUTABLE_SLICE_WHITELIST;
 use crate::first_pass::{FirstPassRecord, OperationData, OperationId, Signature};
-use crate::generator::{InterfaceConstValue, InterfaceMethod, InterfaceMethodKind};
+use crate::generator::{ConstValue, InterfaceMethod, InterfaceMethodKind};
 use crate::idl_type::{IdlType, ToIdlType};
 use crate::Options;
 
@@ -104,20 +104,20 @@ pub(crate) fn array(base_ty: &str, pos: TypePosition, immutable: bool) -> syn::T
 }
 
 /// Map a webidl const value to the correct wasm-bindgen const value
-pub fn webidl_const_v_to_backend_const_v(v: &ConstValue) -> InterfaceConstValue {
+pub fn webidl_const_v_to_backend_const_v(v: &ConstValueLit) -> ConstValue {
     use std::f64::{INFINITY, NAN, NEG_INFINITY};
 
     match *v {
-        ConstValue::Boolean(b) => InterfaceConstValue::BooleanLiteral(b.0),
-        ConstValue::Float(FloatLit::NegInfinity(_)) => {
-            InterfaceConstValue::FloatLiteral(NEG_INFINITY)
+        ConstValueLit::Boolean(b) => ConstValue::BooleanLiteral(b.0),
+        ConstValueLit::Float(FloatLit::NegInfinity(_)) => {
+            ConstValue::FloatLiteral(NEG_INFINITY)
         }
-        ConstValue::Float(FloatLit::Infinity(_)) => InterfaceConstValue::FloatLiteral(INFINITY),
-        ConstValue::Float(FloatLit::NaN(_)) => InterfaceConstValue::FloatLiteral(NAN),
-        ConstValue::Float(FloatLit::Value(s)) => {
-            InterfaceConstValue::FloatLiteral(s.0.parse().unwrap())
+        ConstValueLit::Float(FloatLit::Infinity(_)) => ConstValue::FloatLiteral(INFINITY),
+        ConstValueLit::Float(FloatLit::NaN(_)) => ConstValue::FloatLiteral(NAN),
+        ConstValueLit::Float(FloatLit::Value(s)) => {
+            ConstValue::FloatLiteral(s.0.parse().unwrap())
         }
-        ConstValue::Integer(lit) => {
+        ConstValueLit::Integer(lit) => {
             let mklit = |orig_text: &str, base: u32, offset: usize| {
                 let (negative, text) = if orig_text.starts_with("-") {
                     (true, &orig_text[1..])
@@ -125,7 +125,7 @@ pub fn webidl_const_v_to_backend_const_v(v: &ConstValue) -> InterfaceConstValue 
                     (false, orig_text)
                 };
                 if text == "0" {
-                    return InterfaceConstValue::SignedIntegerLiteral(0);
+                    return ConstValue::SignedIntegerLiteral(0);
                 }
                 let text = &text[offset..];
                 let n = u64::from_str_radix(text, base)
@@ -136,9 +136,9 @@ pub fn webidl_const_v_to_backend_const_v(v: &ConstValue) -> InterfaceConstValue 
                     } else {
                         n.wrapping_neg() as i64
                     };
-                    InterfaceConstValue::SignedIntegerLiteral(n)
+                    ConstValue::SignedIntegerLiteral(n)
                 } else {
-                    InterfaceConstValue::UnsignedIntegerLiteral(n)
+                    ConstValue::UnsignedIntegerLiteral(n)
                 }
             };
             match lit {
@@ -147,7 +147,7 @@ pub fn webidl_const_v_to_backend_const_v(v: &ConstValue) -> InterfaceConstValue 
                 IntegerLit::Dec(h) => mklit(h.0, 10, 0),
             }
         }
-        ConstValue::Null(_) => unimplemented!(),
+        ConstValueLit::Null(_) => unimplemented!(),
     }
 }
 

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -109,14 +109,10 @@ pub fn webidl_const_v_to_backend_const_v(v: &ConstValueLit) -> ConstValue {
 
     match *v {
         ConstValueLit::Boolean(b) => ConstValue::BooleanLiteral(b.0),
-        ConstValueLit::Float(FloatLit::NegInfinity(_)) => {
-            ConstValue::FloatLiteral(NEG_INFINITY)
-        }
+        ConstValueLit::Float(FloatLit::NegInfinity(_)) => ConstValue::FloatLiteral(NEG_INFINITY),
         ConstValueLit::Float(FloatLit::Infinity(_)) => ConstValue::FloatLiteral(INFINITY),
         ConstValueLit::Float(FloatLit::NaN(_)) => ConstValue::FloatLiteral(NAN),
-        ConstValueLit::Float(FloatLit::Value(s)) => {
-            ConstValue::FloatLiteral(s.0.parse().unwrap())
-        }
+        ConstValueLit::Float(FloatLit::Value(s)) => ConstValue::FloatLiteral(s.0.parse().unwrap()),
         ConstValueLit::Integer(lit) => {
             let mklit = |orig_text: &str, base: u32, offset: usize| {
                 let (negative, text) = if orig_text.starts_with("-") {


### PR DESCRIPTION
See https://github.com/rustwasm/weedle/pull/52

This comes with a companion PR https://github.com/rustwasm/wasm-bindgen/pull/2906 which contains new WebGPU bindings generated with these changes, which I figured might be useful for reference. See e.g. [gen_gpu_map_mode.rs](https://github.com/rustwasm/wasm-bindgen/pull/2906/files#diff-fb1d0139afd75f22c2519b2ebd529437297d775d7e33c6a91348282f12b2dacf) for an example of the code that is generated for namespaced constants.

This renames `InterfaceConst` and `InterfaceConstValue` to just `Const` and `ConstValue` and reuses those for namespace constants. It now also tracks API stability for namespaces, as the use-case at hand is WebGPU which is an unstable API. It currently adds the `#[cfg(web_sys_unstable_apis)]` attribute to both the namespace itself and the constants inside the namespace; I'm not sure if that's appropriate or redundant.