### PR TITLE
doc: fix typo in hello-world

### DIFF
--- a/guide/src/examples/hello-world.md
+++ b/guide/src/examples/hello-world.md
@@ -38,7 +38,7 @@ Our JS entry point is quite small!
 
 ## Webpack-specific files
 
-> **Note**: Webpack is not required for this example, and if you're interested
+> **Note**: Webpack is required for this example, and if you're interested
 > in options that don't use a JS bundler [see other examples][wab].
 
 [wab]: without-a-bundler.html


### PR DESCRIPTION
`hello-world` example does use Webpack.