### PR TITLE
take the default export from wasm

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -755,7 +755,7 @@ impl Output {
             write(
                 &js_path,
                 format!(
-                    "import * as wasm from \"./{wasm_name}.wasm\";
+                    "import wasm from \"./{wasm_name}.wasm\";
 import {{ __wbg_set_wasm }} from \"./{js_name}\";
 __wbg_set_wasm(wasm);
 export * from \"./{js_name}\";

--- a/crates/typescript-tests/src/memory.ts
+++ b/crates/typescript-tests/src/memory.ts
@@ -1,3 +1,3 @@
-import * as wasm from '../pkg/typescript_tests_bg.wasm';
+import wasm from '../pkg/typescript_tests_bg.wasm';
 
 const memory: WebAssembly.Memory = wasm.memory;

--- a/crates/typescript-tests/src/simple_async_fn.ts
+++ b/crates/typescript-tests/src/simple_async_fn.ts
@@ -1,5 +1,5 @@
 import * as wbg from '../pkg/typescript_tests';
-import * as wasm from '../pkg/typescript_tests_bg.wasm';
+import wasm from '../pkg/typescript_tests_bg.wasm';
 
 const wbg_async_greet: (a: string) => Promise<void> = wbg.async_greet;
 const wasm_async_greet: (a: number, b: number) => number = wasm.async_greet;

--- a/crates/typescript-tests/src/simple_fn.ts
+++ b/crates/typescript-tests/src/simple_fn.ts
@@ -1,5 +1,5 @@
 import * as wbg from '../pkg/typescript_tests';
-import * as wasm from '../pkg/typescript_tests_bg.wasm';
+import wasm from '../pkg/typescript_tests_bg.wasm';
 
 const wbg_greet: (a: string) => void = wbg.greet;
 const wasm_greet: (a: number, b: number) => void = wasm.greet;


### PR DESCRIPTION
```
importing * as wasm
```
.wasm file generated exporting as a default object. 
creates default package to be name as a attribute 'default' in the imported wasm object. 
in that it will cause function error was.greet not defind, while  function is t here in wasm.default.greet for example. 

