### PR TITLE
Respect `#[wasm_bindgen(skip_typescript)]` on structs

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -66,7 +66,10 @@ pub struct Context<'a> {
 pub struct ExportedClass {
     comments: String,
     contents: String,
+    /// The TypeScript for the class's methods.
     typescript: String,
+    /// Whether TypeScript for this class should be emitted (i.e., `skip_typescript` wasn't specified).
+    generate_typescript: bool,
     has_constructor: bool,
     wrap_needed: bool,
     /// Whether to generate helper methods for inspecting the class
@@ -1015,8 +1018,11 @@ impl<'a> Context<'a> {
         ts_dst.push_str("}\n");
 
         self.export(&name, &dst, Some(&class.comments))?;
-        self.typescript.push_str(&class.comments);
-        self.typescript.push_str(&ts_dst);
+
+        if class.generate_typescript {
+            self.typescript.push_str(&class.comments);
+            self.typescript.push_str(&ts_dst);
+        }
 
         Ok(())
     }
@@ -3477,6 +3483,7 @@ impl<'a> Context<'a> {
         let class = require_class(&mut self.exported_classes, &struct_.name);
         class.comments = format_doc_comments(&struct_.comments, None);
         class.is_inspectable = struct_.is_inspectable;
+        class.generate_typescript = struct_.generate_typescript;
         Ok(())
     }
 

--- a/crates/typescript-tests/src/omit_definition.rs
+++ b/crates/typescript-tests/src/omit_definition.rs
@@ -33,6 +33,11 @@ pub enum MyEnum {
     Three,
 }
 
+#[wasm_bindgen(skip_typescript)]
+pub struct MyStruct {
+    pub field: i32,
+}
+
 macro_rules! generate_ts {
     ($lit:literal) => {
         #[wasm_bindgen(typescript_custom_section)]


### PR DESCRIPTION
Fixes #2941

It looks like there was already a test for this, but the actual struct declaration in Rust was missing; so, I added that.