### PR TITLE
Retain `unsafe` in imports

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -301,6 +301,8 @@ pub struct Function {
     pub rust_attrs: Vec<syn::Attribute>,
     /// The visibility of this function in Rust
     pub rust_vis: syn::Visibility,
+    /// Whether this is an `unsafe` function
+    pub r#unsafe: bool,
     /// Whether this is an `async` function
     pub r#async: bool,
     /// Whether to generate a typescript definition for this function

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1177,6 +1177,11 @@ impl TryToTokens for ast::ImportFunction {
             &self.rust_name,
         );
 
+        let maybe_unsafe = if self.function.r#unsafe {
+            Some(quote! {unsafe})
+        } else {
+            None
+        };
         let maybe_async = if self.function.r#async {
             Some(quote! {async})
         } else {
@@ -1189,7 +1194,7 @@ impl TryToTokens for ast::ImportFunction {
             #[allow(clippy::all, clippy::nursery, clippy::pedantic, clippy::restriction)]
             #(#attrs)*
             #[doc = #doc_comment]
-            #vis #maybe_async fn #rust_name(#me #(#arguments),*) #ret {
+            #vis #maybe_async #maybe_unsafe fn #rust_name(#me #(#arguments),*) #ret {
                 #extern_fn
 
                 unsafe {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -909,6 +909,7 @@ fn function_from_decl(
             ret,
             rust_attrs: attrs,
             rust_vis: vis,
+            r#unsafe: sig.unsafety.is_some(),
             r#async: sig.asyncness.is_some(),
             generate_typescript: opts.skip_typescript().is_none(),
             variadic: opts.variadic().is_some(),


### PR DESCRIPTION
I noticed that `unsafe` wasn't transferred when I specified it in imports, meaning the generated functions didn't have an `unsafe` specifier on them.

```rust
#[wasm_bindgen]
extern "C" {
	type Foo;

	#[wasm_bindgen(method, js_name = foo)]
	unsafe fn foo(&Test);
}

let foo: Foo = ...;
// Can be called without an `unsafe` block.
foo.foo();
```

This was particularly helpful when I was importing functions that were messing with this instances memory, which is actually unsafe.