### PR TITLE
Documentation extensions for ArrayBuffer and DataView

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -510,7 +510,7 @@ extern "C" {
     /// The `ArrayBuffer` object is used to represent a generic,
     /// fixed-length raw binary data buffer. You cannot directly
     /// manipulate the contents of an `ArrayBuffer`; instead, you
-    /// create one of the typed array objects or a `DataView` object
+    /// create one of the typed array objects ([Uint8Array] etc.) or a `DataView` object
     /// which represents the buffer in a specific format, and use that
     /// to read and write the contents of the buffer.
     ///
@@ -818,6 +818,12 @@ impl fmt::Debug for Boolean {
 // DataView
 #[wasm_bindgen]
 extern "C" {
+    /// An accessor to binary data stored inside an [ArrayBuffer]
+    ///
+    /// For statically typed views on the same buffer (which also offer tools for interacting with
+    /// Rust slices), see [Uint8Array], [Int64Array], [Float32Array] and so on. Beware that
+    /// `Uint8Array::new(&my_data_view)` *not* contain the full memory area; using the underlying
+    /// ArrayBuffer (`Uint8Array::new(&my_data_view.buffer())`) does.
     #[wasm_bindgen(extends = Object, typescript_type = "DataView")]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type DataView;


### PR DESCRIPTION
Closes: https://github.com/rustwasm/wasm-bindgen/issues/3170

---

* "the typed objects" previously could not be resolved by a user unfamiliar with the library. Giving one example should enable a human user to generalize; if there could be some shared category (module maybe) for the typed views, that could be linked instead.
* DataView had no pointer at all to these alternatives. It is worth adding one because a DataView is often the type browsers use (eg. the `read_characteristic` future resolves into one), so users will wind up here rather than at the buffer entry page (where they would take a conscious choice for build-time or call-time typing).
* The Uint8Array not being creatable from a `&DataView` but only from its `.buffer()` may be a bug or a feature, I really can't tell. The current text might read as if it's a bug, but if you could tell me how this is a feature, I'd be happy to rephrase.