### PR TITLE
Update Rouille version to fix break tests

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ env_logger = "0.8"
 anyhow = "1.0"
 log = "0.4"
 openssl = { version = '0.10.11', optional = true }
-rouille = { version = "3.0.0", default-features = false }
+rouille = { version = "3.5.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"


### PR DESCRIPTION
> error: package time v0.3.10 cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.0-nightly

Looks like this error is because the crate `time` launched a new release, and it is a dependency of `Rouille`. The current `Rouille` version does not have a time lib version specified. Updating it should solve this issue.
