### PR TITLE
Update actions/setup-node in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - uses: ./.github/actions/setup-geckodriver
@@ -93,7 +93,7 @@ jobs:
   #   - uses: actions/checkout@v3
   #   - run: rustup update --no-self-update stable && rustup default stable
   #   - run: rustup target add wasm32-unknown-unknown
-  #   - uses: actions/setup-node@v2
+  #   - uses: actions/setup-node@v3
   #     with:
   #       node-version: '16'
   #   - uses: ./.github/actions/setup-geckodriver
@@ -114,7 +114,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - run: cargo test
@@ -133,7 +133,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - uses: ./.github/actions/setup-geckodriver
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - uses: ./.github/actions/setup-geckodriver
@@ -178,7 +178,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - run: cargo test -p wasm-bindgen-webidl
@@ -196,7 +196,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
     - run: cd crates/typescript-tests && ./run.sh


### PR DESCRIPTION
Updates the [`actions/setup-node`](https://github.com/actions/setup-node) action used in the GitHub Actions workflow to its newest major version.

Still using v2 of `actions/setup-node` will generate some warning like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/4088020291

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/setup-node`, because v3 uses Node.js 16.