### PR TITLE
Support wrapping unsafe functions

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -531,7 +531,7 @@ impl TryToTokens for ast::Export {
                     all(target_arch = "wasm32", not(target_os = "emscripten")),
                     export_name = #export_name,
                 )]
-                pub extern "C" fn #generated_name(#(#args),*) -> #projection::Abi {
+                pub unsafe extern "C" fn #generated_name(#(#args),*) -> #projection::Abi {
                     #start_check
                     // Scope all local variables to be destroyed after we call
                     // the function to ensure that `#convert_ret`, if it panics,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -759,9 +759,6 @@ impl ConvertToAst<BindgenAttrs> for syn::ItemFn {
                 "can only #[wasm_bindgen] non-const functions"
             );
         }
-        if self.sig.unsafety.is_some() {
-            bail_span!(self.sig.unsafety, "can only #[wasm_bindgen] safe functions");
-        }
 
         let ret = function_from_decl(
             &self.sig.ident,
@@ -1132,9 +1129,6 @@ impl<'a, 'b> MacroParse<(&'a Ident, &'a str)> for &'b mut syn::ImplItemMethod {
                 self.sig.constness,
                 "can only #[wasm_bindgen] non-const functions",
             );
-        }
-        if self.sig.unsafety.is_some() {
-            bail_span!(self.sig.unsafety, "can only bindgen safe functions",);
         }
 
         let opts = BindgenAttrs::find(&mut self.attrs)?;

--- a/crates/macro/ui-tests/invalid-items.rs
+++ b/crates/macro/ui-tests/invalid-items.rs
@@ -4,9 +4,6 @@ use wasm_bindgen::prelude::*;
 fn foo() {}
 
 #[wasm_bindgen]
-pub unsafe fn foo1() {}
-
-#[wasm_bindgen]
 pub const fn foo2() {}
 
 #[wasm_bindgen]

--- a/crates/macro/ui-tests/invalid-items.stderr
+++ b/crates/macro/ui-tests/invalid-items.stderr
@@ -4,62 +4,56 @@ error: can only #[wasm_bindgen] public functions
 4 | fn foo() {}
   | ^^^^^^^^^^^
 
-error: can only #[wasm_bindgen] safe functions
+error: can only #[wasm_bindgen] non-const functions
  --> $DIR/invalid-items.rs:7:5
   |
-7 | pub unsafe fn foo1() {}
-  |     ^^^^^^
-
-error: can only #[wasm_bindgen] non-const functions
-  --> $DIR/invalid-items.rs:10:5
-   |
-10 | pub const fn foo2() {}
-   |     ^^^^^
+7 | pub const fn foo2() {}
+  |     ^^^^^
 
 error: structs with #[wasm_bindgen] cannot have lifetime or type parameters currently
-  --> $DIR/invalid-items.rs:13:11
+  --> $DIR/invalid-items.rs:10:11
    |
-13 | struct Foo<T>(T);
+10 | struct Foo<T>(T);
    |           ^^^
 
 error: cannot import mutable globals yet
-  --> $DIR/invalid-items.rs:17:12
+  --> $DIR/invalid-items.rs:14:12
    |
-17 |     static mut FOO: u32;
+14 |     static mut FOO: u32;
    |            ^^^
 
 error: can't #[wasm_bindgen] variadic functions
-  --> $DIR/invalid-items.rs:19:25
+  --> $DIR/invalid-items.rs:16:25
    |
-19 |     pub fn foo3(x: i32, ...);
+16 |     pub fn foo3(x: i32, ...);
    |                         ^^^
 
 error: only foreign mods with the `C` ABI are allowed
-  --> $DIR/invalid-items.rs:23:8
+  --> $DIR/invalid-items.rs:20:8
    |
-23 | extern "system" {
+20 | extern "system" {
    |        ^^^^^^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:27:12
+  --> $DIR/invalid-items.rs:24:12
    |
-27 | pub fn foo4<T>() {}
+24 | pub fn foo4<T>() {}
    |            ^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:29:12
+  --> $DIR/invalid-items.rs:26:12
    |
-29 | pub fn foo5<'a>() {}
+26 | pub fn foo5<'a>() {}
    |            ^^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:31:12
+  --> $DIR/invalid-items.rs:28:12
    |
-31 | pub fn foo6<'a, T>() {}
+28 | pub fn foo6<'a, T>() {}
    |            ^^^^^^^
 
 error: #[wasm_bindgen] can only be applied to a function, struct, enum, impl, or extern block
-  --> $DIR/invalid-items.rs:34:1
+  --> $DIR/invalid-items.rs:31:1
    |
-34 | trait X {}
+31 | trait X {}
    | ^^^^^^^^^^

--- a/crates/macro/ui-tests/invalid-methods.rs
+++ b/crates/macro/ui-tests/invalid-methods.rs
@@ -39,9 +39,4 @@ impl A {
     pub const fn foo() {}
 }
 
-#[wasm_bindgen]
-impl A {
-    pub unsafe fn foo() {}
-}
-
 fn main() {}

--- a/crates/macro/ui-tests/invalid-methods.stderr
+++ b/crates/macro/ui-tests/invalid-methods.stderr
@@ -52,12 +52,6 @@ error: can only #[wasm_bindgen] non-const functions
 39 |     pub const fn foo() {}
    |         ^^^^^
 
-error: can only bindgen safe functions
-  --> $DIR/invalid-methods.rs:44:9
-   |
-44 |     pub unsafe fn foo() {}
-   |         ^^^^^^
-
 warning: unused macro definition
   --> $DIR/invalid-methods.rs:26:1
    |


### PR DESCRIPTION
Fixes #3022. The implementation cleanly passes the unsafety of user functions on the `extern "C"` wrapper function signature, where it is allowed.