### PR TITLE
add SubmitEvent to web_sys Event types

### DIFF
--- a/crates/web-sys/src/features/gen_SubmitEvent.rs
+++ b/crates/web-sys/src/features/gen_SubmitEvent.rs
@@ -1,0 +1,40 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    # [wasm_bindgen (extends = Event , extends = :: js_sys :: Object , js_name = SubmitEvent , typescript_type = "SubmitEvent")]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `SubmitEvent` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEvent`*"]
+    pub type SubmitEvent;
+    #[cfg(feature = "HtmlElement")]
+    # [wasm_bindgen (structural , method , getter , js_class = "SubmitEvent" , js_name = submitter)]
+    #[doc = "Getter for the `submitter` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlElement`, `SubmitEvent`*"]
+    pub fn submitter(this: &SubmitEvent) -> Option<HtmlElement>;
+    #[wasm_bindgen(catch, constructor, js_class = "SubmitEvent")]
+    #[doc = "The `new SubmitEvent(..)` constructor, creating a new instance of `SubmitEvent`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/SubmitEvent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEvent`*"]
+    pub fn new(type_: &str) -> Result<SubmitEvent, JsValue>;
+    #[cfg(feature = "SubmitEventInit")]
+    #[wasm_bindgen(catch, constructor, js_class = "SubmitEvent")]
+    #[doc = "The `new SubmitEvent(..)` constructor, creating a new instance of `SubmitEvent`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/SubmitEvent)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEvent`, `SubmitEventInit`*"]
+    pub fn new_with_event_init_dict(
+        type_: &str,
+        event_init_dict: &SubmitEventInit,
+    ) -> Result<SubmitEvent, JsValue>;
+}

--- a/crates/web-sys/src/features/gen_SubmitEventInit.rs
+++ b/crates/web-sys/src/features/gen_SubmitEventInit.rs
@@ -1,0 +1,96 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    # [wasm_bindgen (extends = :: js_sys :: Object , js_name = SubmitEventInit)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `SubmitEventInit` dictionary."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEventInit`*"]
+    pub type SubmitEventInit;
+}
+impl SubmitEventInit {
+    #[doc = "Construct a new `SubmitEventInit`."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEventInit`*"]
+    pub fn new() -> Self {
+        #[allow(unused_mut)]
+        let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
+        ret
+    }
+    #[doc = "Change the `bubbles` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEventInit`*"]
+    pub fn bubbles(&mut self, val: bool) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("bubbles"),
+            &JsValue::from(val),
+        );
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
+    #[doc = "Change the `cancelable` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEventInit`*"]
+    pub fn cancelable(&mut self, val: bool) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("cancelable"),
+            &JsValue::from(val),
+        );
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
+    #[doc = "Change the `composed` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SubmitEventInit`*"]
+    pub fn composed(&mut self, val: bool) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("composed"),
+            &JsValue::from(val),
+        );
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
+    #[cfg(feature = "HtmlElement")]
+    #[doc = "Change the `submitter` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlElement`, `SubmitEventInit`*"]
+    pub fn submitter(&mut self, val: Option<&HtmlElement>) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("submitter"),
+            &JsValue::from(val),
+        );
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
+}
+impl Default for SubmitEventInit {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/web-sys/src/features/mod.rs
+++ b/crates/web-sys/src/features/mod.rs
@@ -6742,6 +6742,18 @@ mod gen_StyleSheetList;
 #[cfg(feature = "StyleSheetList")]
 pub use gen_StyleSheetList::*;
 
+#[cfg(feature = "SubmitEvent")]
+#[allow(non_snake_case)]
+mod gen_SubmitEvent;
+#[cfg(feature = "SubmitEvent")]
+pub use gen_SubmitEvent::*;
+
+#[cfg(feature = "SubmitEventInit")]
+#[allow(non_snake_case)]
+mod gen_SubmitEventInit;
+#[cfg(feature = "SubmitEventInit")]
+pub use gen_SubmitEventInit::*;
+
 #[cfg(feature = "SubtleCrypto")]
 #[allow(non_snake_case)]
 mod gen_SubtleCrypto;

--- a/crates/web-sys/webidls/enabled/SubmitEvent.webidl
+++ b/crates/web-sys/webidls/enabled/SubmitEvent.webidl
@@ -1,0 +1,18 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * For more information on this interface, please see
+ * https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submitevent
+ */
+
+[Constructor(DOMString type, optional SubmitEventInit eventInitDict),
+    Exposed=(Window)]
+interface SubmitEvent : Event {
+  readonly attribute HTMLElement? submitter;
+};
+
+dictionary SubmitEventInit : EventInit {
+  HTMLElement? submitter = null;
+};


### PR DESCRIPTION
The SubmitEvent should be included in the list of event types.

Related issues:
https://github.com/rustwasm/wasm-bindgen/issues/2712
https://github.com/yewstack/yew/issues/2691