### PR TITLE
Implement `shim_url`

### DIFF
--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -255,6 +255,9 @@ intrinsics! {
         #[symbol = "__wbindgen_module"]
         #[signature = fn() -> Externref]
         Module,
+        #[symbol = "__wbindgen_shim_url"]
+        #[signature = fn() -> Externref]
+        ShimUrl,
         #[symbol = "__wbindgen_function_table"]
         #[signature = fn() -> Externref]
         FunctionTable,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3545,6 +3545,15 @@ impl<'a> Context<'a> {
                 format!("wasm.{}", self.export_name_of(memory))
             }
 
+            Intrinsic::ShimUrl => {
+                assert_eq!(args.len(), 0);
+                match self.config.mode {
+                    OutputMode::Web => format!("import.meta.url"),
+                    OutputMode::NoModules { .. } => format!("script_src"),
+                    _ => format!("null"),
+                }
+            }
+
             Intrinsic::FunctionTable => {
                 assert_eq!(args.len(), 0);
                 let name = self.export_function_table()?;

--- a/examples/wasm-audio-worklet/src/dependent_module.rs
+++ b/examples/wasm-audio-worklet/src/dependent_module.rs
@@ -2,25 +2,11 @@ use js_sys::{Array, JsString};
 use wasm_bindgen::prelude::*;
 use web_sys::{Blob, BlobPropertyBag, Url};
 
-// This is a not-so-clean approach to get the current bindgen ES module URL
-// in Rust. This will fail at run time on bindgen targets not using ES modules.
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen]
-    type ImportMeta;
-
-    #[wasm_bindgen(method, getter)]
-    fn url(this: &ImportMeta) -> JsString;
-
-    #[wasm_bindgen(js_namespace = import, js_name = meta)]
-    static IMPORT_META: ImportMeta;
-}
-
 pub fn on_the_fly(code: &str) -> Result<String, JsValue> {
     // Generate the import of the bindgen ES module, assuming `--target web`.
     let header = format!(
         "import init, * as bindgen from '{}';\n\n",
-        IMPORT_META.url(),
+        wasm_bindgen::shim_url().expect("not using `--target web`"),
     );
 
     Url::create_object_url_with_blob(&Blob::new_with_str_sequence_and_options(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1364,7 +1364,7 @@ pub fn memory() -> JsValue {
     unsafe { JsValue::_new(__wbindgen_memory()) }
 }
 
-/// Returns the URL to the script that instantiated the wasm module.
+/// Returns the URL of the generated JS shim.
 ///
 /// This will currently return `None` on every target except `web` and `no-modules`.
 /// Additionally it will return `None` when used with the `no-modules` target but

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1084,6 +1084,7 @@ externs! {
 
         fn __wbindgen_memory() -> u32;
         fn __wbindgen_module() -> u32;
+        fn __wbindgen_shim_url() -> u32;
         fn __wbindgen_function_table() -> u32;
     }
 }
@@ -1361,6 +1362,15 @@ pub fn module() -> JsValue {
 /// Returns a handle to this wasm instance's `WebAssembly.Memory`
 pub fn memory() -> JsValue {
     unsafe { JsValue::_new(__wbindgen_memory()) }
+}
+
+/// Returns the URL to the script that instantiated the wasm module.
+///
+/// This will currently return `None` on every target except `web` and `no-modules`.
+/// Additionally it will return `None` when used with the `no-modules` target but
+/// not executed in a document.
+pub fn shim_url() -> Option<String> {
+    unsafe { JsValue::_new(__wbindgen_shim_url()) }.as_string()
 }
 
 /// Returns a handle to this wasm instance's `WebAssembly.Table` which is the


### PR DESCRIPTION
Adjusted #3032 according to @Liamolucko's comment: https://github.com/rustwasm/wasm-bindgen/pull/3032#issuecomment-1396290519.

This is now only implemented for the `web` and `no-modules` targets, all other's return `None`.

Replaces #3032.