### PR TITLE
Docfix: Remove dangling word

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! externs {
     )
 }
 
-/// A module which is typically glob imported from:
+/// A module which is typically glob imported
 ///
 /// ```
 /// use wasm_bindgen::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! externs {
     )
 }
 
-/// A module which is typically glob imported
+/// A module which is typically glob imported.
 ///
 /// ```
 /// use wasm_bindgen::prelude::*;


### PR DESCRIPTION
# Problem

I noticed the [top-level of the generated docs](https://docs.rs/wasm-bindgen/0.2.83/wasm_bindgen/) has a very _mysterious_ dangling word:

<img width="793" alt="Screenshot 2022-12-19 at 23 47 32" src="https://user-images.githubusercontent.com/1052016/208611794-93c8d207-489b-458a-8118-914587274434.png">

(Imported from... _from where?!_)

# Solution

I figured that it made more sense in the source, and it does! It just reads oddly on the front page of the docs. I just removed the one word, which is probably sufficient for both the HTML docs and those reading the source. Feel free to rephrase differently!

## Updated Preview

<img width="481" alt="Screenshot 2022-12-19 at 23 54 02" src="https://user-images.githubusercontent.com/1052016/208613195-a8e24f27-024f-415f-b159-46aa50c63642.png">

It's small, but I hope it's helpful! This is an incredible project; thanks so much for the hard work!

<img src="https://user-images.githubusercontent.com/1052016/208611609-790e4730-2091-454a-9b7c-d5591ac6d8cb.png" height="250px" />