### PR TITLE
Add ability to instantiate WASM module without calling the start function

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -385,7 +385,7 @@ impl<'a> Context<'a> {
                 js.push_str("let wasm;\n");
                 init = self.gen_init(needs_manual_start, None)?;
                 footer.push_str(&format!(
-                    "{} = Object.assign(init, {{ initSync }}, __exports);\n",
+                    "{} = Object.assign(init, {{ initWithoutStart }}, {{ initSync }}, __exports);\n",
                     global
                 ));
             }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -418,6 +418,10 @@ impl<'a> Context<'a> {
                 if needs_manual_start {
                     footer.push_str("\nwasm.__wbindgen_start();\n");
                 }
+
+                if self.start_found {
+                    footer.push_str("\nwasm.__wbindgen_main();\n");
+                }
             }
 
             OutputMode::Deno => {
@@ -431,6 +435,10 @@ impl<'a> Context<'a> {
 
                 if needs_manual_start {
                     footer.push_str("\nwasm.__wbindgen_start();\n");
+                }
+
+                if self.start_found {
+                    footer.push_str("\nwasm.__wbindgen_main();\n");
                 }
             }
 
@@ -465,6 +473,12 @@ impl<'a> Context<'a> {
 
                 if needs_manual_start {
                     start = Some("\nwasm.__wbindgen_start();\n".to_string());
+                }
+
+                if self.start_found {
+                    start
+                        .get_or_insert_with(String::default)
+                        .push_str("\nwasm.__wbindgen_main();\n");
                 }
             }
 
@@ -912,7 +926,7 @@ impl<'a> Context<'a> {
             } else {
                 ""
             },
-            main = if needs_manual_start && self.start_found {
+            main = if self.start_found {
                 "if (start == true) { wasm.__wbindgen_main(); }"
             } else {
                 ""

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -359,7 +359,7 @@ impl Bindgen {
         // auxiliary section for all sorts of miscellaneous information and
         // features #[wasm_bindgen] supports that aren't covered by wasm
         // interface types.
-        wit::process(
+        let wit::ProcessResult { start_found, .. } = wit::process(
             &mut module,
             self.externref,
             self.wasm_interface_types,
@@ -441,7 +441,7 @@ impl Bindgen {
                 .customs
                 .delete_typed::<wit::NonstandardWitSection>()
                 .unwrap();
-            let mut cx = js::Context::new(&mut module, self, &adapters, &aux)?;
+            let mut cx = js::Context::new(&mut module, self, &adapters, &aux, start_found)?;
             cx.generate()?;
             let (js, ts, start) = cx.finalize(stem)?;
             Generated::Js(JsGenerated {

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -1459,7 +1459,7 @@ impl<'a> Context<'a> {
         let mut to_remove = Vec::new();
         for export in self.module.exports.iter() {
             match export.name.as_str() {
-                n if n.starts_with("__wbindgen") => {
+                n if n.starts_with("__wbindgen") && n != "__wbindgen_main" => {
                     to_remove.push(export.id());
                 }
                 _ => {}

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -97,7 +97,7 @@ pub fn process(
     Ok(ProcessResult {
         adapters,
         aux,
-        start_found: cx.start_found,
+        start_found: cx.start_found && cx.support_start,
     })
 }
 

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -239,7 +239,7 @@ fn default_module_path_target_web() {
     let contents = fs::read_to_string(out_dir.join("default_module_path_target_web.js")).unwrap();
     assert!(contents.contains(
         "\
-async function init(input) {
+async function initInternal(input, start) {
     if (typeof input === 'undefined') {
         input = new URL('default_module_path_target_web_bg.wasm', import.meta.url);
     }",
@@ -260,7 +260,7 @@ fn default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
-    async function init(input) {
+    async function initInternal(input, start) {
         if (typeof input === 'undefined') {
             let src;
             if (typeof document === 'undefined') {
@@ -287,7 +287,7 @@ fn omit_default_module_path_target_web() {
         fs::read_to_string(out_dir.join("omit_default_module_path_target_web.js")).unwrap();
     assert!(contents.contains(
         "\
-async function init(input) {
+async function initInternal(input, start) {
 
     const imports = getImports();",
     ));
@@ -307,7 +307,7 @@ fn omit_default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("omit_default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
-    async function init(input) {
+    async function initInternal(input, start) {
 
         const imports = getImports();",
     ));


### PR DESCRIPTION
Currently it's impossible to properly implement WASM multi-threading as a library without the user having to use some workaround to prevent `main` to be called.

I was thinking of just adding a third parameter to the `init` function, not sure if that's a breaking change or not (I don't believe so). Happy to try other approaches to solve this issue.

Fixes #2295.