### PR TITLE
Support for specifying a default `js_namespace` on an `extern "C" { … }` block

### DIFF
--- a/guide/src/reference/attributes/on-js-imports/js_namespace.md
+++ b/guide/src/reference/attributes/on-js-imports/js_namespace.md
@@ -66,4 +66,4 @@ extern "C" {
 }
 ```
 
-`js_namespace = …` on individual items have precedence over its outer block's `js_namespace = …`.
+`js_namespace = …` on an individual item takes precedence over the outer block's `js_namespace = …`.

--- a/guide/src/reference/attributes/on-js-imports/js_namespace.md
+++ b/guide/src/reference/attributes/on-js-imports/js_namespace.md
@@ -39,3 +39,31 @@ write("hello, document!");
 ```
 
 This example shows how to bind `window.document.write` in Rust.
+
+If all items in the `extern "C" { … }` block have the same `js_namespace = …`:
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = Math)]
+    fn random() -> f64;
+    #[wasm_bindgen(js_namespace = Math)]
+    fn log(a: f64) -> f64;
+    // ...
+}
+```
+
+Then that macro argument can also be moved to the outer block:
+
+```rust
+#[wasm_bindgen(js_namespace = Math)]
+extern "C" {
+    #[wasm_bindgen]
+    fn random() -> f64;
+    #[wasm_bindgen]
+    fn log(a: f64) -> f64;
+    // ...
+}
+```
+
+`js_namespace = …` on individual items have precedence over its outer block's `js_namespace = …`.

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -124,11 +124,11 @@ extern "C" {
     fn assert_internal_int(this: &InnerClass, i: u32);
 }
 
-#[wasm_bindgen]
+#[wasm_bindgen(js_namespace = Math)]
 extern "C" {
-    #[wasm_bindgen(js_namespace = Math)]
+    #[wasm_bindgen]
     fn random() -> f64;
-    #[wasm_bindgen(js_namespace = Math)]
+    #[wasm_bindgen]
     fn log(a: f64) -> f64;
 }
 


### PR DESCRIPTION
When importing JS APIs that consist of a whole bunch of namespaced functions it can be quite annoying and verbose/redundant to have to specify the same `js_namespace = "…"` macro argument on every single item in an `extern "C" { … }` block.

This PR adds support for doing this:

```rust
#[wasm_bindgen(js_namespace = Math)]
extern "C" {
    #[wasm_bindgen]
    fn random() -> f64;
    #[wasm_bindgen]
    fn log(a: f64) -> f64;
    // ...
}
```

instead of 

```rust
#[wasm_bindgen]
extern "C" {
    #[wasm_bindgen(js_namespace = Math)]
    fn random() -> f64;
    #[wasm_bindgen(js_namespace = Math)]
    fn log(a: f64) -> f64;
    // ...
}
```

If a sub-item specifies a `js_namespace` of its own then that takes priority over the extern block's default.