### PR TITLE
Document that error types other than `JsValue` are supported

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -58,7 +58,7 @@
     - [`String`](./reference/types/string.md)
     - [Number Slices](./reference/types/number-slices.md)
     - [Boxed Number Slices](./reference/types/boxed-number-slices.md)
-    - [`Result<T, JsValue>`](./reference/types/result.md)
+    - [`Result<T, E>`](./reference/types/result.md)
   - [`#[wasm_bindgen]` Attributes](./reference/attributes/index.md)
     - [On JavaScript Imports](./reference/attributes/on-js-imports/index.md)
       - [`catch`](./reference/attributes/on-js-imports/catch.md)

--- a/guide/src/reference/types/result.md
+++ b/guide/src/reference/types/result.md
@@ -1,14 +1,14 @@
-# `Result<T, JsValue>`
+# `Result<T, E>`
 
 | `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value | `Option<T>` parameter | `Option<T>` return value | JavaScript representation |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| No | No | No | No | No | Yes | Same as `T`, or an exception |
+| No | No | No | Yes | No | No | Same as `T`, or an exception |
 
 The `Result` type can be returned from functions exported to JS as well as
-closures in Rust. Only `Result<T, JsValue>` is supported where `T` can be
-converted to JS. Whenever `Ok(val)` is encountered it's converted to JS and
-handed off, and whenever `Err(error)` is encountered an exception is thrown in
-JS with `error`.
+closures in Rust. The `Ok` type must be able to be converted to JS, and the
+`Err` type must implement `Into<JsValue>`. Whenever `Ok(val)` is encountered
+it's converted to JS and handed off, and whenever `Err(error)` is encountered
+an exception is thrown in JS with `error`.
 
 You can use `Result` to enable handling of JS exceptions with `?` in Rust,
 naturally propagating it upwards to the wasm boundary. Furthermore you can also


### PR DESCRIPTION
Resolves #1004

#2710 added support for returning `Result<T, impl Into<JsValue>>` rather than just `Result<T, JsValue>`, but the `wasm-bindgen` guide still claims that only the latter is supported.

This fixes that, and also fixes a mistake in the table for what forms `Result` can be returned in (it previously claimed that only `Option<Result<...>>` was supported, when in fact only a plain `Result<...>` is supported).