### PR TITLE
examples/wasm-audio-worklet: `link_to!` polyfill

### DIFF
--- a/examples/wasm-audio-worklet/build.sh
+++ b/examples/wasm-audio-worklet/build.sh
@@ -18,4 +18,5 @@ RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
 cargo run -p wasm-bindgen-cli -- \
   ../../target/wasm32-unknown-unknown/release/wasm_audio_worklet.wasm \
   --out-dir . \
-  --target web
+  --target web \
+  --split-linked-modules

--- a/examples/wasm-audio-worklet/src/dependent_module.rs
+++ b/examples/wasm-audio-worklet/src/dependent_module.rs
@@ -17,9 +17,12 @@ extern "C" {
 }
 
 pub fn on_the_fly(code: &str) -> Result<String, JsValue> {
-    // Generate the import of the bindgen ES module, assuming `--target web`:
+    // Generate the import of the bindgen ES module, assuming `--target web`,
+    // preluded by the TextEncoder/TextDecoder polyfill needed inside worklets.
     let header = format!(
-        "import init, * as bindgen from '{}';\n\n",
+        "import '{}';\n\
+        import init, * as bindgen from '{}';\n\n",
+        wasm_bindgen::link_to!(module = "/src/polyfill.js"),
         IMPORT_META.url(),
     );
 

--- a/examples/wasm-audio-worklet/src/polyfill.js
+++ b/examples/wasm-audio-worklet/src/polyfill.js
@@ -21,6 +21,3 @@ if (!globalThis.TextEncoder) {
         }
     };
 }
-
-export function nop() {
-}

--- a/examples/wasm-audio-worklet/src/wasm_audio.rs
+++ b/examples/wasm-audio-worklet/src/wasm_audio.rs
@@ -53,16 +53,7 @@ pub fn wasm_audio_node(
 }
 
 pub async fn prepare_wasm_audio(ctx: &AudioContext) -> Result<(), JsValue> {
-    nop();
     let mod_url = dependent_module!("worklet.js")?;
     JsFuture::from(ctx.audio_worklet()?.add_module(&mod_url)?).await?;
     Ok(())
-}
-
-// TextEncoder and TextDecoder are not available in Audio Worklets, but there
-// is a dirty workaround: Import polyfill.js to install stub implementations
-// of these classes in globalThis.
-#[wasm_bindgen(module = "/src/polyfill.js")]
-extern "C" {
-    fn nop();
 }


### PR DESCRIPTION
Thanks @Liamolucko for reviewing #3069. It can be used to clean up the wasm-audio-worklet example a little bit by removing the nop function.

This should work without `--split-linked-modules` in theory, by importing a data URL in the module, but Chromium does not seem to support this inside worklets. Anyway, the example can just enable split linked modules.