### PR TITLE
Add support for exporting static getters and setters

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -64,6 +64,9 @@ pub struct JsFunction {
     pub js_doc: String,
     pub ts_arg_tys: Vec<String>,
     pub ts_ret_ty: Option<String>,
+    /// Whether this function has a single optional argument.
+    ///
+    /// If the function is a setter, that means that the field it sets is optional.
     pub might_be_optional_field: bool,
     pub catch: bool,
     pub log_error: bool,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1,7 +1,7 @@
 use crate::descriptor::VectorKind;
 use crate::intrinsic::Intrinsic;
 use crate::wit::{
-    Adapter, AdapterId, AdapterJsImportKind, AuxExportMethodKind, AuxReceiverKind, AuxValue,
+    Adapter, AdapterId, AdapterJsImportKind, AuxExportedMethodKind, AuxReceiverKind, AuxValue,
 };
 use crate::wit::{AdapterKind, Instruction, InstructionData};
 use crate::wit::{AuxEnum, AuxExport, AuxExportKind, AuxImport, AuxStruct};
@@ -2595,8 +2595,8 @@ impl<'a> Context<'a> {
                             prefix += "static ";
                         }
                         let ts = match kind {
-                            AuxExportMethodKind::Method => ts_sig,
-                            AuxExportMethodKind::Getter => {
+                            AuxExportedMethodKind::Method => ts_sig,
+                            AuxExportedMethodKind::Getter => {
                                 prefix += "get ";
                                 // For getters and setters, we generate a separate TypeScript definition.
                                 if export.generate_typescript {
@@ -2616,7 +2616,7 @@ impl<'a> Context<'a> {
                                 // Ignore the raw signature.
                                 None
                             }
-                            AuxExportMethodKind::Setter => {
+                            AuxExportedMethodKind::Setter => {
                                 prefix += "set ";
                                 if export.generate_typescript {
                                     let is_optional = exported.push_accessor_ts(
@@ -3786,13 +3786,13 @@ fn check_duplicated_getter_and_setter_names(
                     AuxExportKind::Method {
                         class: first_class,
                         name: first_name,
-                        kind: AuxExportMethodKind::Getter,
+                        kind: AuxExportedMethodKind::Getter,
                         receiver: first_receiver,
                     },
                     AuxExportKind::Method {
                         class: second_class,
                         name: second_name,
-                        kind: AuxExportMethodKind::Getter,
+                        kind: AuxExportedMethodKind::Getter,
                         receiver: second_receiver,
                     },
                 ) => verify_exports(
@@ -3807,13 +3807,13 @@ fn check_duplicated_getter_and_setter_names(
                     AuxExportKind::Method {
                         class: first_class,
                         name: first_name,
-                        kind: AuxExportMethodKind::Setter,
+                        kind: AuxExportedMethodKind::Setter,
                         receiver: first_receiver,
                     },
                     AuxExportKind::Method {
                         class: second_class,
                         name: second_name,
-                        kind: AuxExportMethodKind::Setter,
+                        kind: AuxExportedMethodKind::Setter,
                         receiver: second_receiver,
                     },
                 ) => verify_exports(

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -426,9 +426,9 @@ impl<'a> Context<'a> {
                         }
 
                         let (name, kind) = match op.kind {
-                            decode::OperationKind::Getter(f) => (f, AuxExportMethodKind::Getter),
-                            decode::OperationKind::Setter(f) => (f, AuxExportMethodKind::Setter),
-                            _ => (export.function.name, AuxExportMethodKind::Method),
+                            decode::OperationKind::Getter(f) => (f, AuxExportedMethodKind::Getter),
+                            decode::OperationKind::Setter(f) => (f, AuxExportedMethodKind::Setter),
+                            _ => (export.function.name, AuxExportedMethodKind::Method),
                         };
 
                         AuxExportKind::Method {
@@ -816,7 +816,7 @@ impl<'a> Context<'a> {
                         class: struct_.name.to_string(),
                         name: field.name.to_string(),
                         receiver: AuxReceiverKind::Borrowed,
-                        kind: AuxExportMethodKind::Getter,
+                        kind: AuxExportedMethodKind::Getter,
                     },
                     generate_typescript: field.generate_typescript,
                     variadic: false,
@@ -847,7 +847,7 @@ impl<'a> Context<'a> {
                         class: struct_.name.to_string(),
                         name: field.name.to_string(),
                         receiver: AuxReceiverKind::Borrowed,
-                        kind: AuxExportMethodKind::Setter,
+                        kind: AuxExportedMethodKind::Setter,
                     },
                     generate_typescript: field.generate_typescript,
                     variadic: false,

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -123,13 +123,13 @@ pub enum AuxExportKind {
         class: String,
         name: String,
         receiver: AuxReceiverKind,
-        kind: AuxExportMethodKind,
+        kind: AuxExportedMethodKind,
     },
 }
 
 /// All the possible kinds of exported methods.
 #[derive(Debug, Clone, Copy)]
-pub enum AuxExportMethodKind {
+pub enum AuxExportedMethodKind {
     /// A regular method.
     Method,
     /// A getter for a field.

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -108,38 +108,53 @@ pub enum AuxExportKind {
     /// actually return just an integer which is put on an JS object currently.
     Constructor(String),
 
-    /// This function is intended to be a getter for a field on a class. The
-    /// first argument is the internal pointer and the returned value is
-    /// expected to be the field.
-    Getter {
-        class: String,
-        field: String,
-        // same as `consumed` in `Method`
-        consumed: bool,
-    },
-
-    /// This function is intended to be a setter for a field on a class. The
-    /// first argument is the internal pointer and the second argument is
-    /// expected to be the field's new value.
-    Setter {
-        class: String,
-        field: String,
-        // same as `consumed` in `Method`
-        consumed: bool,
-    },
-
-    /// This is a free function (ish) but scoped inside of a class name.
-    StaticFunction { class: String, name: String },
-
-    /// This is a member function of a class where the first parameter is the
-    /// implicit integer stored in the class instance.
+    /// A function that's associated with a class.
+    ///
+    /// This can either be a static method (indicated by `AuxReceiverKind::None`),
+    /// which is basically just a free function namespaced under the class, or
+    /// a proper method.
+    ///
+    /// It can also be a getter or a setter for a (possibly static) field of
+    /// the class, in which case `name` is the name of the field.
+    ///
+    /// If the function isn't static, the first argument is the index of the
+    /// Rust object in the JS heap.
     Method {
         class: String,
         name: String,
-        /// Whether or not this is calling a by-value method in Rust and should
-        /// clear the internal pointer in JS automatically.
-        consumed: bool,
+        receiver: AuxReceiverKind,
+        kind: AuxExportMethodKind,
     },
+}
+
+/// All the possible kinds of exported methods.
+#[derive(Debug, Clone, Copy)]
+pub enum AuxExportMethodKind {
+    /// A regular method.
+    Method,
+    /// A getter for a field.
+    Getter,
+    /// A setter for a field.
+    Setter,
+}
+
+/// The 'receiver' of a method; in other words, the type that the method is called on.
+///
+/// This is `None` if the method is static, or `Borrowed` or `Owned` if the
+/// method takes `&[mut] self` or `self` respectively.
+#[derive(Debug, Clone, Copy)]
+pub enum AuxReceiverKind {
+    None,
+    Borrowed,
+    Owned,
+}
+
+impl AuxReceiverKind {
+    /// Returns whether this is `AuxReceiverKind::None` (in other words,
+    /// whether the method with this receiver is static).
+    pub fn is_static(self) -> bool {
+        matches!(self, Self::None)
+    }
 }
 
 #[derive(Debug)]

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -16,7 +16,7 @@
 //! generating any JS glue. Any JS glue currently generated is also invalid if
 //! the module contains the wasm bindings section and it's actually respected.
 
-use crate::wit::{AdapterId, AdapterJsImportKind, AdapterType, AuxExportMethodKind, Instruction};
+use crate::wit::{AdapterId, AdapterJsImportKind, AdapterType, AuxExportedMethodKind, Instruction};
 use crate::wit::{AdapterKind, NonstandardWitSection, WasmBindgenAux};
 use crate::wit::{AuxExport, InstructionData};
 use crate::wit::{AuxExportKind, AuxImport, AuxValue, JsImport, JsImportName};
@@ -381,9 +381,9 @@ fn check_standard_export(export: &AuxExport) -> Result<(), Error> {
             class, name, kind, ..
         } => {
             let kind_name = match kind {
-                AuxExportMethodKind::Method => "method",
-                AuxExportMethodKind::Getter => "getter",
-                AuxExportMethodKind::Setter => "setter",
+                AuxExportedMethodKind::Method => "method",
+                AuxExportedMethodKind::Getter => "getter",
+                AuxExportedMethodKind::Setter => "setter",
             };
 
             bail!(

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -16,7 +16,7 @@
 //! generating any JS glue. Any JS glue currently generated is also invalid if
 //! the module contains the wasm bindings section and it's actually respected.
 
-use crate::wit::{AdapterId, AdapterJsImportKind, AdapterType, Instruction};
+use crate::wit::{AdapterId, AdapterJsImportKind, AdapterType, AuxExportMethodKind, Instruction};
 use crate::wit::{AdapterKind, NonstandardWitSection, WasmBindgenAux};
 use crate::wit::{AuxExport, InstructionData};
 use crate::wit::{AuxExportKind, AuxImport, AuxValue, JsImport, JsImportName};
@@ -377,38 +377,22 @@ fn check_standard_export(export: &AuxExport) -> Result<(), Error> {
                 name,
             );
         }
-        AuxExportKind::Getter { class, field, .. } => {
+        AuxExportKind::Method {
+            class, name, kind, ..
+        } => {
+            let kind_name = match kind {
+                AuxExportMethodKind::Method => "method",
+                AuxExportMethodKind::Getter => "getter",
+                AuxExportMethodKind::Setter => "setter",
+            };
+
             bail!(
-                "cannot export `{}::{}` getter function when generating \
-                 a standalone WebAssembly module with no JS glue",
-                class,
-                field,
-            );
-        }
-        AuxExportKind::Setter { class, field, .. } => {
-            bail!(
-                "cannot export `{}::{}` setter function when generating \
-                 a standalone WebAssembly module with no JS glue",
-                class,
-                field,
-            );
-        }
-        AuxExportKind::StaticFunction { class, name } => {
-            bail!(
-                "cannot export `{}::{}` static function when \
+                "cannot export `{}::{}` {} when \
                  generating a standalone WebAssembly module with no \
                  JS glue",
                 class,
-                name
-            );
-        }
-        AuxExportKind::Method { class, name, .. } => {
-            bail!(
-                "cannot export `{}::{}` method when \
-                 generating a standalone WebAssembly module with no \
-                 JS glue",
-                class,
-                name
+                name,
+                kind_name
             );
         }
     }

--- a/crates/typescript-tests/src/getters_setters.rs
+++ b/crates/typescript-tests/src/getters_setters.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub struct ColorWithGetter {
+pub struct ColorWithGetters {
     r: f64,
     _g: f64,
     _b: f64,
@@ -9,15 +9,20 @@ pub struct ColorWithGetter {
 }
 
 #[wasm_bindgen]
-impl ColorWithGetter {
+impl ColorWithGetters {
     #[wasm_bindgen(getter)]
     pub fn r(&self) -> f64 {
         self.r
     }
+
+    #[wasm_bindgen(getter)]
+    pub fn color_space() -> String {
+        "sRGB".to_owned()
+    }
 }
 
 #[wasm_bindgen]
-pub struct ColorWithSetter {
+pub struct ColorWithSetters {
     r: f64,
     _g: f64,
     _b: f64,
@@ -25,7 +30,7 @@ pub struct ColorWithSetter {
 }
 
 #[wasm_bindgen]
-impl ColorWithSetter {
+impl ColorWithSetters {
     #[wasm_bindgen(setter)]
     pub fn set_r(&mut self, r: f64) {
         self.r = r;
@@ -37,6 +42,9 @@ impl ColorWithSetter {
             (self.r * 255.0) as u8
         };
     }
+
+    #[wasm_bindgen(setter)]
+    pub fn set_color_space(_: String) {}
 }
 
 #[wasm_bindgen]

--- a/crates/typescript-tests/src/getters_setters.ts
+++ b/crates/typescript-tests/src/getters_setters.ts
@@ -1,14 +1,16 @@
 import * as wbg from '../pkg/typescript_tests';
 
-const colorWithGetter: wbg.ColorWithGetter = new wbg.ColorWithGetter;
-const _a = colorWithGetter.r;
+const colorWithGetters: wbg.ColorWithGetters = new wbg.ColorWithGetters;
+const _a = colorWithGetters.r;
+const _b = wbg.ColorWithGetters.color_space;
 
-const colorWithSetter: wbg.ColorWithSetter = new wbg.ColorWithSetter;
-colorWithSetter.r = 1;
+const colorWithSetters: wbg.ColorWithSetters = new wbg.ColorWithSetters;
+colorWithSetters.r = 1;
+wbg.ColorWithSetters.color_space = "Linear sRGB";
 
 const colorWithGetterAndSetter: wbg.ColorWithGetterAndSetter = new wbg.ColorWithGetterAndSetter;
 colorWithGetterAndSetter.r = 1;
-const _b = colorWithGetterAndSetter.r;
+const _c = colorWithGetterAndSetter.r;
 
 const colorWithReadonly: wbg.ColorWithReadonly = new wbg.ColorWithReadonly(1, 2, 3);
 const _r: number = colorWithReadonly.r;

--- a/tests/wasm/getters_and_setters.js
+++ b/tests/wasm/getters_and_setters.js
@@ -98,3 +98,10 @@ exports.test_getter_compute = x => {
 exports.test_setter_compute = x => {
   x.foo = 97;
 };
+
+exports.test_statics = x => {
+    assert.equal(x.field, 3);
+    assert.equal(wasm.Statics.field, 4);
+    x.field = 13;
+    wasm.Statics.field = 14;
+}


### PR DESCRIPTION
Fixes #2895

Exported methods with `#[wasm_bindgen(getter/setter)]` and no `self` parameter are now interpreted as getters/setters for static fields. Previously, attempting to do that would cause `wasm-bindgen` to crash.

This can already be done for imports with `static_method_of` + `getter`.