### PR TITLE
Don't attempt to initialise memory views before the wasm module is initialised in the bunder target

### DIFF
--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -6,7 +6,8 @@ let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0;
+let cachedUint8Memory0 = new Uint8Array();
+
 function getUint8Memory0() {
     if (cachedUint8Memory0.byteLength === 0) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
@@ -33,7 +34,8 @@ function handleError(f, args) {
     }
 }
 
-let cachedInt32Memory0;
+let cachedInt32Memory0 = new Int32Array();
+
 function getInt32Memory0() {
     if (cachedInt32Memory0.byteLength === 0) {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
@@ -80,7 +82,4 @@ export function __wbindgen_init_externref_table() {
     table.set(offset + 3, false);
     ;
 };
-
-cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
-cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
 

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -23,7 +23,8 @@ function handleError(f, args) {
     }
 }
 
-let cachedInt32Memory0;
+let cachedInt32Memory0 = new Int32Array();
+
 function getInt32Memory0() {
     if (cachedInt32Memory0.byteLength === 0) {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
@@ -63,6 +64,4 @@ export function exported() {
 export function __wbg_foo_8d66ddef0ff279d6() { return handleError(function () {
     foo();
 }, arguments) };
-
-cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
 

--- a/crates/cli/tests/reference/result-string.js
+++ b/crates/cli/tests/reference/result-string.js
@@ -15,7 +15,8 @@ function addHeapObject(obj) {
     return idx;
 }
 
-let cachedInt32Memory0;
+let cachedInt32Memory0 = new Int32Array();
+
 function getInt32Memory0() {
     if (cachedInt32Memory0.byteLength === 0) {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
@@ -43,7 +44,8 @@ let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0;
+let cachedUint8Memory0 = new Uint8Array();
+
 function getUint8Memory0() {
     if (cachedUint8Memory0.byteLength === 0) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
@@ -82,7 +84,4 @@ export function __wbindgen_number_new(arg0) {
     const ret = arg0;
     return addHeapObject(ret);
 };
-
-cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
-cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
 

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -6,7 +6,8 @@ let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0;
+let cachedUint8Memory0 = new Uint8Array();
+
 function getUint8Memory0() {
     if (cachedUint8Memory0.byteLength === 0) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
@@ -86,6 +87,4 @@ export function foo(a) {
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
 };
-
-cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
 


### PR DESCRIPTION
Fixes #2961

In the bundler target, there's a circular dependency between the bindings and the wasm module. That means that the wasm module's exports aren't available at the top level. In #2886, I didn't realise that and made the memory views be initialised at the top level, which resulted in an error from the wasm module's memory not being available yet.

This fixes that by lazily initialising the memory views like they were before #2886, except that they're reset in `init` (on targets that have it) to make sure they're updated if it's called multiple times (the reason I made them be immediately initialised in the first place).