### PR TITLE
Fix links to WASM audio worklet example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,7 +421,7 @@ jobs:
         tar xf artifacts/doc_api/docs.tar.gz
         mv target/doc gh-pages/api
         mv artifacts/examples1 gh-pages/exbuild
-        mv artifacts/examples2 gh-pages/exbuild/raytrace-parallel
+        mv artifacts/examples2/* gh-pages/exbuild
         mv artifacts/benchmarks gh-pages/benchmarks
         tar czf gh-pages.tar.gz gh-pages
     - uses: actions/upload-artifact@v2

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [web-sys: A Simple Paint Program](./examples/paint.md)
   - [web-sys: WASM in Web Worker](./examples/wasm-in-web-worker.md)
   - [Parallel Raytracing](./examples/raytrace.md)
+  - [WASM Audio Worklet](./examples/wasm-audio-worklet.md)
   - [web-sys: A TODO MVC App](./examples/todomvc.md)
 - [Reference](./reference/index.md)
   - [Deployment](./reference/deployment.md)


### PR DESCRIPTION
- Move https://wasm-bindgen.netlify.app/exbuild/raytrace-parallel/raytrace-parallel/ and https://wasm-bindgen.netlify.app/exbuild/raytrace-parallel/wasm-audio-worklet/ to https://wasm-bindgen.netlify.app/exbuild/raytrace-parallel/ and to https://wasm-bindgen.netlify.app/exbuild/wasm-audio-worklet/ linked to in the README and the guide
- Link to wasm-audio-worklet in the summary