### PR TITLE
Call main only once take 3

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -344,7 +344,8 @@ impl Bindgen {
             builder
         });
 
-        self.threads
+        let thread_count = self
+            .threads
             .run(&mut module, &mut start)
             .with_context(|| "failed to prepare module for threading")?;
 
@@ -390,6 +391,7 @@ impl Bindgen {
             programs,
             self.externref,
             self.wasm_interface_types,
+            thread_count,
             self.emit_start,
         )?;
 

--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -23,6 +23,9 @@ pub struct Config {
     enabled: bool,
 }
 
+#[derive(Clone, Copy)]
+pub struct ThreadCount(walrus::LocalId);
+
 impl Config {
     /// Create a new configuration with default settings.
     pub fn new() -> Config {
@@ -107,9 +110,9 @@ impl Config {
         &self,
         module: &mut Module,
         start: &mut Option<walrus::FunctionBuilder>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<ThreadCount>, Error> {
         if !self.is_enabled(module) {
-            return Ok(());
+            return Ok(None);
         }
 
         let memory = wasm_conventions::get_memory(module)?;
@@ -161,7 +164,7 @@ impl Config {
 
         let _ = module.exports.add("__stack_alloc", stack.alloc);
 
-        inject_start(module, start, &tls, &stack, thread_counter_addr, memory)?;
+        let thread_count = inject_start(module, start, &tls, &stack, thread_counter_addr, memory)?;
 
         // we expose a `__wbindgen_thread_destroy()` helper function that deallocates stack space.
         //
@@ -181,7 +184,21 @@ impl Config {
         //   call while the leader is destroying its stack! You should make sure that this cannot happen.
         inject_destroy(module, &tls, &stack, memory)?;
 
-        Ok(())
+        Ok(Some(thread_count))
+    }
+}
+
+impl ThreadCount {
+    pub fn wrap_start(self, builder: &mut walrus::FunctionBuilder, start: FunctionId) {
+        // We only want to call the start function if we are in the first thread.
+        // The thread counter should be 0 for the first thread.
+        builder.func_body().local_get(self.0).if_else(
+            None,
+            |_| {},
+            |body| {
+                body.call(start);
+            },
+        );
     }
 }
 
@@ -305,13 +322,14 @@ fn inject_start(
     stack: &Stack,
     thread_counter_addr: i32,
     memory: MemoryId,
-) -> Result<(), Error> {
+) -> Result<ThreadCount, Error> {
     use walrus::ir::*;
 
     assert!(stack.size % PAGE_SIZE == 0);
     let builder =
         start.get_or_insert_with(|| walrus::FunctionBuilder::new(&mut module.types, &[], &[]));
     let local = module.locals.add(ValType::I32);
+    let thread_count = module.locals.add(ValType::I32);
 
     let mut body = builder.func_body();
 
@@ -323,6 +341,7 @@ fn inject_start(
     body.i32_const(thread_counter_addr)
         .i32_const(1)
         .atomic_rmw(memory, AtomicOp::Add, AtomicWidth::I32, ATOMIC_MEM_ARG)
+        .local_tee(thread_count)
         .if_else(
             None,
             // If our thread id is nonzero then we're the second or greater thread, so
@@ -359,7 +378,7 @@ fn inject_start(
         .global_get(tls.base)
         .call(tls.init);
 
-    Ok(())
+    Ok(ThreadCount(thread_count))
 }
 
 fn inject_destroy(

--- a/crates/threads-xform/tests/all.rs
+++ b/crates/threads-xform/tests/all.rs
@@ -22,7 +22,7 @@ fn runtest(test: &Test) -> Result<String> {
 
     let config = wasm_bindgen_threads_xform::Config::new();
 
-    config.run(&mut module)?;
+    config.run(&mut module, &mut None)?;
     walrus::passes::gc::run(&mut module);
 
     let features = {


### PR DESCRIPTION
As discussed in #3092, this addresses the possible race condition if one doesn't use `init` when compiling the WASM module.

To make this possible I changed the way the start function was modified in various places.
Currently the start function was always taken from the module and then wrapped into a new function, constructing a pretty nested start function.

With this PR the start function is built on instead of wrapping it over and over again, this allows to use local variables, eg. I stored the current thread counter in a local variable that I can use later to determine if we are in the first thread or not.

Replaces #3062 and #3092.
Fixes #2295.