### PR TITLE
Increase stack size to 128

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -85,7 +85,7 @@ pub struct ExportedClass {
 
 const INITIAL_HEAP_VALUES: &[&str] = &["undefined", "null", "true", "false"];
 // Must be kept in sync with `src/lib.rs` of the `wasm-bindgen` crate
-const INITIAL_HEAP_OFFSET: usize = 32;
+const INITIAL_HEAP_OFFSET: usize = 128;
 
 impl<'a> Context<'a> {
     pub fn new(

--- a/crates/externref-xform/src/lib.rs
+++ b/crates/externref-xform/src/lib.rs
@@ -24,7 +24,7 @@ use walrus::{ElementId, ExportId, ImportId, InstrLocId, TypeId};
 use walrus::{FunctionId, GlobalId, InitExpr, Module, TableId, ValType};
 
 // must be kept in sync with src/lib.rs and EXTERNREF_HEAP_START
-const DEFAULT_MIN: u32 = 32;
+const DEFAULT_MIN: u32 = 128;
 
 /// State of the externref pass, used to collect information while bindings are
 /// generated and used eventually to actually execute the entire pass.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub struct JsValue {
     _marker: marker::PhantomData<*mut u8>, // not at all threadsafe
 }
 
-const JSIDX_OFFSET: u32 = 32; // keep in sync with js/mod.rs
+const JSIDX_OFFSET: u32 = 128; // keep in sync with js/mod.rs
 const JSIDX_UNDEFINED: u32 = JSIDX_OFFSET + 0;
 const JSIDX_NULL: u32 = JSIDX_OFFSET + 1;
 const JSIDX_TRUE: u32 = JSIDX_OFFSET + 2;


### PR DESCRIPTION
This commit increases the stack size of wasm-bindgen from 32 slots to 128 slots. Ideally, there would be some way of just overriding this on a per project basis, however, I don't think there is an obvious way of coordinating the size of the stack between the library and the CLI utility.

I choose 128 as the size since this currently seems sufficient for a custom Emscripten runtime that I am working on that needs a large stack for handling exceptions outside of the module being run.