### PR TITLE
Increase interpreter buffer memory size

### DIFF
--- a/crates/wasm-interpreter/src/lib.rs
+++ b/crates/wasm-interpreter/src/lib.rs
@@ -72,7 +72,7 @@ impl Interpreter {
         // (the LLVM call stack, now the wasm stack). To handle that let's give
         // our selves a little bit of memory and set the stack pointer (global
         // 0) to the top.
-        ret.mem = vec![0; 0x100];
+        ret.mem = vec![0; 0x400];
         ret.sp = ret.mem.len() as i32;
 
         // Figure out where the `__wbindgen_describe` imported function is, if

--- a/crates/wasm-interpreter/tests/smoke.rs
+++ b/crates/wasm-interpreter/tests/smoke.rs
@@ -87,7 +87,8 @@ fn globals() {
             (export "foo" (func $foo))
         )
     "#;
-    interpret(wat, "foo", Some(&[256]));
+    // __wbindgen_describe is called with a global - in Frame.eval we assume all access to globals is the stack pointer
+    interpret(wat, "foo", Some(&[1024]));
 }
 
 #[test]


### PR DESCRIPTION
Long typescript types don't fit into the buffer, causing stack pointer to underflow and wrap to numbers around `usize::MAX`

Fixes #2846