### PR TITLE
webidl: track stability of individual interface & namespace members

### DIFF
--- a/crates/web-sys/src/features/gen_WebGl2RenderingContext.rs
+++ b/crates/web-sys/src/features/gen_WebGl2RenderingContext.rs
@@ -5980,12 +5980,16 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WebGl2RenderingContext`, `WebGlProgram`*"]
     pub fn link_program(this: &WebGl2RenderingContext, program: &WebGlProgram);
+    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "WebGL2RenderingContext" , js_name = makeXRCompatible)]
     #[doc = "The `makeXRCompatible()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/makeXRCompatible)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WebGl2RenderingContext`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn make_xr_compatible(this: &WebGl2RenderingContext) -> ::js_sys::Promise;
     # [wasm_bindgen (method , structural , js_class = "WebGL2RenderingContext" , js_name = pixelStorei)]
     #[doc = "The `pixelStorei()` method."]

--- a/crates/web-sys/src/features/gen_WebGlContextAttributes.rs
+++ b/crates/web-sys/src/features/gen_WebGlContextAttributes.rs
@@ -148,9 +148,13 @@ impl WebGlContextAttributes {
         let _ = r;
         self
     }
+    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `xrCompatible` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WebGlContextAttributes`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn xr_compatible(&mut self, val: bool) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(

--- a/crates/web-sys/src/features/gen_WebGlRenderingContext.rs
+++ b/crates/web-sys/src/features/gen_WebGlRenderingContext.rs
@@ -1599,12 +1599,16 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WebGlProgram`, `WebGlRenderingContext`*"]
     pub fn link_program(this: &WebGlRenderingContext, program: &WebGlProgram);
+    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "WebGLRenderingContext" , js_name = makeXRCompatible)]
     #[doc = "The `makeXRCompatible()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/makeXRCompatible)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WebGlRenderingContext`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn make_xr_compatible(this: &WebGlRenderingContext) -> ::js_sys::Promise;
     # [wasm_bindgen (method , structural , js_class = "WebGLRenderingContext" , js_name = pixelStorei)]
     #[doc = "The `pixelStorei()` method."]

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -710,15 +710,6 @@ impl Dictionary {
             }
         }
 
-        // The constructor is unstable if any of the fields are
-        let (unstable_ctor, unstable_ctor_docs) = match unstable {
-            true => (None, None),
-            false => {
-                let unstable = fields.iter().any(|f| f.unstable);
-                (maybe_unstable_attr(unstable), maybe_unstable_docs(unstable))
-            }
-        };
-
         required_features.remove(&name.to_string());
 
         let cfg_features = get_cfg_features(options, &required_features);
@@ -756,11 +747,9 @@ impl Dictionary {
 
             #unstable_attr
             impl #name {
-                #unstable_ctor
                 #cfg_features
                 #ctor_doc_comment
                 #unstable_docs
-                #unstable_ctor_docs
                 pub fn new(#(#required_args),*) -> Self {
                     #[allow(unused_mut)]
                     let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -35,10 +35,10 @@ use quote::ToTokens;
 use sourcefile::SourceFile;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::ffi::OsStr;
-use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::{fmt, iter};
 use wasm_bindgen_backend::util::rust_ident;
 use weedle::attribute::ExtendedAttributeList;
 use weedle::common::Identifier;
@@ -335,8 +335,14 @@ impl<'src> FirstPassRecord<'src> {
         // > comprise their identifiers.
         let start = dst.len();
         let members = definition.members.body.iter();
-        let partials = dict_data.partials.iter().flat_map(|d| &d.members.body);
-        for member in members.chain(partials) {
+        let partials = dict_data.partials.iter().flat_map(|d| {
+            d.definition
+                .members
+                .body
+                .iter()
+                .zip(iter::repeat(unstable || d.stability.is_unstable()))
+        });
+        for (member, unstable) in members.zip(iter::repeat(unstable)).chain(partials) {
             match self.dictionary_field(member, unstable, unstable_types) {
                 Some(f) => dst.push(f),
                 None => {
@@ -442,7 +448,7 @@ impl<'src> FirstPassRecord<'src> {
         let mut functions = vec![];
 
         for member in ns.consts.iter() {
-            self.append_ns_const(&mut consts, member, unstable);
+            self.append_ns_const(&mut consts, member.clone(), unstable);
         }
 
         for (id, data) in ns.operations.iter() {
@@ -465,22 +471,22 @@ impl<'src> FirstPassRecord<'src> {
     fn append_ns_const(
         &self,
         consts: &mut Vec<Const>,
-        member: &'src weedle::namespace::ConstNamespaceMember<'src>,
+        member: first_pass::ConstNamespaceData<'src>,
         unstable: bool,
     ) {
-        let idl_type = member.const_type.to_idl_type(self);
+        let idl_type = member.definition.const_type.to_idl_type(self);
         let ty = idl_type.to_syn_type(TypePosition::Return).unwrap().unwrap();
 
-        let js_name = member.identifier.0;
+        let js_name = member.definition.identifier.0;
         let name = rust_ident(shouty_snake_case_ident(js_name).as_str());
-        let value = webidl_const_v_to_backend_const_v(&member.const_value);
+        let value = webidl_const_v_to_backend_const_v(&member.definition.const_value);
 
         consts.push(Const {
             name,
             js_name: js_name.to_string(),
             ty,
             value,
-            unstable,
+            unstable: unstable || member.stability.is_unstable(),
         });
     }
 
@@ -567,6 +573,8 @@ impl<'src> FirstPassRecord<'src> {
         let mut methods = vec![];
 
         for member in data.consts.iter() {
+            let unstable = unstable || member.stability.is_unstable();
+            let member = member.definition;
             self.append_interface_const(&mut consts, member, unstable);
         }
 

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -437,15 +437,13 @@ impl<'src> FirstPassRecord<'src> {
             // Stable types can have methods that have unstable argument types.
             // If any of the arguments types are `unstable` then this method is downgraded
             // to be unstable.
-            let unstable_override = match unstable {
-                // only downgrade stable methods
-                false => signature
-                    .orig
-                    .args
-                    .iter()
-                    .any(|arg| is_type_unstable(arg.ty, unstable_types)),
-                true => true,
-            };
+            let has_unstable_args = signature
+                .orig
+                .args
+                .iter()
+                .any(|arg| is_type_unstable(arg.ty, unstable_types));
+
+            let unstable = unstable || data.stability.is_unstable() || has_unstable_args;
 
             if let Some(arguments) = arguments {
                 if let Ok(ret_ty) = ret_ty.to_syn_type(TypePosition::Return) {
@@ -459,7 +457,7 @@ impl<'src> FirstPassRecord<'src> {
                         structural,
                         catch,
                         variadic,
-                        unstable: unstable_override,
+                        unstable,
                     });
                 }
             }
@@ -490,7 +488,7 @@ impl<'src> FirstPassRecord<'src> {
                             structural,
                             catch,
                             variadic: false,
-                            unstable: unstable_override,
+                            unstable,
                         });
                     }
                 }


### PR DESCRIPTION
Fixes #2560

It's possible for some members of an interface (or namespace) to be stable and others not, if a `partial interface` is defined in an unstable webidl file which adds to an interface defined in a stable file. This wasn't properly kept track of for all interface members before, most notably for operations. This PR fixes that.

This did unfortunately root out some WebXR-related bits of WebGL that were marked stable when they shouldn't have been. So, currently, this is a slight breaking change. I'm not sure if I should special-case them to be left as stable or accept the slight risk of breakage, since it seems unlikely that people would be using these isolated bits of WebXR without enabling `--cfg=web_sys_unstable_apis` for the rest of WebXR.