### PR TITLE
Remove obsolete documentation about Stack.

### DIFF
--- a/guide/src/contributing/design/rust-type-conversions.md
+++ b/guide/src/contributing/design/rust-type-conversions.md
@@ -12,7 +12,7 @@ First up let's take a look at going from Rust to JS:
 ```rust
 pub trait IntoWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
-    fn into_abi(self, extra: &mut Stack) -> Self::Abi;
+    fn into_abi(self) -> Self::Abi;
 }
 ```
 
@@ -25,9 +25,7 @@ a Rust value to a JS one. There's a few points here:
   and `f64`, those which can be placed on the boundary and transmitted
   losslessly.
 * And finally we have the `into_abi` function, returning the `Abi` associated
-  type which will be actually passed to JS. There's also this `Stack` parameter,
-  however. Not all Rust values can be communicated in 32 bits to the `Stack`
-  parameter allows transmitting more data, explained in a moment.
+  type which will be actually passed to JS.
 
 This trait is implemented for all types that can be converted to JS and is
 unconditionally used during codegen. For example you'll often see `IntoWasmAbi
@@ -45,25 +43,25 @@ more complicated. Here we've got three traits:
 ```rust
 pub trait FromWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
-    unsafe fn from_abi(js: Self::Abi, extra: &mut Stack) -> Self;
+    unsafe fn from_abi(js: Self::Abi) -> Self;
 }
 
 pub trait RefFromWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
     type Anchor: Deref<Target=Self>;
-    unsafe fn ref_from_abi(js: Self::Abi, extra: &mut Stack) -> Self::Anchor;
+    unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor;
 }
 
 pub trait RefMutFromWasmAbi: WasmDescribe {
     type Abi: WasmAbi;
     type Anchor: DerefMut<Target=Self>;
-    unsafe fn ref_mut_from_abi(js: Self::Abi, extra: &mut Stack) -> Self::Anchor;
+    unsafe fn ref_mut_from_abi(js: Self::Abi) -> Self::Anchor;
 }
 ```
 
 The `FromWasmAbi` is relatively straightforward, basically the opposite of
 `IntoWasmAbi`. It takes the ABI argument (typically the same as
-`IntoWasmAbi::Abi`) and then the auxiliary stack to produce an instance of
+`IntoWasmAbi::Abi`) to produce an instance of
 `Self`. This trait is implemented primarily for types that *don't* have internal
 lifetimes or are references.
 
@@ -81,37 +79,3 @@ The `From*` family of traits are used for converting the Rust arguments in Rust
 exported functions to JS. They are also used for the return value in JS
 functions imported into Rust.
 
-## Global stack
-
-Mentioned above not all Rust types will fit within 32 bits. While we can
-communicate an `f64` we don't necessarily have the ability to use all the bits.
-Types like `&str` need to communicate two items, a pointer and a length (64
-bits). Other types like `&Closure<dyn Fn()>` have even more information to
-transmit.
-
-As a result we need a method of communicating more data through the signatures
-of functions. While we could add more arguments this is somewhat difficult to do
-in the world of closures where code generation isn't quite as dynamic as a
-procedural macro. Consequently a "global stack" is used to transmit extra
-data for a function call.
-
-The global stack is a fixed-sized static allocation in the wasm module. This
-stack is temporary scratch space for any one function call from either JS to
-Rust or Rust to JS. Both Rust and the JS shim generated have pointers to this
-global stack and will read/write information from it.
-
-Using this scheme whenever we want to pass `&str` from JS to Rust we can pass
-the pointer as the actual ABI argument and the length is then placed in the next
-spot on the global stack.
-
-The `Stack` argument to the conversion traits above looks like:
-
-```rust
-pub trait Stack {
-    fn push(&mut self, bits: u32);
-    fn pop(&mut self) -> u32;
-}
-```
-
-A trait is used here to facilitate testing but typically the calls don't end up
-being virtually dispatched at runtime.

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -47,7 +47,7 @@ tys! {
     CLAMPED
 }
 
-#[inline(always)] // see `interpret.rs` in the the cli-support crate
+#[inline(always)] // see the wasm-interpreter crate
 pub fn inform(a: u32) {
     unsafe { super::__wbindgen_describe(a) }
 }


### PR DESCRIPTION
It seems like `Stack` was removed several years ago, but the guide was not updated.