### PR TITLE
Pass 64-bit integers directly across the wasm ABI boundary

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1126,6 +1126,19 @@ impl<'a> Context<'a> {
         ));
     }
 
+    fn expose_assert_bigint(&mut self) {
+        if !self.should_write_global("assert_bigint") {
+            return;
+        }
+        self.global(&format!(
+            "
+            function _assertBigInt(n) {{
+                if (typeof(n) !== 'bigint') throw new Error('expected a bigint argument');
+            }}
+            "
+        ));
+    }
+
     fn expose_assert_bool(&mut self) {
         if !self.should_write_global("assert_bool") {
             return;
@@ -2034,41 +2047,6 @@ impl<'a> Context<'a> {
             }
             ",
         );
-    }
-
-    fn expose_u32_cvt_shim(&mut self) -> &'static str {
-        let name = "u32CvtShim";
-        if !self.should_write_global(name) {
-            return name;
-        }
-        self.global(&format!("const {} = new Uint32Array(2);", name));
-        name
-    }
-
-    fn expose_int64_cvt_shim(&mut self) -> &'static str {
-        let name = "int64CvtShim";
-        if !self.should_write_global(name) {
-            return name;
-        }
-        let n = self.expose_u32_cvt_shim();
-        self.global(&format!(
-            "const {} = new BigInt64Array({}.buffer);",
-            name, n
-        ));
-        name
-    }
-
-    fn expose_uint64_cvt_shim(&mut self) -> &'static str {
-        let name = "uint64CvtShim";
-        if !self.should_write_global(name) {
-            return name;
-        }
-        let n = self.expose_u32_cvt_shim();
-        self.global(&format!(
-            "const {} = new BigUint64Array({}.buffer);",
-            name, n
-        ));
-        name
     }
 
     fn expose_is_like_none(&mut self) {

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -89,8 +89,8 @@ impl InstructionBuilder<'_, '_> {
             Descriptor::U16 => self.number(WitVT::U16, WasmVT::I32),
             Descriptor::I32 => self.number(WitVT::S32, WasmVT::I32),
             Descriptor::U32 => self.number(WitVT::U32, WasmVT::I32),
-            Descriptor::I64 => self.number64(true),
-            Descriptor::U64 => self.number64(false),
+            Descriptor::I64 => self.number(WitVT::S64, WasmVT::I64),
+            Descriptor::U64 => self.number(WitVT::U64, WasmVT::I64),
             Descriptor::F32 => {
                 self.get(AdapterType::F32);
                 self.output.push(AdapterType::F32);
@@ -256,17 +256,7 @@ impl InstructionBuilder<'_, '_> {
             Descriptor::U32 => self.in_option_native(ValType::I32),
             Descriptor::F32 => self.in_option_native(ValType::F32),
             Descriptor::F64 => self.in_option_native(ValType::F64),
-            Descriptor::I64 | Descriptor::U64 => {
-                let (signed, ty) = match arg {
-                    Descriptor::I64 => (true, AdapterType::S64.option()),
-                    _ => (false, AdapterType::U64.option()),
-                };
-                self.instruction(
-                    &[ty],
-                    Instruction::I32SplitOption64 { signed },
-                    &[AdapterType::I32, AdapterType::I32, AdapterType::I32],
-                );
-            }
+            Descriptor::I64 | Descriptor::U64 => self.in_option_native(ValType::I64),
             Descriptor::Boolean => {
                 self.instruction(
                     &[AdapterType::Bool.option()],
@@ -393,18 +383,6 @@ impl InstructionBuilder<'_, '_> {
             &[AdapterType::from_wit(input)],
             Instruction::Standard(std),
             &[AdapterType::from_wasm(output).unwrap()],
-        );
-    }
-
-    fn number64(&mut self, signed: bool) {
-        self.instruction(
-            &[if signed {
-                AdapterType::S64
-            } else {
-                AdapterType::U64
-            }],
-            Instruction::I32Split64 { signed },
-            &[AdapterType::I32, AdapterType::I32],
         );
     }
 

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -1646,7 +1646,7 @@ impl StructUnpacker {
     fn read_ty(&mut self, ty: &AdapterType) -> Result<usize, Error> {
         let (quads, alignment) = match ty {
             AdapterType::I32 | AdapterType::U32 | AdapterType::F32 => (1, 1),
-            AdapterType::F64 => (2, 2),
+            AdapterType::I64 | AdapterType::U64 | AdapterType::F64 => (2, 2),
             other => bail!("invalid aggregate return type {:?}", other),
         };
         Ok(self.append(quads, alignment))

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -256,11 +256,7 @@ fn translate_instruction(
         | RustFromI32 { .. } => {
             bail!("rust types aren't supported in wasm interface types");
         }
-        I32Split64 { .. } | I64FromLoHi { .. } => {
-            bail!("64-bit integers aren't supported in wasm-bindgen");
-        }
-        I32SplitOption64 { .. }
-        | I32FromOptionExternref { .. }
+        I32FromOptionExternref { .. }
         | I32FromOptionU32Sentinel
         | I32FromOptionRust { .. }
         | I32FromOptionBool
@@ -276,8 +272,7 @@ fn translate_instruction(
         | ToOptionNative { .. }
         | OptionBoolFromI32
         | OptionCharFromI32
-        | OptionEnumFromI32 { .. }
-        | Option64FromI32 { .. } => {
+        | OptionEnumFromI32 { .. } => {
             bail!("optional types aren't supported in wasm bindgen");
         }
         UnwrapResult { .. } | UnwrapResultString { .. } => {

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -146,16 +146,6 @@ pub enum Instruction {
     I32FromOptionRust {
         class: String,
     },
-    /// Pops an `s64` or `u64` from the stack, pushing two `i32` values.
-    I32Split64 {
-        signed: bool,
-    },
-    /// Pops an `s64` or `u64` from the stack, pushing three `i32` values.
-    /// First is the "some/none" bit, and the next is the low bits, and the
-    /// next is the high bits.
-    I32SplitOption64 {
-        signed: bool,
-    },
     /// Pops an `externref` from the stack, pushes either 0 if it's "none" or and
     /// index into the owned wasm table it was stored at if it's "some"
     I32FromOptionExternref {
@@ -240,10 +230,6 @@ pub enum Instruction {
     },
     /// pops `i32`, pushes string from that `char`
     StringFromChar,
-    /// pops two `i32`, pushes a 64-bit number
-    I64FromLoHi {
-        signed: bool,
-    },
     /// pops `i32`, pushes an externref for the wrapped rust class
     RustFromI32 {
         class: String,
@@ -301,9 +287,6 @@ pub enum Instruction {
     OptionCharFromI32,
     OptionEnumFromI32 {
         hole: u32,
-    },
-    Option64FromI32 {
-        signed: bool,
     },
 }
 

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -6,7 +6,7 @@ mod schema_hash_approval;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.82";
+pub const SCHEMA_VERSION: &str = "0.2.83";
 
 #[macro_export]
 macro_rules! shared_api {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &'static str = "18229224525184165582";
+const APPROVED_SCHEMA_FILE_HASH: &'static str = "6377323169918973918";
 
 #[test]
 fn schema_version() {

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -100,6 +100,8 @@ pub unsafe trait WasmAbi {}
 
 unsafe impl WasmAbi for u32 {}
 unsafe impl WasmAbi for i32 {}
+unsafe impl WasmAbi for u64 {}
+unsafe impl WasmAbi for i64 {}
 unsafe impl WasmAbi for f32 {}
 unsafe impl WasmAbi for f64 {}
 


### PR DESCRIPTION
Previously, they were passed as a pair of `i32`s; this changes them to be passed as a single `i64`, which is directly converted to a bigint on the JS end.

I think they were previously passed as a pair because `wasm-bindgen`'s support for 64-bit integers predated the WebAssembly bigint integration that translates `i64`s to bigints. However, that feature has been around for quite a while now, so I think it should be fine to use.

I also bumped the schema version - although the schema itself hasn't changed, the ABI has, so using an older version of the CLI with this version of the `wasm-bindgen` crate or vice versa won't work and I want the version-mismatch warning to show up.

Fixes cloudflare/serde-wasm-bindgen#28. This doesn't rely on a global `BigInt64Array` like the previous `i32`-pair version, which means that code using 64-bit integers will no longer fail at load time in browsers without bigint support.