### PR TITLE
Deprecate `JsValue::from_serde` and `JsValue::into_serde`

### DIFF
--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -8,11 +8,9 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2.82", features = ["serde-serialize"]  }
+wasm-bindgen = "0.2.82"
 js-sys = "0.3.59"
 wasm-bindgen-futures = "0.4.32"
-serde = { version = "1.0.80", features = ["derive"] }
-serde_derive = "^1.0.59"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,36 +1,7 @@
-use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response};
-
-/// A struct to hold some data from the github Branch API.
-///
-/// Note how we don't have to define every member -- serde will ignore extra
-/// data when deserializing
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Branch {
-    pub name: String,
-    pub commit: Commit,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Commit {
-    pub sha: String,
-    pub commit: CommitDetails,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CommitDetails {
-    pub author: Signature,
-    pub committer: Signature,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Signature {
-    pub name: String,
-    pub email: String,
-}
 
 #[wasm_bindgen]
 pub async fn run(repo: String) -> Result<JsValue, JsValue> {
@@ -56,9 +27,6 @@ pub async fn run(repo: String) -> Result<JsValue, JsValue> {
     // Convert this other `Promise` into a rust `Future`.
     let json = JsFuture::from(resp.json()?).await?;
 
-    // Use serde to parse the JSON into a struct.
-    let branch_info: Branch = json.into_serde().unwrap();
-
-    // Send the `Branch` struct back to JS as an `Object`.
-    Ok(JsValue::from_serde(&branch_info).unwrap())
+    // Send the JSON response back to JS.
+    Ok(json)
 }

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -13,8 +13,9 @@ js-sys = "0.3.59"
 rayon = "1.1.0"
 rayon-core = "1.5.0"
 raytracer = { git = 'https://github.com/alexcrichton/raytracer', branch = 'update-deps' }
+serde-wasm-bindgen = "0.4.3"
 futures-channel-preview = "0.3.0-alpha.18"
-wasm-bindgen = { version = "0.2.82", features = ['serde-serialize'] }
+wasm-bindgen = "0.2.82"
 wasm-bindgen-futures = "0.4.32"
 
 [dependencies.web-sys]

--- a/examples/raytrace-parallel/src/lib.rs
+++ b/examples/raytrace-parallel/src/lib.rs
@@ -28,11 +28,10 @@ impl Scene {
     /// Creates a new scene from the JSON description in `object`, which we
     /// deserialize here into an actual scene.
     #[wasm_bindgen(constructor)]
-    pub fn new(object: &JsValue) -> Result<Scene, JsValue> {
+    pub fn new(object: JsValue) -> Result<Scene, JsValue> {
         console_error_panic_hook::set_once();
         Ok(Scene {
-            inner: object
-                .into_serde()
+            inner: serde_wasm_bindgen::from_value(object)
                 .map_err(|e| JsValue::from(e.to_string()))?,
         })
     }

--- a/examples/webxr/Cargo.toml
+++ b/examples/webxr/Cargo.toml
@@ -10,10 +10,8 @@ crate-type = ["cdylib"]
 [dependencies]
 futures = "0.3.4"
 js-sys = "0.3.59"
-wasm-bindgen = {version = "0.2.82", features = ["serde-serialize"]}
+wasm-bindgen = "0.2.82"
 wasm-bindgen-futures = "0.4.32"
-serde = { version = "1.0.80", features = ["derive"] }
-serde_derive = "^1.0.59"
 
 [dependencies.web-sys]
 version = "0.3.36"

--- a/examples/webxr/src/lib.rs
+++ b/examples/webxr/src/lib.rs
@@ -41,7 +41,8 @@ pub fn create_webgl_context(xr_mode: bool) -> Result<WebGl2RenderingContext, JsV
             &gl_attribs,
             &JsValue::from_str("xrCompatible"),
             &JsValue::TRUE,
-        ).unwrap();
+        )
+        .unwrap();
 
         canvas
             .get_context_with_context_options("webgl2", &gl_attribs)?

--- a/examples/webxr/src/lib.rs
+++ b/examples/webxr/src/lib.rs
@@ -3,16 +3,13 @@
 #[macro_use]
 mod utils;
 
-use futures::{future, Future};
-use js_sys::Promise;
+use js_sys::{Object, Promise, Reflect};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::rc::Rc;
 use utils::set_panic_hook;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
-use wasm_bindgen_futures::JsFuture;
 use web_sys::*;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.
@@ -39,12 +36,15 @@ pub fn create_webgl_context(xr_mode: bool) -> Result<WebGl2RenderingContext, JsV
         .unwrap();
 
     let gl: WebGl2RenderingContext = if xr_mode {
-        let mut gl_attribs = HashMap::new();
-        gl_attribs.insert(String::from("xrCompatible"), true);
-        let js_gl_attribs = JsValue::from_serde(&gl_attribs).unwrap();
+        let gl_attribs = Object::new();
+        Reflect::set(
+            &gl_attribs,
+            &JsValue::from_str("xrCompatible"),
+            &JsValue::TRUE,
+        ).unwrap();
 
         canvas
-            .get_context_with_context_options("webgl2", &js_gl_attribs)?
+            .get_context_with_context_options("webgl2", &gl_attribs)?
             .unwrap()
             .dyn_into()?
     } else {
@@ -77,7 +77,6 @@ impl XrApp {
     pub fn init(&self) -> Promise {
         log!("Starting WebXR...");
         let navigator: web_sys::Navigator = web_sys::window().unwrap().navigator();
-        let gpu = navigator.gpu();
         let xr = navigator.xr();
         let session_mode = XrSessionMode::Inline;
         let session_supported_promise = xr.is_session_supported(session_mode);
@@ -121,7 +120,7 @@ impl XrApp {
         let g = f.clone();
 
         let mut i = 0;
-        *g.borrow_mut() = Some(Closure::new(move |time: f64, frame: XrFrame| {
+        *g.borrow_mut() = Some(Closure::new(move |_time: f64, frame: XrFrame| {
             log!("Frame rendering...");
             if i > 2 {
                 log!("All done!");

--- a/guide/src/examples/fetch.md
+++ b/guide/src/examples/fetch.md
@@ -11,8 +11,7 @@ then parses the resulting JSON.
 ## `Cargo.toml`
 
 The `Cargo.toml` enables a number of features related to the `fetch` API and
-types used: `Headers`, `Request`, etc. It also enables `wasm-bindgen`'s `serde`
-support.
+types used: `Headers`, `Request`, etc.
 
 ```toml
 {{#include ../../../examples/fetch/Cargo.toml}}

--- a/guide/src/reference/arbitrary-data-with-serde.md
+++ b/guide/src/reference/arbitrary-data-with-serde.md
@@ -140,12 +140,13 @@ pub fn receive_example_from_js(val: JsValue) {
 
 [`gloo_utils::format::JsValueSerdeExt`]: https://docs.rs/gloo-utils/latest/gloo_utils/format/trait.JsValueSerdeExt.html
 
-## `JsValue::from_serde` / `JsValue::into_serde`
+## History
 
-In previous versions of `wasm-bindgen`, `JsValue::from_serde` and
-`JsValue::into_serde` were the recommended way of using Serde to convert
-to/from JS values. These were implemented using the JSON approach with
-`serde_json`. This caused problems when certain features of `serde_json` and
-other crates were enabled that caused it to depend on `wasm-bindgen`, creating
-a circular dependency, which is illegal in Rust and caused people's code to
-fail to compile. So, they were deprecated.
+In previous versions of `wasm-bindgen`, `gloo-utils`'s JSON-based Serde support
+(`JsValue::from_serde` and `JsValue::into_serde`) was built into `wasm-bindgen`
+itself. However, this required a dependency on `serde_json`, which had a
+problem: with certain features of `serde_json` and other crates enabled,
+`serde_json` would end up with a circular dependency on `wasm-bindgen`, which
+is illegal in Rust and caused people's code to fail to compile. So, these
+methods were extracted out into `gloo-utils` with an extension trait and the
+originals were deprecated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,13 @@ impl JsValue {
     /// Creates a new `JsValue` from the JSON serialization of the object `t`
     /// provided.
     ///
+    /// **This function is deprecated**, due to [creating a dependency cycle in
+    /// some circumstances][dep-cycle-issue]. Use [`serde-wasm-bindgen`]
+    /// instead, or manually call `serde_json::to_string` + `JSON.parse`.
+    ///
+    /// [dep-cycle-issue]: https://github.com/rustwasm/wasm-bindgen/issues/2770
+    /// [`serde-wasm-bindgen`]: https://docs.rs/serde-wasm-bindgen
+    ///
     /// This function will serialize the provided value `t` to a JSON string,
     /// send the JSON string to JS, parse it into a JS object, and then return
     /// a handle to the JS object. This is unlikely to be super speedy so it's
@@ -214,6 +221,7 @@ impl JsValue {
     ///
     /// Returns any error encountered when serializing `T` into JSON.
     #[cfg(feature = "serde-serialize")]
+    #[deprecated = "causes dependency cycles, use `serde-wasm-bindgen` instead"]
     pub fn from_serde<T>(t: &T) -> serde_json::Result<JsValue>
     where
         T: serde::ser::Serialize + ?Sized,
@@ -224,6 +232,13 @@ impl JsValue {
 
     /// Invokes `JSON.stringify` on this value and then parses the resulting
     /// JSON into an arbitrary Rust value.
+    ///
+    /// **This function is deprecated**, due to [creating a dependency cycle in
+    /// some circumstances][dep-cycle-issue]. Use [`serde-wasm-bindgen`]
+    /// instead, or manually call `JSON.stringify` + `serde_json::from_str`.
+    ///
+    /// [dep-cycle-issue]: https://github.com/rustwasm/wasm-bindgen/issues/2770
+    /// [`serde-wasm-bindgen`]: https://docs.rs/serde-wasm-bindgen
     ///
     /// This function will first call `JSON.stringify` on the `JsValue` itself.
     /// The resulting string is then passed into Rust which then parses it as
@@ -236,6 +251,7 @@ impl JsValue {
     ///
     /// Returns any error encountered when parsing the JSON into a `T`.
     #[cfg(feature = "serde-serialize")]
+    #[deprecated = "causes dependency cycles, use `serde-wasm-bindgen` instead"]
     pub fn into_serde<T>(&self) -> serde_json::Result<T>
     where
         T: for<'a> serde::de::Deserialize<'a>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,11 +202,12 @@ impl JsValue {
     /// provided.
     ///
     /// **This function is deprecated**, due to [creating a dependency cycle in
-    /// some circumstances][dep-cycle-issue]. Use [`serde-wasm-bindgen`]
-    /// instead, or manually call `serde_json::to_string` + `JSON.parse`.
+    /// some circumstances][dep-cycle-issue]. Use [`serde-wasm-bindgen`] or
+    /// [`gloo_utils::format::JsValueSerdeExt`] instead.
     ///
     /// [dep-cycle-issue]: https://github.com/rustwasm/wasm-bindgen/issues/2770
     /// [`serde-wasm-bindgen`]: https://docs.rs/serde-wasm-bindgen
+    /// [`gloo_utils::format::JsValueSerdeExt`]: https://docs.rs/gloo-utils/latest/gloo_utils/format/trait.JsValueSerdeExt.html
     ///
     /// This function will serialize the provided value `t` to a JSON string,
     /// send the JSON string to JS, parse it into a JS object, and then return
@@ -221,7 +222,7 @@ impl JsValue {
     ///
     /// Returns any error encountered when serializing `T` into JSON.
     #[cfg(feature = "serde-serialize")]
-    #[deprecated = "causes dependency cycles, use `serde-wasm-bindgen` instead"]
+    #[deprecated = "causes dependency cycles, use `serde-wasm-bindgen` or `gloo_utils::format::JsValueSerdeExt` instead"]
     pub fn from_serde<T>(t: &T) -> serde_json::Result<JsValue>
     where
         T: serde::ser::Serialize + ?Sized,
@@ -234,11 +235,12 @@ impl JsValue {
     /// JSON into an arbitrary Rust value.
     ///
     /// **This function is deprecated**, due to [creating a dependency cycle in
-    /// some circumstances][dep-cycle-issue]. Use [`serde-wasm-bindgen`]
-    /// instead, or manually call `JSON.stringify` + `serde_json::from_str`.
+    /// some circumstances][dep-cycle-issue]. Use [`serde-wasm-bindgen`] or
+    /// [`gloo_utils::format::JsValueSerdeExt`] instead.
     ///
     /// [dep-cycle-issue]: https://github.com/rustwasm/wasm-bindgen/issues/2770
     /// [`serde-wasm-bindgen`]: https://docs.rs/serde-wasm-bindgen
+    /// [`gloo_utils::format::JsValueSerdeExt`]: https://docs.rs/gloo-utils/latest/gloo_utils/format/trait.JsValueSerdeExt.html
     ///
     /// This function will first call `JSON.stringify` on the `JsValue` itself.
     /// The resulting string is then passed into Rust which then parses it as
@@ -251,7 +253,7 @@ impl JsValue {
     ///
     /// Returns any error encountered when parsing the JSON into a `T`.
     #[cfg(feature = "serde-serialize")]
-    #[deprecated = "causes dependency cycles, use `serde-wasm-bindgen` instead"]
+    #[deprecated = "causes dependency cycles, use `serde-wasm-bindgen` or `gloo_utils::format::JsValueSerdeExt` instead"]
     pub fn into_serde<T>(&self) -> serde_json::Result<T>
     where
         T: for<'a> serde::de::Deserialize<'a>,


### PR DESCRIPTION
I've listed `serde-wasm-bindgen` as the replacement, and changed the section of the guide that talks about Serde to talk about `serde-wasm-bindgen` instead of the deprecated methods.

I didn't remove it entirely because I can imagine someone remembering it and trying to look it back up, only to find that it no longer exists, which would quite frustrating. I also added a footnote about the deprecated methods in case someone remembers the old way and wants to know what happened.

There were several examples using `from_serde`/`into_serde`, which I updated to use `serde-wasm-bindgen` or not use `serde` altogether.

The `fetch` example was a bit weird, in that it took a JS value, parsed it into a Rust value, only to serialize it back into a JS value. I removed that entirely in favour of just passing the original JS value directly. I suppose it behaves slightly differently in that it loses the extra validation, but a panic isn't all that much better than a JS runtime error.

Fixes #2770
Fixes tkaitchuck/aHash#95

This also indirectly 'fixes' issues about the deprecated functions:

Resolves #1258 
Resolves #2017
Resolves #2539