### PR TITLE
codegen: Ignore `clippy::drop_non_drop` in generated free fn

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -214,6 +214,7 @@ impl ToTokens for ast::Struct {
             const #free_fn_const: () = {
                 #[no_mangle]
                 #[doc(hidden)]
+                #[allow(clippy::drop_non_drop)]
                 pub unsafe extern "C" fn #free_fn(ptr: u32) {
                     drop(<#name as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr));
                 }


### PR DESCRIPTION
Depending on the underlying types clippy can warn:

> call to `std::mem::drop` with a value that does not implement `Drop`. Dropping such a type only extends its contained lifetimes

However such a `drop` is ultimately harmless and in generated code it's easier to ignore it than to conditionally generate code with/without the drop.

This is an alternative to #2984 and is related to #2858.