### PR TITLE
Improve error messages for invalidly invoked closures

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -571,7 +571,7 @@ macro_rules! doit {
                     $($var: <$var as FromWasmAbi>::Abi),*
                 ) -> <R as ReturnWasmAbi>::Abi {
                     if a == 0 {
-                        throw_str("closure invoked recursively or destroyed already");
+                        throw_str("closure invoked after being dropped");
                     }
                     // Make sure all stack variables are converted before we
                     // convert `ret` as it may throw (for `Result`, for
@@ -623,7 +623,7 @@ macro_rules! doit {
                     $($var: <$var as FromWasmAbi>::Abi),*
                 ) -> <R as ReturnWasmAbi>::Abi {
                     if a == 0 {
-                        throw_str("closure invoked recursively or destroyed already");
+                        throw_str("closure invoked recursively or after being dropped");
                     }
                     // Make sure all stack variables are converted before we
                     // convert `ret` as it may throw (for `Result`, for
@@ -759,7 +759,7 @@ where
             arg: <A as RefFromWasmAbi>::Abi,
         ) -> <R as ReturnWasmAbi>::Abi {
             if a == 0 {
-                throw_str("closure invoked recursively or destroyed already");
+                throw_str("closure invoked after being dropped");
             }
             // Make sure all stack variables are converted before we
             // convert `ret` as it may throw (for `Result`, for
@@ -802,7 +802,7 @@ where
             arg: <A as RefFromWasmAbi>::Abi,
         ) -> <R as ReturnWasmAbi>::Abi {
             if a == 0 {
-                throw_str("closure invoked recursively or destroyed already");
+                throw_str("closure invoked recursively or after being dropped");
             }
             // Make sure all stack variables are converted before we
             // convert `ret` as it may throw (for `Result`, for

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -29,7 +29,7 @@ macro_rules! stack_closures {
             $($var: <$var as FromWasmAbi>::Abi),*
         ) -> <R as ReturnWasmAbi>::Abi {
             if a == 0 {
-                throw_str("closure invoked recursively or destroyed already");
+                throw_str("closure invoked after being dropped");
             }
             // Scope all local variables before we call `return_abi` to
             // ensure they're all destroyed as `return_abi` may throw
@@ -78,7 +78,7 @@ macro_rules! stack_closures {
             $($var: <$var as FromWasmAbi>::Abi),*
         ) -> <R as ReturnWasmAbi>::Abi {
             if a == 0 {
-                throw_str("closure invoked recursively or destroyed already");
+                throw_str("closure invoked recursively or after being dropped");
             }
             // Scope all local variables before we call `return_abi` to
             // ensure they're all destroyed as `return_abi` may throw
@@ -145,7 +145,7 @@ unsafe extern "C" fn invoke1_ref<A: RefFromWasmAbi, R: ReturnWasmAbi>(
     arg: <A as RefFromWasmAbi>::Abi,
 ) -> <R as ReturnWasmAbi>::Abi {
     if a == 0 {
-        throw_str("closure invoked recursively or destroyed already");
+        throw_str("closure invoked after being dropped");
     }
     // Scope all local variables before we call `return_abi` to
     // ensure they're all destroyed as `return_abi` may throw
@@ -197,7 +197,7 @@ unsafe extern "C" fn invoke1_mut_ref<A: RefFromWasmAbi, R: ReturnWasmAbi>(
     arg: <A as RefFromWasmAbi>::Abi,
 ) -> <R as ReturnWasmAbi>::Abi {
     if a == 0 {
-        throw_str("closure invoked recursively or destroyed already");
+        throw_str("closure invoked recursively or after being dropped");
     }
     // Scope all local variables before we call `return_abi` to
     // ensure they're all destroyed as `return_abi` may throw


### PR DESCRIPTION
The error message for an `Fn` closure being invoked after being dropped was confusing, because it was the same as for `FnMut`, 'closure invoked recursively or destroyed already'. The bit about being invoked recursively is misleading, since it's perfectly valid for an `Fn` closure to be invoked recursively. So, I removed that bit from the error message for `Fn` closures. I also rephrased 'destroyed already' to 'after being dropped', since I think that makes it a bit clearer that it's caused by the closure being dropped on the Rust side, rather than the more abstract wording of 'destroyed'.