### PR TITLE
Add a proper error for attempting to use a linked module outside the main thread with `--target no-modules` + `--split-linked-modules`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3159,7 +3159,19 @@ impl<'a> Context<'a> {
                         OutputMode::Node {
                             experimental_modules: false,
                         } => "require('url').pathToFileURL(__filename)",
-                        OutputMode::NoModules { .. } => "script_src",
+                        OutputMode::NoModules { .. } => {
+                            prelude.push_str(
+                                "if (script_src === undefined) {
+                                    throw new Error(
+                                        \"When `--split-linked-modules` is enabled on the `no-modules` target, \
+                                          linked modules cannot be used outside of a web page's main thread.\n\
+                                          \n\
+                                          To fix this, disable `--split-linked-modules`.\"
+                                    );
+                                 }",
+                            );
+                            "script_src"
+                        }
                     };
                     Ok(format!("new URL('{}', {}).toString()", path, base))
                 } else {


### PR DESCRIPTION
Previously, it would give an unhelpful 'invalid URL' error, which would probably be quite annoying to debug. With this PR, an error is thrown instead, which clearly states 'disable `--split-linked-modules` to fix this'.