### PR TITLE
Add aarch64-apple-darwin binary to releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -329,7 +329,7 @@ jobs:
         name: dist_linux_aarch64_gnu
         path: "target/aarch64-unknown-linux-gnu/release/wasm*"
 
-  dist_macos:
+  dist_macos_x86_64:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -339,8 +339,23 @@ jobs:
         MACOSX_DEPLOYMENT_TARGET: 10.7
     - uses: actions/upload-artifact@v2
       with:
-        name: dist_macos
+        name: dist_macos_x86_64
         path: "target/release/wasm*"
+
+  dist_macos_aarch64:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add aarch64-apple-darwin
+    - run: |
+        cargo build --manifest-path crates/cli/Cargo.toml --target aarch64-apple-darwin --release
+      env:
+        MACOSX_DEPLOYMENT_TARGET: 10.7
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist_macos_aarch64
+        path: "target/aarch64-apple-darwin/release/wasm*"
 
   dist_windows:
     runs-on: windows-latest
@@ -392,7 +407,8 @@ jobs:
       - doc_book
       - dist_linux_x86_64_musl
       - dist_linux_aarch64_gnu
-      - dist_macos
+      - dist_macos_x86_64
+      - dist_macos_aarch64
       - dist_windows
       - build_examples
       - build_nightly
@@ -428,7 +444,8 @@ jobs:
         }
         mk x86_64-unknown-linux-musl dist_linux_x86_64_musl
         mk aarch64-unknown-linux-gnu dist_linux_aarch64_gnu
-        mk x86_64-apple-darwin dist_macos
+        mk x86_64-apple-darwin dist_macos_x86_64
+        mk aarch64-apple-darwin dist_macos_aarch64
         mk x86_64-pc-windows-msvc dist_windows
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
I tested the aarch64 artifact at https://github.com/rustwasm/wasm-bindgen/actions/runs/3366801582 and it worked on my machine.

See #2550