### PR TITLE
Update CI rust nightly version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: rustup default nightly-2021-09-02
+    - run: rustup default nightly-2022-05-19
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
     # Note: we only run the browser tests here, because wasm-bindgen doesn't support threading in Node yet.
@@ -242,7 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: rustup default nightly-2021-09-02
+    - run: rustup default nightly-2022-05-19
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
     - run: |


### PR DESCRIPTION
We are getting the current error:
> error: package time v0.3.10 cannot be built because it requires rustc 1.57.0 or newer, while the currently active rustc version is 1.56.0-nightly

The crate `time` launched a new release that depends on a newer version of `rustc`, updating the nightly version should resolve this issue.