### PR TITLE
Allow returning Result from tests

### DIFF
--- a/crates/test/sample/tests/common/mod.rs
+++ b/crates/test/sample/tests/common/mod.rs
@@ -10,9 +10,9 @@ fn pass() {
 #[wasm_bindgen_test]
 async fn pass_after_2s() {
     console_log!("immediate log");
-    Timeout::new(Duration::new(1, 0)).await;
+    Timeout::new(Duration::from_secs(1)).await;
     console_log!("log after 1s");
-    Timeout::new(Duration::new(1, 0)).await;
+    Timeout::new(Duration::from_secs(1)).await;
     console_log!("log at end");
 }
 
@@ -25,10 +25,29 @@ fn fail() {
 #[wasm_bindgen_test]
 async fn fail_after_3s() {
     console_log!("immediate log");
-    Timeout::new(Duration::new(1, 0)).await;
+    Timeout::new(Duration::from_secs(1)).await;
     console_log!("log after 1s");
-    Timeout::new(Duration::new(1, 0)).await;
+    Timeout::new(Duration::from_secs(1)).await;
     console_log!("log after 2s");
-    Timeout::new(Duration::new(1, 0)).await;
+    Timeout::new(Duration::from_secs(1)).await;
     panic!("end");
+}
+
+#[wasm_bindgen_test]
+fn result_fail() -> Result<(), Box<dyn std::error::Error>> {
+    Err("failed via Result".into())
+}
+
+#[wasm_bindgen_test]
+async fn result_fail_after_1s() -> Result<(), Box<dyn std::error::Error>> {
+    Timeout::new(Duration::from_secs(1)).await;
+    Err("failed via Result".into())
+}
+
+#[wasm_bindgen_test]
+fn panic_before_result_fail() -> Result<(), Box<dyn std::error::Error>> {
+    panic!("panic before Result fail");
+
+    #[allow(unreachable_code)]
+    Err("failed via Result".into())
 }


### PR DESCRIPTION
Makes it possible to use the newer `-> Result<(), E>` way of reporting test failures instead of just panicking in `#[wasm_bindgen_test]`, similarly to how you can do that in regular `#[test]`.

Resolves #2565.