### PR TITLE
Refactor: normalized encoding of ImportModule

### DIFF
--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -880,13 +880,6 @@ impl<'a> Context<'a> {
     }
 
     fn determine_import(&self, import: &decode::Import<'_>, item: &str) -> Result<JsImport, Error> {
-        let is_local_snippet = match import.module {
-            Some(decode::ImportModule::Named(s)) => self.aux.local_modules.contains_key(s),
-            Some(decode::ImportModule::RawNamed(_)) => false,
-            Some(decode::ImportModule::Inline(_)) => true,
-            None => false,
-        };
-
         // Similar to `--target no-modules`, only allow vendor prefixes
         // basically for web apis, shouldn't be necessary for things like npm
         // packages or other imported items.
@@ -894,7 +887,7 @@ impl<'a> Context<'a> {
         if let Some(vendor_prefixes) = vendor_prefixes {
             assert!(vendor_prefixes.len() > 0);
 
-            if is_local_snippet {
+            if let Some(decode::ImportModule::Inline(_)) = &import.module {
                 bail!(
                     "local JS snippets do not support vendor prefixes for \
                      the import of `{}` with a polyfill of `{}`",
@@ -938,18 +931,14 @@ impl<'a> Context<'a> {
         };
 
         let name = match import.module {
-            Some(decode::ImportModule::Named(module)) if is_local_snippet => {
-                JsImportName::LocalModule {
-                    module: module.to_string(),
-                    name: name.to_string(),
-                }
-            }
-            Some(decode::ImportModule::Named(module) | decode::ImportModule::RawNamed(module)) => {
-                JsImportName::Module {
-                    module: module.to_string(),
-                    name: name.to_string(),
-                }
-            }
+            Some(decode::ImportModule::Named(module)) => JsImportName::LocalModule {
+                module: module.to_string(),
+                name: name.to_string(),
+            },
+            Some(decode::ImportModule::RawNamed(module)) => JsImportName::Module {
+                module: module.to_string(),
+                name: name.to_string(),
+            },
             Some(decode::ImportModule::Inline(idx)) => {
                 let offset = self
                     .aux

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -887,7 +887,9 @@ impl<'a> Context<'a> {
         if let Some(vendor_prefixes) = vendor_prefixes {
             assert!(vendor_prefixes.len() > 0);
 
-            if let Some(decode::ImportModule::Inline(_)) = &import.module {
+            if let Some(decode::ImportModule::Inline(_) | decode::ImportModule::Named(_)) =
+                &import.module
+            {
                 bail!(
                     "local JS snippets do not support vendor prefixes for \
                      the import of `{}` with a polyfill of `{}`",
@@ -895,7 +897,7 @@ impl<'a> Context<'a> {
                     &vendor_prefixes[0]
                 );
             }
-            if let Some(decode::ImportModule::Named(module)) = &import.module {
+            if let Some(decode::ImportModule::RawNamed(module)) = &import.module {
                 bail!(
                     "import of `{}` from `{}` has a polyfill of `{}` listed, but
                      vendor prefixes aren't supported when importing from modules",


### PR DESCRIPTION
With uninterpreted paths (not starting with `./`, `../`, or `/`), `ImportModule::Named` and `ImportModule::RawNamed` are equivalent (because the attributes are too). However, while the attributes should be designed for user convenience, the binary encoding should be optimized for simple processing. Attribute handling should be done purely in the `macro-support` crate. Therefore, it makes sense to normalize uninterpreted paths to `ImportModule::RawNamed` in the binary encoding.