### PR TITLE
Revert #3248's changes to the `wasm-in-web-worker` example

### DIFF
--- a/examples/wasm-in-web-worker/index.js
+++ b/examples/wasm-in-web-worker/index.js
@@ -1,9 +1,18 @@
-async function run_wasm() {
-    console.log('index.js loaded');
+// We only need `startup` here which is the main entry point
+// In theory, we could also use all other functions/struct types from Rust which we have bound with
+// `#[wasm_bindgen]`
+const {startup} = wasm_bindgen;
 
+async function run_wasm() {
     // Load the wasm file by awaiting the Promise returned by `wasm_bindgen`
     // `wasm_bindgen` was imported in `index.html`
     await wasm_bindgen('./pkg/wasm_in_web_worker_bg.wasm');
+
+    console.log('index.js loaded');
+
+    // Run main WASM entry point
+    // This will create a worker from within our Rust code compiled to WASM
+    startup();
 }
 
 run_wasm();

--- a/examples/wasm-in-web-worker/src/lib.rs
+++ b/examples/wasm-in-web-worker/src/lib.rs
@@ -42,8 +42,8 @@ impl NumberEval {
 }
 
 /// Run entry point for the main thread.
-#[wasm_bindgen(start)]
-fn start() {
+#[wasm_bindgen]
+pub fn startup() {
     // Here, we create our worker. In a larger app, multiple callbacks should be
     // able to interact with the code in the worker. Therefore, we wrap it in
     // `Rc<RefCell>` following the interior mutability pattern. Here, it would

--- a/guide/src/examples/wasm-in-web-worker.md
+++ b/guide/src/examples/wasm-in-web-worker.md
@@ -27,10 +27,11 @@ the JS console, creating a worker and reacting to message events.
 ## `src/lib.rs`
 
 Creates a struct `NumberEval` with methods to act as stateful object in the
-worker and `start` function. Also includes internal helper functions
-`setup_input_oninput_callback` to attach a `wasm_bindgen::Closure` as callback
-to the `oninput` event of the input field and `get_on_msg_callback` to create a
-`wasm_bindgen::Closure` which is triggered when the worker returns a message.
+worker and function `startup` to be launched in the main thread. Also includes
+internal helper functions `setup_input_oninput_callback` to attach a
+`wasm_bindgen::Closure` as callback to the `oninput` event of the input field
+and `get_on_msg_callback` to create a `wasm_bindgen::Closure` which is triggered
+when the worker returns a message.
 
 ```rust
 {{#include ../../../examples/wasm-in-web-worker/src/lib.rs}}
@@ -50,8 +51,8 @@ both `wasm_in_web_worker.js` and `index.js`.
 
 ## `index.js`
 
-Loads our WASM file asynchronously which calls the `start` function and creates
-a worker.
+Loads our WASM file asynchronously and calls the entry point `startup` of the
+main thread which will create a worker.
 
 ```js
 {{#include ../../../examples/wasm-in-web-worker/index.js}}


### PR DESCRIPTION
#3248 tried to change the example to take advantage of #3236 and use a regular `#[wasm_bindgen(start)]` function. However, the start function still gets called on every thread in that example because it doesn't actually use wasm multithreading; each thread's instance has it's own separate memory pool and is completely unaware of the other thread. So, attempting to switch it to use a regular start function caused the worker thread to spawn another one, which does likewise, quickly spiralling out of control.

It also ended up panicking because, thinking it was the main thread, the code was trying to access `window` inside of a worker.