### PR TITLE
Refactor: None is not an ImportModule

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -78,8 +78,8 @@ pub enum MethodSelf {
 #[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[derive(Clone)]
 pub struct Import {
-    /// The type of module being imported from
-    pub module: ImportModule,
+    /// The type of module being imported from, if any
+    pub module: Option<ImportModule>,
     /// The namespace to access the item through, if any
     pub js_namespace: Option<Vec<String>>,
     /// The type of item being imported
@@ -90,8 +90,6 @@ pub struct Import {
 #[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[derive(Clone)]
 pub enum ImportModule {
-    /// No module / import from global scope
-    None,
     /// Import from the named module, with relative paths interpreted
     Named(String, Span),
     /// Import from the named module, without interpreting paths
@@ -103,9 +101,6 @@ pub enum ImportModule {
 impl Hash for ImportModule {
     fn hash<H: Hasher>(&self, h: &mut H) {
         match self {
-            ImportModule::None => {
-                0u8.hash(h);
-            }
             ImportModule::Named(name, _) => {
                 1u8.hash(h);
                 name.hash(h);

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -101,18 +101,9 @@ pub enum ImportModule {
 impl Hash for ImportModule {
     fn hash<H: Hasher>(&self, h: &mut H) {
         match self {
-            ImportModule::Named(name, _) => {
-                1u8.hash(h);
-                name.hash(h);
-            }
-            ImportModule::Inline(idx, _) => {
-                2u8.hash(h);
-                idx.hash(h);
-            }
-            ImportModule::RawNamed(name, _) => {
-                3u8.hash(h);
-                name.hash(h);
-            }
+            ImportModule::Named(name, _) => (1u8, name).hash(h),
+            ImportModule::Inline(idx, _) => (2u8, idx).hash(h),
+            ImportModule::RawNamed(name, _) => (3u8, name).hash(h),
         }
     }
 }

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -239,7 +239,11 @@ fn shared_variant<'a>(v: &'a ast::Variant, intern: &'a Interner) -> EnumVariant<
 
 fn shared_import<'a>(i: &'a ast::Import, intern: &'a Interner) -> Result<Import<'a>, Diagnostic> {
     Ok(Import {
-        module: Option::transpose(i.module.as_ref().map(|m| shared_module(m, intern)))?,
+        module: i
+            .module
+            .as_ref()
+            .map(|m| shared_module(m, intern))
+            .transpose()?,
         js_namespace: i.js_namespace.clone(),
         kind: shared_import_kind(&i.kind, intern)?,
     })

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -240,12 +240,14 @@ fn shared_variant<'a>(v: &'a ast::Variant, intern: &'a Interner) -> EnumVariant<
 fn shared_import<'a>(i: &'a ast::Import, intern: &'a Interner) -> Result<Import<'a>, Diagnostic> {
     Ok(Import {
         module: match &i.module {
-            ast::ImportModule::Named(m, span) => {
-                ImportModule::Named(intern.resolve_import_module(m, *span)?)
+            Some(ast::ImportModule::Named(m, span)) => {
+                Some(ImportModule::Named(intern.resolve_import_module(m, *span)?))
             }
-            ast::ImportModule::RawNamed(m, _span) => ImportModule::RawNamed(intern.intern_str(m)),
-            ast::ImportModule::Inline(idx, _) => ImportModule::Inline(*idx as u32),
-            ast::ImportModule::None => ImportModule::None,
+            Some(ast::ImportModule::RawNamed(m, _span)) => {
+                Some(ImportModule::RawNamed(intern.intern_str(m)))
+            }
+            Some(ast::ImportModule::Inline(idx, _)) => Some(ImportModule::Inline(*idx as u32)),
+            None => None,
         },
         js_namespace: i.js_namespace.clone(),
         kind: shared_import_kind(&i.kind, intern)?,

--- a/crates/backend/src/util.rs
+++ b/crates/backend/src/util.rs
@@ -119,7 +119,7 @@ pub fn ident_ty(ident: Ident) -> syn::Type {
 /// Convert an ImportFunction into the more generic Import type, wrapping the provided function
 pub fn wrap_import_function(function: ast::ImportFunction) -> ast::Import {
     ast::Import {
-        module: ast::ImportModule::None,
+        module: None,
         js_namespace: None,
         kind: ast::ImportKind::Function(function),
     }

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -64,7 +64,7 @@ export function exported() {
     }
 }
 
-export function __wbg_foo_8d66ddef0ff279d6() { return handleError(function () {
+export function __wbg_foo_95fe1a04017077db() { return handleError(function () {
     foo();
 }, arguments) };
 

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -61,7 +61,7 @@ export function exported() {
     }
 }
 
-export function __wbg_foo_8d66ddef0ff279d6() { return handleError(function () {
+export function __wbg_foo_95fe1a04017077db() { return handleError(function () {
     foo();
 }, arguments) };
 

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -25,13 +25,12 @@ macro_rules! shared_api {
         }
 
         struct Import<'a> {
-            module: ImportModule<'a>,
+            module: Option<ImportModule<'a>>,
             js_namespace: Option<Vec<String>>,
             kind: ImportKind<'a>,
         }
 
         enum ImportModule<'a> {
-            None,
             Named(&'a str),
             RawNamed(&'a str),
             Inline(u32),

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &'static str = "6377323169918973918";
+const APPROVED_SCHEMA_FILE_HASH: &'static str = "17656911631008664055";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
`ImportModule::None` is neither a module nor an import. (What would its contents or its `from` part be?) Therefore, the correct name for ImportModule would be ImportModuleOption, or `Option<ImportModule>` in idiomatic Rust. Also, this change allows to enforce non-`None` modules by the type system, which is handy, but not strictly needed, for #3019.