### PR TITLE
allow thread destruction to run in other thread

### DIFF
--- a/crates/threads-xform/tests/basic.wat
+++ b/crates/threads-xform/tests/basic.wat
@@ -76,41 +76,56 @@
     global.set 1
     global.get 1
     call $__wasm_init_tls)
-  (func $__wbindgen_thread_destroy (type 0)
-    global.get 1
-    i32.const 128
-    call $__wbindgen_free
-    i32.const -2147483648
-    global.set 1
-    i32.const 393216
-    global.set 2
-    loop  ;; label = @1
+  (func $__wbindgen_thread_destroy (type 3) (param i32 i32)
+    (local i32 i32)
+    local.get 0
+    if  ;; label = @1
+      local.get 0
+      i32.const 128
+      call $__wbindgen_free
+    else
+      global.get 1
+      i32.const 128
+      call $__wbindgen_free
+      i32.const -2147483648
+      global.set 1
+    end
+    local.get 1
+    if  ;; label = @1
+      local.get 1
+      i32.const 1048576
+      call $__wbindgen_free
+    else
+      i32.const 393216
+      global.set 2
+      loop  ;; label = @2
+        i32.const 327684
+        i32.const 0
+        i32.const 1
+        i32.atomic.rmw.cmpxchg
+        if  ;; label = @3
+          i32.const 327684
+          i32.const 1
+          i64.const -1
+          memory.atomic.wait32
+          drop
+          br 1 (;@2;)
+        else
+        end
+      end
+      global.get 3
+      i32.const 1048576
+      call $__wbindgen_free
       i32.const 327684
       i32.const 0
+      i32.atomic.store
+      i32.const 327684
       i32.const 1
-      i32.atomic.rmw.cmpxchg
-      if  ;; label = @2
-        i32.const 327684
-        i32.const 1
-        i64.const -1
-        memory.atomic.wait32
-        drop
-        br 1 (;@1;)
-      else
-      end
-    end
-    global.get 3
-    i32.const 1048576
-    call $__wbindgen_free
-    i32.const 327684
-    i32.const 0
-    i32.atomic.store
-    i32.const 327684
-    i32.const 1
-    memory.atomic.notify
-    drop
-    i32.const 0
-    global.set 3)
+      memory.atomic.notify
+      drop
+      i32.const 0
+      global.set 3
+    end)
   (func $__wasm_init_tls (type 1) (param i32)
     i32.const 232323
     drop)
@@ -120,14 +135,15 @@
   (func $__wbindgen_malloc (type 2) (param i32) (result i32)
     i32.const 999999)
   (func $__wbindgen_free (type 3) (param i32 i32))
-  (global (;0;) i32 (i32.const 393216))
-  (global (;1;) (mut i32) (i32.const 0))
-  (global (;2;) (mut i32) (i32.const 65536))
-  (global (;3;) (mut i32) (i32.const 0))
+  (global (;0;) i32 i32.const 393216)
+  (global (;1;) (mut i32) i32.const 0)
+  (global (;2;) (mut i32) i32.const 65536)
+  (global (;3;) (mut i32) i32.const 0)
   (export "__wbindgen_malloc" (func $__wbindgen_malloc))
   (export "__wbindgen_free" (func $__wbindgen_free))
   (export "__heap_base" (global 0))
   (export "__tls_base" (global 1))
+  (export "__stack_alloc" (global 3))
   (export "__wbindgen_thread_destroy" (func $__wbindgen_thread_destroy))
   (start 0))
 ;)

--- a/crates/threads-xform/tests/unaligned.wat
+++ b/crates/threads-xform/tests/unaligned.wat
@@ -76,41 +76,56 @@
     global.set 1
     global.get 1
     call $__wasm_init_tls)
-  (func $__wbindgen_thread_destroy (type 0)
-    global.get 1
-    i32.const 128
-    call $__wbindgen_free
-    i32.const -2147483648
-    global.set 1
-    i32.const 393216
-    global.set 2
-    loop  ;; label = @1
+  (func $__wbindgen_thread_destroy (type 3) (param i32 i32)
+    (local i32 i32)
+    local.get 0
+    if  ;; label = @1
+      local.get 0
+      i32.const 128
+      call $__wbindgen_free
+    else
+      global.get 1
+      i32.const 128
+      call $__wbindgen_free
+      i32.const -2147483648
+      global.set 1
+    end
+    local.get 1
+    if  ;; label = @1
+      local.get 1
+      i32.const 1048576
+      call $__wbindgen_free
+    else
+      i32.const 393216
+      global.set 2
+      loop  ;; label = @2
+        i32.const 327688
+        i32.const 0
+        i32.const 1
+        i32.atomic.rmw.cmpxchg
+        if  ;; label = @3
+          i32.const 327688
+          i32.const 1
+          i64.const -1
+          memory.atomic.wait32
+          drop
+          br 1 (;@2;)
+        else
+        end
+      end
+      global.get 3
+      i32.const 1048576
+      call $__wbindgen_free
       i32.const 327688
       i32.const 0
+      i32.atomic.store
+      i32.const 327688
       i32.const 1
-      i32.atomic.rmw.cmpxchg
-      if  ;; label = @2
-        i32.const 327688
-        i32.const 1
-        i64.const -1
-        memory.atomic.wait32
-        drop
-        br 1 (;@1;)
-      else
-      end
-    end
-    global.get 3
-    i32.const 1048576
-    call $__wbindgen_free
-    i32.const 327688
-    i32.const 0
-    i32.atomic.store
-    i32.const 327688
-    i32.const 1
-    memory.atomic.notify
-    drop
-    i32.const 0
-    global.set 3)
+      memory.atomic.notify
+      drop
+      i32.const 0
+      global.set 3
+    end)
   (func $__wasm_init_tls (type 1) (param i32)
     i32.const 232323
     drop)
@@ -120,14 +135,15 @@
   (func $__wbindgen_malloc (type 2) (param i32) (result i32)
     i32.const 999999)
   (func $__wbindgen_free (type 3) (param i32 i32))
-  (global (;0;) i32 (i32.const 393219))
-  (global (;1;) (mut i32) (i32.const 0))
-  (global (;2;) (mut i32) (i32.const 65536))
-  (global (;3;) (mut i32) (i32.const 0))
+  (global (;0;) i32 i32.const 393219)
+  (global (;1;) (mut i32) i32.const 0)
+  (global (;2;) (mut i32) i32.const 65536)
+  (global (;3;) (mut i32) i32.const 0)
   (export "__wbindgen_malloc" (func $__wbindgen_malloc))
   (export "__wbindgen_free" (func $__wbindgen_free))
   (export "__heap_base" (global 0))
   (export "__tls_base" (global 1))
+  (export "__stack_alloc" (global 3))
   (export "__wbindgen_thread_destroy" (func $__wbindgen_thread_destroy))
   (start 0))
 ;)


### PR DESCRIPTION
This is the bare minimum that it's needed to allow running thread destructors from another thread.

Fixes https://github.com/rustwasm/wasm-bindgen/issues/3176