### PR TITLE
js-sys: Fix `BigInt::from(usize)` and `BigInt::from(isize)`

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1051,7 +1051,7 @@ macro_rules! bigint_from {
         }
     )*)
 }
-bigint_from!(i8 u8 i16 u16 i32 u32);
+bigint_from!(i8 u8 i16 u16 i32 u32 isize usize);
 
 macro_rules! bigint_from_big {
     ($($x:ident)*) => ($(
@@ -1070,7 +1070,7 @@ macro_rules! bigint_from_big {
         }
     )*)
 }
-bigint_from_big!(i64 u64 i128 u128 isize usize);
+bigint_from_big!(i64 u64 i128 u128);
 
 impl PartialEq<Number> for BigInt {
     #[inline]

--- a/crates/js-sys/tests/wasm/BigInt.rs
+++ b/crates/js-sys/tests/wasm/BigInt.rs
@@ -25,8 +25,6 @@ fn from() {
     assert_jsvalue_eq(BigInt::from(-3isize), -3i64);
 }
 
-
-
 #[wasm_bindgen_test]
 fn eq() {
     // Test that all the `Eq` impls work properly.
@@ -43,4 +41,3 @@ fn eq() {
     assert_eq!(BigInt::from(-3i64), -3i128);
     assert_eq!(BigInt::from(-3i64), -3isize);
 }
-

--- a/crates/js-sys/tests/wasm/BigInt.rs
+++ b/crates/js-sys/tests/wasm/BigInt.rs
@@ -1,0 +1,46 @@
+use js_sys::BigInt;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+/// `assert_eq!`, but the arguments are converted to `JsValue`s.
+#[track_caller]
+fn assert_jsvalue_eq(a: impl Into<JsValue>, b: impl Into<JsValue>) {
+    assert_eq!(a.into(), b.into());
+}
+
+#[wasm_bindgen_test]
+fn from() {
+    // Test that all the `From` impls work properly.
+    assert_jsvalue_eq(BigInt::from(1u8), 1u64);
+    assert_jsvalue_eq(BigInt::from(1u16), 1u64);
+    assert_jsvalue_eq(BigInt::from(1u32), 1u64);
+    assert_jsvalue_eq(BigInt::from(1u64), 1u64);
+    assert_jsvalue_eq(BigInt::from(1u128), 1u64);
+    assert_jsvalue_eq(BigInt::from(1usize), 1u64);
+    assert_jsvalue_eq(BigInt::from(-3i8), -3i64);
+    assert_jsvalue_eq(BigInt::from(-3i16), -3i64);
+    assert_jsvalue_eq(BigInt::from(-3i32), -3i64);
+    assert_jsvalue_eq(BigInt::from(-3i64), -3i64);
+    assert_jsvalue_eq(BigInt::from(-3i128), -3i64);
+    assert_jsvalue_eq(BigInt::from(-3isize), -3i64);
+}
+
+
+
+#[wasm_bindgen_test]
+fn eq() {
+    // Test that all the `Eq` impls work properly.
+    assert_eq!(BigInt::from(1u64), 1u8);
+    assert_eq!(BigInt::from(1u64), 1u16);
+    assert_eq!(BigInt::from(1u64), 1u32);
+    assert_eq!(BigInt::from(1u64), 1u64);
+    assert_eq!(BigInt::from(1u64), 1u128);
+    assert_eq!(BigInt::from(1u64), 1usize);
+    assert_eq!(BigInt::from(-3i64), -3i8);
+    assert_eq!(BigInt::from(-3i64), -3i16);
+    assert_eq!(BigInt::from(-3i64), -3i32);
+    assert_eq!(BigInt::from(-3i64), -3i64);
+    assert_eq!(BigInt::from(-3i64), -3i128);
+    assert_eq!(BigInt::from(-3i64), -3isize);
+}
+

--- a/crates/js-sys/tests/wasm/main.rs
+++ b/crates/js-sys/tests/wasm/main.rs
@@ -4,6 +4,7 @@
 pub mod Array;
 pub mod ArrayBuffer;
 pub mod ArrayIterator;
+pub mod BigInt;
 pub mod Boolean;
 pub mod DataView;
 pub mod Date;


### PR DESCRIPTION
Fixes #3055

This changes `isize` and `usize` to be converted to `BigInt` in the same way as `i32`/`u32`, `BigInt(JsValue::from(n))`, rather than `JsValue::from(n).unchecked_into()`. The latter is now wrong because as of #2978 that `JsValue::from` returns a `Number`, not a `BigInt`.