### PR TITLE
Update syn dependency version

### DIFF
--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -17,7 +17,7 @@ extra-traits = ["syn/extra-traits"]
 strict-macro = []
 
 [dependencies]
-syn = { version = '1.0.67', features = ['visit', 'full'] }
+syn = { version = '1.0.84', features = ['visit', 'full'] }
 quote = '1.0'
 proc-macro2 = "1.0"
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.83" }


### PR DESCRIPTION
The latest release uses the [`syn::parse_quoted_spanned!`](https://github.com/rustwasm/wasm-bindgen/commit/595b04b24aeadd467bbea01c75193d63c3ab6db5#diff-c3d389037d8eda9768f1fef9029fef9b723ac402a47bb782eb03e6ccddba800fR110)  macro that was added in [`1.0.84`](https://github.com/dtolnay/syn/releases/tag/1.0.84)