### PR TITLE
Get rid of the circular dependency when targeting ES modules

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -437,10 +437,6 @@ impl<'a> Context<'a> {
             | OutputMode::Node {
                 experimental_modules: true,
             } => {
-                imports.push_str(&format!(
-                    "import * as wasm from './{}_bg.wasm';\n",
-                    module_name
-                ));
                 for (id, js) in crate::sorted_iter(&self.wasm_import_definitions) {
                     let import = self.module.imports.get_mut(*id);
                     import.module = format!("./{}_bg.js", module_name);
@@ -458,6 +454,13 @@ impl<'a> Context<'a> {
                         footer.push_str(";\n");
                     }
                 }
+
+                self.imports_post.push_str("\
+                    let wasm;
+                    export function __wbg_set_wasm(val) {
+                        wasm = val;
+                    }
+                ");
 
                 if needs_manual_start {
                     start = Some("\nwasm.__wbindgen_start();\n".to_string());

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -500,20 +500,23 @@ impl<'a> Context<'a> {
             !self.config.mode.uses_es_modules() || js.is_empty(),
             "ES modules require imports to be at the start of the file"
         );
-        js.push_str(&imports);
-        js.push_str("\n");
-        js.push_str(&self.imports_post);
-        js.push_str("\n");
+
+        let mut push_with_newline = |s| {
+            js.push_str(s);
+            if !s.is_empty() {
+                js.push('\n');
+            }
+        };
+
+        push_with_newline(&imports);
+        push_with_newline(&self.imports_post);
 
         // Emit all our exports from this module
-        js.push_str(&self.globals);
-        js.push_str("\n");
+        push_with_newline(&self.globals);
 
         // Generate the initialization glue, if there was any
-        js.push_str(&init_js);
-        js.push_str("\n");
-        js.push_str(&footer);
-        js.push_str("\n");
+        push_with_newline(&init_js);
+        push_with_newline(&footer);
         if self.config.mode.no_modules() {
             js.push_str("})();\n");
         }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -455,12 +455,14 @@ impl<'a> Context<'a> {
                     }
                 }
 
-                self.imports_post.push_str("\
+                self.imports_post.push_str(
+                    "\
                     let wasm;
                     export function __wbg_set_wasm(val) {
                         wasm = val;
                     }
-                ");
+                    ",
+                );
 
                 if needs_manual_start {
                     start = Some("\nwasm.__wbindgen_start();\n".to_string());

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -755,8 +755,11 @@ impl Output {
             write(
                 &js_path,
                 format!(
-                    "import * as wasm from \"./{}.wasm\";\nexport * from \"./{}\";{}",
-                    wasm_name, js_name, start
+                    "import * as wasm from \"./{wasm_name}.wasm\";
+import {{ __wbg_set_wasm }} from \"./{js_name}\";
+__wbg_set_wasm(wasm);
+export * from \"./{js_name}\";
+{start}"
                 ),
             )?;
 

--- a/crates/cli/tests/reference/add.js
+++ b/crates/cli/tests/reference/add.js
@@ -1,4 +1,7 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
 
 /**
 * @param {number} a

--- a/crates/cli/tests/reference/anyref-empty.js
+++ b/crates/cli/tests/reference/anyref-empty.js
@@ -1,4 +1,8 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
 
 export function __wbindgen_init_externref_table() {
     const table = wasm.__wbindgen_export_0;

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -1,4 +1,8 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
 
 const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 

--- a/crates/cli/tests/reference/anyref-nop.js
+++ b/crates/cli/tests/reference/anyref-nop.js
@@ -1,4 +1,7 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
 
 /**
 */

--- a/crates/cli/tests/reference/empty.js
+++ b/crates/cli/tests/reference/empty.js
@@ -1,2 +1,5 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
 

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -1,4 +1,8 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
 
 const heap = new Array(32).fill(undefined);
 

--- a/crates/cli/tests/reference/nop.js
+++ b/crates/cli/tests/reference/nop.js
@@ -1,4 +1,7 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
 
 /**
 */

--- a/crates/cli/tests/reference/result-string.js
+++ b/crates/cli/tests/reference/result-string.js
@@ -1,4 +1,8 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
 
 const heap = new Array(32).fill(undefined);
 

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -1,4 +1,8 @@
-import * as wasm from './reference_test_bg.wasm';
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
 
 const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 


### PR DESCRIPTION
Fixes #3102
Fixes #3149

I've changed the `*_bg.js` file to not import from the wasm module, eliminating the circular dependency between them.

It begins with an undefined `let wasm` which gets initialized by the user-facing JS file before calling `__wbindgen_start`, by calling an exported function `__wbg_set_wasm` that sets `wasm`.