### PR TITLE
Validate the schema version before processing descriptors

### DIFF
--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -45,13 +45,11 @@ struct InstructionBuilder<'a, 'b> {
 
 pub fn process(
     module: &mut Module,
+    programs: Vec<decode::Program>,
     externref_enabled: bool,
     wasm_interface_types: bool,
     support_start: bool,
 ) -> Result<(NonstandardWitSectionId, WasmBindgenAuxId), Error> {
-    let mut storage = Vec::new();
-    let programs = extract_programs(module, &mut storage)?;
-
     let mut cx = Context {
         adapters: Default::default(),
         aux: Default::default(),
@@ -1493,7 +1491,11 @@ impl<'a> Context<'a> {
     }
 }
 
-fn extract_programs<'a>(
+/// Extract all of the `Program`s encoded in our custom section.
+///
+/// `program_storage` is used to squirrel away the raw bytes of the custom
+///  section, so that they can be referenced by the `Program`s we return.
+pub fn extract_programs<'a>(
     module: &mut Module,
     program_storage: &'a mut Vec<Vec<u8>>,
 ) -> Result<Vec<decode::Program<'a>>, Error> {


### PR DESCRIPTION
While looking into #3204 I noticed that the error given by `wasm-pack test` was a panic while decoding descriptors, rather than the 'version mismatch' error that using an incompatible CLI version should give. It turns out that that was happening because descriptors were getting parsed before the custom section, and hence before the version check.

So, I reordered things so that the custom section is parsed (but not processed) before the descriptors, which includes checking the schema version. The custom section still gets processed afterwards, though, since that seems to depend on the results of processing descriptors.