### PR TITLE
test(ci) Remove duplicate actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,6 @@ jobs:
         node-version: '16'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --target wasm32-unknown-unknown
-    - run: cargo test --target wasm32-unknown-unknown
     - run: cargo test --target wasm32-unknown-unknown --features serde-serialize
     - run: cargo test --target wasm32-unknown-unknown --features enable-interning
     - run: cargo test --target wasm32-unknown-unknown -p no-std


### PR DESCRIPTION
I was wondering if running `cargo test --target wasm32-unknown-unknown`
_twice_ is necessary. If not, please discard this commit.