### PR TITLE
removes unnecessary drop()

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -225,7 +225,7 @@ impl ToTokens for ast::Struct {
                 #[no_mangle]
                 #[doc(hidden)]
                 pub unsafe extern "C" fn #free_fn(ptr: u32) {
-                    drop(<#name as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr));
+                    let _ = <#name as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr); //implicit `drop()`
                 }
             };
 


### PR DESCRIPTION
The drop function is unnecessary as it will be droped anyway.
But if we leave it and the `struct` implements `Copy` clippy complains
about dropping the copy an not the original.

Without this, this code

```
use wasm_bindgen::prelude::*;

#[wasm_bindgen]
#[derive(Copy, Clone)]
pub struct Test {
    pub a: u32
}
```
produces:
```
error: calls to `std::mem::drop` with a value that implements `Copy`. Dropping a copy leaves the original intact
 --> src/lib.rs:3:1
  |
3 | #[wasm_bindgen]
  | ^^^^^^^^^^^^^^^
  |
  = note: `#[deny(clippy::drop_copy)]` on by default
note: argument has type `Test`
 --> src/lib.rs:3:1
  |
3 | #[wasm_bindgen]
  | ^^^^^^^^^^^^^^^
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#drop_copy
  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
```
It is also a solution to the already closed #2858