### PR TITLE
Expose `WebAssembly.Instance.exports`

### DIFF
--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -252,6 +252,9 @@ intrinsics! {
         #[symbol = "__wbindgen_memory"]
         #[signature = fn() -> Externref]
         Memory,
+        #[symbol = "__wbindgen_exports"]
+        #[signature = fn() -> Externref]
+        Exports,
         #[symbol = "__wbindgen_module"]
         #[signature = fn() -> Externref]
         Module,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3498,6 +3498,11 @@ impl<'a> Context<'a> {
                 format!("init.__wbindgen_wasm_module")
             }
 
+            Intrinsic::Exports => {
+                assert_eq!(args.len(), 0);
+                "wasm".to_string()
+            }
+
             Intrinsic::Memory => {
                 assert_eq!(args.len(), 0);
                 let mut memories = self.module.memories.iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1082,6 +1082,7 @@ externs! {
 
         fn __wbindgen_not(idx: u32) -> u32;
 
+        fn __wbindgen_exports() -> u32;
         fn __wbindgen_memory() -> u32;
         fn __wbindgen_module() -> u32;
         fn __wbindgen_function_table() -> u32;
@@ -1356,6 +1357,11 @@ where
 #[doc(hidden)]
 pub fn module() -> JsValue {
     unsafe { JsValue::_new(__wbindgen_module()) }
+}
+
+/// Returns a handle to this wasm instance's `WebAssembly.Instance.prototype.exports`
+pub fn exports() -> JsValue {
+    unsafe { JsValue::_new(__wbindgen_exports()) }
 }
 
 /// Returns a handle to this wasm instance's `WebAssembly.Memory`


### PR DESCRIPTION
I was specifically attempting to use https://github.com/rustwasm/wasm-bindgen/pull/3177 but noticed it was impossible to call `__wbindgen_thread_destroy()` or get `__tls_base` and `__stack_alloc` from inside Rust.

~~Alternatively we could expose `WebAssembly.Instance.prototype.exports` directly instead.~~
EDIT: I decided to go ahead and expose the exports directly. Mainly because there were some targets that were much harder for me to implement exposing the instance for.

Or if we don't want a general-purpose solution like this we could expose  `__wbindgen_thread_destroy()`, `__tls_base` and `__stack_alloc` through more intrinsics.

I'm not aware of any downsides.
EDIT: I was thinking that maybe exposing exports directly is worse then exposing the instance, but it seems that you can't do anything else with the instance anyway: https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Instance.

Fixes #2513.