### PR TITLE
Refactor try_unescape in macro-support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,6 +121,7 @@ jobs:
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli
     - run: cargo test -p wasm-bindgen-externref-xform
+    - run: cargo test -p wasm-bindgen-macro-support
     - run: cargo test -p wasm-bindgen-multi-value-xform
     - run: cargo test -p wasm-bindgen-wasm-interpreter
     - run: cargo test -p wasm-bindgen-futures

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1529,25 +1529,13 @@ fn extract_doc_comments(attrs: &[syn::Attribute]) -> Vec<String> {
 }
 
 // Unescapes a quoted string. char::escape_debug() was used to escape the text.
-fn try_unescape(s: &str) -> Option<String> {
-    if s.is_empty() {
-        return Some(String::new());
-    }
+fn try_unescape(mut s: &str) -> Option<String> {
+    s = s.strip_prefix('"').unwrap_or(s);
+    s = s.strip_suffix('"').unwrap_or(s);
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars();
-    for i in 0.. {
-        let c = match chars.next() {
-            Some(c) => c,
-            None => {
-                if result.ends_with('"') {
-                    result.pop();
-                }
-                return Some(result);
-            }
-        };
-        if i == 0 && c == '"' {
-            // ignore it
-        } else if c == '\\' {
+    while let Some(c) = chars.next() {
+        if c == '\\' {
             let c = chars.next()?;
             match c {
                 't' => result.push('\t'),
@@ -1570,30 +1558,17 @@ fn try_unescape(s: &str) -> Option<String> {
             result.push(c);
         }
     }
-    None
+    Some(result)
 }
 
 fn unescape_unicode(chars: &mut Chars) -> Option<(char, char)> {
     let mut value = 0;
-    for i in 0..7 {
-        let c = chars.next()?;
-        let num = if c >= '0' && c <= '9' {
-            c as u32 - '0' as u32
-        } else if c >= 'a' && c <= 'f' {
-            c as u32 - 'a' as u32 + 10
-        } else if c >= 'A' && c <= 'F' {
-            c as u32 - 'A' as u32 + 10
-        } else {
-            if i == 0 {
-                return None;
-            }
-            let decoded = char::from_u32(value)?;
-            return Some((decoded, c));
-        };
-        if i >= 6 {
-            return None;
+    for (i, c) in chars.enumerate() {
+        match (i, c.to_digit(16)) {
+            (0..=5, Some(num)) => value = (value << 4) | num,
+            (1.., None) => return Some((char::from_u32(value)?, c)),
+            _ => break,
         }
-        value = (value << 4) | num;
     }
     None
 }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1697,3 +1697,23 @@ pub fn link_to(opts: BindgenAttrs) -> Result<ast::LinkToModule, Diagnostic> {
     program.linked_modules.push(module);
     Ok(ast::LinkToModule(program))
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_try_unescape() {
+        use super::try_unescape;
+        assert_eq!(try_unescape("hello").unwrap(), "hello");
+        assert_eq!(try_unescape("\"hello").unwrap(), "hello");
+        assert_eq!(try_unescape("hello\"").unwrap(), "hello");
+        assert_eq!(try_unescape("\"hello\"").unwrap(), "hello");
+        assert_eq!(try_unescape("hello\\\\").unwrap(), "hello\\");
+        assert_eq!(try_unescape("hello\\n").unwrap(), "hello\n");
+        assert_eq!(try_unescape("hello\\u"), None);
+        assert_eq!(try_unescape("hello\\u{"), None);
+        assert_eq!(try_unescape("hello\\u{}"), None);
+        assert_eq!(try_unescape("hello\\u{0}").unwrap(), "hello\0");
+        assert_eq!(try_unescape("hello\\u{000000}").unwrap(), "hello\0");
+        assert_eq!(try_unescape("hello\\u{0000000}"), None);
+    }
+}


### PR DESCRIPTION
This is one of the few places (possibly the single one) where fixing clippy lints (inspired by #3271) is most cleanly done by a little refactoring. The other clippy fixes should be trivial.

Both functions should behave identically after this refactoring. I have added some tests to check that.