### PR TITLE
Allow returning `Result<*mut T, _>` and `Result<*const T, _>` from async functions

### DIFF
--- a/crates/macro/ui-tests/async-errors.stderr
+++ b/crates/macro/ui-tests/async-errors.stderr
@@ -41,9 +41,7 @@ error[E0277]: the trait bound `wasm_bindgen::JsValue: From<BadType>` is not sati
                <wasm_bindgen::JsValue as From<&'a T>>
                <wasm_bindgen::JsValue as From<&'a str>>
                <wasm_bindgen::JsValue as From<*const T>>
-               <wasm_bindgen::JsValue as From<*mut T>>
-               <wasm_bindgen::JsValue as From<JsError>>
-             and 73 others
+             and 75 others
      = note: required because of the requirements on the impl of `Into<wasm_bindgen::JsValue>` for `BadType`
      = note: required because of the requirements on the impl of `IntoJsResult` for `BadType`
 note: required by `into_js_result`

--- a/crates/macro/ui-tests/async-errors.stderr
+++ b/crates/macro/ui-tests/async-errors.stderr
@@ -40,6 +40,8 @@ error[E0277]: the trait bound `wasm_bindgen::JsValue: From<BadType>` is not sati
                <wasm_bindgen::JsValue as From<&'a String>>
                <wasm_bindgen::JsValue as From<&'a T>>
                <wasm_bindgen::JsValue as From<&'a str>>
+               <wasm_bindgen::JsValue as From<*const T>>
+               <wasm_bindgen::JsValue as From<*mut T>>
                <wasm_bindgen::JsValue as From<JsError>>
              and 73 others
      = note: required because of the requirements on the impl of `Into<wasm_bindgen::JsValue>` for `BadType`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,20 @@ impl<'a> From<&'a str> for JsValue {
     }
 }
 
+impl<T> From<*mut T> for JsValue {
+    #[inline]
+    fn from(s: *mut T) -> JsValue {
+        JsValue::from(s as usize)
+    }
+}
+
+impl<T> From<*const T> for JsValue {
+    #[inline]
+    fn from(s: *const T) -> JsValue {
+        JsValue::from(s as usize)
+    }
+}
+
 if_std! {
     impl<'a> From<&'a String> for JsValue {
         #[inline]


### PR DESCRIPTION
The following code does not work currently, the goal of this PR is to fix it.

```rust
#[wasm_bindgen]
pub async fn foo() -> Result<*mut (), JsError> {
     Ok(std::ptr::null())
}
```

The base error is:
```
the trait bound `std::result::Result<*mut T, _>: wasm_bindgen::__rt::IntoJsResult` is not satisfied
the following other types implement trait `wasm_bindgen::__rt::IntoJsResult`:
  std::result::Result<(), E>
  std::result::Result<T, E>
```

The same code does compile using a sync function.