### PR TITLE
chore: Remove extra `dbg` calls

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -61,8 +61,8 @@ fn main() -> anyhow::Result<()> {
     } else {
         wasm_file_to_test
             .parent() // chop off file name
-            .and_then(|p| dbg!(p.parent())) // chop off `deps`
-            .and_then(|p| dbg!(p.parent())) // chop off `debug`
+            .and_then(|p| p.parent()) // chop off `deps`
+            .and_then(|p| p.parent()) // chop off `debug`
     }
     .map(|p| p.join("wbg-tmp"))
     .ok_or_else(|| anyhow!("file to test doesn't follow the expected Cargo conventions"))?;


### PR DESCRIPTION
These were probably left by mistake.