### PR TITLE
Enforce strict attribute checking

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -94,7 +94,6 @@ macro_rules! methods {
     ($(($name:ident, $variant:ident($($contents:tt)*)),)*) => {
         $(methods!(@method $name, $variant($($contents)*));)*
 
-        #[cfg(feature = "strict-macro")]
         fn check_used(self) -> Result<(), Diagnostic> {
             // Account for the fact this method was called
             ATTRS.with(|state| state.checks.set(state.checks.get() + 1));
@@ -104,25 +103,12 @@ macro_rules! methods {
                 if used.get() {
                     continue
                 }
-                // The check below causes rustc to crash on powerpc64 platforms
-                // with an LLVM error. To avoid this, we instead use #[cfg()]
-                // and duplicate the function below. See #58516 for details.
-                /*if !cfg!(feature = "strict-macro") {
-                    continue
-                }*/
                 let span = match attr {
                     $(BindgenAttr::$variant(span, ..) => span,)*
                 };
                 errors.push(Diagnostic::span_error(*span, "unused #[wasm_bindgen] attribute"));
             }
             Diagnostic::from_vec(errors)
-        }
-
-        #[cfg(not(feature = "strict-macro"))]
-        fn check_used(self) -> Result<(), Diagnostic> {
-            // Account for the fact this method was called
-            ATTRS.with(|state| state.checks.set(state.checks.get() + 1));
-            Ok(())
         }
     };
 

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -25,5 +25,5 @@ quote = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"
-wasm-bindgen = { path = "../..", version = "0.2.82", features = ['strict-macro'] }
+wasm-bindgen = { path = "../..", version = "0.2.82" }
 wasm-bindgen-futures = { path = "../futures", version = "0.4.32" }


### PR DESCRIPTION
Enforce strict attribute checking as I proposed in #3038. Enabling features should not break code, because the crate enabling the feature and the crate whose code breaks may be unrelated. This change is also allowed without major update by the [SemVer Compatibility chapter](https://doc.rust-lang.org/cargo/reference/semver.html) of the Cargo book:

> Some changes are marked as "minor", even though they carry the potential risk of breaking a build. This is for situations where the potential is extremely low, and the potentially breaking code is unlikely to be written in idiomatic Rust, or is specifically discouraged from use.

I don't know whether the precedence is stronger in the "or" or in the "and". In any case, potentially breaking code is unlikely to be written in idiomatic Rust because the idiomatic tool for specifying information with no effect are comments, not attributes. And such code is specifically discouraged from use, because the `strict-macro` feature is a form of discourgement.