### PR TITLE
use console.error for error macro

### DIFF
--- a/examples/wasm-in-wasm-imports/src/lib.rs
+++ b/examples/wasm-in-wasm-imports/src/lib.rs
@@ -20,7 +20,7 @@ macro_rules! console_log {
 
 #[macro_use]
 macro_rules! console_error {
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
+    ($($t:tt)*) => (error(&format_args!($($t)*).to_string()))
 }
 
 const WASM: &[u8] = include_bytes!("native_add.wasm");


### PR DESCRIPTION
Looks like a copy-&-paste mistake to me. The symbol is already imported, just not being used.