### PR TITLE
Added `#[track_caller]` and Improved Debug message for `unwrap_throw()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 #![no_std]
 #![allow(coherence_leak_check)]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
-use std::format;
 use core::convert::TryFrom;
 use core::fmt;
 use core::marker;
@@ -17,6 +16,7 @@ use core::ops::{
     Add, BitAnd, BitOr, BitXor, Deref, DerefMut, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub,
 };
 use core::u32;
+use std::format;
 
 use crate::convert::{FromWasmAbi, WasmSlice};
 
@@ -1318,7 +1318,7 @@ pub trait UnwrapThrowExt<T>: Sized {
             loc.line(),
             loc.column()
         );
-        self.expect_throw(&msg)
+        self.expect_throw(msg.as_str())
     }
 
     /// Unwrap this container's `T` value, or throw an error to JS with the
@@ -1358,7 +1358,6 @@ where
         }
     }
 }
-
 
 /// Returns a handle to this wasm instance's `WebAssembly.Module`
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,21 +1309,22 @@ pub fn anyref_heap_live_count() -> u32 {
 pub trait UnwrapThrowExt<T>: Sized {
     /// Unwrap this `Option` or `Result`, but instead of panicking on failure,
     /// throw an exception to JavaScript.
+    #[cfg(feature = "std")]
     #[track_caller]
     fn unwrap_throw(self) -> T {
         let loc = core::panic::Location::caller();
-        let mut msg = String::new();
-        core::fmt::write(
-            &mut msg,
-            core::format_args!(
-                "`unwrap_throw` failed (at {}:{}:{})",
-                loc.file(),
-                loc.line(),
-                loc.column()
-            ),
-        )
-        .expect("Error occurred while trying to write in String");
-        self.expect_throw(msg.as_str())
+        let msg = std::format!(
+            "`unwrap_throw` failed ({}:{}:{})",
+            loc.file(),
+            loc.line(),
+            loc.column()
+        );
+        self.expect_throw(&msg)
+    }
+
+    #[cfg(not(feature = "std"))]
+    fn unwrap_throw(self) -> T {
+        self.expect_throw("`unwrap_throw` failed")
     }
 
     /// Unwrap this container's `T` value, or throw an error to JS with the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,33 +1309,31 @@ pub fn anyref_heap_live_count() -> u32 {
 pub trait UnwrapThrowExt<T>: Sized {
     /// Unwrap this `Option` or `Result`, but instead of panicking on failure,
     /// throw an exception to JavaScript.
-    #[cfg(all(feature = "std", debug_assertions))]
-    #[track_caller]
-    fn unwrap_throw(self) -> T {
-        let loc = core::panic::Location::caller();
-        let msg = std::format!(
-            "`unwrap_throw` failed ({}:{}:{})",
-            loc.file(),
-            loc.line(),
-            loc.column()
-        );
-        self.expect_throw(&msg)
-    }
 
-    #[cfg(not(all(feature = "std", debug_assertions)))]
     fn unwrap_throw(self) -> T {
-        self.expect_throw("`unwrap_throw` failed")
+        if cfg!(all(debug_assertions, track_caller, std)) {
+            let loc = core::panic::Location::caller();
+            let msg = std::format!(
+                "`unwrap_throw` failed ({}:{}:{})",
+                loc.file(),
+                loc.line(),
+                loc.column()
+            );
+            self.expect_throw(&msg)
+        } else {
+            self.expect_throw("`unwrap_throw` failed")
+        }
     }
 
     /// Unwrap this container's `T` value, or throw an error to JS with the
     /// given message if the `T` value is unavailable (e.g. an `Option<T>` is
     /// `None`).
-    #[track_caller]
+    #[cfg_attr(debug_assertions, track_caller)]
     fn expect_throw(self, message: &str) -> T;
 }
 
 impl<T> UnwrapThrowExt<T> for Option<T> {
-    #[track_caller]
+    #[cfg_attr(debug_assertions, track_caller)]
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(target_arch = "wasm32", not(target_os = "emscripten"))) {
             match self {
@@ -1352,7 +1350,7 @@ impl<T, E> UnwrapThrowExt<T> for Result<T, E>
 where
     E: core::fmt::Debug,
 {
-    #[track_caller]
+    #[cfg_attr(debug_assertions, track_caller)]
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(target_arch = "wasm32", not(target_os = "emscripten"))) {
             match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![no_std]
 #![allow(coherence_leak_check)]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
-
+use std::format;
 use core::convert::TryFrom;
 use core::fmt;
 use core::marker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1322,7 +1322,7 @@ pub trait UnwrapThrowExt<T>: Sized {
         self.expect_throw(&msg)
     }
 
-    #[cfg(not(feature = "std"))]
+    #[cfg(not(all(feature = "std", debug_assertions)))]
     fn unwrap_throw(self) -> T {
         self.expect_throw("`unwrap_throw` failed")
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use core::ops::{
     Add, BitAnd, BitOr, BitXor, Deref, DerefMut, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub,
 };
 use core::u32;
-use std::format;
 
 use crate::convert::{FromWasmAbi, WasmSlice};
 
@@ -1313,7 +1312,7 @@ pub trait UnwrapThrowExt<T>: Sized {
     fn unwrap_throw(self) -> T {
         let loc = core::panic::Location::caller();
         let msg = format!(
-            "`unwrap_throw` failed ({}:{}:{})",
+            "`unwrap_throw` failed (at {}:{}:{})",
             loc.file(),
             loc.line(),
             loc.column()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,7 +1309,7 @@ pub fn anyref_heap_live_count() -> u32 {
 pub trait UnwrapThrowExt<T>: Sized {
     /// Unwrap this `Option` or `Result`, but instead of panicking on failure,
     /// throw an exception to JavaScript.
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", debug_assertions))]
     #[track_caller]
     fn unwrap_throw(self) -> T {
         let loc = core::panic::Location::caller();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,9 +1309,9 @@ pub fn anyref_heap_live_count() -> u32 {
 pub trait UnwrapThrowExt<T>: Sized {
     /// Unwrap this `Option` or `Result`, but instead of panicking on failure,
     /// throw an exception to JavaScript.
-
+    #[cfg_attr(debug_assertions, track_caller)]
     fn unwrap_throw(self) -> T {
-        if cfg!(all(debug_assertions, track_caller, std)) {
+        if cfg!(all(debug_assertions, feature = "std")) {
             let loc = core::panic::Location::caller();
             let msg = std::format!(
                 "`unwrap_throw` failed ({}:{}:{})",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,17 +1309,27 @@ pub fn anyref_heap_live_count() -> u32 {
 pub trait UnwrapThrowExt<T>: Sized {
     /// Unwrap this `Option` or `Result`, but instead of panicking on failure,
     /// throw an exception to JavaScript.
+    #[track_caller]
     fn unwrap_throw(self) -> T {
-        self.expect_throw("`unwrap_throw` failed")
+        let loc = core::panic::Location::caller();
+        let msg = format!(
+            "`unwrap_throw` failed ({}:{}:{})",
+            loc.file(),
+            loc.line(),
+            loc.column()
+        );
+        self.expect_throw(&msg)
     }
 
     /// Unwrap this container's `T` value, or throw an error to JS with the
     /// given message if the `T` value is unavailable (e.g. an `Option<T>` is
     /// `None`).
+    #[track_caller]
     fn expect_throw(self, message: &str) -> T;
 }
 
 impl<T> UnwrapThrowExt<T> for Option<T> {
+    #[track_caller]
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(target_arch = "wasm32", not(target_os = "emscripten"))) {
             match self {
@@ -1336,6 +1346,7 @@ impl<T, E> UnwrapThrowExt<T> for Result<T, E>
 where
     E: core::fmt::Debug,
 {
+    #[track_caller]
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(target_arch = "wasm32", not(target_os = "emscripten"))) {
             match self {
@@ -1347,6 +1358,7 @@ where
         }
     }
 }
+
 
 /// Returns a handle to this wasm instance's `WebAssembly.Module`
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ use core::ops::{
     Add, BitAnd, BitOr, BitXor, Deref, DerefMut, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub,
 };
 use core::u32;
-use std::format;
 
 use crate::convert::{FromWasmAbi, WasmSlice};
 
@@ -1313,12 +1312,17 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[track_caller]
     fn unwrap_throw(self) -> T {
         let loc = core::panic::Location::caller();
-        let msg = format!(
-            "`unwrap_throw` failed (at {}:{}:{})",
-            loc.file(),
-            loc.line(),
-            loc.column()
-        );
+        let mut msg = String::new();
+        core::fmt::write(
+            &mut msg,
+            core::format_args!(
+                "`unwrap_throw` failed (at {}:{}:{})",
+                loc.file(),
+                loc.line(),
+                loc.column()
+            ),
+        )
+        .expect("Error occurred while trying to write in String");
         self.expect_throw(msg.as_str())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![no_std]
 #![allow(coherence_leak_check)]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
+
 use core::convert::TryFrom;
 use core::fmt;
 use core::marker;
@@ -16,6 +17,7 @@ use core::ops::{
     Add, BitAnd, BitOr, BitXor, Deref, DerefMut, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub,
 };
 use core::u32;
+use std::format;
 
 use crate::convert::{FromWasmAbi, WasmSlice};
 


### PR DESCRIPTION
Tested on firefox and edge (on fedora) with my own trait on top locally, I could not get it to run off a path dep due to 
```
thread 'main' panicked at 'assertion failed: mid <= self.len()', /home/billy/.cargo/registry/src/github.com-1ecc6299db9ec823/wasm-bindgen-cli-support-0.2.80/src/decode.rs:43:27
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Help would be appreciated.

- Added `#[track_caller]`
- Using `core::panic::location` to retreive called file, line, col locations
- matches existing api