### PR TITLE
Remove faulty `location.href` fallback and disable `--split-linked-modules` by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
   test_wasm_bindgen:
     name: "Run wasm-bindgen crate tests (unix)"
     runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
     steps:
     - uses: actions/checkout@v2
     - run: rustup update --no-self-update stable && rustup default stable

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -381,9 +381,7 @@ impl<'a> Context<'a> {
                 js.push_str("let script_src;\n");
                 js.push_str(
                     "\
-                    if (typeof document === 'undefined') {
-                        script_src = location.href;
-                    } else {
+                    if (typeof document !== 'undefined') {
                         script_src = new URL(document.currentScript.src, location.href).toString();
                     }\n",
                 );
@@ -720,7 +718,7 @@ impl<'a> Context<'a> {
                     stem = self.config.stem()?
                 ),
                 OutputMode::NoModules { .. } => "\
-                    if (typeof input === 'undefined') {
+                    if (typeof input === 'undefined' && script_src !== 'undefined') {
                         input = script_src.replace(/\\.js$/, '_bg.wasm');
                     }"
                 .to_string(),

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -121,7 +121,7 @@ impl Bindgen {
             wasm_interface_types,
             encode_into: EncodeInto::Test,
             omit_default_module_path: true,
-            split_linked_modules: true,
+            split_linked_modules: false,
         }
     }
 

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -167,6 +167,10 @@ integration test.\
         TestMode::NoModule => b.no_modules(true)?,
     };
 
+    if std::env::var("WASM_BINDGEN_SPLIT_LINKED_MODULES").is_ok() {
+        b.split_linked_modules(true);
+    }
+
     b.debug(debug)
         .input_module(module, wasm)
         .keep_debug(false)

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -260,16 +260,14 @@ fn default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
-    if (typeof document === 'undefined') {
-        script_src = location.href;
-    } else {
+    if (typeof document !== 'undefined') {
         script_src = new URL(document.currentScript.src, location.href).toString();
     }",
     ));
     assert!(contents.contains(
         "\
     async function init(input) {
-        if (typeof input === 'undefined') {
+        if (typeof input === 'undefined' && script_src !== 'undefined') {
             input = script_src.replace(/\\.js$/, '_bg.wasm');
         }",
     ));

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -122,3 +122,7 @@ using a plugin. Alternatively, you can leave the syntax as is and instead
 manually configure the bundler to copy all files in `snippets/` to the output
 directory, preserving their paths relative to whichever bundled file ends up
 containing the JS shim.
+
+On the no-modules target, `link_to!` won't work if used outside of a document,
+e.g. inside a worker. This is because it's impossible to figure out what the
+URL of the linked module is without a reference point like `import.meta.url`.


### PR DESCRIPTION
This removes the faulty fallback to `location.href` on the no-modules target.
> The problem is that if you are in a worker and using `importScripts()`, `location.href` can never return the path to the imported script, the shim, which is what we want, instead `location.href` will return the path to the script that starts the worker, which is not useful in this context and in fact will break any path created for linked modules.

Additionally it disables `--split-linked-modules` by default when using `wasm-bindgen-cli-support`, which was probably an oversight. In return I added a new environment variable `WASM_BINDGEN_SPLIT_LINKED_MODULES` for `wasm-bindgen-test-runner` to enable it for whomever requires it.

Fixes #3277.