### PR TITLE
Remove explicit allocator

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -18,10 +18,6 @@ use std::path::PathBuf;
 use std::thread;
 use wasm_bindgen_cli_support::Bindgen;
 
-// no need for jemalloc bloat in this binary (and we don't need speed)
-#[global_allocator]
-static ALLOC: std::alloc::System = std::alloc::System;
-
 mod deno;
 mod headless;
 mod node;

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -5,10 +5,6 @@ use std::path::PathBuf;
 use std::process;
 use wasm_bindgen_cli_support::{Bindgen, EncodeInto};
 
-// no need for jemalloc bloat in this binary (and we don't need speed)
-#[global_allocator]
-static ALLOC: std::alloc::System = std::alloc::System;
-
 const USAGE: &'static str = "
 Generating JS bindings for a wasm file
 

--- a/crates/cli/src/bin/wasm2es6js.rs
+++ b/crates/cli/src/bin/wasm2es6js.rs
@@ -4,10 +4,6 @@ use serde::Deserialize;
 use std::fs;
 use std::path::PathBuf;
 
-// no need for jemalloc bloat in this binary (and we don't need speed)
-#[global_allocator]
-static ALLOC: std::alloc::System = std::alloc::System;
-
 const USAGE: &'static str = "
 Converts a wasm file to an ES6 JS module
 


### PR DESCRIPTION
The jemalloc default was removed [4 years ago in Rust 1.32](https://releases.rs/docs/1.32.0/). wasm-bindgen does not support Rust 1.32 without using an old Cargo.lock. Since then, the system allocator is the default. Therefore, the explicit setting can be removed. In the worst case, wasm-bindgen developers using old compilers, partially updating their Cargo.lock, may get bloated binaries.

@alexcrichton, you added the explicit system allocator in wasm-bindgen and removed the jemalloc default in Rust. What do you think?