### PR TITLE
fix: convert `None` to `null` instead of `undefined`

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -983,10 +983,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
         Instruction::OptionRustFromI32 { class } => {
             js.cx.require_class_wrap(class);
             let val = js.pop();
-            js.push(format!(
-                "{0} === 0 ? undefined : {1}.__wrap({0})",
-                val, class,
-            ))
+            js.push(format!("{0} === 0 ? null : {1}.__wrap({0})", val, class,))
         }
 
         Instruction::CachedStringLoad {
@@ -1121,7 +1118,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             let ptr = js.pop();
             let f = js.cx.expose_get_vector_from_wasm(kind.clone(), *mem)?;
             js.push(format!(
-                "{ptr} === 0 ? undefined : {f}({ptr}, {len})",
+                "{ptr} === 0 ? null : {f}({ptr}, {len})",
                 ptr = ptr,
                 len = len,
                 f = f
@@ -1130,14 +1127,14 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
 
         Instruction::OptionU32Sentinel => {
             let val = js.pop();
-            js.push(format!("{0} === 0xFFFFFF ? undefined : {0}", val));
+            js.push(format!("{0} === 0xFFFFFF ? null : {0}", val));
         }
 
         Instruction::ToOptionNative { ty, signed } => {
             let val = js.pop();
             let present = js.pop();
             js.push(format!(
-                "{} === 0 ? undefined : {}",
+                "{} === 0 ? null : {}",
                 present,
                 if *signed {
                     val
@@ -1153,20 +1150,20 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
 
         Instruction::OptionBoolFromI32 => {
             let val = js.pop();
-            js.push(format!("{0} === 0xFFFFFF ? undefined : {0} !== 0", val));
+            js.push(format!("{0} === 0xFFFFFF ? null : {0} !== 0", val));
         }
 
         Instruction::OptionCharFromI32 => {
             let val = js.pop();
             js.push(format!(
-                "{0} === 0xFFFFFF ? undefined : String.fromCodePoint({0})",
+                "{0} === 0xFFFFFF ? null : String.fromCodePoint({0})",
                 val,
             ));
         }
 
         Instruction::OptionEnumFromI32 { hole } => {
             let val = js.pop();
-            js.push(format!("{0} === {1} ? undefined : {0}", val, hole));
+            js.push(format!("{0} === {1} ? null : {0}", val, hole));
         }
     }
     Ok(())
@@ -1283,7 +1280,7 @@ fn adapter2ts(ty: &AdapterType, dst: &mut String) {
         AdapterType::Vector(kind) => dst.push_str(&kind.js_ty()),
         AdapterType::Option(ty) => {
             adapter2ts(ty, dst);
-            dst.push_str(" | undefined");
+            dst.push_str(" | null");
         }
         AdapterType::NamedExternref(name) => dst.push_str(name),
         AdapterType::Struct(name) => dst.push_str(name),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -841,7 +841,7 @@ where
     fn from(s: Option<T>) -> JsValue {
         match s {
             Some(s) => s.into(),
-            None => JsValue::undefined(),
+            None => JsValue::null(),
         }
     }
 }

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -176,7 +176,7 @@ exports.js_conditional_bindings = () => {
 };
 
 exports.js_assert_none = x => {
-  assert.strictEqual(x, undefined);
+  assert.strictEqual(x, null);
 };
 exports.js_assert_some = x => {
   assert.ok(x instanceof wasm.OptionClass);
@@ -186,7 +186,7 @@ exports.js_return_none2 = () => undefined;
 exports.js_return_some = x => x;
 
 exports.js_test_option_classes = () => {
-  assert.strictEqual(wasm.option_class_none(), undefined);
+  assert.strictEqual(wasm.option_class_none(), null);
   wasm.option_class_assert_none(undefined);
   wasm.option_class_assert_none(null);
   const c = wasm.option_class_some();

--- a/tests/wasm/enums.js
+++ b/tests/wasm/enums.js
@@ -32,7 +32,7 @@ exports.js_expect_enum = (a, b) => {
 };
 
 exports.js_expect_enum_none = a => {
-  assert.strictEqual(a, undefined);
+  assert.strictEqual(a, null);
 };
 
 exports.js_renamed_enum = b => {

--- a/tests/wasm/option.js
+++ b/tests/wasm/option.js
@@ -7,7 +7,7 @@ class MyType {
 exports.MyType = MyType;
 
 exports.take_none_byval = x => {
-    assert.strictEqual(x, undefined);
+    assert.strictEqual(x, null);
 };
 exports.take_some_byval = x => {
     assert.ok(x !== null && x !== undefined);

--- a/tests/wasm/optional_primitives.js
+++ b/tests/wasm/optional_primitives.js
@@ -17,86 +17,86 @@ exports.optional_bool_js_identity = a => a;
 exports.optional_char_js_identity = a => a;
 
 exports.js_works = () => {
-    assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_none()), undefined);
+    assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_none()), null);
     assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_zero()), 0);
     assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_one()), 1);
     assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_neg_one()), -1);
     assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_min()), -2147483648);
     assert.strictEqual(wasm.optional_i32_identity(wasm.optional_i32_max()), 2147483647);
 
-    assert.strictEqual(wasm.optional_u32_identity(wasm.optional_u32_none()), undefined);
+    assert.strictEqual(wasm.optional_u32_identity(wasm.optional_u32_none()), null);
     assert.strictEqual(wasm.optional_u32_identity(wasm.optional_u32_zero()), 0);
     assert.strictEqual(wasm.optional_u32_identity(wasm.optional_u32_one()), 1);
     assert.strictEqual(wasm.optional_u32_identity(wasm.optional_u32_min()), 0);
     assert.strictEqual(wasm.optional_u32_identity(wasm.optional_u32_max()), 4294967295);
 
-    assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_none()), undefined);
+    assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_none()), null);
     assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_zero()), 0);
     assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_one()), 1);
     assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_neg_one()), -1);
     assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_min()), -2147483648);
     assert.strictEqual(wasm.optional_isize_identity(wasm.optional_isize_max()), 2147483647);
 
-    assert.strictEqual(wasm.optional_usize_identity(wasm.optional_usize_none()), undefined);
+    assert.strictEqual(wasm.optional_usize_identity(wasm.optional_usize_none()), null);
     assert.strictEqual(wasm.optional_usize_identity(wasm.optional_usize_zero()), 0);
     assert.strictEqual(wasm.optional_usize_identity(wasm.optional_usize_one()), 1);
     assert.strictEqual(wasm.optional_usize_identity(wasm.optional_usize_min()), 0);
     assert.strictEqual(wasm.optional_usize_identity(wasm.optional_usize_max()), 4294967295);
 
-    assert.strictEqual(wasm.optional_f32_identity(wasm.optional_f32_none()), undefined);
+    assert.strictEqual(wasm.optional_f32_identity(wasm.optional_f32_none()), null);
     assert.strictEqual(wasm.optional_f32_identity(wasm.optional_f32_zero()), 0);
     assert.strictEqual(wasm.optional_f32_identity(wasm.optional_f32_one()), 1);
     assert.strictEqual(wasm.optional_f32_identity(wasm.optional_f32_neg_one()), -1);
 
-    assert.strictEqual(wasm.optional_f64_identity(wasm.optional_f64_none()), undefined);
+    assert.strictEqual(wasm.optional_f64_identity(wasm.optional_f64_none()), null);
     assert.strictEqual(wasm.optional_f64_identity(wasm.optional_f64_zero()), 0);
     assert.strictEqual(wasm.optional_f64_identity(wasm.optional_f64_one()), 1);
     assert.strictEqual(wasm.optional_f64_identity(wasm.optional_f64_neg_one()), -1);
 
-    assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_none()), undefined);
+    assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_none()), null);
     assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_zero()), 0);
     assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_one()), 1);
     assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_neg_one()), -1);
     assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_min()), -128);
     assert.strictEqual(wasm.optional_i8_identity(wasm.optional_i8_max()), 127);
 
-    assert.strictEqual(wasm.optional_u8_identity(wasm.optional_u8_none()), undefined);
+    assert.strictEqual(wasm.optional_u8_identity(wasm.optional_u8_none()), null);
     assert.strictEqual(wasm.optional_u8_identity(wasm.optional_u8_zero()), 0);
     assert.strictEqual(wasm.optional_u8_identity(wasm.optional_u8_one()), 1);
     assert.strictEqual(wasm.optional_u8_identity(wasm.optional_u8_min()), 0);
     assert.strictEqual(wasm.optional_u8_identity(wasm.optional_u8_max()), 255);
 
-    assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_none()), undefined);
+    assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_none()), null);
     assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_zero()), 0);
     assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_one()), 1);
     assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_neg_one()), -1);
     assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_min()), -32768);
     assert.strictEqual(wasm.optional_i16_identity(wasm.optional_i16_max()), 32767);
 
-    assert.strictEqual(wasm.optional_u16_identity(wasm.optional_u16_none()), undefined);
+    assert.strictEqual(wasm.optional_u16_identity(wasm.optional_u16_none()), null);
     assert.strictEqual(wasm.optional_u16_identity(wasm.optional_u16_zero()), 0);
     assert.strictEqual(wasm.optional_u16_identity(wasm.optional_u16_one()), 1);
     assert.strictEqual(wasm.optional_u16_identity(wasm.optional_u16_min()), 0);
     assert.strictEqual(wasm.optional_u16_identity(wasm.optional_u16_max()), 65535);
 
-    assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_none()), undefined);
+    assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_none()), null);
     assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_zero()), BigInt('0'));
     assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_one()), BigInt('1'));
     assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_neg_one()), BigInt('-1'));
     assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_min()), BigInt('-9223372036854775808'));
     assert.strictEqual(wasm.optional_i64_identity(wasm.optional_i64_max()), BigInt('9223372036854775807'));
 
-    assert.strictEqual(wasm.optional_u64_identity(wasm.optional_u64_none()), undefined);
+    assert.strictEqual(wasm.optional_u64_identity(wasm.optional_u64_none()), null);
     assert.strictEqual(wasm.optional_u64_identity(wasm.optional_u64_zero()), BigInt('0'));
     assert.strictEqual(wasm.optional_u64_identity(wasm.optional_u64_one()), BigInt('1'));
     assert.strictEqual(wasm.optional_u64_identity(wasm.optional_u64_min()), BigInt('0'));
     assert.strictEqual(wasm.optional_u64_identity(wasm.optional_u64_max()), BigInt('18446744073709551615'));
 
-    assert.strictEqual(wasm.optional_bool_identity(wasm.optional_bool_none()), undefined);
+    assert.strictEqual(wasm.optional_bool_identity(wasm.optional_bool_none()), null);
     assert.strictEqual(wasm.optional_bool_identity(wasm.optional_bool_false()), false);
     assert.strictEqual(wasm.optional_bool_identity(wasm.optional_bool_true()), true);
 
-    assert.strictEqual(wasm.optional_char_identity(wasm.optional_char_none()), undefined);
+    assert.strictEqual(wasm.optional_char_identity(wasm.optional_char_none()), null);
     assert.strictEqual(wasm.optional_char_identity(wasm.optional_char_letter()), 'a');
     assert.strictEqual(wasm.optional_char_identity(wasm.optional_char_face()), '😀');
 };

--- a/tests/wasm/result.js
+++ b/tests/wasm/result.js
@@ -116,7 +116,7 @@ exports.call_option = function() {
     });
     assert.doesNotThrow(() => {
         let o = wasm.return_option_ok_none();
-        assert.strictEqual(o, undefined);
+        assert.strictEqual(o, null);
     });
     assert.throws(() => {
         wasm.return_option_err();

--- a/tests/wasm/simple.js
+++ b/tests/wasm/simple.js
@@ -44,7 +44,7 @@ exports.test_jsvalue_typeof = function() {
 };
 
 exports.optional_str_none = function(x) {
-  assert.strictEqual(x, undefined);
+  assert.strictEqual(x, null);
 };
 
 exports.optional_str_some = function(x) {
@@ -52,7 +52,7 @@ exports.optional_str_some = function(x) {
 };
 
 exports.optional_slice_none = function(x) {
-  assert.strictEqual(x, undefined);
+  assert.strictEqual(x, null);
 };
 
 exports.optional_slice_some = function(x) {

--- a/tests/wasm/slice.js
+++ b/tests/wasm/slice.js
@@ -48,7 +48,7 @@ const test_import = (a, b, c) => {
     assert.strictEqual(b.length, 2);
     assert.strictEqual(b[0], 1);
     assert.strictEqual(b[1], 2);
-    assert.strictEqual(c, undefined);
+    assert.strictEqual(c, null);
     return a;
 };
 
@@ -128,7 +128,7 @@ const import_mut_foo = (a, b, c) => {
     assert.strictEqual(b[2], 6);
     b[0] = 8;
     b[1] = 7;
-    assert.strictEqual(c, undefined);
+    assert.strictEqual(c, null);
 };
 
 exports.import_mut_js_i8 = import_mut_foo;


### PR DESCRIPTION
Converting `None` to `undefined` in JS land, means that `Enum::Variant(None)` will be converted to `{ "Variant": undefined }` . This is mostly fine in JS but when trying to serialize the resulting object using `JSON.stringify`, it will skip `undefined` properties and I think that is counter-intutive so `None` should be mapped to `null` instead.

ref: tauri-apps/tauri#5993