### PR TITLE
Better BigInt conversions

### DIFF
--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -193,9 +193,21 @@ intrinsics! {
         #[symbol = "__wbindgen_number_new"]
         #[signature = fn(F64) -> Externref]
         NumberNew,
-        #[symbol = "__wbindgen_bigint_new"]
+        #[symbol = "__wbindgen_bigint_from_str"]
         #[signature = fn(ref_string()) -> Externref]
-        BigIntNew,
+        BigIntFromStr,
+        #[symbol = "__wbindgen_bigint_from_i64"]
+        #[signature = fn(I64) -> Externref]
+        BigIntFromI64,
+        #[symbol = "__wbindgen_bigint_from_u64"]
+        #[signature = fn(U64) -> Externref]
+        BigIntFromU64,
+        #[symbol = "__wbindgen_bigint_from_i128"]
+        #[signature = fn(I64, U64) -> Externref]
+        BigIntFromI128,
+        #[symbol = "__wbindgen_bigint_from_u128"]
+        #[signature = fn(U64, U64) -> Externref]
+        BigIntFromU128,
         #[symbol = "__wbindgen_string_new"]
         #[signature = fn(ref_string()) -> Externref]
         StringNew,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3323,9 +3323,19 @@ impl<'a> Context<'a> {
                 args[0].clone()
             }
 
-            Intrinsic::BigIntNew => {
+            Intrinsic::BigIntFromStr => {
                 assert_eq!(args.len(), 1);
                 format!("BigInt({})", args[0])
+            }
+
+            Intrinsic::BigIntFromI64 | Intrinsic::BigIntFromU64 => {
+                assert_eq!(args.len(), 1);
+                args[0].clone()
+            }
+
+            Intrinsic::BigIntFromI128 | Intrinsic::BigIntFromU128 => {
+                assert_eq!(args.len(), 2);
+                format!("{} << BigInt(64) | {}", args[0], args[1])
             }
 
             Intrinsic::StringNew => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ impl JsValue {
     /// allocated large integer) and returns a handle to the JS version of it.
     #[inline]
     pub fn bigint_from_str(s: &str) -> JsValue {
-        unsafe { JsValue::_new(__wbindgen_bigint_new(s.as_ptr(), s.len())) }
+        unsafe { JsValue::_new(__wbindgen_bigint_from_str(s.as_ptr(), s.len())) }
     }
 
     /// Creates a new JS value which is a boolean.
@@ -868,7 +868,7 @@ macro_rules! numbers {
 numbers! { i8 u8 i16 u16 i32 u32 f32 f64 }
 
 macro_rules! big_numbers {
-    ($($n:ident)*) => ($(
+    (|$arg:ident|, $($n:ident = $handle:expr,)*) => ($(
         impl PartialEq<$n> for JsValue {
             #[inline]
             fn eq(&self, other: &$n) -> bool {
@@ -878,14 +878,20 @@ macro_rules! big_numbers {
 
         impl From<$n> for JsValue {
             #[inline]
-            fn from(n: $n) -> JsValue {
-                JsValue::bigint_from_str(&n.to_string())
+            fn from($arg: $n) -> JsValue {
+                unsafe { JsValue::_new($handle) }
             }
         }
     )*)
 }
 
-big_numbers! { i64 u64 i128 u128 }
+big_numbers! {
+    |n|,
+    i64 = __wbindgen_bigint_from_i64(n),
+    u64 = __wbindgen_bigint_from_u64(n),
+    i128 = __wbindgen_bigint_from_i128((n >> 64) as i64, n as u64),
+    u128 = __wbindgen_bigint_from_u128((n >> 64) as u64, n as u64),
+}
 
 // `usize` and `isize` have to be treated a bit specially, because we know that
 // they're 32-bit but the compiler conservatively assumes they might be bigger.
@@ -926,7 +932,11 @@ externs! {
 
         fn __wbindgen_string_new(ptr: *const u8, len: usize) -> u32;
         fn __wbindgen_number_new(f: f64) -> u32;
-        fn __wbindgen_bigint_new(ptr: *const u8, len: usize) -> u32;
+        fn __wbindgen_bigint_from_str(ptr: *const u8, len: usize) -> u32;
+        fn __wbindgen_bigint_from_i64(n: i64) -> u32;
+        fn __wbindgen_bigint_from_u64(n: u64) -> u32;
+        fn __wbindgen_bigint_from_i128(hi: i64, lo: u64) -> u32;
+        fn __wbindgen_bigint_from_u128(hi: u64, lo: u64) -> u32;
         fn __wbindgen_symbol_named_new(ptr: *const u8, len: usize) -> u32;
         fn __wbindgen_symbol_anonymous_new() -> u32;
 

--- a/tests/wasm/bigint.js
+++ b/tests/wasm/bigint.js
@@ -13,17 +13,33 @@ exports.js_works = () => {
     assert.strictEqual(wasm.i64_min(), BigInt('-9223372036854775808'));
     assert.strictEqual(wasm.u64_max(), BigInt('18446744073709551615'));
 
-    assert.strictEqual(wasm.i64_rust_identity(BigInt('0')), BigInt('0'));
-    assert.strictEqual(wasm.i64_rust_identity(BigInt('1')), BigInt('1'));
-    assert.strictEqual(wasm.i64_rust_identity(BigInt('-1')), BigInt('-1'));
-    assert.strictEqual(wasm.u64_rust_identity(BigInt('0')), BigInt('0'));
-    assert.strictEqual(wasm.u64_rust_identity(BigInt('1')), BigInt('1'));
-    assert.strictEqual(wasm.u64_rust_identity(BigInt('1') << BigInt('64')), BigInt('0'));
-
-    const u64_max = BigInt('18446744073709551615');
     const i64_min = BigInt('-9223372036854775808');
-    assert.strictEqual(wasm.i64_rust_identity(i64_min), i64_min);
-    assert.strictEqual(wasm.u64_rust_identity(u64_max), u64_max);
+    const u64_max = BigInt('18446744073709551615');
+
+    const identityTestI64Values = [
+        BigInt('0'),
+        BigInt('1'),
+        BigInt('-1'),
+        i64_min,
+    ];
+    for (const value of identityTestI64Values) {
+        assert.strictEqual(wasm.i64_rust_identity(value), value);
+        assert.strictEqual(wasm.i64_jsvalue_identity(value), value);
+    }
+
+    const identityTestU64Values = [
+        BigInt('0'),
+        BigInt('1'),
+        u64_max,
+    ];
+    for (const value of identityTestU64Values) {
+        assert.strictEqual(wasm.u64_rust_identity(value), value);
+        assert.strictEqual(wasm.u64_jsvalue_identity(value), value);
+    }
+
+    assert.strictEqual(wasm.u64_rust_identity(BigInt('1') << BigInt('64')), BigInt('0'));
+    assert.strictEqual(wasm.i128_min_jsvalue(), BigInt('-170141183460469231731687303715884105728'));
+    assert.strictEqual(wasm.u128_max_jsvalue(), BigInt('340282366920938463463374607431768211455'));
 
     assert.deepStrictEqual(wasm.u64_slice([]), new BigUint64Array());
     assert.deepStrictEqual(wasm.i64_slice([]), new BigInt64Array());

--- a/tests/wasm/bigint.rs
+++ b/tests/wasm/bigint.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
-#[wasm_bindgen(module = "tests/wasm/u64.js")]
+#[wasm_bindgen(module = "tests/wasm/bigint.js")]
 extern "C" {
     fn i64_js_identity(a: i64) -> i64;
     fn u64_js_identity(a: u64) -> u64;
@@ -51,6 +51,26 @@ pub fn i64_rust_identity(a: i64) -> i64 {
 #[wasm_bindgen]
 pub fn u64_rust_identity(a: u64) -> u64 {
     u64_js_identity(a)
+}
+
+#[wasm_bindgen]
+pub fn i64_jsvalue_identity(a: i64) -> JsValue {
+    JsValue::from(a)
+}
+
+#[wasm_bindgen]
+pub fn u64_jsvalue_identity(a: u64) -> JsValue {
+    JsValue::from(a)
+}
+
+#[wasm_bindgen]
+pub fn i128_min_jsvalue() -> JsValue {
+    JsValue::from(i128::min_value())
+}
+
+#[wasm_bindgen]
+pub fn u128_max_jsvalue() -> JsValue {
+    JsValue::from(u128::max_value())
 }
 
 #[wasm_bindgen]

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -14,6 +14,7 @@ use wasm_bindgen::prelude::*;
 
 pub mod api;
 pub mod arg_names;
+pub mod bigint;
 pub mod char;
 pub mod classes;
 pub mod closures;
@@ -43,7 +44,6 @@ pub mod simple;
 pub mod slice;
 pub mod structural;
 pub mod truthy_falsy;
-pub mod u64;
 pub mod usize;
 pub mod validate_prt;
 pub mod variadic;


### PR DESCRIPTION
Add some `[iu](64|128)` intrinsics to convert large numbers to `JsValue` directly, without stringifying and parsing them back.

Also adding a few more tests as previously those conversions didn't have any test coverage.