### PR TITLE
Update setup-geckodriver action to use Node 16

### DIFF
--- a/.github/actions/setup-geckodriver/action.yml
+++ b/.github/actions/setup-geckodriver/action.yml
@@ -2,5 +2,5 @@ name: 'Setup Geckodriver'
 description: 'Setup Geckodriver'
 
 runs:
-  using: node12
+  using: node16
   main: 'main.js'


### PR DESCRIPTION
Updates the action to setup Geckodriver used in the GitHub Actions workflow to run on Node 16 instead of Node 12.

Still using Node.js 12 for that action will generate some warning like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/4088210706

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: ./.github/actions/setup-geckodriver. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The switch to Node.js 16 will get rid of this warning.