### PR TITLE
Update actions/download-artifact in GitHub Actions workflows to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -427,7 +427,7 @@ jobs:
       with:
         fetch-depth: 0
     - run: rustup update --no-self-update nightly && rustup default nightly
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         path: artifacts
     - run: find artifacts


### PR DESCRIPTION
Updates the `actions/download-artifact` action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/download-artifact](https://github.com/actions/download-artifact):
> ## v3.0.2
> - Bump `@actions/artifact` to v1.1.1
> - Fixed a bug in Node16 where if an HTTP download finished too quickly (<1ms, e.g. when it's mocked) we attempt to delete a temp file that has not been created yet
>
> ## v3.0.1
> - Bump @actions/core to 1.10.0
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/download-artifact` will generate some warning like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/4088020291

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/download-artifact@v2, JamesIves/github-pages-deploy-action@4.1.4. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/download-artifact`, because v3 uses Node.js 16.