### PR TITLE
Call main only once

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -331,7 +331,8 @@ impl Bindgen {
                 .context("failed getting Wasm module")?,
         };
 
-        self.threads
+        let thread_counter_addr = self
+            .threads
             .run(&mut module)
             .with_context(|| "failed to prepare module for threading")?;
 
@@ -363,6 +364,7 @@ impl Bindgen {
             &mut module,
             self.externref,
             self.wasm_interface_types,
+            thread_counter_addr,
             self.emit_start,
         )?;
 


### PR DESCRIPTION
As discussed in #3062, we use an atomic to only call the main function once.

For context, this change adjusts the `init` function to only call `main` or the function exported by `# [wasm_bindgen(start)]` only once even if `init` is called multiple times. This is important when using it in a context of spawning workers, otherwise each worker would call the `main` function again, which is probably unintended.

This might be considered a breaking change, because somebody out there might be relying on this behavior. But considering this is a nightly only feature (I believe), it should be fine?

The way I did this here is to re-use the thread counter. I had to somehow return it from `wasm_bindgen_threads_xform::Config::run()`, where it is created, so I created a `ThreadCounterAddr` that also has a method that is able to wrap the main function behind the atomic check.

I'm not really familiar with the code-base, but I did try my best to implement this as cleanly as possible, I'm open to suggestions of course.

Replaces #3062.