### PR TITLE
Add `JsCast` to `wasm_bindgen::prelude`

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -2,7 +2,6 @@ extern crate wasm_bindgen;
 extern crate web_sys;
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::Node;
 
 #[wasm_bindgen(raw_module = "../globals.js")]

--- a/crates/futures/src/stream.rs
+++ b/crates/futures/src/stream.rs
@@ -11,7 +11,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use futures_core::stream::Stream;
 use js_sys::{AsyncIterator, IteratorNext};
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::prelude::*;
 
 /// A `Stream` that yields values from an underlying `AsyncIterator`.
 pub struct JsStream {

--- a/crates/futures/src/task/multithread.rs
+++ b/crates/futures/src/task/multithread.rs
@@ -8,7 +8,6 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 const SLEEPING: i32 = 0;
 const AWAKE: i32 = 1;

--- a/crates/futures/src/task/wait_async_polyfill.rs
+++ b/crates/futures/src/task/wait_async_polyfill.rs
@@ -40,7 +40,6 @@ use js_sys::{encode_uri_component, Array, Promise};
 use std::cell::RefCell;
 use std::sync::atomic::AtomicI32;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::{MessageEvent, Worker};
 
 const HELPER_CODE: &'static str = "

--- a/crates/futures/tests/tests.rs
+++ b/crates/futures/tests/tests.rs
@@ -5,7 +5,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 use futures_channel::oneshot;
 use js_sys::Promise;
 use std::ops::FnMut;
-use wasm_bindgen::{prelude::*, JsValue};
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{future_to_promise, spawn_local, JsFuture};
 use wasm_bindgen_test::*;
 
@@ -138,7 +138,6 @@ async fn can_create_multiple_futures_from_same_promise() {
 #[wasm_bindgen_test]
 async fn can_use_an_async_iterable_as_stream() {
     use futures_lite::stream::StreamExt;
-    use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::stream::JsStream;
 
     let async_iter = js_sys::Function::new_no_args(

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -29,7 +29,6 @@ use std::str;
 use std::str::FromStr;
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 // When adding new imports:
 //

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -1,8 +1,6 @@
 use js_sys::*;
 use std::iter::FromIterator;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
 macro_rules! js_array {

--- a/crates/js-sys/tests/wasm/JSON.rs
+++ b/crates/js-sys/tests/wasm/JSON.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]

--- a/crates/js-sys/tests/wasm/JsString.rs
+++ b/crates/js-sys/tests/wasm/JsString.rs
@@ -1,7 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
-use wasm_bindgen::JsValue;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/JsString.js")]

--- a/crates/js-sys/tests/wasm/Number.rs
+++ b/crates/js-sys/tests/wasm/Number.rs
@@ -2,7 +2,6 @@ use std::f64::{INFINITY, NAN};
 
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/Number.js")]

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -1,7 +1,6 @@
 use js_sys::*;
 use std::f64::NAN;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen]

--- a/crates/js-sys/tests/wasm/Set.rs
+++ b/crates/js-sys/tests/wasm/Set.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 fn set2vec(s: &Set) -> Vec<JsValue> {

--- a/crates/js-sys/tests/wasm/SharedArrayBuffer.rs
+++ b/crates/js-sys/tests/wasm/SharedArrayBuffer.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/SharedArrayBuffer.js")]

--- a/crates/js-sys/tests/wasm/Temporal.rs
+++ b/crates/js-sys/tests/wasm/Temporal.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/Temporal.js")]

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 macro_rules! each {

--- a/crates/js-sys/tests/wasm/WeakMap.rs
+++ b/crates/js-sys/tests/wasm/WeakMap.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen]

--- a/crates/js-sys/tests/wasm/WeakSet.rs
+++ b/crates/js-sys/tests/wasm/WeakSet.rs
@@ -1,6 +1,5 @@
 use js_sys::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen]

--- a/crates/js-sys/tests/wasm/WebAssembly.rs
+++ b/crates/js-sys/tests/wasm/WebAssembly.rs
@@ -1,5 +1,5 @@
 use js_sys::*;
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::{Headers, Response, ResponseInit};

--- a/crates/test/src/rt/detect.rs
+++ b/crates/test/src/rt/detect.rs
@@ -1,7 +1,6 @@
 //! Runtime detection of whether we're in node.js or a browser.
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 #[wasm_bindgen]
 extern "C" {

--- a/crates/web-sys/tests/wasm/blob.rs
+++ b/crates/web-sys/tests/wasm/blob.rs
@@ -1,6 +1,5 @@
 use js_sys::{Array, ArrayBuffer};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::Blob;

--- a/crates/web-sys/tests/wasm/event.rs
+++ b/crates/web-sys/tests/wasm/event.rs
@@ -1,6 +1,5 @@
 use js_sys::{Object, Promise};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::Event;

--- a/crates/web-sys/tests/wasm/html_element.rs
+++ b/crates/web-sys/tests/wasm/html_element.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 use web_sys::HtmlElement;
 

--- a/crates/web-sys/tests/wasm/response.rs
+++ b/crates/web-sys/tests/wasm/response.rs
@@ -1,6 +1,5 @@
 use js_sys::{ArrayBuffer, DataView, Object, Promise, Reflect, WebAssembly};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 use web_sys::{Headers, Response, ResponseInit};

--- a/crates/web-sys/tests/wasm/rtc_rtp_transceiver_direction.rs
+++ b/crates/web-sys/tests/wasm/rtc_rtp_transceiver_direction.rs
@@ -1,4 +1,4 @@
-use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 

--- a/crates/webidl-tests/maplike.rs
+++ b/crates/webidl-tests/maplike.rs
@@ -1,6 +1,5 @@
 use crate::generated::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 macro_rules! read_test_suite {

--- a/crates/webidl-tests/simple.rs
+++ b/crates/webidl-tests/simple.rs
@@ -1,7 +1,6 @@
 use crate::generated::*;
 use js_sys::Object;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -1,6 +1,5 @@
 use std::f64;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(start)]
 pub fn start() {

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -1,6 +1,5 @@
 use js_sys::{Array, Date};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::{Document, Element, HtmlElement, Window};
 
 #[wasm_bindgen(start)]

--- a/examples/fetch/src/lib.rs
+++ b/examples/fetch/src/lib.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{Request, RequestInit, RequestMode, Response};
 

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cell::Cell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 #[wasm_bindgen(start)]
 pub fn start() -> Result<(), JsValue> {

--- a/examples/raytrace-parallel/src/lib.rs
+++ b/examples/raytrace-parallel/src/lib.rs
@@ -2,7 +2,6 @@ use futures_channel::oneshot;
 use js_sys::{Promise, Uint8ClampedArray, WebAssembly};
 use rayon::prelude::*;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 macro_rules! console_log {
     ($($t:tt)*) => (crate::log(&format_args!($($t)*).to_string()))

--- a/examples/raytrace-parallel/src/pool.rs
+++ b/examples/raytrace-parallel/src/pool.rs
@@ -8,7 +8,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::{DedicatedWorkerGlobalScope, MessageEvent};
 use web_sys::{ErrorEvent, Event, Worker};
 

--- a/examples/request-animation-frame/src/lib.rs
+++ b/examples/request-animation-frame/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 
 fn window() -> web_sys::Window {
     web_sys::window().expect("no global `window` exists")

--- a/examples/todomvc/src/element.rs
+++ b/examples/todomvc/src/element.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::EventTarget;
 
 /// Wrapper for `web_sys::Element` to simplify calling different interfaces

--- a/examples/todomvc/src/view.rs
+++ b/examples/todomvc/src/view.rs
@@ -5,7 +5,6 @@ use crate::store::ItemList;
 use crate::{Message, Scheduler};
 use std::cell::RefCell;
 use std::rc::Rc;
-use wasm_bindgen::JsCast;
 
 use crate::template::Template;
 

--- a/examples/wasm-in-wasm-imports/src/lib.rs
+++ b/examples/wasm-in-wasm-imports/src/lib.rs
@@ -1,6 +1,5 @@
 use js_sys::{Function, Map, Object, Reflect, WebAssembly};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 #[wasm_bindgen]

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -1,6 +1,5 @@
 use js_sys::{Function, Object, Reflect, WebAssembly};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
 
 // lifted from the `console_log` example

--- a/examples/wasm-in-web-worker/src/lib.rs
+++ b/examples/wasm-in-web-worker/src/lib.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::{console, HtmlElement, HtmlInputElement, MessageEvent, Worker};
 
 /// A number evaluation struct

--- a/examples/weather_report/src/lib.rs
+++ b/examples/weather_report/src/lib.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, UNIX_EPOCH};
 use gloo::events::EventListener;
 use json::JsonValue;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use web_sys::Document;
 use web_sys::Element;

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlShader};
 
 #[wasm_bindgen(start)]

--- a/examples/webrtc_datachannel/src/lib.rs
+++ b/examples/webrtc_datachannel/src/lib.rs
@@ -1,6 +1,5 @@
 use js_sys::Reflect;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{
     MessageEvent, RtcDataChannelEvent, RtcPeerConnection, RtcPeerConnectionIceEvent, RtcSdpType,

--- a/examples/websockets/src/lib.rs
+++ b/examples/websockets/src/lib.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use web_sys::{ErrorEvent, MessageEvent, WebSocket};
 
 macro_rules! console_log {

--- a/examples/webxr/src/lib.rs
+++ b/examples/webxr/src/lib.rs
@@ -8,7 +8,6 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use utils::set_panic_hook;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::future_to_promise;
 use web_sys::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ macro_rules! externs {
 /// use wasm_bindgen::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::JsCast;
     pub use crate::JsValue;
     pub use crate::UnwrapThrowExt;
     #[doc(hidden)]

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -1,6 +1,5 @@
 use js_sys::{Uint8Array, WebAssembly};
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::{self, JsCast};
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/api.js")]

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -493,7 +493,6 @@ fn test_closure_returner() {
     type ClosureType = dyn FnMut() -> BadStruct;
 
     use js_sys::{Object, Reflect};
-    use wasm_bindgen::JsCast;
 
     js_test_closure_returner();
 

--- a/tests/wasm/jscast.rs
+++ b/tests/wasm/jscast.rs
@@ -1,5 +1,4 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/jscast.js")]

--- a/tests/wasm/simple.rs
+++ b/tests/wasm/simple.rs
@@ -1,5 +1,5 @@
 use wasm_bindgen::prelude::*;
-use wasm_bindgen::{intern, unintern, JsCast};
+use wasm_bindgen::{intern, unintern};
 use wasm_bindgen_test::*;
 
 #[wasm_bindgen(module = "tests/wasm/simple.js")]


### PR DESCRIPTION
`JsCast` is a very commonly used trait, but for some reason has never been added to `wasm_bindgen::prelude`, leading to the constant annoyance of having to manually import it.