### PR TITLE
Call __destroy_into_raw everywhere a value is consumed

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -716,8 +716,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.assert_class(&val, &class);
             js.assert_not_moved(&val);
             let i = js.tmp();
-            js.prelude(&format!("var ptr{} = {}.ptr;", i, val));
-            js.prelude(&format!("{}.ptr = 0;", val));
+            js.prelude(&format!("var ptr{} = {}.__destroy_into_raw();", i, val));
             js.push(format!("ptr{}", i));
         }
 
@@ -736,8 +735,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.prelude(&format!("if (!isLikeNone({0})) {{", val));
             js.assert_class(&val, class);
             js.assert_not_moved(&val);
-            js.prelude(&format!("ptr{} = {}.ptr;", i, val));
-            js.prelude(&format!("{}.ptr = 0;", val));
+            js.prelude(&format!("ptr{} = {}.__destroy_into_raw();", i, val));
             js.prelude("}");
             js.push(format!("ptr{}", i));
         }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
@@ -107,6 +107,7 @@ pub fn execute(
     exec(
         Command::new("node")
             .env("NODE_PATH", env::join_paths(&path).unwrap())
+            .arg("--expose-gc")
             .args(&extra_node_args)
             .arg(&js_path)
             .args(args),

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -43,9 +43,10 @@ exports.js_exceptions = () => {
     let b = wasm.ClassesExceptions1.new();
     b.foo(b);
     assert.throws(() => b.bar(b), /recursive use of an object/);
-    // TODO: fails because it tries to borrow_mut, but the throw_str from the previous line doesn't clean up the
-    // RefMut so the object is left in a broken state
-    b.free();
+    // TODO: throws because it tries to borrow_mut, but the throw_str from the previous line doesn't clean up the
+    // RefMut so the object is left in a broken state.
+    // We still try to call free here so the object is removed from the FinalizationRegistry when weak refs are enabled.
+    assert.throws(() => b.free(), /recursive use of an object/);
 
     let c = wasm.ClassesExceptions1.new();
     let d = wasm.ClassesExceptions2.new();

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -43,6 +43,9 @@ exports.js_exceptions = () => {
     let b = wasm.ClassesExceptions1.new();
     b.foo(b);
     assert.throws(() => b.bar(b), /recursive use of an object/);
+    // TODO: fails because it tries to borrow_mut, but the throw_str from the previous line doesn't clean up the
+    // RefMut so the object is left in a broken state
+    b.free();
 
     let c = wasm.ClassesExceptions1.new();
     let d = wasm.ClassesExceptions2.new();

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -37,6 +37,7 @@ pub mod no_shims;
 pub mod node;
 pub mod option;
 pub mod optional_primitives;
+pub mod owned;
 pub mod result;
 pub mod result_jserror;
 pub mod rethrow;

--- a/tests/wasm/owned.js
+++ b/tests/wasm/owned.js
@@ -1,0 +1,13 @@
+const wasm = require("wasm-bindgen-test.js");
+
+exports.create_garbage = async function () {
+  for (let i = 0; i < 100; i++) {
+    new wasm.OwnedValue(1).add(new wasm.OwnedValue(2)).n();
+  }
+
+  if ("gc" in global) {
+    global.gc();
+  } else {
+    console.warn("test runner doesn't expose GC function");
+  }
+};

--- a/tests/wasm/owned.rs
+++ b/tests/wasm/owned.rs
@@ -30,6 +30,6 @@ extern "C" {
 }
 
 #[wasm_bindgen_test]
-fn test_create_garbageexceptions() {
+fn test_create_garbage() {
     create_garbage()
 }

--- a/tests/wasm/owned.rs
+++ b/tests/wasm/owned.rs
@@ -1,0 +1,35 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen]
+pub struct OwnedValue {
+    pub n: f64,
+}
+
+#[wasm_bindgen]
+impl OwnedValue {
+    #[wasm_bindgen(constructor)]
+    pub fn new(n: f64) -> Self {
+        Self { n }
+    }
+
+    pub fn add(self, other: OwnedValue) -> Self {
+        Self {
+            n: self.n + other.n,
+        }
+    }
+
+    pub fn n(self) -> f64 {
+        self.n
+    }
+}
+
+#[wasm_bindgen(module = "tests/wasm/owned.js")]
+extern "C" {
+    fn create_garbage();
+}
+
+#[wasm_bindgen_test]
+fn test_create_garbageexceptions() {
+    create_garbage()
+}


### PR DESCRIPTION
When using weak references the object needs to be unregistered from the finalization registry when we pass it to a Rust method that takes in the object by value. This wasn't happening, which meant that the finalizer was called despite the object already being freed. For me this manifested as a 'recursive use of an object detected which would lead to unsafe aliasing in rust' exception.