### PR TITLE
Apply `#[allow(dead_code)]` to `#[wasm_bindgen]`'d functions

### DIFF
--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -928,6 +928,10 @@ impl<'a> MacroParse<(Option<BindgenAttrs>, &'a mut TokenStream)> for syn::Item {
                     _ => {}
                 }
                 let comments = extract_doc_comments(&f.attrs);
+                // If the function isn't used for anything other than being exported to JS,
+                // it'll be unused when not building for the wasm target and produce a
+                // `dead_code` warning. So, add `#[allow(dead_code)]` before it to avoid that.
+                quote::quote! { #[allow(dead_code)] }.to_tokens(tokens);
                 f.to_tokens(tokens);
                 let opts = opts.unwrap_or_default();
                 if opts.start().is_some() {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -931,7 +931,7 @@ impl<'a> MacroParse<(Option<BindgenAttrs>, &'a mut TokenStream)> for syn::Item {
                 // If the function isn't used for anything other than being exported to JS,
                 // it'll be unused when not building for the wasm target and produce a
                 // `dead_code` warning. So, add `#[allow(dead_code)]` before it to avoid that.
-                quote::quote! { #[allow(dead_code)] }.to_tokens(tokens);
+                tokens.extend(quote::quote! { #[allow(dead_code)] });
                 f.to_tokens(tokens);
                 let opts = opts.unwrap_or_default();
                 if opts.start().is_some() {


### PR DESCRIPTION
Fixes #2726

`#[wasm_bindgen]`'d functions are always used, since they're exported to JS. However, that doesn't happen when not building for the wasm target, and so a dead code warning is shown if the function isn't used for anything else. This fixes that by adding `#[allow(dead_code)]` to `#[wasm_bindgen]`'d functions to supress the warning.