### PR TITLE
Fix references passed to async functions

### DIFF
--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -90,7 +90,7 @@ pub struct Closure {
     pub mutable: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum VectorKind {
     I8,
     U8,

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -28,6 +28,7 @@ tys! {
     STRING
     REF
     REFMUT
+    LONGREF
     SLICE
     VECTOR
     EXTERNREF
@@ -132,6 +133,15 @@ impl Descriptor {
             CLOSURE => Descriptor::Closure(Box::new(Closure::decode(data))),
             REF => Descriptor::Ref(Box::new(Descriptor::_decode(data, clamped))),
             REFMUT => Descriptor::RefMut(Box::new(Descriptor::_decode(data, clamped))),
+            LONGREF => {
+                // This descriptor basically just serves as a macro, where most things
+                // become normal `Ref`s, but long refs to externrefs become owned.
+                let contents = Descriptor::_decode(data, clamped);
+                match contents {
+                    Descriptor::Externref | Descriptor::NamedExternref(_) => contents,
+                    _ => Descriptor::Ref(Box::new(contents)),
+                }
+            }
             SLICE => Descriptor::Slice(Box::new(Descriptor::_decode(data, clamped))),
             VECTOR => Descriptor::Vector(Box::new(Descriptor::_decode(data, clamped))),
             OPTIONAL => Descriptor::Option(Box::new(Descriptor::_decode(data, clamped))),

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -84,6 +84,10 @@ fn opt_i64() -> Descriptor {
     Descriptor::Option(Box::new(Descriptor::I64))
 }
 
+fn slice(contents: Descriptor) -> Descriptor {
+    Descriptor::Ref(Box::new(Descriptor::Slice(Box::new(contents))))
+}
+
 intrinsics! {
     pub enum Intrinsic {
         #[symbol = "__wbindgen_jsval_eq"]
@@ -263,6 +267,9 @@ intrinsics! {
         #[symbol = "__wbindgen_json_serialize"]
         #[signature = fn(ref_externref()) -> String]
         JsonSerialize,
+        #[symbol = "__wbindgen_copy_to_typed_array"]
+        #[signature = fn(slice(U8), ref_externref()) -> Unit]
+        CopyToTypedArray,
         #[symbol = "__wbindgen_externref_heap_live_count"]
         #[signature = fn() -> I32]
         ExternrefHeapLiveCount,

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -948,8 +948,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.push(format!("len{}", i));
             // Then we give wasm a reference to the original typed array, so that it can
             // update it with modifications made on the wasm side before returning.
-            js.cx.expose_add_heap_object();
-            js.push(format!("addHeapObject({val})"));
+            js.push(val);
         }
 
         Instruction::BoolFromI32 => {

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -929,15 +929,8 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.push(format!("len{}", i));
         }
 
-        Instruction::MutableSliceToMemory {
-            kind,
-            malloc,
-            mem,
-            free,
-        } => {
-            // First up, pass the JS value into wasm, getting out a pointer and
-            // a length. These two pointer/length values get pushed onto the
-            // value stack.
+        Instruction::MutableSliceToMemory { kind, malloc, mem } => {
+            // Copy the contents of the typed array into wasm.
             let val = js.pop();
             let func = js.cx.pass_to_wasm_function(kind.clone(), *mem)?;
             let malloc = js.cx.export_name_of(*malloc);
@@ -950,25 +943,13 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
                 malloc = malloc,
             ));
             js.prelude(&format!("var len{} = WASM_VECTOR_LEN;", i));
+            // Then pass it the pointer and the length of where we copied it.
             js.push(format!("ptr{}", i));
             js.push(format!("len{}", i));
-
-            // Next we set up a `finally` clause which will both update the
-            // original mutable slice with any modifications, and then free the
-            // Rust-backed memory.
-            let free = js.cx.export_name_of(*free);
-            let get = js.cx.memview_function(kind.clone(), *mem);
-            js.finally(&format!(
-                "
-                    {val}.set({get}().subarray(ptr{i} / {size}, ptr{i} / {size} + len{i}));
-                    wasm.{free}(ptr{i}, len{i} * {size});
-                ",
-                val = val,
-                get = get,
-                free = free,
-                size = kind.size(),
-                i = i,
-            ));
+            // Then we give wasm a reference to the original typed array, so that it can
+            // update it with modifications made on the wasm side before returning.
+            js.cx.expose_add_heap_object();
+            js.push(format!("addHeapObject({val})"));
         }
 
         Instruction::BoolFromI32 => {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3498,6 +3498,15 @@ impl<'a> Context<'a> {
                 "JSON.stringify(obj === undefined ? null : obj)".to_string()
             }
 
+            Intrinsic::CopyToTypedArray => {
+                assert_eq!(args.len(), 2);
+                format!(
+                    "new Uint8Array({dst}.buffer, {dst}.byteOffset, {dst}.byteLength).set({src})",
+                    src = args[0],
+                    dst = args[1]
+                )
+            }
+
             Intrinsic::ExternrefHeapLiveCount => {
                 assert_eq!(args.len(), 0);
                 self.expose_global_heap();

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -204,7 +204,6 @@ impl InstructionBuilder<'_, '_> {
                             kind,
                             malloc: self.cx.malloc()?,
                             mem: self.cx.memory()?,
-                            free: self.cx.free()?,
                         },
                         &[AdapterType::I32, AdapterType::I32],
                     );

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -185,7 +185,6 @@ pub enum Instruction {
     MutableSliceToMemory {
         kind: VectorKind,
         malloc: walrus::FunctionId,
-        free: walrus::FunctionId,
         mem: walrus::MemoryId,
     },
 
@@ -469,12 +468,9 @@ impl walrus::CustomSection for NonstandardWitSection {
                         roots.push_memory(mem);
                         roots.push_func(malloc);
                     }
-                    MutableSliceToMemory {
-                        free, malloc, mem, ..
-                    } => {
+                    MutableSliceToMemory { malloc, mem, .. } => {
                         roots.push_memory(mem);
                         roots.push_func(malloc);
-                        roots.push_func(free);
                     }
                     VectorLoad { free, mem, .. }
                     | OptionVectorLoad { free, mem, .. }

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -65,7 +65,7 @@ pub enum AdapterJsImportKind {
     Normal,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AdapterType {
     S8,
     S16,

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: FromWasmAbi` is not satisfied
-  --> $DIR/missing-catch.rs:6:9
-   |
-6  |     pub fn foo() -> Result<JsValue, JsValue>;
-   |            ^^^ the trait `FromWasmAbi` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
-   |
+ --> ui-tests/missing-catch.rs:6:9
+  |
+6 |     pub fn foo() -> Result<JsValue, JsValue>;
+  |            ^^^ the trait `FromWasmAbi` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+  |
 note: required by a bound in `FromWasmAbi`
-  --> $DIR/traits.rs:23:1
-   |
-23 | / pub trait FromWasmAbi: WasmDescribe {
-24 | |     /// The wasm ABI type that this converts from when coming back out from the
-25 | |     /// ABI boundary.
-26 | |     type Abi: WasmAbi;
-...  |
-35 | |     unsafe fn from_abi(js: Self::Abi) -> Self;
-36 | | }
-   | |_^ required by this bound in `FromWasmAbi`
+ --> $WORKSPACE/src/convert/traits.rs
+  |
+  | / pub trait FromWasmAbi: WasmDescribe {
+  | |     /// The wasm ABI type that this converts from when coming back out from the
+  | |     /// ABI boundary.
+  | |     type Abi: WasmAbi;
+... |
+  | |     unsafe fn from_abi(js: Self::Abi) -> Self;
+  | | }
+  | |_^ required by this bound in `FromWasmAbi`

--- a/crates/macro/ui-tests/traits-not-implemented.stderr
+++ b/crates/macro/ui-tests/traits-not-implemented.stderr
@@ -1,18 +1,18 @@
 error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
-  --> $DIR/traits-not-implemented.rs:5:1
-   |
-5  | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `A`
-   |
+ --> ui-tests/traits-not-implemented.rs:5:1
+  |
+5 | #[wasm_bindgen]
+  | ^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `A`
+  |
 note: required by a bound in `IntoWasmAbi`
-  --> $DIR/traits.rs:9:1
-   |
-9  | / pub trait IntoWasmAbi: WasmDescribe {
-10 | |     /// The wasm ABI type that this converts into when crossing the ABI
-11 | |     /// boundary.
-12 | |     type Abi: WasmAbi;
-...  |
-16 | |     fn into_abi(self) -> Self::Abi;
-17 | | }
-   | |_^ required by this bound in `IntoWasmAbi`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $WORKSPACE/src/convert/traits.rs
+  |
+  | / pub trait IntoWasmAbi: WasmDescribe {
+  | |     /// The wasm ABI type that this converts into when crossing the ABI
+  | |     /// boundary.
+  | |     type Abi: WasmAbi;
+... |
+  | |     fn into_abi(self) -> Self::Abi;
+  | | }
+  | |_^ required by this bound in `IntoWasmAbi`
+  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -6,7 +6,7 @@ mod schema_hash_approval;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.83";
+pub const SCHEMA_VERSION: &str = "0.2.84";
 
 #[macro_export]
 macro_rules! shared_api {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &'static str = "17656911631008664055";
+const APPROVED_SCHEMA_FILE_HASH: &'static str = "1473650450341157828";
 
 #[test]
 fn schema_version() {

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -2,7 +2,7 @@ use core::char;
 use core::mem::{self, ManuallyDrop};
 
 use crate::convert::traits::WasmAbi;
-use crate::convert::{FromWasmAbi, IntoWasmAbi, RefFromWasmAbi};
+use crate::convert::{FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, RefFromWasmAbi};
 use crate::convert::{OptionFromWasmAbi, OptionIntoWasmAbi, ReturnWasmAbi};
 use crate::{Clamped, JsError, JsValue};
 
@@ -245,6 +245,16 @@ impl RefFromWasmAbi for JsValue {
     #[inline]
     unsafe fn ref_from_abi(js: u32) -> Self::Anchor {
         ManuallyDrop::new(JsValue::_new(js))
+    }
+}
+
+impl LongRefFromWasmAbi for JsValue {
+    type Abi = u32;
+    type Anchor = JsValue;
+
+    #[inline]
+    unsafe fn long_ref_from_abi(js: u32) -> Self::Anchor {
+        Self::from_abi(js)
     }
 }
 

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -34,6 +34,7 @@ tys! {
     STRING
     REF
     REFMUT
+    LONGREF
     SLICE
     VECTOR
     EXTERNREF

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1075,6 +1075,8 @@ externs! {
         fn __wbindgen_jsval_eq(a: u32, b: u32) -> u32;
         fn __wbindgen_jsval_loose_eq(a: u32, b: u32) -> u32;
 
+        fn __wbindgen_copy_to_typed_array(ptr: *const u8, len: usize, idx: u32) -> ();
+
         fn __wbindgen_not(idx: u32) -> u32;
 
         fn __wbindgen_memory() -> u32;
@@ -1367,6 +1369,7 @@ pub fn function_table() -> JsValue {
 #[doc(hidden)]
 pub mod __rt {
     use crate::JsValue;
+    use core::borrow::{Borrow, BorrowMut};
     use core::cell::{Cell, UnsafeCell};
     use core::ops::{Deref, DerefMut};
 
@@ -1486,6 +1489,13 @@ pub mod __rt {
         }
     }
 
+    impl<'b, T: ?Sized> Borrow<T> for Ref<'b, T> {
+        #[inline]
+        fn borrow(&self) -> &T {
+            self.value
+        }
+    }
+
     impl<'b, T: ?Sized> Drop for Ref<'b, T> {
         fn drop(&mut self) {
             self.borrow.set(self.borrow.get() - 1);
@@ -1509,6 +1519,20 @@ pub mod __rt {
     impl<'b, T: ?Sized> DerefMut for RefMut<'b, T> {
         #[inline]
         fn deref_mut(&mut self) -> &mut T {
+            self.value
+        }
+    }
+
+    impl<'b, T: ?Sized> Borrow<T> for RefMut<'b, T> {
+        #[inline]
+        fn borrow(&self) -> &T {
+            self.value
+        }
+    }
+
+    impl<'b, T: ?Sized> BorrowMut<T> for RefMut<'b, T> {
+        #[inline]
+        fn borrow_mut(&mut self) -> &mut T {
             self.value
         }
     }

--- a/tests/wasm/futures.js
+++ b/tests/wasm/futures.js
@@ -18,6 +18,10 @@ exports.call_exports = async function() {
   assert.strictEqual("Hi, Jim!", await wasm.async_take_reference("Jim"));
   const foo = await new wasm.AsyncStruct();
   assert.strictEqual(42, await foo.method());
+  await wasm.async_take_js_reference(42);
+  const buffer = new Int32Array([1, 2, 3, 4]);
+  await wasm.async_take_mut_slice(buffer);
+  assert.deepStrictEqual(buffer, new Int32Array([42, 42, 42, 42]));
 };
 
 exports.call_promise = async function() {

--- a/tests/wasm/futures.rs
+++ b/tests/wasm/futures.rs
@@ -126,6 +126,16 @@ impl AsyncStruct {
     }
 }
 
+#[wasm_bindgen]
+pub async fn async_take_js_reference(x: &JsValue) {
+    assert_eq!(*x, 42);
+}
+
+#[wasm_bindgen]
+pub async fn async_take_mut_slice(x: &mut [i32]) {
+    x.fill(42);
+}
+
 #[wasm_bindgen_test]
 async fn test_promise() {
     assert_eq!(call_promise().await.as_string(), Some(String::from("ok")))


### PR DESCRIPTION
Fixes #3167

#3167 was happening because references to `JsValue`s work by pushing the JS value onto the JS stack, and then popping it off again when the function returns. This breaks for async functions, because the `JsValue` needs to remain valid for the lifetime of the future, not just the initial synchronous call.

To fix this, I introduced a new descriptor, `LONGREF`, which is used instead of `REF` in async functions and marks that the reference can't be invalidated after the function returns. I then made a `LONGREF` to a `JsValue` behave the same as an owned `JsValue`, while working like a regular `REF` for everything else.

I also had to add a new version of `RefFromWasmAbi`, `LongRefFromWasmAbi`, to accomodate for `LONGREF`s to `JsValue`s requiring that the `JsValue` is destroyed from the Rust side.

While working on that, I also noticed that mutable references to slices were broken in async functions. They work by copying the data from JS to Rust, and then copying it back after the function returns to apply the changes. For async functions, that means that it's copied back before the future is actually finished, and so the changes won't be applied properly. To fix that, I changed it so that the data is copied back from the Rust side when the anchor is dropped, which happens when the future resolves for async functions.

I also bumped the schema version, since this is a breaking change in the interface between the macro and the CLI, even though the schema itself is unchanged.