### PR TITLE
Improve error message when `#[wasm_bindgen(getter_with_clone)]` is used on non-`Clone` JS types

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -349,8 +349,12 @@ pub struct StructField {
     pub comments: Vec<String>,
     /// Whether to generate a typescript definition for this field
     pub generate_typescript: bool,
-    /// Whether to use .clone() in the auto-generated getter for this field
-    pub getter_with_clone: bool,
+    /// The span of the `#[wasm_bindgen(getter_with_clone)]` attribute applied
+    /// to this field, if any.
+    ///
+    /// If this is `Some`, the auto-generated getter for this field must clone
+    /// the field instead of copying it.
+    pub getter_with_clone: Option<Span>,
 }
 
 /// Information about an Enum being exported

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -5,9 +5,9 @@ use once_cell::sync::Lazy;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote_spanned;
 use quote::{quote, ToTokens};
-use syn::spanned::Spanned;
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
+use syn::spanned::Spanned;
 use wasm_bindgen_shared as shared;
 
 /// A trait for converting AST structs into Tokens and adding them to a TokenStream,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -409,7 +409,7 @@ impl<'a> ConvertToAst<BindgenAttrs> for &'a mut syn::ItemStruct {
             .map(|s| s.0.to_string())
             .unwrap_or(self.ident.to_string());
         let is_inspectable = attrs.inspectable().is_some();
-        let getter_with_clone = attrs.getter_with_clone().is_some();
+        let getter_with_clone = attrs.getter_with_clone();
         for (i, field) in self.fields.iter_mut().enumerate() {
             match field.vis {
                 syn::Visibility::Public(..) => {}
@@ -445,7 +445,7 @@ impl<'a> ConvertToAst<BindgenAttrs> for &'a mut syn::ItemStruct {
                 setter: Ident::new(&setter, Span::call_site()),
                 comments,
                 generate_typescript: attrs.skip_typescript().is_none(),
-                getter_with_clone: getter_with_clone || attrs.getter_with_clone().is_some(),
+                getter_with_clone: attrs.getter_with_clone().or(getter_with_clone).copied(),
             });
             attrs.check_used();
         }

--- a/crates/macro/ui-tests/struct-fields.rs
+++ b/crates/macro/ui-tests/struct-fields.rs
@@ -1,0 +1,15 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    pub type Foo;
+}
+
+#[wasm_bindgen]
+struct Bar {
+    pub a: Foo,
+    #[wasm_bindgen(getter_with_clone)]
+    pub b: Foo,
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/struct-fields.stderr
+++ b/crates/macro/ui-tests/struct-fields.stderr
@@ -1,0 +1,20 @@
+error[E0277]: the trait bound `Foo: std::marker::Copy` is not satisfied
+  --> ui-tests/struct-fields.rs:10:12
+   |
+10 |     pub a: Foo,
+   |            ^^^ the trait `std::marker::Copy` is not implemented for `Foo`
+   |
+note: required by a bound in `__wbg_get_bar_a::assert_copy`
+  --> ui-tests/struct-fields.rs:8:1
+   |
+8  | #[wasm_bindgen]
+   | ^^^^^^^^^^^^^^^ required by this bound in `__wbg_get_bar_a::assert_copy`
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `Foo: Clone` is not satisfied
+  --> ui-tests/struct-fields.rs:11:20
+   |
+11 |     #[wasm_bindgen(getter_with_clone)]
+   |                    ^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `Foo`
+   |
+note: required by `clone`


### PR DESCRIPTION


Fixes #3291

Previously, the implementation of that attribute would call `.clone()` on the field to try and clone it. The problem is that imported JS types implement `Deref<Target = JsValue>`, which meant that calling `.clone()` would auto-deref the type into a `JsValue`, and then clone that. So, instead of a '`Foo` does not implement `Clone`' error, you would get a cryptic error about a type mismatch.

This fixes that by clarifying the `clone` call to use the `<Foo as Clone>::clone(&val)` syntax instead. I also added some spans so that the error message will point out the field that's causing the problem.