### PR TITLE
Replace `cfg=web_sys_unstable_apis` with `unstable` feature

### DIFF
--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -14,7 +14,6 @@ edition = "2018"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg=web_sys_unstable_apis"]
 
 [lib]
 doctest = false

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -41,7 +41,7 @@ fn comment(mut comment: String, features: &Option<String>) -> TokenStream {
 fn maybe_unstable_attr(unstable: bool) -> Option<proc_macro2::TokenStream> {
     if unstable {
         Some(quote! {
-            #[cfg(web_sys_unstable_apis)]
+            #[cfg(feature = "unstable")]
         })
     } else {
         None
@@ -52,8 +52,7 @@ fn maybe_unstable_docs(unstable: bool) -> Option<proc_macro2::TokenStream> {
     if unstable {
         Some(quote! {
             #[doc = ""]
-            #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-            #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+            #[doc = "*This API is unstable and requires the `unstable` crate feature to be activated*"]
         })
     } else {
         None

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -812,20 +812,23 @@ pub fn generate(from: &Path, to: &Path, options: Options) -> Result<String> {
     rustfmt(&to.join("mod.rs"), "mod")?;
 
     return if generate_features {
-        let features = features
-            .iter()
-            .map(|(name, feature)| {
-                let features = feature
-                    .required_features
-                    .iter()
-                    .map(|x| format!("\"{}\"", x))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{} = [{}]", name, features)
-            })
+        // Define the global "unstable" feature
+        let unstable_feature = core::iter::once("unstable = []".to_string());
+        // Then define all the other features from the WebIDLs
+        let generated_features = features.iter().map(|(name, feature)| {
+            let features = feature
+                .required_features
+                .iter()
+                .map(|x| format!("\"{}\"", x))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{} = [{}]", name, features)
+        });
+        // Return the newline-separated features
+        Ok(unstable_feature
+            .chain(generated_features)
             .collect::<Vec<_>>()
-            .join("\n");
-        Ok(features)
+            .join("\n"))
     } else {
         Ok(String::new())
     };

--- a/guide/src/web-sys/unstable-apis.md
+++ b/guide/src/web-sys/unstable-apis.md
@@ -10,22 +10,17 @@ previously published `web-sys` versions would be invalid, because the browser
 API may have been changed to match the updated WebIDL.
 
 To avoid frequent breaking changes for unstable APIs, `web-sys` hides all
-unstable APIs through an attribute that looks like:
+unstable APIs behind the `unstable` feature.
 
-```rust
-#[cfg(web_sys_unstable_apis)]
-pub struct Foo;
-```
-
-By hiding unstable APIs through an attribute, it's necessary for crates to
+By hiding unstable APIs through a feature gate, it's necessary for crates to
 explicitly opt-in to these reduced stability guarantees in order to use these
-APIs. Specifically, these APIs do not follow semver and may break whenever the
-WebIDL changes.
+APIs. Specifically, these APIs do not follow [semver](https://semver.org/) and
+may break whenever the WebIDL changes.
 
-Crates can opt-in to unstable APIs at compile-time by passing the `cfg` flag
-`web_sys_unstable_apis`. Typically the `RUSTFLAGS` environment variable is used
-to do this. For example:
-
-```bash
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run
+Crates can opt-in to unstable APIs at compile-time by setting the `unstable`
+feature flag for `web-sys` in their `Cargo.toml`. For example, since the `Gpu`
+struct is unstable, a user would write
+```
+[dependencies]
+web-sys = { version = "0.3", features = ["unstable", "Gpu"] }
 ```


### PR DESCRIPTION
This resolves a long-standing issue I've had with `web-sys`.

## Problem

I'm building a webapp that relies on the [MediaSession API](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession). **There is no way for my crate to use an unstable API without user intervention** (whether that be by setting `RUSTCFLAGS` or otherwise). Currently, my build instructions say
>  Set the following in ~/.cargo/config:
> ```
> [build]
> rustflags = ["--cfg=web_sys_unstable_apis"]
> rustdocflags = ["--cfg=web_sys_unstable_apis"]
>```
This is an odd requirement, and a barrier to usage.

## Solution

Just gate all the unstable APIs behind a new `unstable` feature flag (in addition to their existing feature flags). This satisfies the requirement that users must explicitly opt into the unstable APIs, while streamlining their use for crates that really do want them.

I understand this change is of a structural nature, so I'd love to hear others' thoughts on this.

## What this PR has

* A simple switch in `web-sys` to using `#[cfg(feature = "unstable")]` instead of `#[cfg(web_sys_unstable_apis)]`
* An updated guide page on using the `unstable` feature

## What this PR does not have

For succinctness, I have _not_ regenerated the `web-sys` files. **Please let me know when I can regen `web-sys`** before this is merged