### PR TITLE
js-sys: Atomics support for BigInt64Array

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -827,6 +827,9 @@ pub mod Atomics {
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn add(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = add)]
+        pub fn add_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
+
         /// The static `Atomics.and()` method computes a bitwise AND with a given
         /// value at a given position in the array, and returns the old value
         /// at that position.
@@ -836,6 +839,9 @@ pub mod Atomics {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn and(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = and)]
+        pub fn and_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
         /// The static `Atomics.compareExchange()` method exchanges a given
         /// replacement value at a given position in the array, if a given expected
@@ -853,6 +859,14 @@ pub mod Atomics {
             replacement_value: i32,
         ) -> Result<i32, JsValue>;
 
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = compareExchange)]
+        pub fn compare_exchange_bigint(
+            typed_array: &JsValue,
+            index: u32,
+            expected_value: i64,
+            replacement_value: i64,
+        ) -> Result<i64, JsValue>;
+
         /// The static `Atomics.exchange()` method stores a given value at a given
         /// position in the array and returns the old value at that position.
         /// This atomic operation guarantees that no other write happens
@@ -861,6 +875,13 @@ pub mod Atomics {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn exchange(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = exchange)]
+        pub fn exchange_bigint(
+            typed_array: &JsValue,
+            index: u32,
+            value: i64,
+        ) -> Result<i64, JsValue>;
 
         /// The static `Atomics.isLockFree()` method is used to determine
         /// whether to use locks or atomic operations. It returns true,
@@ -877,6 +898,9 @@ pub mod Atomics {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn load(typed_array: &JsValue, index: u32) -> Result<i32, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = load)]
+        pub fn load_bigint(typed_array: &JsValue, index: i64) -> Result<i64, JsValue>;
 
         /// The static `Atomics.notify()` method notifies up some agents that
         /// are sleeping in the wait queue.
@@ -904,12 +928,18 @@ pub mod Atomics {
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn or(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = or)]
+        pub fn or_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
+
         /// The static `Atomics.store()` method stores a given value at the given
         /// position in the array and returns that value.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn store(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = store)]
+        pub fn store_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
         /// The static `Atomics.sub()` method substracts a given value at a
         /// given position in the array and returns the old value at that position.
@@ -919,6 +949,9 @@ pub mod Atomics {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn sub(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = sub)]
+        pub fn sub_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
         /// The static `Atomics.wait()` method verifies that a given
         /// position in an `Int32Array` still contains a given value
@@ -931,6 +964,13 @@ pub mod Atomics {
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn wait(typed_array: &Int32Array, index: u32, value: i32) -> Result<JsString, JsValue>;
 
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        pub fn wait_bigint(
+            typed_array: &Int32Array,
+            index: u32,
+            value: i64,
+        ) -> Result<JsString, JsValue>;
+
         /// Like `wait()`, but with timeout
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
@@ -939,6 +979,14 @@ pub mod Atomics {
             typed_array: &Int32Array,
             index: u32,
             value: i32,
+            timeout: f64,
+        ) -> Result<JsString, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        pub fn wait_with_timeout_bigint(
+            typed_array: &Int32Array,
+            index: u32,
+            value: i64,
             timeout: f64,
         ) -> Result<JsString, JsValue>;
 
@@ -951,6 +999,9 @@ pub mod Atomics {
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn xor(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
+
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = xor)]
+        pub fn xor_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
     }
 }
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -823,10 +823,20 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `add_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn add(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.add()` method adds a given value at a given
+        /// position in the array and returns the old value at that position.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = add)]
         pub fn add_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
@@ -836,10 +846,21 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `and_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn and(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.and()` method computes a bitwise AND with a given
+        /// value at a given position in the array, and returns the old value
+        /// at that position.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = and)]
         pub fn and_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
@@ -850,6 +871,8 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `compare_exchange_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = compareExchange)]
         pub fn compare_exchange(
@@ -859,6 +882,16 @@ pub mod Atomics {
             replacement_value: i32,
         ) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.compareExchange()` method exchanges a given
+        /// replacement value at a given position in the array, if a given expected
+        /// value equals the old value. It returns the old value at that position
+        /// whether it was equal to the expected value or not.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = compareExchange)]
         pub fn compare_exchange_bigint(
             typed_array: &JsValue,
@@ -872,10 +905,20 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `exchange_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn exchange(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.exchange()` method stores a given value at a given
+        /// position in the array and returns the old value at that position.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = exchange)]
         pub fn exchange_bigint(
             typed_array: &JsValue,
@@ -895,10 +938,18 @@ pub mod Atomics {
         /// The static `Atomics.load()` method returns a value at a given
         /// position in the array.
         ///
+        /// You should use `load_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn load(typed_array: &JsValue, index: u32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.load()` method returns a value at a given
+        /// position in the array.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = load)]
         pub fn load_bigint(typed_array: &JsValue, index: i64) -> Result<i64, JsValue>;
 
@@ -924,20 +975,38 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `or_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn or(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.or()` method computes a bitwise OR with a given value
+        /// at a given position in the array, and returns the old value at that position.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = or)]
         pub fn or_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
         /// The static `Atomics.store()` method stores a given value at the given
         /// position in the array and returns that value.
         ///
+        /// You should use `store_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn store(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.store()` method stores a given value at the given
+        /// position in the array and returns that value.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = store)]
         pub fn store_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
@@ -946,10 +1015,20 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `sub_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn sub(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.sub()` method substracts a given value at a
+        /// given position in the array and returns the old value at that position.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = sub)]
         pub fn sub_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
 
@@ -960,10 +1039,22 @@ pub mod Atomics {
         /// Note: This operation only works with a shared `Int32Array`
         /// and may not be allowed on the main thread.
         ///
+        /// You should use `wait_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn wait(typed_array: &Int32Array, index: u32, value: i32) -> Result<JsString, JsValue>;
 
+        /// The static `Atomics.wait()` method verifies that a given
+        /// position in an `Int32Array` still contains a given value
+        /// and if so sleeps, awaiting a wakeup or a timeout.
+        /// It returns a string which is either "ok", "not-equal", or "timed-out".
+        /// Note: This operation only works with a shared `Int32Array`
+        /// and may not be allowed on the main thread.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
         pub fn wait_bigint(
             typed_array: &Int32Array,
@@ -972,6 +1063,8 @@ pub mod Atomics {
         ) -> Result<JsString, JsValue>;
 
         /// Like `wait()`, but with timeout
+        ///
+        /// You should use `wait_with_timeout_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
@@ -982,6 +1075,11 @@ pub mod Atomics {
             timeout: f64,
         ) -> Result<JsString, JsValue>;
 
+        /// Like `wait()`, but with timeout
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
         pub fn wait_with_timeout_bigint(
             typed_array: &Int32Array,
@@ -996,10 +1094,21 @@ pub mod Atomics {
         /// This atomic operation guarantees that no other write happens
         /// until the modified value is written back.
         ///
+        /// You should use `xor_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn xor(typed_array: &JsValue, index: u32, value: i32) -> Result<i32, JsValue>;
 
+        /// The static `Atomics.xor()` method computes a bitwise XOR
+        /// with a given value at a given position in the array,
+        /// and returns the old value at that position.
+        /// This atomic operation guarantees that no other write happens
+        /// until the modified value is written back.
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = xor)]
         pub fn xor_bigint(typed_array: &JsValue, index: u32, value: i64) -> Result<i64, JsValue>;
     }


### PR DESCRIPTION
Fixes #3121 

This pr adds the following methods for manipulating BigInt64Array:
`Atomics::add_bigint`, `Atomics::and_bigint`, `Atomics::compare_exchange_bigint`, `Atomics::exchange_bigint`, `Atomics::load_bigint`, `Atomics::or_bigint`, `Atomics::store_bigint`, `Atomics::sub_bigint`, `Atomics::wait_bigint`, `Atomics::wait_with_timeout_bigint`, `Atomics::xor_bigint`