### PR TITLE
Fix automatic .wasm file detection with no-modules output

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -378,6 +378,15 @@ impl<'a> Context<'a> {
             // function.
             OutputMode::NoModules { global } => {
                 js.push_str("const __exports = {};\n");
+                js.push_str("let script_src;\n");
+                js.push_str(
+                    "\
+                    if (typeof document === 'undefined') {
+                        script_src = location.href;
+                    } else {
+                        script_src = document.currentScript.src;
+                    }\n",
+                );
                 js.push_str("let wasm;\n");
                 init = self.gen_init(needs_manual_start, None)?;
                 footer.push_str(&format!(
@@ -712,13 +721,7 @@ impl<'a> Context<'a> {
                 ),
                 OutputMode::NoModules { .. } => "\
                     if (typeof input === 'undefined') {
-                        let src;
-                        if (typeof document === 'undefined') {
-                            src = location.href;
-                        } else {
-                            src = document.currentScript.src;
-                        }
-                        input = src.replace(/\\.js$/, '_bg.wasm');
+                        input = script_src.replace(/\\.js$/, '_bg.wasm');
                     }"
                 .to_string(),
                 _ => "".to_string(),

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -260,15 +260,17 @@ fn default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
+    if (typeof document === 'undefined') {
+        script_src = location.href;
+    } else {
+        script_src = document.currentScript.src;
+    }",
+    ));
+    assert!(contents.contains(
+        "\
     async function init(input) {
         if (typeof input === 'undefined') {
-            let src;
-            if (typeof document === 'undefined') {
-                src = location.href;
-            } else {
-                src = document.currentScript.src;
-            }
-            input = src.replace(/\\.js$/, '_bg.wasm');
+            input = script_src.replace(/\\.js$/, '_bg.wasm');
         }",
     ));
 }


### PR DESCRIPTION
Currently with no-modules output the line `document.currentScript.src` will always return `null`, because it only works during processing of the script. This fixes the issue by caching `document.currentScript.src` beforehand.

Fixes #2502.