### PR TITLE
Use standard mode in tests

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>


### PR DESCRIPTION
I noticed that tests were running in quirks mode because of the missing `<!DOCTYPE html>`.
This should fix it.