### PR TITLE
unused that must be used

### DIFF
--- a/examples/wasm-audio-worklet/src/gui.rs
+++ b/examples/wasm-audio-worklet/src/gui.rs
@@ -16,7 +16,10 @@ pub fn create_gui(params: &'static Params, ctx: AudioContext) {
     let listener = Closure::<dyn FnMut(_)>::new(move |_: web_sys::Event| {
         params.set_frequency(frequency.value().parse().unwrap());
         params.set_volume(volume.value().parse().unwrap());
-        ctx.resume().unwrap();
+        #[allow(unused_must_use)]
+        {
+            ctx.resume().unwrap();
+        }
     })
     .into_js_value();
 


### PR DESCRIPTION
- Silence the following warning in the wasm audio worklet example

unused `Promise` that must be used
`#[warn(unused_must_use)]` on by default