### PR TITLE
Put FontFace constructor to Immutable slice whitelist

### DIFF
--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -87,6 +87,8 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "writeBuffer",
         "writeTexture",
         // AudioBuffer
-        "copyToChannel", // TODO: Add another type's functions here. Leave a comment header with the type name
+        "copyToChannel",
+        // FontFace
+        "FontFace", // TODO: Add another type's functions here. Leave a comment header with the type name
     ])
 });


### PR DESCRIPTION
FontFace's constructor `new_with_u8_array` takes mutable slice which could be immutable slice. So I added it to whitelist.

It's my first time so I followed ImageData cases.