### PR TITLE
Call main only once take 4

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -338,7 +338,8 @@ impl Bindgen {
                 .context("failed getting Wasm module")?,
         };
 
-        self.threads
+        let thread_count = self
+            .threads
             .run(&mut module)
             .with_context(|| "failed to prepare module for threading")?;
 
@@ -383,6 +384,7 @@ impl Bindgen {
             programs,
             self.externref,
             self.wasm_interface_types,
+            thread_count,
             self.emit_start,
         )?;
 

--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -23,6 +23,9 @@ pub struct Config {
     enabled: bool,
 }
 
+#[derive(Clone, Copy)]
+pub struct ThreadCount(walrus::LocalId);
+
 impl Config {
     /// Create a new configuration with default settings.
     pub fn new() -> Config {
@@ -103,9 +106,9 @@ impl Config {
     /// * Some stack space is prepared for each thread after the first one.
     ///
     /// More and/or less may happen here over time, stay tuned!
-    pub fn run(&self, module: &mut Module) -> Result<(), Error> {
+    pub fn run(&self, module: &mut Module) -> Result<Option<ThreadCount>, Error> {
         if !self.is_enabled(module) {
-            return Ok(());
+            return Ok(None);
         }
 
         let memory = wasm_conventions::get_memory(module)?;
@@ -157,7 +160,7 @@ impl Config {
 
         let _ = module.exports.add("__stack_alloc", stack.alloc);
 
-        inject_start(module, &tls, &stack, thread_counter_addr, memory)?;
+        let thread_count = inject_start(module, &tls, &stack, thread_counter_addr, memory)?;
 
         // we expose a `__wbindgen_thread_destroy()` helper function that deallocates stack space.
         //
@@ -177,7 +180,21 @@ impl Config {
         //   call while the leader is destroying its stack! You should make sure that this cannot happen.
         inject_destroy(module, &tls, &stack, memory)?;
 
-        Ok(())
+        Ok(Some(thread_count))
+    }
+}
+
+impl ThreadCount {
+    pub fn wrap_start(self, builder: &mut walrus::FunctionBuilder, start: FunctionId) {
+        // We only want to call the start function if we are in the first thread.
+        // The thread counter should be 0 for the first thread.
+        builder.func_body().local_get(self.0).if_else(
+            None,
+            |_| {},
+            |body| {
+                body.call(start);
+            },
+        );
     }
 }
 
@@ -300,12 +317,13 @@ fn inject_start(
     stack: &Stack,
     thread_counter_addr: i32,
     memory: MemoryId,
-) -> Result<(), Error> {
+) -> Result<ThreadCount, Error> {
     use walrus::ir::*;
 
     assert!(stack.size % PAGE_SIZE == 0);
 
     let local = module.locals.add(ValType::I32);
+    let thread_count = module.locals.add(ValType::I32);
 
     let malloc = find_function(module, "__wbindgen_malloc")?;
 
@@ -319,6 +337,7 @@ fn inject_start(
     body.i32_const(thread_counter_addr)
         .i32_const(1)
         .atomic_rmw(memory, AtomicOp::Add, AtomicWidth::I32, ATOMIC_MEM_ARG)
+        .local_tee(thread_count)
         .if_else(
             None,
             // If our thread id is nonzero then we're the second or greater thread, so
@@ -355,7 +374,7 @@ fn inject_start(
         .global_get(tls.base)
         .call(tls.init);
 
-    Ok(())
+    Ok(ThreadCount(thread_count))
 }
 
 fn inject_destroy(

--- a/crates/wasm-conventions/src/lib.rs
+++ b/crates/wasm-conventions/src/lib.rs
@@ -8,7 +8,8 @@
 
 use anyhow::{anyhow, bail, Result};
 use walrus::{
-    ir::Value, ElementId, FunctionId, GlobalId, GlobalKind, InitExpr, MemoryId, Module, ValType,
+    ir::Value, ElementId, FunctionBuilder, FunctionId, FunctionKind, GlobalId, GlobalKind,
+    InitExpr, MemoryId, Module, ValType,
 };
 
 /// Get a Wasm module's canonical linear memory.
@@ -111,4 +112,39 @@ pub fn get_function_table_entry(module: &Module, idx: u32) -> Result<FunctionTab
         }
     }
     bail!("failed to find `{}` in function table", idx);
+}
+
+pub fn get_or_insert_start_builder(module: &mut Module) -> &mut FunctionBuilder {
+    let prev_start = {
+        match module.start {
+            Some(start) => match module.funcs.get_mut(start).kind {
+                FunctionKind::Import(_) => Err(Some(start)),
+                FunctionKind::Local(_) => Ok(start),
+                FunctionKind::Uninitialized(_) => todo!(),
+            },
+            None => Err(None),
+        }
+    };
+
+    let id = match prev_start {
+        Ok(id) => id,
+        Err(prev_start) => {
+            let mut builder = FunctionBuilder::new(&mut module.types, &[], &[]);
+
+            if let Some(prev_start) = prev_start {
+                builder.func_body().call(prev_start);
+            }
+
+            let id = builder.finish(Vec::new(), &mut module.funcs);
+            module.start = Some(id);
+            id
+        }
+    };
+
+    module
+        .funcs
+        .get_mut(id)
+        .kind
+        .unwrap_local_mut()
+        .builder_mut()
 }


### PR DESCRIPTION
As discussed in #3092, this addresses the possible race condition if one doesn't use `init` when compiling the WASM module.

To make this possible I changed the way the start function was modified in various places.
Currently the start function was always taken from the module and then wrapped into a new function, constructing a pretty nested start function.

With this PR the start function is constantly being modified instead of wrapping it over and over again, this allows to use local variables, eg. I stored the current thread counter in a local variable that I can use later to determine if we are in the first thread or not.

I hope it's alright that I put some shared functionality into `wasm-bindgen-wasm-conventions`.

Replaces #3062, #3092 and #3234.
Fixes #2295.