### PR TITLE
Don't emit BigInt literals

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -795,8 +795,12 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             }
             js.push(format!("!isLikeNone({0})", val));
             js.push(format!(
-                "isLikeNone({val}) ? 0{n} : {val}",
-                n = if *ty == ValType::I64 { "n" } else { "" }
+                "isLikeNone({val}) ? {zero} : {val}",
+                zero = if *ty == ValType::I64 {
+                    "BigInt(0)"
+                } else {
+                    "0"
+                }
             ));
         }
 


### PR DESCRIPTION
This PR replaces `wasm-bindgen`'s emitted [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) literals with calls to the [`BigInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt) constructor, to fix errors when bundling with [esbuild](https://esbuild.github.io/) in [Vite](https://vitejs.dev/).

<details>
<summary><b>Click here to expand this to see detailed repro steps.</b></summary>

1. Run this command:

   ```sh
   yarn create vite
   ```

   Call the project `wasm-bindgen-bigint-vite-example`, and select the "Vanilla" framework with the "JavaScript" variant. Then `cd` into the project directory and run `yarn`.

1. Create `Cargo.toml` with these contents:

   ```toml
   [package]
   edition = "2021"
   name = "wasm-bindgen-bigint-vite-example"
   version = "0.0.0"

   [lib]
   crate-type = ["cdylib"]

   [dependencies]
   serde = {version = "1", features = ["derive"]}
   serde-wasm-bindgen = "0.4"
   wasm-bindgen = "0.2"
   ```

1. Create `src/lib.rs` with these contents:

   ```rust
   use wasm_bindgen::prelude::wasm_bindgen;

   #[wasm_bindgen]
   pub fn foo(x: Vec<i64>) -> i64 {
       x.iter().sum()
   }
   ```

1. Create `build.sh` with these contents:

   ```sh
   cargo build --target=wasm32-unknown-unknown --release
   wasm-bindgen --target=web --out-dir=wbg target/wasm32-unknown-unknown/release/wasm_bindgen_bigint_vite_example.wasm
   yarn build
   ```

1. Replace `counter.js` with these contents:

   ```js
   import init, { foo } from './wbg/wasm_bindgen_bigint_vite_example';

   export async function setupCounter(element) {
     await init();
     element.innerHTML = foo([BigInt(5), BigInt(8)]);
   }
   ```

1. Run these commands:

   ```sh
   sh build.sh
   yarn dev
   ```

   Observe that the first finishes without error. Click the http://localhost:5173/ link given by the second, and observe that the page says "13".

1. Replace `src/lib.rs` with these contents:

   ```rust
   use wasm_bindgen::{prelude::wasm_bindgen, JsValue};

   #[wasm_bindgen]
   pub fn foo(o: JsValue) -> i64 {
       let xs: Vec<i64> = serde_wasm_bindgen::from_value(o).unwrap();
       xs.iter().sum()
   }
   ```

1. Run this command again:

   ```sh
   sh build.sh
   ```

   Observe that it gives the following error:

   ```
   [vite:esbuild-transpile] Transform failed with 1 error:
   assets/index.baa0f021.js:431:63: ERROR: Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)

   Big integer literals are not available in the configured target environment ("chrome87", "edge88", "es2020", "firefox78", "safari13" + 2 overrides)
   429|          const v = getObject(arg1);
   430|          const ret = typeof(v) === 'bigint' ? v : undefined;
   431|          getBigInt64Memory0()[arg0 / 8 + 1] = isLikeNone(ret) ? 0n : ret;
      |                                                                 ^
   432|          getInt32Memory0()[arg0 / 4 + 0] = !isLikeNone(ret);
   433|      };
   ```

1. Check out this `wasm-bindgen` PR, and install it via this command:

   ```sh
   cargo install --path crates/cli
   ```

1. Run these commands again:

   ```sh
   sh build.sh
   yarn dev
   ```

   Observe that once again the first finishes without error, and the http://localhost:5173/ page given by the second still says "13".

</details>