### PR TITLE
`#[wasm_bindgen(start)]` shouldn't require `pub`

### DIFF
--- a/crates/cli/tests/wasm-bindgen/npm.rs
+++ b/crates/cli/tests/wasm-bindgen/npm.rs
@@ -14,7 +14,7 @@ fn no_modules_rejects_npm() {
                 }
 
                 #[wasm_bindgen(start)]
-                pub fn main() {
+                fn main() {
                     foo();
                 }
             "#,
@@ -48,7 +48,7 @@ fn more_package_json_fields_ignored() {
                 }
 
                 #[wasm_bindgen(start)]
-                pub fn main() {
+                fn main() {
                     foo();
                 }
             "#,
@@ -102,7 +102,7 @@ fn npm_conflict_rejected() {
                 }
 
                 #[wasm_bindgen(start)]
-                pub fn main() {
+                fn main() {
                     foo();
                     bar::foo();
                 }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -745,6 +745,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ItemFn {
     fn convert(self, attrs: BindgenAttrs) -> Result<Self::Target, Diagnostic> {
         match self.vis {
             syn::Visibility::Public(_) => {}
+            _ if attrs.start().is_some() => {}
             _ => bail_span!(self, "can only #[wasm_bindgen] public functions"),
         }
         if self.sig.constness.is_some() {

--- a/crates/macro/ui-tests/start-function.rs
+++ b/crates/macro/ui-tests/start-function.rs
@@ -1,33 +1,33 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
-pub fn foo() {}
+fn foo() {}
 
 #[wasm_bindgen(start)]
-pub fn foo2(x: u32) {}
+fn foo2(x: u32) {}
 
 #[wasm_bindgen(start)]
-pub fn foo3<T>() {}
+fn foo3<T>() {}
 
 #[wasm_bindgen(start)]
-pub fn foo4() -> Result<(), JsValue> { Ok(()) }
+fn foo4() -> Result<(), JsValue> { Ok(()) }
 
 #[wasm_bindgen(start)]
-pub fn foo5() -> Result<JsValue, ()> { Err(()) }
+fn foo5() -> Result<JsValue, ()> { Err(()) }
 
 #[wasm_bindgen(start)]
-pub fn foo6() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+fn foo6() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
 
 #[wasm_bindgen(start)]
-pub async fn foo_async1() {}
+async fn foo_async1() {}
 
 #[wasm_bindgen(start)]
-pub async fn foo_async2() -> Result<(), JsValue> { Ok(()) }
+async fn foo_async2() -> Result<(), JsValue> { Ok(()) }
 
 #[wasm_bindgen(start)]
-pub async fn foo_async3() -> Result<JsValue, ()> { Err(()) }
+async fn foo_async3() -> Result<JsValue, ()> { Err(()) }
 
 #[wasm_bindgen(start)]
-pub async fn foo_async4() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+async fn foo_async4() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
 
 fn main() {}

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -1,14 +1,14 @@
 error: the start function cannot have arguments
- --> ui-tests/start-function.rs:7:13
+ --> ui-tests/start-function.rs:7:9
   |
-7 | pub fn foo2(x: u32) {}
-  |             ^^^^^^
+7 | fn foo2(x: u32) {}
+  |         ^^^^^^
 
 error: the start function cannot have generics
-  --> ui-tests/start-function.rs:10:12
+  --> ui-tests/start-function.rs:10:8
    |
-10 | pub fn foo3<T>() {}
-   |            ^^^
+10 | fn foo3<T>() {}
+   |        ^^^
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
     --> ui-tests/start-function.rs:15:1

--- a/examples/canvas/src/lib.rs
+++ b/examples/canvas/src/lib.rs
@@ -2,7 +2,7 @@ use std::f64;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
-pub fn start() {
+fn start() {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();
     let canvas: web_sys::HtmlCanvasElement = canvas

--- a/examples/closures/src/lib.rs
+++ b/examples/closures/src/lib.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::{Document, Element, HtmlElement, Window};
 
 #[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+fn run() -> Result<(), JsValue> {
     let window = web_sys::window().expect("should have a window in this context");
     let document = window.document().expect("window should have a document");
 

--- a/examples/console_log/src/lib.rs
+++ b/examples/console_log/src/lib.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
-pub fn run() {
+fn run() {
     bare_bones();
     using_a_macro();
     using_web_sys();

--- a/examples/dom/src/lib.rs
+++ b/examples/dom/src/lib.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::*;
 
 // Called by our JS entry point to run the example
 #[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+fn run() -> Result<(), JsValue> {
     // Use `web_sys`'s global `window` function to get a handle on the global
     // window object.
     let window = web_sys::window().expect("no global `window` exists");

--- a/examples/import_js/crate/src/lib.rs
+++ b/examples/import_js/crate/src/lib.rs
@@ -25,7 +25,7 @@ extern "C" {
 }
 
 #[wasm_bindgen(start)]
-pub fn run() {
+fn run() {
     log(&format!("Hello from {}!", name())); // should output "Hello from Rust!"
 
     let x = MyClass::new();

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]
-pub fn start() -> Result<(), JsValue> {
+fn start() -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document
         .create_element("canvas")?

--- a/examples/performance/src/lib.rs
+++ b/examples/performance/src/lib.rs
@@ -14,7 +14,7 @@ macro_rules! console_log {
 }
 
 #[wasm_bindgen(start)]
-pub fn run() {
+fn run() {
     let window = web_sys::window().expect("should have a window in this context");
     let performance = window
         .performance()

--- a/examples/request-animation-frame/src/lib.rs
+++ b/examples/request-animation-frame/src/lib.rs
@@ -24,7 +24,7 @@ fn body() -> web_sys::HtmlElement {
 
 // This function is automatically invoked after the wasm module is instantiated.
 #[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+fn run() -> Result<(), JsValue> {
     // Here we want to call `requestAnimationFrame` in a loop, but only a fixed
     // number of times. After it's done we want all our resources cleaned up. To
     // achieve this we're using an `Rc`. The `Rc` will eventually store the

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -58,7 +58,7 @@ fn app(name: &str) {
 
 /// Entry point into the program from JavaScript
 #[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+fn run() -> Result<(), JsValue> {
     console_error_panic_hook::set_once();
     app("todos-wasmbindgen");
 

--- a/examples/wasm-in-wasm-imports/src/lib.rs
+++ b/examples/wasm-in-wasm-imports/src/lib.rs
@@ -73,7 +73,7 @@ impl Imports {
 }
 
 #[wasm_bindgen(start)]
-pub fn run() {
+fn run() {
     spawn_local(async {
         match run_async().await {
             Ok(_) => console_log!("Finished"),

--- a/examples/wasm-in-wasm/src/lib.rs
+++ b/examples/wasm-in-wasm/src/lib.rs
@@ -41,7 +41,7 @@ async fn run_async() -> Result<(), JsValue> {
 }
 
 #[wasm_bindgen(start)]
-pub fn run() {
+fn run() {
     spawn_local(async {
         run_async().await.unwrap_throw();
     });

--- a/examples/wasm2js/src/lib.rs
+++ b/examples/wasm2js/src/lib.rs
@@ -8,6 +8,6 @@ extern "C" {
 }
 
 #[wasm_bindgen(start)]
-pub fn run() {
+fn run() {
     log("Hello, World!");
 }

--- a/examples/weather_report/src/lib.rs
+++ b/examples/weather_report/src/lib.rs
@@ -19,7 +19,7 @@ extern "C" {
 }
 
 #[wasm_bindgen(start)]
-pub fn run() -> Result<(), JsValue> {
+fn run() -> Result<(), JsValue> {
     let window = web_sys::window().expect("no global `window` exists");
     let document = window.document().expect("should have a document on window");
     let body = document.body().expect("document should have a body");

--- a/examples/webgl/src/lib.rs
+++ b/examples/webgl/src/lib.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlShader};
 
 #[wasm_bindgen(start)]
-pub fn start() -> Result<(), JsValue> {
+fn start() -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
     let canvas = document.get_element_by_id("canvas").unwrap();
     let canvas: web_sys::HtmlCanvasElement = canvas.dyn_into::<web_sys::HtmlCanvasElement>()?;

--- a/examples/webrtc_datachannel/src/lib.rs
+++ b/examples/webrtc_datachannel/src/lib.rs
@@ -22,7 +22,7 @@ extern "C" {
 }
 
 #[wasm_bindgen(start)]
-pub async fn start() -> Result<(), JsValue> {
+async fn start() -> Result<(), JsValue> {
     /*
      * Set up PeerConnections
      * pc1 <=> pc2

--- a/examples/websockets/src/lib.rs
+++ b/examples/websockets/src/lib.rs
@@ -12,7 +12,7 @@ extern "C" {
 }
 
 #[wasm_bindgen(start)]
-pub fn start_websocket() -> Result<(), JsValue> {
+fn start_websocket() -> Result<(), JsValue> {
     // Connect to an echo server
     let ws = WebSocket::new("wss://echo.websocket.events")?;
     // For small binary messages, like CBOR, Arraybuffer is more efficient than Blob handling

--- a/examples/without-a-bundler-no-modules/src/lib.rs
+++ b/examples/without-a-bundler-no-modules/src/lib.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::*;
 
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]
-pub fn main() -> Result<(), JsValue> {
+fn main() -> Result<(), JsValue> {
     // Use `web_sys`'s global `window` function to get a handle on the global
     // window object.
     let window = web_sys::window().expect("no global `window` exists");

--- a/examples/without-a-bundler/src/lib.rs
+++ b/examples/without-a-bundler/src/lib.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::*;
 
 // Called when the wasm module is instantiated
 #[wasm_bindgen(start)]
-pub fn main() -> Result<(), JsValue> {
+fn main() -> Result<(), JsValue> {
     // Use `web_sys`'s global `window` function to get a handle on the global
     // window object.
     let window = web_sys::window().expect("no global `window` exists");

--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -6,7 +6,7 @@ soon as the wasm module is instantiated.
 
 ```rust
 #[wasm_bindgen(start)]
-pub fn main() {
+fn main() {
     // executed automatically ...
 }
 ```

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -52,6 +52,6 @@ pub mod vendor_prefix;
 
 // should not be executed
 #[wasm_bindgen(start)]
-pub fn start() {
+fn start() {
     panic!();
 }


### PR DESCRIPTION
I noticed that every time I used `#[wasm_bindgen(start)]` it required me to add the `pub` visibility modifier, which I thought could be improved.