### PR TITLE
add HtmlInputElement::show_picker from latest spec draft

### DIFF
--- a/crates/web-sys/README.md
+++ b/crates/web-sys/README.md
@@ -29,6 +29,7 @@ If you don't see a particular web API in `web-sys`, here is how to add it.
    [spec](https://w3c.github.io/mediasession/#the-mediasession-interface). The
    [very bottom](https://w3c.github.io/mediasession/#idl-index) of _that_ page
    is the IDL.
-2. Run `cargo run --release --package wasm-bindgen-webidl -- webidls src/features`
-3. Copy the contents of `features` into the `[features]` section of `Cargo.toml`
-4. Run `git add .` to add all the generated files into git.
+2. Annotate the functions that can throw with `[Throws]`
+3. Run `cargo run --release --package wasm-bindgen-webidl -- webidls src/features`
+4. Copy the contents of `features` into the `[features]` section of `Cargo.toml`
+5. Run `git add .` to add all the generated files into git.

--- a/crates/web-sys/src/features/gen_HtmlInputElement.rs
+++ b/crates/web-sys/src/features/gen_HtmlInputElement.rs
@@ -698,4 +698,11 @@ extern "C" {
         end: u32,
         direction: &str,
     ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "HTMLInputElement" , js_name = showPicker)]
+    #[doc = "The `showPicker()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlInputElement`*"]
+    pub fn show_picker(this: &HtmlInputElement) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLInputElement.webidl
@@ -135,6 +135,9 @@ interface HTMLInputElement : HTMLElement {
   [Throws]
   undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
+  [Throws]
+  undefined showPicker();
+
   // also has obsolete members
 };
 


### PR DESCRIPTION
Hey! First, thank you for wasm-bindgen. I've started a project using it a few months ago, and it's been awesome!

I just now came across one function that seems missing to me (that was already reported in #3036), so I'm trying to add it in this PR. Unfortunately, I can't figure out a way to try it out (using `[patch.crates-io]` to run with patched js-sys, wasm-bindgen and web-sys leads to `trunk`'s wasm-bindgen call panicking on array indexing):
```
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', crates/cli-support/src/descriptor.rs:208:15
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic_bounds_check
   3: wasm_bindgen_cli_support::descriptor::Descriptor::_decode
   4: wasm_bindgen_cli_support::descriptor::Function::decode
   5: wasm_bindgen_cli_support::descriptor::Descriptor::_decode
   6: wasm_bindgen_cli_support::Bindgen::generate_output
   7: wasm_bindgen_cli_support::Bindgen::generate
   8: wasm_bindgen::main
```

So I'm not sure that's actually correct; but I tried to import the IDL from the latest spec and then rerun the command mentioned in the readme (minus the `--release` because after dinner the compilation still hadn't finished)

I didn't update the whole IDL and just added the function from upstream, because it seemed like additional care had been put in the IDL in wasm-bindgen compared to the spec's.

Hopefully this can help! FWIW, the following works fine as a workaround:
```rust
#[wasm_bindgen(inline_js = "export function show_picker(elt) { elt.showPicker(); }")]
extern "C" {
    fn show_picker(elt: &web_sys::HtmlInputElement);
}
```

Below, the commit message:
-----

Copy-paste the `showPicker` WebIDL from [1] into the hopefully proper location.

Fixes #3036

[1] https://html.spec.whatwg.org/multipage/input.html