### PR TITLE
Exclude `#[wasm_bindgen]`'d functions in `discover_main`

### DIFF
--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -22,7 +22,9 @@ struct Context<'a> {
     module: &'a mut Module,
     adapters: NonstandardWitSection,
     aux: WasmBindgenAux,
+    /// All of the wasm module's exported functions.
     function_exports: HashMap<String, (ExportId, FunctionId)>,
+    /// All of the wasm module's imported functions.
     function_imports: HashMap<String, (ImportId, FunctionId)>,
     /// A map from the signature of a function in the function table to its adapter, if we've already created it.
     table_adapters: HashMap<Function, AdapterId>,
@@ -268,7 +270,7 @@ impl<'a> Context<'a> {
                 // actually a `main` function. Unfortunately, there doesn't seem to be any 100%
                 // reliable way to make sure that it is, but we can at least rule out any
                 // `#[wasm_bindgen]` exported functions.
-                let unknown = !self.function_exports.contains_key("main");
+                let unknown = !self.adapters.exports.iter().any(|(name, _)| name == "main");
                 name_matches && type_matches && unknown
             })
             .map(|x| x.id());

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -264,7 +264,12 @@ impl<'a> Context<'a> {
                 // type has to be `(i32, i32) -> i32`
                 let ty = self.module.types.get(x.ty());
                 let type_matches = ty.params() == [I32, I32] && ty.results() == [I32];
-                name_matches && type_matches
+                // Having the correct name and signature doesn't necessarily mean that it's
+                // actually a `main` function. Unfortunately, there doesn't seem to be any 100%
+                // reliable way to make sure that it is, but we can at least rule out any
+                // `#[wasm_bindgen]` exported functions.
+                let unknown = !self.function_exports.contains_key("main");
+                name_matches && type_matches && unknown
             })
             .map(|x| x.id());
         let main_id = match main_id {


### PR DESCRIPTION
This is a partial fix for #3199. I couldn't find any way to reliably detect whether a `main` function was actually a proper Rust `main` function, but the common case of a `#[wasm_bindgen]`'d function named `main` happening to have the same signature can be avoided, by just checking whether the function is a `#[wasm_bindgen]` export before marking it as the start function. This PR does that.

It's still possible for a function to be mistakenly treated as `main` if it's exported manually, but that's much less likely to occur.

Resolves #3199.