### PR TITLE
Convert Big[Ui,I]nt64Array bindings to use [u/i]64

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -5854,9 +5854,9 @@ arrays! {
 
     /// `BigInt64Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array
-    BigInt64Array: BigInt,
+    BigInt64Array: i64,
 
     /// `BigUint64Array()`
     /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array
-    BigUint64Array: BigInt,
+    BigUint64Array: u64,
 }

--- a/crates/js-sys/tests/wasm/Array.js
+++ b/crates/js-sys/tests/wasm/Array.js
@@ -1,6 +1,7 @@
 // Used for `Array.rs` tests
-exports.populate_array =  function(arr, start, len) {
+exports.populate_array = function(arr, start, len) {
+  var isBigInt = typeof(arr[0]) === "bigint";
   for (i = 0; i < len; i++) {
-    arr[i] = start + i;
+    arr[i] = isBigInt ? BigInt(start + i) : start + i;
   }
 };

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -595,6 +595,15 @@ fn Int32Array_view_mut_raw() {
 }
 
 #[wasm_bindgen_test]
+fn BigInt64Array_view_mut_raw() {
+    test_array_view_mut_raw(
+        js_sys::BigInt64Array::view_mut_raw,
+        i64::from,
+        JsValue::from,
+    );
+}
+
+#[wasm_bindgen_test]
 fn Uint8Array_view_mut_raw() {
     test_array_view_mut_raw(js_sys::Uint8Array::view_mut_raw, u8::from, JsValue::from);
 }
@@ -616,6 +625,15 @@ fn Uint16Array_view_mut_raw() {
 #[wasm_bindgen_test]
 fn Uint32Array_view_mut_raw() {
     test_array_view_mut_raw(js_sys::Uint32Array::view_mut_raw, u32::from, JsValue::from);
+}
+
+#[wasm_bindgen_test]
+fn BigUint64Array_view_mut_raw() {
+    test_array_view_mut_raw(
+        js_sys::BigUint64Array::view_mut_raw,
+        u64::from,
+        JsValue::from,
+    );
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Using BigInt as the macro parameters leads to absurd signatures like
slices of BigInt objects (can't exist). Instead, just use the numeric
types. bindgen already converts them to bigint when appropriate.

Closes: https://github.com/rustwasm/wasm-bindgen/issues/3009
Fixes: d6d056cd ("Add math-related intrinsics/functions for `JsValue`s (#2629)")

**Breaking change**: This is technically a breaking change, but I'm not sure if anyone has managed to use it in the old state.

I added some brief tests but I haven't tested all the functions yet. Will do some more testing later in my own project.