### PR TITLE
Add VideoFrame and OffscreenCanvas to CanvasImageSource.

### DIFF
--- a/crates/web-sys/src/features/gen_CanvasRenderingContext2d.rs
+++ b/crates/web-sys/src/features/gen_CanvasRenderingContext2d.rs
@@ -385,6 +385,7 @@ extern "C" {
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -392,6 +393,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `VideoFrame`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_video_frame(
         this: &CanvasRenderingContext2d,
         image: &VideoFrame,
@@ -488,6 +492,7 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -495,6 +500,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `VideoFrame`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_video_frame_and_dw_and_dh(
         this: &CanvasRenderingContext2d,
         image: &VideoFrame,
@@ -617,6 +625,7 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -624,6 +633,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `VideoFrame`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_video_frame_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &CanvasRenderingContext2d,
         image: &VideoFrame,
@@ -888,6 +900,7 @@ extern "C" {
         image: &OffscreenCanvas,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "VideoFrame",))]
     # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -895,6 +908,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `CanvasRenderingContext2d`, `VideoFrame`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_video_frame(
         this: &CanvasRenderingContext2d,
         image: &VideoFrame,

--- a/crates/web-sys/src/features/gen_CanvasRenderingContext2d.rs
+++ b/crates/web-sys/src/features/gen_CanvasRenderingContext2d.rs
@@ -372,6 +372,32 @@ extern "C" {
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
+    #[doc = "The `drawImage()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `OffscreenCanvas`*"]
+    pub fn draw_image_with_offscreen_canvas(
+        this: &CanvasRenderingContext2d,
+        image: &OffscreenCanvas,
+        dx: f64,
+        dy: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
+    #[doc = "The `drawImage()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `VideoFrame`*"]
+    pub fn draw_image_with_video_frame(
+        this: &CanvasRenderingContext2d,
+        image: &VideoFrame,
+        dx: f64,
+        dy: f64,
+    ) -> Result<(), JsValue>;
     #[cfg(feature = "HtmlImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -442,6 +468,36 @@ extern "C" {
     pub fn draw_image_with_image_bitmap_and_dw_and_dh(
         this: &CanvasRenderingContext2d,
         image: &ImageBitmap,
+        dx: f64,
+        dy: f64,
+        dw: f64,
+        dh: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
+    #[doc = "The `drawImage()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `OffscreenCanvas`*"]
+    pub fn draw_image_with_offscreen_canvas_and_dw_and_dh(
+        this: &CanvasRenderingContext2d,
+        image: &OffscreenCanvas,
+        dx: f64,
+        dy: f64,
+        dw: f64,
+        dh: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
+    #[doc = "The `drawImage()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `VideoFrame`*"]
+    pub fn draw_image_with_video_frame_and_dw_and_dh(
+        this: &CanvasRenderingContext2d,
+        image: &VideoFrame,
         dx: f64,
         dy: f64,
         dw: f64,
@@ -533,6 +589,44 @@ extern "C" {
     pub fn draw_image_with_image_bitmap_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &CanvasRenderingContext2d,
         image: &ImageBitmap,
+        sx: f64,
+        sy: f64,
+        sw: f64,
+        sh: f64,
+        dx: f64,
+        dy: f64,
+        dw: f64,
+        dh: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
+    #[doc = "The `drawImage()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `OffscreenCanvas`*"]
+    pub fn draw_image_with_offscreen_canvas_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+        this: &CanvasRenderingContext2d,
+        image: &OffscreenCanvas,
+        sx: f64,
+        sy: f64,
+        sw: f64,
+        sh: f64,
+        dx: f64,
+        dy: f64,
+        dw: f64,
+        dh: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = drawImage)]
+    #[doc = "The `drawImage()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `VideoFrame`*"]
+    pub fn draw_image_with_video_frame_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+        this: &CanvasRenderingContext2d,
+        image: &VideoFrame,
         sx: f64,
         sy: f64,
         sw: f64,
@@ -780,6 +874,30 @@ extern "C" {
     pub fn create_pattern_with_image_bitmap(
         this: &CanvasRenderingContext2d,
         image: &ImageBitmap,
+        repetition: &str,
+    ) -> Result<Option<CanvasPattern>, JsValue>;
+    #[cfg(all(feature = "CanvasPattern", feature = "OffscreenCanvas",))]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = createPattern)]
+    #[doc = "The `createPattern()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createPattern)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `CanvasRenderingContext2d`, `OffscreenCanvas`*"]
+    pub fn create_pattern_with_offscreen_canvas(
+        this: &CanvasRenderingContext2d,
+        image: &OffscreenCanvas,
+        repetition: &str,
+    ) -> Result<Option<CanvasPattern>, JsValue>;
+    #[cfg(all(feature = "CanvasPattern", feature = "VideoFrame",))]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = createPattern)]
+    #[doc = "The `createPattern()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createPattern)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `CanvasRenderingContext2d`, `VideoFrame`*"]
+    pub fn create_pattern_with_video_frame(
+        this: &CanvasRenderingContext2d,
+        image: &VideoFrame,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
     #[cfg(feature = "CanvasGradient")]

--- a/crates/web-sys/src/features/gen_VideoFrame.rs
+++ b/crates/web-sys/src/features/gen_VideoFrame.rs
@@ -190,6 +190,29 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_image_bitmap(image: &ImageBitmap) -> Result<VideoFrame, JsValue>;
     #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "OffscreenCanvas")]
+    #[wasm_bindgen(catch, constructor, js_class = "VideoFrame")]
+    #[doc = "The `new VideoFrame(..)` constructor, creating a new instance of `VideoFrame`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/VideoFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `VideoFrame`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn new_with_offscreen_canvas(image: &OffscreenCanvas) -> Result<VideoFrame, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[wasm_bindgen(catch, constructor, js_class = "VideoFrame")]
+    #[doc = "The `new VideoFrame(..)` constructor, creating a new instance of `VideoFrame`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/VideoFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn new_with_video_frame(image: &VideoFrame) -> Result<VideoFrame, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "HtmlImageElement", feature = "VideoFrameInit",))]
     #[wasm_bindgen(catch, constructor, js_class = "VideoFrame")]
     #[doc = "The `new VideoFrame(..)` constructor, creating a new instance of `VideoFrame`."]
@@ -262,6 +285,36 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_image_bitmap_and_video_frame_init(
         image: &ImageBitmap,
+        init: &VideoFrameInit,
+    ) -> Result<VideoFrame, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(all(feature = "OffscreenCanvas", feature = "VideoFrameInit",))]
+    #[wasm_bindgen(catch, constructor, js_class = "VideoFrame")]
+    #[doc = "The `new VideoFrame(..)` constructor, creating a new instance of `VideoFrame`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/VideoFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `VideoFrame`, `VideoFrameInit`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn new_with_offscreen_canvas_and_video_frame_init(
+        image: &OffscreenCanvas,
+        init: &VideoFrameInit,
+    ) -> Result<VideoFrame, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "VideoFrameInit")]
+    #[wasm_bindgen(catch, constructor, js_class = "VideoFrame")]
+    #[doc = "The `new VideoFrame(..)` constructor, creating a new instance of `VideoFrame`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/VideoFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `VideoFrameInit`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn new_with_video_frame_and_video_frame_init(
+        image: &VideoFrame,
         init: &VideoFrameInit,
     ) -> Result<VideoFrame, JsValue>;
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_Window.rs
+++ b/crates/web-sys/src/features/gen_Window.rs
@@ -2412,6 +2412,28 @@ extern "C" {
         this: &Window,
         a_image: &ImageBitmap,
     ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `Window`*"]
+    pub fn create_image_bitmap_with_offscreen_canvas(
+        this: &Window,
+        a_image: &OffscreenCanvas,
+    ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `Window`*"]
+    pub fn create_image_bitmap_with_video_frame(
+        this: &Window,
+        a_image: &VideoFrame,
+    ) -> Result<::js_sys::Promise, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
@@ -2532,6 +2554,36 @@ extern "C" {
     pub fn create_image_bitmap_with_image_bitmap_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &ImageBitmap,
+        a_sx: i32,
+        a_sy: i32,
+        a_sw: i32,
+        a_sh: i32,
+    ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `Window`*"]
+    pub fn create_image_bitmap_with_offscreen_canvas_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
+        this: &Window,
+        a_image: &OffscreenCanvas,
+        a_sx: i32,
+        a_sy: i32,
+        a_sw: i32,
+        a_sh: i32,
+    ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `Window`*"]
+    pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
+        this: &Window,
+        a_image: &VideoFrame,
         a_sx: i32,
         a_sy: i32,
         a_sw: i32,

--- a/crates/web-sys/src/features/gen_Window.rs
+++ b/crates/web-sys/src/features/gen_Window.rs
@@ -2423,6 +2423,7 @@ extern "C" {
         this: &Window,
         a_image: &OffscreenCanvas,
     ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -2430,6 +2431,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `Window`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_image_bitmap_with_video_frame(
         this: &Window,
         a_image: &VideoFrame,
@@ -2574,6 +2578,7 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
     ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -2581,6 +2586,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `Window`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &VideoFrame,

--- a/crates/web-sys/src/features/gen_WorkerGlobalScope.rs
+++ b/crates/web-sys/src/features/gen_WorkerGlobalScope.rs
@@ -335,6 +335,28 @@ extern "C" {
         this: &WorkerGlobalScope,
         a_image: &ImageBitmap,
     ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WorkerGlobalScope`*"]
+    pub fn create_image_bitmap_with_offscreen_canvas(
+        this: &WorkerGlobalScope,
+        a_image: &OffscreenCanvas,
+    ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `WorkerGlobalScope`*"]
+    pub fn create_image_bitmap_with_video_frame(
+        this: &WorkerGlobalScope,
+        a_image: &VideoFrame,
+    ) -> Result<::js_sys::Promise, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
@@ -455,6 +477,36 @@ extern "C" {
     pub fn create_image_bitmap_with_image_bitmap_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &ImageBitmap,
+        a_sx: i32,
+        a_sy: i32,
+        a_sw: i32,
+        a_sh: i32,
+    ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "OffscreenCanvas")]
+    # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WorkerGlobalScope`*"]
+    pub fn create_image_bitmap_with_offscreen_canvas_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
+        this: &WorkerGlobalScope,
+        a_image: &OffscreenCanvas,
+        a_sx: i32,
+        a_sy: i32,
+        a_sw: i32,
+        a_sh: i32,
+    ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(feature = "VideoFrame")]
+    # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
+    #[doc = "The `createImageBitmap()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `WorkerGlobalScope`*"]
+    pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
+        this: &WorkerGlobalScope,
+        a_image: &VideoFrame,
         a_sx: i32,
         a_sy: i32,
         a_sw: i32,

--- a/crates/web-sys/src/features/gen_WorkerGlobalScope.rs
+++ b/crates/web-sys/src/features/gen_WorkerGlobalScope.rs
@@ -346,6 +346,7 @@ extern "C" {
         this: &WorkerGlobalScope,
         a_image: &OffscreenCanvas,
     ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -353,6 +354,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `WorkerGlobalScope`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_image_bitmap_with_video_frame(
         this: &WorkerGlobalScope,
         a_image: &VideoFrame,
@@ -497,6 +501,7 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
     ) -> Result<::js_sys::Promise, JsValue>;
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -504,6 +509,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `WorkerGlobalScope`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &VideoFrame,

--- a/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
@@ -32,7 +32,9 @@ typedef (HTMLImageElement or
 typedef (HTMLOrSVGImageElement or
          HTMLCanvasElement or
          HTMLVideoElement or
-         ImageBitmap) CanvasImageSource;
+         ImageBitmap or
+         OffscreenCanvas or
+         VideoFrame) CanvasImageSource;
 
 interface CanvasRenderingContext2D {
 

--- a/crates/web-sys/webidls/enabled/ImageBitmap.webidl
+++ b/crates/web-sys/webidls/enabled/ImageBitmap.webidl
@@ -28,6 +28,8 @@ typedef (HTMLImageElement or
          ImageData or
          CanvasRenderingContext2D or
          ImageBitmap or
+         OffscreenCanvas or
+         VideoFrame or
          BufferSource) ImageBitmapSource;
 
 [Exposed=(Window,Worker)]

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -441,7 +441,11 @@ impl<'src> FirstPassRecord<'src> {
                 .orig
                 .args
                 .iter()
-                .any(|arg| is_type_unstable(arg.ty, unstable_types));
+                .any(|arg| is_type_unstable(arg.ty, unstable_types))
+                | signature
+                    .args
+                    .iter()
+                    .any(|arg| is_idl_type_unstable(arg, unstable_types));
 
             let unstable = unstable || data.stability.is_unstable() || has_unstable_args;
 
@@ -528,6 +532,13 @@ pub fn is_type_unstable(ty: &weedle::types::Type, unstable_types: &HashSet<Ident
             // Check if the type in the unstable type list
             unstable_types.contains(&i.type_)
         }
+        _ => false,
+    }
+}
+
+fn is_idl_type_unstable(ty: &IdlType, unstable_types: &HashSet<Identifier>) -> bool {
+    match ty {
+        IdlType::Interface(name) => unstable_types.contains(&Identifier(name)),
         _ => false,
     }
 }


### PR DESCRIPTION
According to [this](https://html.spec.whatwg.org/#2dcontext), `VideoFrame` and `OffscreenCanvas` are variants of `CanvasImageSource`, so I've added them. Since `CanvasImageSource` is also one of the variants of `ImageBitmapSource` [here](https://html.spec.whatwg.org/#images-2), I added them there too.