### PR TITLE
Adjust examples to automatic `.wasm` file detection for the `no-modules` target

### DIFF
--- a/examples/raytrace-parallel/index.js
+++ b/examples/raytrace-parallel/index.js
@@ -26,7 +26,7 @@ function loadWasm() {
     return
   }
 
-  wasm_bindgen('./raytrace_parallel_bg.wasm')
+  wasm_bindgen()
     .then(run)
     .catch(console.error);
 }

--- a/examples/wasm-in-web-worker/index.js
+++ b/examples/wasm-in-web-worker/index.js
@@ -6,7 +6,7 @@ const {startup} = wasm_bindgen;
 async function run_wasm() {
     // Load the wasm file by awaiting the Promise returned by `wasm_bindgen`
     // `wasm_bindgen` was imported in `index.html`
-    await wasm_bindgen('./pkg/wasm_in_web_worker_bg.wasm');
+    await wasm_bindgen();
 
     console.log('index.js loaded');
 

--- a/examples/without-a-bundler-no-modules/index.html
+++ b/examples/without-a-bundler-no-modules/index.html
@@ -19,7 +19,7 @@
       const { add } = wasm_bindgen;
 
       async function run() {
-        await wasm_bindgen('./pkg/without_a_bundler_no_modules_bg.wasm');
+        await wasm_bindgen();
 
         const result = add(1, 2);
         console.log(`1 + 2 = ${result}`);


### PR DESCRIPTION
Follow-up for #3169.

I couldn't really try it because I can't get wasm-pack to work for me.