### PR TITLE
Move async function arguments into spawned futures

### DIFF
--- a/tests/wasm/futures.js
+++ b/tests/wasm/futures.js
@@ -15,6 +15,9 @@ exports.call_exports = async function() {
   await assert.rejects(wasm.async_throw_message(), /async message/);
   await assert.rejects(wasm.async_throw_jserror(), /async message/);
   await assert.rejects(wasm.async_throw_custom_error(), /custom error/);
+  assert.strictEqual("Hi, Jim!", await wasm.async_take_reference("Jim"));
+  const foo = await new wasm.AsyncStruct();
+  assert.strictEqual(42, await foo.method());
 };
 
 exports.call_promise = async function() {

--- a/tests/wasm/futures.rs
+++ b/tests/wasm/futures.rs
@@ -106,6 +106,26 @@ pub async fn async_throw_custom_error() -> Result<AsyncCustomReturn, AsyncCustom
     })
 }
 
+#[wasm_bindgen]
+pub async fn async_take_reference(x: &str) -> String {
+    format!("Hi, {x}!")
+}
+
+#[wasm_bindgen]
+pub struct AsyncStruct;
+
+#[wasm_bindgen]
+impl AsyncStruct {
+    #[wasm_bindgen(constructor)]
+    pub async fn new() -> AsyncStruct {
+        AsyncStruct
+    }
+
+    pub async fn method(&self) -> u32 {
+        42
+    }
+}
+
 #[wasm_bindgen_test]
 async fn test_promise() {
     assert_eq!(call_promise().await.as_string(), Some(String::from("ok")))


### PR DESCRIPTION
Fixes #3042

Previously, any exported async functions which borrowed their arguments would fail to compile, because the values being referenced are stored on the stack of the initial synchronous call and then dropped, leaving nothing for the spawned future to reference.

This moves the referenced values into the spawned future, fixing that.