### PR TITLE
Add an option to keep LLD exports

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -30,6 +30,7 @@ pub struct Bindgen {
     typescript: bool,
     omit_imports: bool,
     demangle: bool,
+    keep_lld_exports: bool,
     keep_debug: bool,
     remove_name_section: bool,
     remove_producers_section: bool,
@@ -107,6 +108,7 @@ impl Bindgen {
             typescript: false,
             omit_imports: false,
             demangle: true,
+            keep_lld_exports: false,
             keep_debug: false,
             remove_name_section: false,
             remove_producers_section: false,
@@ -267,6 +269,11 @@ impl Bindgen {
         self
     }
 
+    pub fn keep_lld_exports(&mut self, keep_lld_exports: bool) -> &mut Bindgen {
+        self.keep_lld_exports = keep_lld_exports;
+        self
+    }
+
     pub fn keep_debug(&mut self, keep_debug: bool) -> &mut Bindgen {
         self.keep_debug = keep_debug;
         self
@@ -340,7 +347,9 @@ impl Bindgen {
         if self.demangle {
             demangle(&mut module);
         }
-        unexported_unused_lld_things(&mut module);
+        if !self.keep_lld_exports {
+            unexported_unused_lld_things(&mut module);
+        }
 
         // We're making quite a few changes, list ourselves as a producer.
         module

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -31,6 +31,7 @@ Options:
     --omit-imports               Don't emit imports in generated JavaScript
     --debug                      Include otherwise-extraneous debug checks in output
     --no-demangle                Don't demangle Rust symbol names
+    --keep-lld-exports           Keep exports synthesized by LLD
     --keep-debug                 Keep debug sections in wasm files
     --remove-name-section        Remove the debugging `name` section of the file
     --remove-producers-section   Remove the telemetry `producers` section
@@ -64,6 +65,7 @@ struct Args {
     flag_remove_producers_section: bool,
     flag_weak_refs: Option<bool>,
     flag_reference_types: Option<bool>,
+    flag_keep_lld_exports: bool,
     flag_keep_debug: bool,
     flag_encode_into: Option<String>,
     flag_target: Option<String>,
@@ -115,6 +117,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .no_modules(args.flag_no_modules)?
         .debug(args.flag_debug)
         .demangle(!args.flag_no_demangle)
+        .keep_lld_exports(args.flag_keep_lld_exports)
         .keep_debug(args.flag_keep_debug)
         .remove_name_section(args.flag_remove_name_section)
         .remove_producers_section(args.flag_remove_producers_section)

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -68,6 +68,11 @@ errors, but this output isn't intended to be shipped to production.
 When post-processing the `.wasm` binary, do not demangle Rust symbols in the
 "names" custom section.
 
+### `--keep-lld-exports`
+
+When post-processing the `.wasm` binary, do not remove exports that are
+synthesized by Rust's linker, LLD.
+
 ### `--keep-debug`
 
 When post-processing the `.wasm` binary, do not strip DWARF debug info custom


### PR DESCRIPTION
We are looking to use `wasm-bindgen` for penrose/penrose#1092, but we need the `__indirect_function_table` export. This PR adds a CLI flag to not remove that export from the binary, along with the `__heap_base` and `__data_end` exports which are also currently removed by the `unexported_unused_lld_things` function.