### PR TITLE
Add support for `local.tee` to `wasm-bindgen-wasm-interpreter`

### DIFF
--- a/crates/wasm-interpreter/src/lib.rs
+++ b/crates/wasm-interpreter/src/lib.rs
@@ -270,6 +270,10 @@ impl Frame<'_> {
                 let val = stack.pop().unwrap();
                 self.locals.insert(e.local, val);
             }
+            Instr::LocalTee(e) => {
+                let val = stack.last().unwrap().clone();
+                self.locals.insert(e.local, val);
+            }
 
             // Blindly assume all globals are the stack pointer
             Instr::GlobalGet(_) => stack.push(self.interp.sp),


### PR DESCRIPTION
This doesn't solve #2969, since WASI uses plenty of instructions we don't support aside from `local.tee`, but it hopefully might solve [@tv42's issue](https://github.com/rustwasm/wasm-bindgen/issues/2969#issuecomment-1374524820).