### PR TITLE
doc: include attribute position for vertex attrib pointer

### DIFF
--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -72,7 +72,14 @@ pub fn start() -> Result<(), JsValue> {
         .ok_or("Could not create vertex array object")?;
     context.bind_vertex_array(Some(&vao));
 
-    context.vertex_attrib_pointer_with_i32(position_attribute_location as u32, 3, WebGl2RenderingContext::FLOAT, false, 0, 0);
+    context.vertex_attrib_pointer_with_i32(
+        position_attribute_location as u32,
+        3,
+        WebGl2RenderingContext::FLOAT,
+        false,
+        0,
+        0,
+    );
     context.enable_vertex_attrib_array(position_attribute_location as u32);
 
     context.bind_vertex_array(Some(&vao));

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -72,7 +72,7 @@ pub fn start() -> Result<(), JsValue> {
         .ok_or("Could not create vertex array object")?;
     context.bind_vertex_array(Some(&vao));
 
-    context.vertex_attrib_pointer_with_i32(0, 3, WebGl2RenderingContext::FLOAT, false, 0, 0);
+    context.vertex_attrib_pointer_with_i32(position_attribute_location as u32, 3, WebGl2RenderingContext::FLOAT, false, 0, 0);
     context.enable_vertex_attrib_array(position_attribute_location as u32);
 
     context.bind_vertex_array(Some(&vao));


### PR DESCRIPTION
In the guide's WebGL example, [vertex_attrib_pointer_with_i32](https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.WebGl2RenderingContext.html#method.vertex_attrib_pointer_with_i32) is used which takes an attribute location (indx). The attributes location position_attribute_location should be used instead of a hard coded 0.

You can see #2609 updated
```rust
context.enable_vertex_attrib_array(0);
```
to be
```rust
context.enable_vertex_attrib_array(position_attribute_location as u32);
```
but failed to also update
```rust
context.vertex_attrib_pointer_with_i32(0, 3, WebGl2RenderingContext::FLOAT, false, 0, 0);
```
to be
```rust
context.vertex_attrib_pointer_with_i32(position_attribute_location as u32, 3, WebGl2RenderingContext::FLOAT, false, 0, 0);
```