### PR TITLE
Show conversion to JsValue

### DIFF
--- a/guide/src/reference/attributes/on-rust-exports/typescript_type.md
+++ b/guide/src/reference/attributes/on-rust-exports/typescript_type.md
@@ -29,7 +29,8 @@ pub struct TextStyle {
 #[wasm_bindgen]
 impl TextStyle {
     #[wasm_bindgen(constructor)]
-    pub fn new(_i: ITextStyle) -> TextStyle {
+    pub fn new(i: ITextStyle) -> TextStyle {
+        let _js_value: JsValue = i.into();
         // parse JsValue
         TextStyle::default()
     }


### PR DESCRIPTION
Possible minor documentation improvement ([link](https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-rust-exports/typescript_type.html#typescript_type)). It was not immediately clear to me how to go from `ITextStyle` to the parsed object, and it's difficult to see how the macro affects the struct. I can add the parsing with `into_serde` too, but that might be too specific?