### PR TITLE
Support `Result<(), impl Debug>` in `#[wasm_bindgen(start)]`

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -489,7 +489,10 @@ impl TryToTokens for ast::Export {
                     quote! { () },
                     quote! { () },
                     quote! {
-                        <#syn_ret as wasm_bindgen::__rt::Start>::start(#ret.await)
+                        {
+                            use wasm_bindgen::__rt::Start;
+                            wasm_bindgen::__rt::StartWrapper(#ret.await).__wasm_bindgen_start()
+                        }
                     },
                 )
             } else {
@@ -505,7 +508,12 @@ impl TryToTokens for ast::Export {
             (
                 quote! { () },
                 quote! { () },
-                quote! { <#syn_ret as wasm_bindgen::__rt::Start>::start(#ret) },
+                quote! {
+                    {
+                        use wasm_bindgen::__rt::Start;
+                        wasm_bindgen::__rt::StartWrapper(#ret).__wasm_bindgen_start()
+                    }
+                },
             )
         } else {
             (quote! { #syn_ret }, quote! { #syn_ret }, quote! { #ret })

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -10,62 +10,34 @@ error: the start function cannot have generics
 10 | fn foo3<T>() {}
    |        ^^^
 
-error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:15:1
-     |
-15   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
-note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0599]: no method named `__wasm_bindgen_start` found for struct `StartWrapper` in the current scope
+  --> ui-tests/start-function.rs:15:1
+   |
+15 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ method not found in `StartWrapper<Result<wasm_bindgen::JsValue, ()>>`
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:18:1
-     |
-18   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
-note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0599]: no method named `__wasm_bindgen_start` found for struct `StartWrapper` in the current scope
+  --> ui-tests/start-function.rs:18:1
+   |
+18 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ method not found in `StartWrapper<Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>>`
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:27:1
-     |
-27   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
-note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0599]: no method named `__wasm_bindgen_start` found for struct `StartWrapper` in the current scope
+  --> ui-tests/start-function.rs:27:1
+   |
+27 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ method not found in `StartWrapper<Result<wasm_bindgen::JsValue, ()>>`
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:30:1
-     |
-30   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
-note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+error[E0599]: no method named `__wasm_bindgen_start` found for struct `StartWrapper` in the current scope
+  --> ui-tests/start-function.rs:30:1
+   |
+30 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ method not found in `StartWrapper<Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>>`
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This adds support to `#[wasm_bindgen(start)]` to support more types closer to what Rusts `fn main()` supports while not changing the current behavior of throwing `JsValue`s when available.

Looking at [`Termination`](https://doc.rust-lang.org/std/process/trait.Termination.html), which is what `fn main()` uses, I added support for [`Infallible`](https://doc.rust-lang.org/std/convert/enum.Infallible.html) and `Result<(), impl Debug>`.
I intentionally left `ExitCode` unaddressed because I don't know exactly what to throw in that case.

I contemplated introducing a new trait, like `JsTermination` to mirror exactly what Rust does, but that's not really compatible with the current way `#[wasm_bindgen(start)]` works. We could however introduce it with a new `#[wasm_bindgen(main)]` if that is desired? See #3252 for a similar proposal.

The way this problem was solved is by using Autoref-based specialization, see [this case study by dtolnay](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md), which is sometimes used to solve this kind of problem in macros.

Fixes #3262.