### PR TITLE
Lazily initialize memory views

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -787,10 +787,10 @@ impl<'a> Context<'a> {
             for kind in views {
                 writeln!(
                     init_memviews,
-                    // Reset the memory views to empty in case `init` gets called multiple times.
+                    // Reset the memory views to null in case `init` gets called multiple times.
                     // Without this, the `length = 0` check would never detect that the view was
                     // outdated.
-                    "cached{kind}Memory{num} = new {kind}Array();",
+                    "cached{kind}Memory{num} = null;",
                     kind = kind,
                     num = num,
                 )
@@ -1782,14 +1782,12 @@ impl<'a> Context<'a> {
             format!("{cache}.byteLength === 0", cache = cache)
         };
 
-        // Initialize the cache to an empty array, which will trigger the resized check
-        // on the first call and initialise the view.
-        self.global(&format!("let {cache} = new {kind}Array();\n"));
+        self.global(&format!("let {cache} = null;\n"));
 
         self.global(&format!(
             "
             function {name}() {{
-                if ({resized_check}) {{
+                if ({cache} === null || {resized_check}) {{
                     {cache} = new {kind}Array(wasm.{mem}.buffer);
                 }}
                 return {cache};

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -10,10 +10,10 @@ let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0 = new Uint8Array();
+let cachedUint8Memory0 = null;
 
 function getUint8Memory0() {
-    if (cachedUint8Memory0.byteLength === 0) {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
     }
     return cachedUint8Memory0;
@@ -38,10 +38,10 @@ function handleError(f, args) {
     }
 }
 
-let cachedInt32Memory0 = new Int32Array();
+let cachedInt32Memory0 = null;
 
 function getInt32Memory0() {
-    if (cachedInt32Memory0.byteLength === 0) {
+    if (cachedInt32Memory0 === null || cachedInt32Memory0.byteLength === 0) {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
     }
     return cachedInt32Memory0;

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -27,10 +27,10 @@ function handleError(f, args) {
     }
 }
 
-let cachedInt32Memory0 = new Int32Array();
+let cachedInt32Memory0 = null;
 
 function getInt32Memory0() {
-    if (cachedInt32Memory0.byteLength === 0) {
+    if (cachedInt32Memory0 === null || cachedInt32Memory0.byteLength === 0) {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
     }
     return cachedInt32Memory0;

--- a/crates/cli/tests/reference/result-string.js
+++ b/crates/cli/tests/reference/result-string.js
@@ -19,10 +19,10 @@ function addHeapObject(obj) {
     return idx;
 }
 
-let cachedInt32Memory0 = new Int32Array();
+let cachedInt32Memory0 = null;
 
 function getInt32Memory0() {
-    if (cachedInt32Memory0.byteLength === 0) {
+    if (cachedInt32Memory0 === null || cachedInt32Memory0.byteLength === 0) {
         cachedInt32Memory0 = new Int32Array(wasm.memory.buffer);
     }
     return cachedInt32Memory0;
@@ -48,10 +48,10 @@ let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0 = new Uint8Array();
+let cachedUint8Memory0 = null;
 
 function getUint8Memory0() {
-    if (cachedUint8Memory0.byteLength === 0) {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
     }
     return cachedUint8Memory0;

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -10,10 +10,10 @@ let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true
 
 cachedTextDecoder.decode();
 
-let cachedUint8Memory0 = new Uint8Array();
+let cachedUint8Memory0 = null;
 
 function getUint8Memory0() {
-    if (cachedUint8Memory0.byteLength === 0) {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
         cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
     }
     return cachedUint8Memory0;


### PR DESCRIPTION
This stops load-time errors in versions of Safari before 15 if the `BigInt64Array` or `BigUint64Array` memory views are included but never used.

Pointed out in https://github.com/rustwasm/wasm-bindgen/issues/2716#issuecomment-1397621198.