### PR TITLE
feat(jsvalue) Implement `From<()>` for `JsValue`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,6 +806,13 @@ where
     }
 }
 
+impl From<()> for JsValue {
+    #[inline]
+    fn from(_: ()) -> JsValue {
+        JsValue::UNDEFINED
+    }
+}
+
 impl JsCast for JsValue {
     // everything is a `JsValue`!
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1521,12 +1521,6 @@ pub mod __rt {
         fn into_js_result(self) -> Result<JsValue, JsValue>;
     }
 
-    impl IntoJsResult for () {
-        fn into_js_result(self) -> Result<JsValue, JsValue> {
-            Ok(JsValue::undefined())
-        }
-    }
-
     impl<T: Into<JsValue>> IntoJsResult for T {
         fn into_js_result(self) -> Result<JsValue, JsValue> {
             Ok(self.into())
@@ -1537,15 +1531,6 @@ pub mod __rt {
         fn into_js_result(self) -> Result<JsValue, JsValue> {
             match self {
                 Ok(e) => Ok(e.into()),
-                Err(e) => Err(e.into()),
-            }
-        }
-    }
-
-    impl<E: Into<JsValue>> IntoJsResult for Result<(), E> {
-        fn into_js_result(self) -> Result<JsValue, JsValue> {
-            match self {
-                Ok(()) => Ok(JsValue::undefined()),
                 Err(e) => Err(e.into()),
             }
         }


### PR DESCRIPTION
This could be controversial, but I reckon it makes sense to map `()`
in Rust to `undefined` in JavaScript. When a Rust function returns
“nothing”, it's idiomatic to return `()`. In JavaScript, it is the
equivalent of returning `undefined`.

Supporting this pattern is useful for automatic Rust to JavaScript
conversions.

Edit: Turns out, `()` was already mapped to `JsValue` with the help of the `IntoJsValue` trait. Implementing `From<()>` for `JsValue` directly help removing 2 implementations of `IntoJsValue`. 