### PR TITLE
Properly implement `From<usize/isize>` and `PartialEq<usize/isize>` for `JsValue`

### DIFF
--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -7,4 +7,5 @@ pub mod simple_async_fn;
 pub mod simple_fn;
 pub mod simple_struct;
 pub mod typescript_type;
+pub mod usize;
 pub mod web_sys;

--- a/crates/typescript-tests/src/usize.rs
+++ b/crates/typescript-tests/src/usize.rs
@@ -1,0 +1,13 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn usize_identity(x: usize) -> usize { x }
+
+#[wasm_bindgen]
+pub fn isize_identity(x: isize) -> isize { x }
+
+#[wasm_bindgen]
+pub async fn async_usize_identity(x: usize) -> usize { x }
+
+#[wasm_bindgen]
+pub async fn async_isize_identity(x: isize) -> isize { x }

--- a/crates/typescript-tests/src/usize.ts
+++ b/crates/typescript-tests/src/usize.ts
@@ -1,0 +1,6 @@
+import * as wbg from "../pkg/typescript_tests";
+
+const _f1: (x: number) => number = wbg.usize_identity;
+const _f2: (x: number) => number = wbg.isize_identity;
+const _f3: (x: number) => Promise<number> = wbg.async_usize_identity;
+const _f4: (x: number) => Promise<number> = wbg.async_isize_identity;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -867,7 +867,38 @@ macro_rules! big_numbers {
     )*)
 }
 
-big_numbers! { i64 u64 i128 u128 isize usize }
+big_numbers! { i64 u64 i128 u128 }
+
+// `usize` and `isize` have to be treated a bit specially, because we know that
+// they're 32-bit but the compiler conservatively assumes they might be bigger.
+// So, we have to manually forward to the `u32`/`i32` versions.
+impl PartialEq<usize> for JsValue {
+    #[inline]
+    fn eq(&self, other: &usize) -> bool {
+        *self == (*other as u32)
+    }
+}
+
+impl From<usize> for JsValue {
+    #[inline]
+    fn from(n: usize) -> Self {
+        Self::from(n as u32)
+    }
+}
+
+impl PartialEq<isize> for JsValue {
+    #[inline]
+    fn eq(&self, other: &isize) -> bool {
+        *self == (*other as i32)
+    }
+}
+
+impl From<isize> for JsValue {
+    #[inline]
+    fn from(n: isize) -> Self {
+        Self::from(n as i32)
+    }
+}
 
 externs! {
     #[link(wasm_import_module = "__wbindgen_placeholder__")]

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -43,6 +43,7 @@ pub mod slice;
 pub mod structural;
 pub mod truthy_falsy;
 pub mod u64;
+pub mod usize;
 pub mod validate_prt;
 pub mod variadic;
 pub mod vendor_prefix;

--- a/tests/wasm/usize.js
+++ b/tests/wasm/usize.js
@@ -1,0 +1,39 @@
+const wasm = require('wasm-bindgen-test.js');
+const assert = require('assert');
+
+exports.isize_js_identity = a => a;
+exports.usize_js_identity = a => a;
+
+exports.js_works = async () => {
+    assert.strictEqual(wasm.usize_zero(), 0);
+    assert.strictEqual(wasm.usize_one(), 1);
+    assert.strictEqual(wasm.isize_neg_one(), -1);
+    assert.strictEqual(wasm.isize_i32_min(), -2147483648);
+    assert.strictEqual(wasm.isize_min(), -2147483648);
+    assert.strictEqual(wasm.usize_u32_max(), 4294967295);
+    assert.strictEqual(wasm.usize_max(), 4294967295);
+
+    assert.strictEqual(wasm.isize_rust_identity(0), 0);
+    assert.strictEqual(wasm.isize_rust_identity(1), 1);
+    assert.strictEqual(wasm.isize_rust_identity(-1), -1);
+    assert.strictEqual(wasm.usize_rust_identity(0), 0);
+    assert.strictEqual(wasm.usize_rust_identity(1), 1);
+
+    const usize_max = 4294967295;
+    const isize_min = -2147483648;
+    assert.strictEqual(wasm.isize_rust_identity(isize_min), isize_min);
+    assert.strictEqual(wasm.usize_rust_identity(usize_max), usize_max);
+
+    assert.deepStrictEqual(wasm.usize_slice([]), new Uint32Array());
+    assert.deepStrictEqual(wasm.isize_slice([]), new Int32Array());
+    const arr1 = new Uint32Array([1, 2]);
+    assert.deepStrictEqual(wasm.usize_slice([1, 2]), arr1);
+    const arr2 = new Int32Array([1, 2]);
+    assert.deepStrictEqual(wasm.isize_slice([1, 2]), arr2);
+
+    assert.deepStrictEqual(wasm.isize_slice([isize_min]), new Int32Array([isize_min]));
+    assert.deepStrictEqual(wasm.usize_slice([usize_max]), new Uint32Array([usize_max]));
+
+    assert.deepStrictEqual(await wasm.async_usize_one(), 1);
+    assert.deepStrictEqual(await wasm.async_isize_neg_one(), -1);
+};

--- a/tests/wasm/usize.rs
+++ b/tests/wasm/usize.rs
@@ -1,0 +1,79 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/usize.js")]
+extern "C" {
+    fn isize_js_identity(a: isize) -> isize;
+    fn usize_js_identity(a: usize) -> usize;
+    fn js_works();
+}
+
+#[wasm_bindgen]
+pub fn usize_zero() -> usize {
+    0
+}
+
+#[wasm_bindgen]
+pub fn usize_one() -> usize {
+    1
+}
+
+#[wasm_bindgen]
+pub fn isize_neg_one() -> isize {
+    -1
+}
+
+#[wasm_bindgen]
+pub fn isize_i32_min() -> isize {
+    i32::min_value() as isize
+}
+
+#[wasm_bindgen]
+pub fn usize_u32_max() -> usize {
+    u32::max_value() as usize
+}
+
+#[wasm_bindgen]
+pub fn isize_min() -> isize {
+    isize::min_value()
+}
+
+#[wasm_bindgen]
+pub fn usize_max() -> usize {
+    usize::max_value()
+}
+
+#[wasm_bindgen]
+pub fn isize_rust_identity(a: isize) -> isize {
+    isize_js_identity(a)
+}
+
+#[wasm_bindgen]
+pub fn usize_rust_identity(a: usize) -> usize {
+    usize_js_identity(a)
+}
+
+#[wasm_bindgen]
+pub fn isize_slice(a: &[isize]) -> Vec<isize> {
+    a.to_vec()
+}
+
+#[wasm_bindgen]
+pub fn usize_slice(a: &[usize]) -> Vec<usize> {
+    a.to_vec()
+}
+
+#[wasm_bindgen]
+pub async fn async_usize_one() -> usize {
+    1
+}
+
+#[wasm_bindgen]
+pub async fn async_isize_neg_one() -> isize {
+    -1
+}
+
+#[wasm_bindgen_test]
+fn works() {
+    js_works();
+}


### PR DESCRIPTION
Fixes #2977

Previously, `usize` and `isize` were converted to bigints when converting to JS values, when they should be converted to regular JS numbers due to being 32-bit. `PartialEq` was then implemented on top of that, checking whether `self == JsValue::from(n)`.

It could be argued that they should be bigints to try and be forwards-compatible with 64-bit WebAssembly; however, they're already represented as regular numbers everywhere else.

One major issue here is that this is a breaking change. You can't just use a number where a bigint is expected (or vice versa), so this will break any code that used `From` to convert from a `usize`/`isize` to `JsValue`. That happens most commonly indirectly, through the return type of async functions, which are internally converted using `Into<JsValue>`.