### PR TITLE
web-sys: Added [Throws] attributes to Streams API

### DIFF
--- a/crates/web-sys/src/features/gen_ByteLengthQueuingStrategy.rs
+++ b/crates/web-sys/src/features/gen_ByteLengthQueuingStrategy.rs
@@ -18,13 +18,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ByteLengthQueuingStrategy`*"]
     pub fn high_water_mark(this: &ByteLengthQueuingStrategy) -> f64;
-    # [wasm_bindgen (structural , method , getter , js_class = "ByteLengthQueuingStrategy" , js_name = size)]
+    # [wasm_bindgen (structural , catch , method , getter , js_class = "ByteLengthQueuingStrategy" , js_name = size)]
     #[doc = "Getter for the `size` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ByteLengthQueuingStrategy/size)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ByteLengthQueuingStrategy`*"]
-    pub fn size(this: &ByteLengthQueuingStrategy) -> ::js_sys::Function;
+    pub fn size(this: &ByteLengthQueuingStrategy) -> Result<::js_sys::Function, JsValue>;
     #[cfg(feature = "QueuingStrategyInit")]
     #[wasm_bindgen(catch, constructor, js_class = "ByteLengthQueuingStrategy")]
     #[doc = "The `new ByteLengthQueuingStrategy(..)` constructor, creating a new instance of `ByteLengthQueuingStrategy`."]

--- a/crates/web-sys/src/features/gen_CountQueuingStrategy.rs
+++ b/crates/web-sys/src/features/gen_CountQueuingStrategy.rs
@@ -18,13 +18,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CountQueuingStrategy`*"]
     pub fn high_water_mark(this: &CountQueuingStrategy) -> f64;
-    # [wasm_bindgen (structural , method , getter , js_class = "CountQueuingStrategy" , js_name = size)]
+    # [wasm_bindgen (structural , catch , method , getter , js_class = "CountQueuingStrategy" , js_name = size)]
     #[doc = "Getter for the `size` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CountQueuingStrategy/size)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CountQueuingStrategy`*"]
-    pub fn size(this: &CountQueuingStrategy) -> ::js_sys::Function;
+    pub fn size(this: &CountQueuingStrategy) -> Result<::js_sys::Function, JsValue>;
     #[cfg(feature = "QueuingStrategyInit")]
     #[wasm_bindgen(catch, constructor, js_class = "CountQueuingStrategy")]
     #[doc = "The `new CountQueuingStrategy(..)` constructor, creating a new instance of `CountQueuingStrategy`."]

--- a/crates/web-sys/src/features/gen_ReadableByteStreamController.rs
+++ b/crates/web-sys/src/features/gen_ReadableByteStreamController.rs
@@ -12,13 +12,15 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`*"]
     pub type ReadableByteStreamController;
     #[cfg(feature = "ReadableStreamByobRequest")]
-    # [wasm_bindgen (structural , method , getter , js_class = "ReadableByteStreamController" , js_name = byobRequest)]
+    # [wasm_bindgen (structural , catch , method , getter , js_class = "ReadableByteStreamController" , js_name = byobRequest)]
     #[doc = "Getter for the `byobRequest` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/byobRequest)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`, `ReadableStreamByobRequest`*"]
-    pub fn byob_request(this: &ReadableByteStreamController) -> Option<ReadableStreamByobRequest>;
+    pub fn byob_request(
+        this: &ReadableByteStreamController,
+    ) -> Result<Option<ReadableStreamByobRequest>, JsValue>;
     # [wasm_bindgen (structural , method , getter , js_class = "ReadableByteStreamController" , js_name = desiredSize)]
     #[doc = "Getter for the `desiredSize` field of this object."]
     #[doc = ""]
@@ -26,14 +28,14 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`*"]
     pub fn desired_size(this: &ReadableByteStreamController) -> Option<f64>;
-    # [wasm_bindgen (method , structural , js_class = "ReadableByteStreamController" , js_name = close)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableByteStreamController" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/close)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`*"]
-    pub fn close(this: &ReadableByteStreamController);
-    # [wasm_bindgen (method , structural , js_class = "ReadableByteStreamController" , js_name = enqueue)]
+    pub fn close(this: &ReadableByteStreamController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableByteStreamController" , js_name = enqueue)]
     #[doc = "The `enqueue()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/enqueue)"]
@@ -42,26 +44,32 @@ extern "C" {
     pub fn enqueue_with_array_buffer_view(
         this: &ReadableByteStreamController,
         chunk: &::js_sys::Object,
-    );
-    # [wasm_bindgen (method , structural , js_class = "ReadableByteStreamController" , js_name = enqueue)]
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableByteStreamController" , js_name = enqueue)]
     #[doc = "The `enqueue()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/enqueue)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`*"]
-    pub fn enqueue_with_u8_array(this: &ReadableByteStreamController, chunk: &mut [u8]);
-    # [wasm_bindgen (method , structural , js_class = "ReadableByteStreamController" , js_name = error)]
+    pub fn enqueue_with_u8_array(
+        this: &ReadableByteStreamController,
+        chunk: &mut [u8],
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableByteStreamController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`*"]
-    pub fn error(this: &ReadableByteStreamController);
-    # [wasm_bindgen (method , structural , js_class = "ReadableByteStreamController" , js_name = error)]
+    pub fn error(this: &ReadableByteStreamController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableByteStreamController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableByteStreamController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableByteStreamController`*"]
-    pub fn error_with_e(this: &ReadableByteStreamController, e: &::wasm_bindgen::JsValue);
+    pub fn error_with_e(
+        this: &ReadableByteStreamController,
+        e: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_ReadableStream.rs
+++ b/crates/web-sys/src/features/gen_ReadableStream.rs
@@ -74,15 +74,15 @@ extern "C" {
         this: &ReadableStream,
         reason: &::wasm_bindgen::JsValue,
     ) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStream" , js_name = getReader)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStream" , js_name = getReader)]
     #[doc = "The `getReader()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/getReader)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStream`*"]
-    pub fn get_reader(this: &ReadableStream) -> ::js_sys::Object;
+    pub fn get_reader(this: &ReadableStream) -> Result<::js_sys::Object, JsValue>;
     #[cfg(feature = "ReadableStreamGetReaderOptions")]
-    # [wasm_bindgen (method , structural , js_class = "ReadableStream" , js_name = getReader)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStream" , js_name = getReader)]
     #[doc = "The `getReader()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/getReader)"]
@@ -91,17 +91,20 @@ extern "C" {
     pub fn get_reader_with_options(
         this: &ReadableStream,
         options: &ReadableStreamGetReaderOptions,
-    ) -> ::js_sys::Object;
+    ) -> Result<::js_sys::Object, JsValue>;
     #[cfg(feature = "ReadableWritablePair")]
-    # [wasm_bindgen (method , structural , js_class = "ReadableStream" , js_name = pipeThrough)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStream" , js_name = pipeThrough)]
     #[doc = "The `pipeThrough()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeThrough)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStream`, `ReadableWritablePair`*"]
-    pub fn pipe_through(this: &ReadableStream, transform: &ReadableWritablePair) -> ReadableStream;
+    pub fn pipe_through(
+        this: &ReadableStream,
+        transform: &ReadableWritablePair,
+    ) -> Result<ReadableStream, JsValue>;
     #[cfg(all(feature = "ReadableWritablePair", feature = "StreamPipeOptions",))]
-    # [wasm_bindgen (method , structural , js_class = "ReadableStream" , js_name = pipeThrough)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStream" , js_name = pipeThrough)]
     #[doc = "The `pipeThrough()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeThrough)"]
@@ -111,7 +114,7 @@ extern "C" {
         this: &ReadableStream,
         transform: &ReadableWritablePair,
         options: &StreamPipeOptions,
-    ) -> ReadableStream;
+    ) -> Result<ReadableStream, JsValue>;
     #[cfg(feature = "WritableStream")]
     # [wasm_bindgen (method , structural , js_class = "ReadableStream" , js_name = pipeTo)]
     #[doc = "The `pipeTo()` method."]
@@ -132,11 +135,11 @@ extern "C" {
         destination: &WritableStream,
         options: &StreamPipeOptions,
     ) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStream" , js_name = tee)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStream" , js_name = tee)]
     #[doc = "The `tee()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStream`*"]
-    pub fn tee(this: &ReadableStream) -> ::js_sys::Array;
+    pub fn tee(this: &ReadableStream) -> Result<::js_sys::Array, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_ReadableStreamByobReader.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamByobReader.rs
@@ -46,13 +46,13 @@ extern "C" {
         this: &ReadableStreamByobReader,
         view: &mut [u8],
     ) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBReader" , js_name = releaseLock)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamBYOBReader" , js_name = releaseLock)]
     #[doc = "The `releaseLock()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader/releaseLock)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamByobReader`*"]
-    pub fn release_lock(this: &ReadableStreamByobReader);
+    pub fn release_lock(this: &ReadableStreamByobReader) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBReader" , js_name = cancel)]
     #[doc = "The `cancel()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_ReadableStreamByobRequest.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamByobRequest.rs
@@ -18,21 +18,27 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamByobRequest`*"]
     pub fn view(this: &ReadableStreamByobRequest) -> Option<::js_sys::Object>;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respond)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respond)]
     #[doc = "The `respond()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBRequest/respond)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamByobRequest`*"]
-    pub fn respond_with_u32(this: &ReadableStreamByobRequest, bytes_written: u32);
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respond)]
+    pub fn respond_with_u32(
+        this: &ReadableStreamByobRequest,
+        bytes_written: u32,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respond)]
     #[doc = "The `respond()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBRequest/respond)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamByobRequest`*"]
-    pub fn respond_with_f64(this: &ReadableStreamByobRequest, bytes_written: f64);
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respondWithNewView)]
+    pub fn respond_with_f64(
+        this: &ReadableStreamByobRequest,
+        bytes_written: f64,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respondWithNewView)]
     #[doc = "The `respondWithNewView()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView)"]
@@ -41,12 +47,15 @@ extern "C" {
     pub fn respond_with_new_view_with_array_buffer_view(
         this: &ReadableStreamByobRequest,
         view: &::js_sys::Object,
-    );
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respondWithNewView)]
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamBYOBRequest" , js_name = respondWithNewView)]
     #[doc = "The `respondWithNewView()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBRequest/respondWithNewView)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamByobRequest`*"]
-    pub fn respond_with_new_view_with_u8_array(this: &ReadableStreamByobRequest, view: &mut [u8]);
+    pub fn respond_with_new_view_with_u8_array(
+        this: &ReadableStreamByobRequest,
+        view: &mut [u8],
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_ReadableStreamDefaultController.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamDefaultController.rs
@@ -18,21 +18,21 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultController`*"]
     pub fn desired_size(this: &ReadableStreamDefaultController) -> Option<f64>;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultController" , js_name = close)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamDefaultController" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/close)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultController`*"]
-    pub fn close(this: &ReadableStreamDefaultController);
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultController" , js_name = enqueue)]
+    pub fn close(this: &ReadableStreamDefaultController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamDefaultController" , js_name = enqueue)]
     #[doc = "The `enqueue()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/enqueue)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultController`*"]
-    pub fn enqueue(this: &ReadableStreamDefaultController);
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultController" , js_name = enqueue)]
+    pub fn enqueue(this: &ReadableStreamDefaultController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamDefaultController" , js_name = enqueue)]
     #[doc = "The `enqueue()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/enqueue)"]
@@ -41,19 +41,22 @@ extern "C" {
     pub fn enqueue_with_chunk(
         this: &ReadableStreamDefaultController,
         chunk: &::wasm_bindgen::JsValue,
-    );
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultController" , js_name = error)]
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamDefaultController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultController`*"]
-    pub fn error(this: &ReadableStreamDefaultController);
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultController" , js_name = error)]
+    pub fn error(this: &ReadableStreamDefaultController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamDefaultController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultController`*"]
-    pub fn error_with_e(this: &ReadableStreamDefaultController, e: &::wasm_bindgen::JsValue);
+    pub fn error_with_e(
+        this: &ReadableStreamDefaultController,
+        e: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_ReadableStreamDefaultReader.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamDefaultReader.rs
@@ -33,13 +33,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultReader`*"]
     pub fn read(this: &ReadableStreamDefaultReader) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultReader" , js_name = releaseLock)]
+    # [wasm_bindgen (catch , method , structural , js_class = "ReadableStreamDefaultReader" , js_name = releaseLock)]
     #[doc = "The `releaseLock()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/releaseLock)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ReadableStreamDefaultReader`*"]
-    pub fn release_lock(this: &ReadableStreamDefaultReader);
+    pub fn release_lock(this: &ReadableStreamDefaultReader) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "ReadableStreamDefaultReader" , js_name = cancel)]
     #[doc = "The `cancel()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_TransformStreamDefaultController.rs
+++ b/crates/web-sys/src/features/gen_TransformStreamDefaultController.rs
@@ -18,14 +18,14 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TransformStreamDefaultController`*"]
     pub fn desired_size(this: &TransformStreamDefaultController) -> Option<f64>;
-    # [wasm_bindgen (method , structural , js_class = "TransformStreamDefaultController" , js_name = enqueue)]
+    # [wasm_bindgen (catch , method , structural , js_class = "TransformStreamDefaultController" , js_name = enqueue)]
     #[doc = "The `enqueue()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController/enqueue)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TransformStreamDefaultController`*"]
-    pub fn enqueue(this: &TransformStreamDefaultController);
-    # [wasm_bindgen (method , structural , js_class = "TransformStreamDefaultController" , js_name = enqueue)]
+    pub fn enqueue(this: &TransformStreamDefaultController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "TransformStreamDefaultController" , js_name = enqueue)]
     #[doc = "The `enqueue()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController/enqueue)"]
@@ -34,15 +34,15 @@ extern "C" {
     pub fn enqueue_with_chunk(
         this: &TransformStreamDefaultController,
         chunk: &::wasm_bindgen::JsValue,
-    );
-    # [wasm_bindgen (method , structural , js_class = "TransformStreamDefaultController" , js_name = error)]
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "TransformStreamDefaultController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TransformStreamDefaultController`*"]
-    pub fn error(this: &TransformStreamDefaultController);
-    # [wasm_bindgen (method , structural , js_class = "TransformStreamDefaultController" , js_name = error)]
+    pub fn error(this: &TransformStreamDefaultController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "TransformStreamDefaultController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController/error)"]
@@ -51,12 +51,12 @@ extern "C" {
     pub fn error_with_reason(
         this: &TransformStreamDefaultController,
         reason: &::wasm_bindgen::JsValue,
-    );
-    # [wasm_bindgen (method , structural , js_class = "TransformStreamDefaultController" , js_name = terminate)]
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "TransformStreamDefaultController" , js_name = terminate)]
     #[doc = "The `terminate()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController/terminate)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TransformStreamDefaultController`*"]
-    pub fn terminate(this: &TransformStreamDefaultController);
+    pub fn terminate(this: &TransformStreamDefaultController) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_WritableStream.rs
+++ b/crates/web-sys/src/features/gen_WritableStream.rs
@@ -57,14 +57,14 @@ extern "C" {
         underlying_sink: &::js_sys::Object,
         strategy: &QueuingStrategy,
     ) -> Result<WritableStream, JsValue>;
-    # [wasm_bindgen (method , structural , js_class = "WritableStream" , js_name = abort)]
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStream" , js_name = abort)]
     #[doc = "The `abort()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/abort)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStream`*"]
-    pub fn abort(this: &WritableStream) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "WritableStream" , js_name = abort)]
+    pub fn abort(this: &WritableStream) -> Result<::js_sys::Promise, JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStream" , js_name = abort)]
     #[doc = "The `abort()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/abort)"]
@@ -73,7 +73,7 @@ extern "C" {
     pub fn abort_with_reason(
         this: &WritableStream,
         reason: &::wasm_bindgen::JsValue,
-    ) -> ::js_sys::Promise;
+    ) -> Result<::js_sys::Promise, JsValue>;
     # [wasm_bindgen (method , structural , js_class = "WritableStream" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
@@ -82,11 +82,11 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `WritableStream`*"]
     pub fn close(this: &WritableStream) -> ::js_sys::Promise;
     #[cfg(feature = "WritableStreamDefaultWriter")]
-    # [wasm_bindgen (method , structural , js_class = "WritableStream" , js_name = getWriter)]
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStream" , js_name = getWriter)]
     #[doc = "The `getWriter()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream/getWriter)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStream`, `WritableStreamDefaultWriter`*"]
-    pub fn get_writer(this: &WritableStream) -> WritableStreamDefaultWriter;
+    pub fn get_writer(this: &WritableStream) -> Result<WritableStreamDefaultWriter, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_WritableStreamDefaultController.rs
+++ b/crates/web-sys/src/features/gen_WritableStreamDefaultController.rs
@@ -19,18 +19,21 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AbortSignal`, `WritableStreamDefaultController`*"]
     pub fn signal(this: &WritableStreamDefaultController) -> AbortSignal;
-    # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultController" , js_name = error)]
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStreamDefaultController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultController`*"]
-    pub fn error(this: &WritableStreamDefaultController);
-    # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultController" , js_name = error)]
+    pub fn error(this: &WritableStreamDefaultController) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStreamDefaultController" , js_name = error)]
     #[doc = "The `error()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultController/error)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultController`*"]
-    pub fn error_with_e(this: &WritableStreamDefaultController, e: &::wasm_bindgen::JsValue);
+    pub fn error_with_e(
+        this: &WritableStreamDefaultController,
+        e: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_WritableStreamDefaultWriter.rs
+++ b/crates/web-sys/src/features/gen_WritableStreamDefaultWriter.rs
@@ -18,13 +18,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultWriter`*"]
     pub fn closed(this: &WritableStreamDefaultWriter) -> ::js_sys::Promise;
-    # [wasm_bindgen (structural , method , getter , js_class = "WritableStreamDefaultWriter" , js_name = desiredSize)]
+    # [wasm_bindgen (structural , catch , method , getter , js_class = "WritableStreamDefaultWriter" , js_name = desiredSize)]
     #[doc = "Getter for the `desiredSize` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/desiredSize)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultWriter`*"]
-    pub fn desired_size(this: &WritableStreamDefaultWriter) -> Option<f64>;
+    pub fn desired_size(this: &WritableStreamDefaultWriter) -> Result<Option<f64>, JsValue>;
     # [wasm_bindgen (structural , method , getter , js_class = "WritableStreamDefaultWriter" , js_name = ready)]
     #[doc = "Getter for the `ready` field of this object."]
     #[doc = ""]
@@ -40,14 +40,14 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStream`, `WritableStreamDefaultWriter`*"]
     pub fn new(stream: &WritableStream) -> Result<WritableStreamDefaultWriter, JsValue>;
-    # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultWriter" , js_name = abort)]
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStreamDefaultWriter" , js_name = abort)]
     #[doc = "The `abort()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/abort)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultWriter`*"]
-    pub fn abort(this: &WritableStreamDefaultWriter) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultWriter" , js_name = abort)]
+    pub fn abort(this: &WritableStreamDefaultWriter) -> Result<::js_sys::Promise, JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStreamDefaultWriter" , js_name = abort)]
     #[doc = "The `abort()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/abort)"]
@@ -56,7 +56,7 @@ extern "C" {
     pub fn abort_with_reason(
         this: &WritableStreamDefaultWriter,
         reason: &::wasm_bindgen::JsValue,
-    ) -> ::js_sys::Promise;
+    ) -> Result<::js_sys::Promise, JsValue>;
     # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultWriter" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
@@ -64,13 +64,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultWriter`*"]
     pub fn close(this: &WritableStreamDefaultWriter) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultWriter" , js_name = releaseLock)]
+    # [wasm_bindgen (catch , method , structural , js_class = "WritableStreamDefaultWriter" , js_name = releaseLock)]
     #[doc = "The `releaseLock()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WritableStreamDefaultWriter/releaseLock)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WritableStreamDefaultWriter`*"]
-    pub fn release_lock(this: &WritableStreamDefaultWriter);
+    pub fn release_lock(this: &WritableStreamDefaultWriter) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "WritableStreamDefaultWriter" , js_name = write)]
     #[doc = "The `write()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/Streams.webidl
+++ b/crates/web-sys/webidls/enabled/Streams.webidl
@@ -6,19 +6,21 @@
  *
  * The origin of this IDL file is
  * https://streams.spec.whatwg.org/#idl-index
+ * `[Throws]` attributes copied from Mozilla's webidl tree as of Aug. 31, 2022
+ * https://hg.mozilla.org/mozilla-central/file/tip/dom/webidl/
  */
 
 [Exposed=*, Transferable]
 interface ReadableStream {
-  constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});
+  [Throws] constructor(optional object underlyingSource, optional QueuingStrategy strategy = {});
 
   readonly attribute boolean locked;
 
   Promise<undefined> cancel(optional any reason);
-  ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
-  ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
+  [Throws] ReadableStreamReader getReader(optional ReadableStreamGetReaderOptions options = {});
+  [Throws] ReadableStream pipeThrough(ReadableWritablePair transform, optional StreamPipeOptions options = {});
   Promise<undefined> pipeTo(WritableStream destination, optional StreamPipeOptions options = {});
-  sequence<ReadableStream> tee();
+  [Throws] sequence<ReadableStream> tee();
 
   async iterable<any>(optional ReadableStreamIteratorOptions options = {});
 };
@@ -71,10 +73,10 @@ interface mixin ReadableStreamGenericReader {
 
 [Exposed=*]
 interface ReadableStreamDefaultReader {
-  constructor(ReadableStream stream);
+  [Throws] constructor(ReadableStream stream);
 
   Promise<ReadableStreamReadResult> read();
-  undefined releaseLock();
+  [Throws] undefined releaseLock();
 };
 ReadableStreamDefaultReader includes ReadableStreamGenericReader;
 
@@ -85,10 +87,10 @@ dictionary ReadableStreamReadResult {
 
 [Exposed=*]
 interface ReadableStreamBYOBReader {
-  constructor(ReadableStream stream);
+  [Throws] constructor(ReadableStream stream);
 
   Promise<ReadableStreamReadResult> read(ArrayBufferView view);
-  undefined releaseLock();
+  [Throws] undefined releaseLock();
 };
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;
 
@@ -96,38 +98,38 @@ ReadableStreamBYOBReader includes ReadableStreamGenericReader;
 interface ReadableStreamDefaultController {
   readonly attribute unrestricted double? desiredSize;
 
-  undefined close();
-  undefined enqueue(optional any chunk);
-  undefined error(optional any e);
+  [Throws] undefined close();
+  [Throws] undefined enqueue(optional any chunk);
+  [Throws] undefined error(optional any e);
 };
 
 [Exposed=*]
 interface ReadableByteStreamController {
-  readonly attribute ReadableStreamBYOBRequest? byobRequest;
+  [Throws] readonly attribute ReadableStreamBYOBRequest? byobRequest;
   readonly attribute unrestricted double? desiredSize;
 
-  undefined close();
-  undefined enqueue(ArrayBufferView chunk);
-  undefined error(optional any e);
+  [Throws] undefined close();
+  [Throws] undefined enqueue(ArrayBufferView chunk);
+  [Throws] undefined error(optional any e);
 };
 
 [Exposed=*]
 interface ReadableStreamBYOBRequest {
   readonly attribute ArrayBufferView? view;
 
-  undefined respond([EnforceRange] unsigned long long bytesWritten);
-  undefined respondWithNewView(ArrayBufferView view);
+  [Throws] undefined respond([EnforceRange] unsigned long long bytesWritten);
+  [Throws] undefined respondWithNewView(ArrayBufferView view);
 };
 
 [Exposed=*, Transferable]
 interface WritableStream {
-  constructor(optional object underlyingSink, optional QueuingStrategy strategy = {});
+  [Throws] constructor(optional object underlyingSink, optional QueuingStrategy strategy = {});
 
   readonly attribute boolean locked;
 
-  Promise<undefined> abort(optional any reason);
+  [Throws] Promise<undefined> abort(optional any reason);
   Promise<undefined> close();
-  WritableStreamDefaultWriter getWriter();
+  [Throws] WritableStreamDefaultWriter getWriter();
 };
 
 dictionary UnderlyingSink {
@@ -145,26 +147,27 @@ callback UnderlyingSinkAbortCallback = Promise<undefined> (optional any reason);
 
 [Exposed=*]
 interface WritableStreamDefaultWriter {
-  constructor(WritableStream stream);
+  [Throws] constructor(WritableStream stream);
 
   readonly attribute Promise<undefined> closed;
-  readonly attribute unrestricted double? desiredSize;
+  [Throws] readonly attribute unrestricted double? desiredSize;
   readonly attribute Promise<undefined> ready;
 
-  Promise<undefined> abort(optional any reason);
+  [Throws] Promise<undefined> abort(optional any reason);
   Promise<undefined> close();
-  undefined releaseLock();
+  [Throws] undefined releaseLock();
   Promise<undefined> write(optional any chunk);
 };
 
 [Exposed=*]
 interface WritableStreamDefaultController {
   readonly attribute AbortSignal signal;
-  undefined error(optional any e);
+  [Throws] undefined error(optional any e);
 };
 
 [Exposed=*, Transferable]
 interface TransformStream {
+  [Throws]
   constructor(optional object transformer,
               optional QueuingStrategy writableStrategy = {},
               optional QueuingStrategy readableStrategy = {});
@@ -189,9 +192,9 @@ callback TransformerTransformCallback = Promise<undefined> (any chunk, Transform
 interface TransformStreamDefaultController {
   readonly attribute unrestricted double? desiredSize;
 
-  undefined enqueue(optional any chunk);
-  undefined error(optional any reason);
-  undefined terminate();
+  [Throws] undefined enqueue(optional any chunk);
+  [Throws] undefined error(optional any reason);
+  [Throws] undefined terminate();
 };
 
 dictionary QueuingStrategy {
@@ -210,7 +213,7 @@ interface ByteLengthQueuingStrategy {
   constructor(QueuingStrategyInit init);
 
   readonly attribute unrestricted double highWaterMark;
-  readonly attribute Function size;
+  [Throws] readonly attribute Function size;
 };
 
 [Exposed=*]
@@ -218,7 +221,7 @@ interface CountQueuingStrategy {
   constructor(QueuingStrategyInit init);
 
   readonly attribute unrestricted double highWaterMark;
-  readonly attribute Function size;
+  [Throws] readonly attribute Function size;
 };
 
 interface mixin GenericTransformStream {


### PR DESCRIPTION
Following the comment in https://github.com/rustwasm/wasm-bindgen/pull/3046#issuecomment-1233461732, I went through `Streams.webidl` and added a `[Throws]` attribute on every method and member that [Mozilla](https://hg.mozilla.org/mozilla-central/file/tip/dom/webidl/) places a `[Throws]` attribute on.

cc @Liamolucko