### PR TITLE
Don't copy doc comments on imported functions to generated `extern` blocks

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -162,7 +162,7 @@ pub struct ImportFunction {
     /// necessary conversions (EG adding a try/catch to change a thrown error into a Result)
     pub shim: Ident,
     /// The doc comment on this import, if one is provided
-    pub doc_comment: Option<String>,
+    pub doc_comment: String,
 }
 
 /// The type of a function being imported

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1074,10 +1074,7 @@ impl TryToTokens for ast::ImportFunction {
         let abi_arguments = &abi_arguments;
         let abi_argument_names = &abi_argument_names;
 
-        let doc_comment = match &self.doc_comment {
-            None => "",
-            Some(doc_string) => doc_string,
-        };
+        let doc_comment = &self.doc_comment;
         let me = if is_method {
             quote! { &self, }
         } else {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -627,7 +627,9 @@ impl<'a> ConvertToAst<(BindgenAttrs, &'a ast::ImportModule)> for syn::ForeignIte
             /// or `None` if it isn't one.
             fn get_docs(attr: &syn::Attribute) -> Option<String> {
                 if attr.path.is_ident("doc") {
-                    syn::parse2::<DocContents>(attr.tokens.clone()).ok().map(|doc| doc.contents)
+                    syn::parse2::<DocContents>(attr.tokens.clone())
+                        .ok()
+                        .map(|doc| doc.contents)
                 } else {
                     None
                 }


### PR DESCRIPTION
This was causing lots of 'unused doc comment' warnings while compiling `web-sys`, since doc comments have no effect on `extern` blocks.

I've implemented this by removing any doc comments from the list of attributes we're copying and then adding them back to the public function.

I'm not sure how good of an idea it is to forward all attributes to the extern block in the first place, but I'm playing it safe and leaving it as is.