### PR TITLE
Adjust examples and documentation to thread-aware `start`

### DIFF
--- a/crates/wasm-conventions/src/lib.rs
+++ b/crates/wasm-conventions/src/lib.rs
@@ -120,7 +120,7 @@ pub fn get_or_insert_start_builder(module: &mut Module) -> &mut FunctionBuilder 
             Some(start) => match module.funcs.get_mut(start).kind {
                 FunctionKind::Import(_) => Err(Some(start)),
                 FunctionKind::Local(_) => Ok(start),
-                FunctionKind::Uninitialized(_) => todo!(),
+                FunctionKind::Uninitialized(_) => unimplemented!(),
             },
             None => Err(None),
         }

--- a/examples/wasm-in-web-worker/index.js
+++ b/examples/wasm-in-web-worker/index.js
@@ -1,18 +1,9 @@
-// We only need `startup` here which is the main entry point
-// In theory, we could also use all other functions/struct types from Rust which we have bound with
-// `#[wasm_bindgen]`
-const {startup} = wasm_bindgen;
-
 async function run_wasm() {
+    console.log('index.js loaded');
+
     // Load the wasm file by awaiting the Promise returned by `wasm_bindgen`
     // `wasm_bindgen` was imported in `index.html`
     await wasm_bindgen('./pkg/wasm_in_web_worker_bg.wasm');
-
-    console.log('index.js loaded');
-
-    // Run main WASM entry point
-    // This will create a worker from within our Rust code compiled to WASM
-    startup();
 }
 
 run_wasm();

--- a/examples/wasm-in-web-worker/src/lib.rs
+++ b/examples/wasm-in-web-worker/src/lib.rs
@@ -42,8 +42,8 @@ impl NumberEval {
 }
 
 /// Run entry point for the main thread.
-#[wasm_bindgen]
-pub fn startup() {
+#[wasm_bindgen(start)]
+fn start() {
     // Here, we create our worker. In a larger app, multiple callbacks should be
     // able to interact with the code in the worker. Therefore, we wrap it in
     // `Rc<RefCell>` following the interior mutability pattern. Here, it would

--- a/guide/src/examples/wasm-in-web-worker.md
+++ b/guide/src/examples/wasm-in-web-worker.md
@@ -27,11 +27,10 @@ the JS console, creating a worker and reacting to message events.
 ## `src/lib.rs`
 
 Creates a struct `NumberEval` with methods to act as stateful object in the
-worker and function `startup` to be launched in the main thread. Also includes
-internal helper functions `setup_input_oninput_callback` to attach a
-`wasm_bindgen::Closure` as callback to the `oninput` event of the input field
-and `get_on_msg_callback` to create a `wasm_bindgen::Closure` which is triggered
-when the worker returns a message.
+worker and `start` function. Also includes internal helper functions
+`setup_input_oninput_callback` to attach a `wasm_bindgen::Closure` as callback
+to the `oninput` event of the input field and `get_on_msg_callback` to create a
+`wasm_bindgen::Closure` which is triggered when the worker returns a message.
 
 ```rust
 {{#include ../../../examples/wasm-in-web-worker/src/lib.rs}}
@@ -51,8 +50,8 @@ both `wasm_in_web_worker.js` and `index.js`.
 
 ## `index.js`
 
-Loads our WASM file asynchronously and calls the entry point `startup` of the
-main thread which will create a worker.
+Loads our WASM file asynchronously which calls the `start` function and creates
+a worker.
 
 ```js
 {{#include ../../../examples/wasm-in-web-worker/index.js}}

--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -25,7 +25,5 @@ There's a few caveats to be aware of when using the `start` attribute:
   dependencies. If more than one is specified then `wasm-bindgen` will fail when
   the CLI is run. It's recommended that only applications use this attribute.
 * The `start` function will not be executed when testing.
-* If you're experimenting with WebAssembly threads, the `start` function is
-  executed *once per thread*, not once globally!
 * Note that the `start` function is relatively new, so if you find any bugs with
   it, please feel free to report an issue!


### PR DESCRIPTION
We didn't adjust the examples and documentation after #3236.
This addresses that.

I honestly wasn't able to test the `wasm-in-web-worker` example because I couldn't get wasm-pack working.