### PR TITLE
Add an IDL file for the WebXR Gamepads Module

### DIFF
--- a/crates/web-sys/src/features/gen_XrInputSource.rs
+++ b/crates/web-sys/src/features/gen_XrInputSource.rs
@@ -74,4 +74,16 @@ extern "C" {
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn profiles(this: &XrInputSource) -> ::js_sys::Array;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "Gamepad")]
+    # [wasm_bindgen (structural , method , getter , js_class = "XRInputSource" , js_name = gamepad)]
+    #[doc = "Getter for the `gamepad` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource/gamepad)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Gamepad`, `XrInputSource`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn gamepad(this: &XrInputSource) -> Option<Gamepad>;
 }

--- a/crates/web-sys/webidls/unstable/WebXRGamepadsModule.webidl
+++ b/crates/web-sys/webidls/unstable/WebXRGamepadsModule.webidl
@@ -1,0 +1,11 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/*
+ * WebXR Device API
+ * W3C Working Draft, 31 March 2022
+ * The origin of this IDL file is:
+ * https://www.w3.org/TR/2022/WD-webxr-gamepads-module-1-20220426/
+ */
+
+partial interface XRInputSource {
+  [SameObject] readonly attribute Gamepad? gamepad;
+};


### PR DESCRIPTION
See https://www.w3.org/TR/2022/WD-webxr-gamepads-module-1-20220426/.