### PR TITLE
Implement `#[wasm_bindgen(start_async)]`

### DIFF
--- a/crates/macro/ui-tests/start-function.rs
+++ b/crates/macro/ui-tests/start-function.rs
@@ -30,4 +30,7 @@ async fn foo_async3() -> Result<JsValue, ()> { Err(()) }
 #[wasm_bindgen(start)]
 async fn foo_async4() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
 
+#[wasm_bindgen(start_async)]
+fn foo_missing_async() {}
+
 fn main() {}

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -10,6 +10,12 @@ error: the start function cannot have generics
 10 | fn foo3<T>() {}
    |        ^^^
 
+error: the start_async function has to be async
+  --> ui-tests/start-function.rs:34:1
+   |
+34 | fn foo_missing_async() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
     --> ui-tests/start-function.rs:15:1
      |

--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -29,3 +29,17 @@ There's a few caveats to be aware of when using the `start` attribute:
   executed *once per thread*, not once globally!
 * Note that the `start` function is relatively new, so if you find any bugs with
   it, please feel free to report an issue!
+
+To support `async fn main()` in a binary, you can use the `start_async` attribute,
+à la `#[tokio::main]`, like this:
+
+# `start_async`
+```rust
+#[wasm_bindgen(start_async)]
+async fn main() {
+    // executed automatically ...
+}
+```
+
+This will otherwise behave the same as `start`, except that it rewrites the function
+to a sync version.


### PR DESCRIPTION
Adds a new attribute called `start_async`, it has the exact same behavior as `start` but rewrites the function to a non-async version that contains the `spawn_local` inside it.

The purpose is to allow `async fn main()` to be used in Cargo binaries. It's similar to what `#[tokio::main]` and others do.

This could have also been done by adjusting `start`, but the issue is that it might break some behavior, for example one could rely on the function actually being `async`, which it wouldn't be after the rewrite. This could be mitigated by adjusting the behavior only for functions called `main`, but it's still a breaking change I would argue.

Fixes #3076.