### PR TITLE
Undeprecate Safari WebIDL

### DIFF
--- a/crates/web-sys/src/features/gen_AudioScheduledSourceNode.rs
+++ b/crates/web-sys/src/features/gen_AudioScheduledSourceNode.rs
@@ -10,9 +10,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioScheduledSourceNode)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioScheduledSourceNode`*"]
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     pub type AudioScheduledSourceNode;
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     # [wasm_bindgen (structural , method , getter , js_class = "AudioScheduledSourceNode" , js_name = onended)]
     #[doc = "Getter for the `onended` field of this object."]
     #[doc = ""]
@@ -20,7 +18,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioScheduledSourceNode`*"]
     pub fn onended(this: &AudioScheduledSourceNode) -> Option<::js_sys::Function>;
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     # [wasm_bindgen (structural , method , setter , js_class = "AudioScheduledSourceNode" , js_name = onended)]
     #[doc = "Setter for the `onended` field of this object."]
     #[doc = ""]
@@ -28,7 +25,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioScheduledSourceNode`*"]
     pub fn set_onended(this: &AudioScheduledSourceNode, value: Option<&::js_sys::Function>);
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     # [wasm_bindgen (catch , method , structural , js_class = "AudioScheduledSourceNode" , js_name = start)]
     #[doc = "The `start()` method."]
     #[doc = ""]
@@ -36,7 +32,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioScheduledSourceNode`*"]
     pub fn start(this: &AudioScheduledSourceNode) -> Result<(), JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     # [wasm_bindgen (catch , method , structural , js_class = "AudioScheduledSourceNode" , js_name = start)]
     #[doc = "The `start()` method."]
     #[doc = ""]
@@ -44,7 +39,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioScheduledSourceNode`*"]
     pub fn start_with_when(this: &AudioScheduledSourceNode, when: f64) -> Result<(), JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     # [wasm_bindgen (catch , method , structural , js_class = "AudioScheduledSourceNode" , js_name = stop)]
     #[doc = "The `stop()` method."]
     #[doc = ""]
@@ -52,7 +46,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioScheduledSourceNode`*"]
     pub fn stop(this: &AudioScheduledSourceNode) -> Result<(), JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use parent class methods instead")]
     # [wasm_bindgen (catch , method , structural , js_class = "AudioScheduledSourceNode" , js_name = stop)]
     #[doc = "The `stop()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_BaseAudioContext.rs
+++ b/crates/web-sys/src/features/gen_BaseAudioContext.rs
@@ -10,9 +10,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`*"]
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     pub type BaseAudioContext;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AudioDestinationNode")]
     # [wasm_bindgen (structural , method , getter , js_class = "BaseAudioContext" , js_name = destination)]
     #[doc = "Getter for the `destination` field of this object."]
@@ -21,7 +19,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioDestinationNode`, `BaseAudioContext`*"]
     pub fn destination(this: &BaseAudioContext) -> AudioDestinationNode;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (structural , method , getter , js_class = "BaseAudioContext" , js_name = sampleRate)]
     #[doc = "Getter for the `sampleRate` field of this object."]
     #[doc = ""]
@@ -29,7 +26,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`*"]
     pub fn sample_rate(this: &BaseAudioContext) -> f32;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (structural , method , getter , js_class = "BaseAudioContext" , js_name = currentTime)]
     #[doc = "Getter for the `currentTime` field of this object."]
     #[doc = ""]
@@ -37,7 +33,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`*"]
     pub fn current_time(this: &BaseAudioContext) -> f64;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AudioListener")]
     # [wasm_bindgen (structural , method , getter , js_class = "BaseAudioContext" , js_name = listener)]
     #[doc = "Getter for the `listener` field of this object."]
@@ -46,7 +41,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioListener`, `BaseAudioContext`*"]
     pub fn listener(this: &BaseAudioContext) -> AudioListener;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AudioContextState")]
     # [wasm_bindgen (structural , method , getter , js_class = "BaseAudioContext" , js_name = state)]
     #[doc = "Getter for the `state` field of this object."]
@@ -55,7 +49,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioContextState`, `BaseAudioContext`*"]
     pub fn state(this: &BaseAudioContext) -> AudioContextState;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AudioWorklet")]
     # [wasm_bindgen (structural , catch , method , getter , js_class = "BaseAudioContext" , js_name = audioWorklet)]
     #[doc = "Getter for the `audioWorklet` field of this object."]
@@ -64,7 +57,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioWorklet`, `BaseAudioContext`*"]
     pub fn audio_worklet(this: &BaseAudioContext) -> Result<AudioWorklet, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (structural , method , getter , js_class = "BaseAudioContext" , js_name = onstatechange)]
     #[doc = "Getter for the `onstatechange` field of this object."]
     #[doc = ""]
@@ -72,7 +64,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`*"]
     pub fn onstatechange(this: &BaseAudioContext) -> Option<::js_sys::Function>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (structural , method , setter , js_class = "BaseAudioContext" , js_name = onstatechange)]
     #[doc = "Setter for the `onstatechange` field of this object."]
     #[doc = ""]
@@ -80,7 +71,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`*"]
     pub fn set_onstatechange(this: &BaseAudioContext, value: Option<&::js_sys::Function>);
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AnalyserNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createAnalyser)]
     #[doc = "The `createAnalyser()` method."]
@@ -89,7 +79,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AnalyserNode`, `BaseAudioContext`*"]
     pub fn create_analyser(this: &BaseAudioContext) -> Result<AnalyserNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "BiquadFilterNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createBiquadFilter)]
     #[doc = "The `createBiquadFilter()` method."]
@@ -98,7 +87,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `BiquadFilterNode`*"]
     pub fn create_biquad_filter(this: &BaseAudioContext) -> Result<BiquadFilterNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AudioBuffer")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createBuffer)]
     #[doc = "The `createBuffer()` method."]
@@ -112,7 +100,6 @@ extern "C" {
         length: u32,
         sample_rate: f32,
     ) -> Result<AudioBuffer, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "AudioBufferSourceNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createBufferSource)]
     #[doc = "The `createBufferSource()` method."]
@@ -121,7 +108,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`, `BaseAudioContext`*"]
     pub fn create_buffer_source(this: &BaseAudioContext) -> Result<AudioBufferSourceNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ChannelMergerNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createChannelMerger)]
     #[doc = "The `createChannelMerger()` method."]
@@ -130,7 +116,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `ChannelMergerNode`*"]
     pub fn create_channel_merger(this: &BaseAudioContext) -> Result<ChannelMergerNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ChannelMergerNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createChannelMerger)]
     #[doc = "The `createChannelMerger()` method."]
@@ -142,7 +127,6 @@ extern "C" {
         this: &BaseAudioContext,
         number_of_inputs: u32,
     ) -> Result<ChannelMergerNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ChannelSplitterNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createChannelSplitter)]
     #[doc = "The `createChannelSplitter()` method."]
@@ -152,7 +136,6 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `ChannelSplitterNode`*"]
     pub fn create_channel_splitter(this: &BaseAudioContext)
         -> Result<ChannelSplitterNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ChannelSplitterNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createChannelSplitter)]
     #[doc = "The `createChannelSplitter()` method."]
@@ -164,7 +147,6 @@ extern "C" {
         this: &BaseAudioContext,
         number_of_outputs: u32,
     ) -> Result<ChannelSplitterNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ConstantSourceNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createConstantSource)]
     #[doc = "The `createConstantSource()` method."]
@@ -173,7 +155,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `ConstantSourceNode`*"]
     pub fn create_constant_source(this: &BaseAudioContext) -> Result<ConstantSourceNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ConvolverNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createConvolver)]
     #[doc = "The `createConvolver()` method."]
@@ -182,7 +163,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `ConvolverNode`*"]
     pub fn create_convolver(this: &BaseAudioContext) -> Result<ConvolverNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "DelayNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createDelay)]
     #[doc = "The `createDelay()` method."]
@@ -191,7 +171,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `DelayNode`*"]
     pub fn create_delay(this: &BaseAudioContext) -> Result<DelayNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "DelayNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createDelay)]
     #[doc = "The `createDelay()` method."]
@@ -203,7 +182,6 @@ extern "C" {
         this: &BaseAudioContext,
         max_delay_time: f64,
     ) -> Result<DelayNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "DynamicsCompressorNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createDynamicsCompressor)]
     #[doc = "The `createDynamicsCompressor()` method."]
@@ -214,7 +192,6 @@ extern "C" {
     pub fn create_dynamics_compressor(
         this: &BaseAudioContext,
     ) -> Result<DynamicsCompressorNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "GainNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createGain)]
     #[doc = "The `createGain()` method."]
@@ -223,7 +200,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `GainNode`*"]
     pub fn create_gain(this: &BaseAudioContext) -> Result<GainNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "IirFilterNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createIIRFilter)]
     #[doc = "The `createIIRFilter()` method."]
@@ -236,7 +212,6 @@ extern "C" {
         feedforward: &::wasm_bindgen::JsValue,
         feedback: &::wasm_bindgen::JsValue,
     ) -> Result<IirFilterNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "OscillatorNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createOscillator)]
     #[doc = "The `createOscillator()` method."]
@@ -245,7 +220,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `OscillatorNode`*"]
     pub fn create_oscillator(this: &BaseAudioContext) -> Result<OscillatorNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "PannerNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createPanner)]
     #[doc = "The `createPanner()` method."]
@@ -254,7 +228,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `PannerNode`*"]
     pub fn create_panner(this: &BaseAudioContext) -> Result<PannerNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "PeriodicWave")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createPeriodicWave)]
     #[doc = "The `createPeriodicWave()` method."]
@@ -267,7 +240,6 @@ extern "C" {
         real: &mut [f32],
         imag: &mut [f32],
     ) -> Result<PeriodicWave, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(all(feature = "PeriodicWave", feature = "PeriodicWaveConstraints",))]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createPeriodicWave)]
     #[doc = "The `createPeriodicWave()` method."]
@@ -281,7 +253,6 @@ extern "C" {
         imag: &mut [f32],
         constraints: &PeriodicWaveConstraints,
     ) -> Result<PeriodicWave, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ScriptProcessorNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createScriptProcessor)]
     #[doc = "The `createScriptProcessor()` method."]
@@ -291,7 +262,6 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `ScriptProcessorNode`*"]
     pub fn create_script_processor(this: &BaseAudioContext)
         -> Result<ScriptProcessorNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ScriptProcessorNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createScriptProcessor)]
     #[doc = "The `createScriptProcessor()` method."]
@@ -303,7 +273,6 @@ extern "C" {
         this: &BaseAudioContext,
         buffer_size: u32,
     ) -> Result<ScriptProcessorNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ScriptProcessorNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createScriptProcessor)]
     #[doc = "The `createScriptProcessor()` method."]
@@ -316,7 +285,6 @@ extern "C" {
         buffer_size: u32,
         number_of_input_channels: u32,
     ) -> Result<ScriptProcessorNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "ScriptProcessorNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createScriptProcessor)]
     #[doc = "The `createScriptProcessor()` method."]
@@ -330,7 +298,6 @@ extern "C" {
         number_of_input_channels: u32,
         number_of_output_channels: u32,
     ) -> Result<ScriptProcessorNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "StereoPannerNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createStereoPanner)]
     #[doc = "The `createStereoPanner()` method."]
@@ -339,7 +306,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `StereoPannerNode`*"]
     pub fn create_stereo_panner(this: &BaseAudioContext) -> Result<StereoPannerNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     #[cfg(feature = "WaveShaperNode")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = createWaveShaper)]
     #[doc = "The `createWaveShaper()` method."]
@@ -348,7 +314,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `BaseAudioContext`, `WaveShaperNode`*"]
     pub fn create_wave_shaper(this: &BaseAudioContext) -> Result<WaveShaperNode, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = decodeAudioData)]
     #[doc = "The `decodeAudioData()` method."]
     #[doc = ""]
@@ -359,7 +324,6 @@ extern "C" {
         this: &BaseAudioContext,
         audio_data: &::js_sys::ArrayBuffer,
     ) -> Result<::js_sys::Promise, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = decodeAudioData)]
     #[doc = "The `decodeAudioData()` method."]
     #[doc = ""]
@@ -371,7 +335,6 @@ extern "C" {
         audio_data: &::js_sys::ArrayBuffer,
         success_callback: &::js_sys::Function,
     ) -> Result<::js_sys::Promise, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = decodeAudioData)]
     #[doc = "The `decodeAudioData()` method."]
     #[doc = ""]
@@ -384,7 +347,6 @@ extern "C" {
         success_callback: &::js_sys::Function,
         error_callback: &::js_sys::Function,
     ) -> Result<::js_sys::Promise, JsValue>;
-    #[deprecated(note = "doesn't exist in Safari, use `AudioContext` instead now")]
     # [wasm_bindgen (catch , method , structural , js_class = "BaseAudioContext" , js_name = resume)]
     #[doc = "The `resume()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/AudioScheduledSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioScheduledSourceNode.webidl
@@ -10,7 +10,6 @@
  * liability, trademark and document use rules apply.
  */
 
-[RustDeprecated="doesn't exist in Safari, use parent class methods instead"]
 interface AudioScheduledSourceNode : AudioNode {
 };
 

--- a/crates/web-sys/webidls/enabled/BaseAudioContext.webidl
+++ b/crates/web-sys/webidls/enabled/BaseAudioContext.webidl
@@ -19,7 +19,6 @@ enum AudioContextState {
     "closed"
 };
 
-[RustDeprecated="doesn't exist in Safari, use `AudioContext` instead now"]
 interface BaseAudioContext : EventTarget {
 };
 


### PR DESCRIPTION
[Four years ago](https://github.com/rustwasm/wasm-bindgen/commit/bb7271aa4381120bc45cbe74500e9f72f7162da3), we manually deprecated `BaseAudioContext` and `AudioScheduledSourceNode` because Safari did not support them. The stable version of Safari at the time was 12.0 (September 2018). The current stable version of Safari is 16.1 (October 2022). Safari has introduced support for [`AudioScheduledSourceNode` in version 14.0](https://developer.mozilla.org/en-US/docs/Web/API/AudioScheduledSourceNode#browser_compatibility) (September 2020), and [`BaseAudioContext` in version 14.1](https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext#browser_compatibility) (April 2021).