### PR TITLE
Return `false` from instanceof if the type being checked against doesn't exist

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2956,7 +2956,20 @@ impl<'a> Context<'a> {
                 assert!(!variadic);
                 assert_eq!(args.len(), 1);
                 let js = self.import_name(js)?;
-                Ok(format!("{} instanceof {}", args[0], js))
+                write!(
+                    prelude,
+                    "\
+                    let result;
+                    try {{
+                        result = {} instanceof {};
+                    }} catch {{
+                        result = false;
+                    }}
+                    ",
+                    args[0], js,
+                )
+                .unwrap();
+                Ok("result".to_owned())
             }
 
             AuxImport::Static(js) => {


### PR DESCRIPTION
Fixes #2272

Previously, checking if a value was an instance of a nonexistent type would result in an uncaught exception. This changes it to return `false` instead, avoiding having to do an extra feature-test of whether the type exists before calling `dyn_into`/`dyn_ref`/etc.