### PR TITLE
Allow non-literal constants in `typescript_custom_section`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: rustup update --no-self-update 1.56.0 && rustup default 1.56.0
+    - run: rustup update --no-self-update 1.57.0 && rustup default 1.57.0
     - run: cargo test -p wasm-bindgen-macro
 
   build_examples:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -35,7 +35,7 @@ strict-macro = ["wasm-bindgen-macro/strict-macro"]
 xxx_debug_only_print_generated_code = ["wasm-bindgen-macro/xxx_debug_only_print_generated_code"]
 
 [dependencies]
-wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.83" }
+wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.84" }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 cfg-if = "1.0.0"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend"
@@ -22,4 +22,4 @@ once_cell = "1.12"
 proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '1.0', features = ['full'] }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.83" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.84" }

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -21,7 +21,7 @@ pub struct Program {
     /// rust structs
     pub structs: Vec<Struct>,
     /// custom typescript sections to be included in the definition file
-    pub typescript_custom_sections: Vec<String>,
+    pub typescript_custom_sections: Vec<LiteralOrExpression>,
     /// Inline JS snippets
     pub inline_js: Vec<String>,
 }
@@ -450,4 +450,15 @@ impl Function {
         }
         Ok(name[4..].to_string())
     }
+}
+
+/// Either the value of a string literal, or the [`proc_macro2::TokenStream`]
+/// representation of a constant expression.
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
+#[derive(Clone)]
+pub enum LiteralOrExpression {
+    /// Literal string.
+    Literal(String),
+    /// Expression computing a constant string.
+    Expression(syn::Expr),
 }

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-cli-support"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli-support"
@@ -19,12 +19,12 @@ rustc-demangle = "0.1.13"
 serde_json = "1.0"
 tempfile = "3.0"
 walrus = "0.19.0"
-wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.83' }
-wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.83' }
-wasm-bindgen-shared = { path = "../shared", version = '=0.2.83' }
-wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.83' }
-wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.83' }
-wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.83' }
+wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.84' }
+wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.84' }
+wasm-bindgen-shared = { path = "../shared", version = '=0.2.84' }
+wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.84' }
+wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.84' }
+wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.84' }
 wit-text = "0.8.0"
 wit-walrus = "0.6.0"
 wit-validator = "0.2.0"

--- a/crates/cli-support/src/decode.rs
+++ b/crates/cli-support/src/decode.rs
@@ -5,7 +5,7 @@ pub trait Decode<'src>: Sized {
 
     fn decode_all(mut data: &'src [u8]) -> Self {
         let ret = Self::decode(&mut data);
-        assert!(data.len() == 0);
+        assert_eq!(data.len(), 0);
         return ret;
     }
 }
@@ -152,6 +152,13 @@ macro_rules! decode_api {
         decode_enum!($name () $($variants)*);
         decode_api!($($rest)*);
     );
+}
+
+mod syn {
+    /// Alias `syn::Expr` to `str` when decoding; an expression is evaluated as
+    /// a Rust constant during compilation, so when we decode the buffer we can
+    /// expect a string instead.
+    pub type Expr = str;
 }
 
 wasm_bindgen_shared::shared_api!(decode_api);

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -389,6 +389,11 @@ impl<'a> Context<'a> {
             self.struct_(struct_)?;
         }
         for section in typescript_custom_sections {
+            let section = match section {
+                decode::LiteralOrExpression::Literal(section) => section,
+                decode::LiteralOrExpression::Expression(x) => x, // match *x {},
+            };
+
             self.aux.extra_typescript.push_str(section);
             self.aux.extra_typescript.push_str("\n\n");
         }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-cli"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli"
@@ -26,8 +26,8 @@ serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
 walrus = { version = "0.19.0", features = ['parallel'] }
-wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.83" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.83" }
+wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.84" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.84" }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-externref-xform"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/externref-xform"

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 cfg-if = "1.0.0"
 js-sys = { path = "../js-sys", version = '0.3.60' }
-wasm-bindgen = { path = "../..", version = '0.2.83' }
+wasm-bindgen = { path = "../..", version = '0.2.84' }
 futures-core =  { version = '0.3.8', default-features = false, optional = true }
 
 [features]

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -19,7 +19,7 @@ test = false
 doctest = false
 
 [dependencies]
-wasm-bindgen = { path = "../..", version = "0.2.83" }
+wasm-bindgen = { path = "../..", version = "0.2.84" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = { path = '../test', version = '=0.3.33' }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support"
@@ -20,5 +20,5 @@ strict-macro = []
 syn = { version = '1.0.84', features = ['visit', 'full'] }
 quote = '1.0'
 proc-macro2 = "1.0"
-wasm-bindgen-backend = { path = "../backend", version = "=0.2.83" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.83" }
+wasm-bindgen-backend = { path = "../backend", version = "=0.2.84" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.84" }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1335,17 +1335,15 @@ impl MacroParse<BindgenAttrs> for syn::ItemConst {
             bail_span!(self, "#[wasm_bindgen] will not work on constants unless you are defining a #[wasm_bindgen(typescript_custom_section)].");
         }
 
-        match get_expr(&self.expr) {
-            syn::Expr::Lit(syn::ExprLit {
-                lit: syn::Lit::Str(litstr),
-                ..
-            }) => {
-                program.typescript_custom_sections.push(litstr.value());
-            }
-            expr => {
-                bail_span!(expr, "Expected a string literal to be used with #[wasm_bindgen(typescript_custom_section)].");
-            }
-        }
+        program
+            .typescript_custom_sections
+            .push(match get_expr(&self.expr) {
+                syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(litstr),
+                    ..
+                }) => ast::LiteralOrExpression::Literal(litstr.value()),
+                expr => ast::LiteralOrExpression::Expression(expr.clone()),
+            });
 
         opts.check_used();
 

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro"
@@ -20,10 +20,10 @@ xxx_debug_only_print_generated_code = []
 strict-macro = ["wasm-bindgen-macro-support/strict-macro"]
 
 [dependencies]
-wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.83" }
+wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.84" }
 quote = "1.0"
 
 [dev-dependencies]
 trybuild = "1.0"
-wasm-bindgen = { path = "../..", version = "0.2.83" }
+wasm-bindgen = { path = "../..", version = "0.2.84" }
 wasm-bindgen-futures = { path = "../futures", version = "0.4.33" }

--- a/crates/macro/README.md
+++ b/crates/macro/README.md
@@ -17,11 +17,11 @@ To add a test:
 * Create `ui-tests/my-awesome-test.rs`
 * Write an invalid `#[wasm_bindgen]` invocation, testing the error you're
   generating
-* Execute `cargo test -p ui-tests`, the test will fail
+* Execute `cargo test -p wasm-bindgen-macro`, the test will fail
 * From within the `ui-tests` folder, execute `./update-all-references.sh`. This
   should create a `my-awesome-test.stderr` file.
 * Inspect `my-awesome-test.stderr` to make sure it looks ok
-* Rerun `cargo test -p ui-tests` and your tests should pass!
+* Rerun `cargo test -p wasm-bindgen-macro` and your tests should pass!
 
 Testing here is a work in progress, see
 [#601](https://github.com/rustwasm/wasm-bindgen/issues/601) for more

--- a/crates/macro/ui-tests/async-errors.stderr
+++ b/crates/macro/ui-tests/async-errors.stderr
@@ -1,68 +1,68 @@
 error[E0277]: the trait bound `Result<(), ()>: IntoJsResult` is not satisfied
-    --> ui-tests/async-errors.rs:30:1
-     |
-30   | #[wasm_bindgen]
-     | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), ()>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as IntoJsResult>
-               <Result<T, E> as IntoJsResult>
+  --> ui-tests/async-errors.rs:30:1
+   |
+30 | #[wasm_bindgen]
+   | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), ()>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as IntoJsResult>
+             <Result<T, E> as IntoJsResult>
 note: required by `into_js_result`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn into_js_result(self) -> Result<JsValue, JsValue>;
-     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn into_js_result(self) -> Result<JsValue, JsValue>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<(), BadType>: IntoJsResult` is not satisfied
-    --> ui-tests/async-errors.rs:32:1
-     |
-32   | #[wasm_bindgen]
-     | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), BadType>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as IntoJsResult>
-               <Result<T, E> as IntoJsResult>
+  --> ui-tests/async-errors.rs:32:1
+   |
+32 | #[wasm_bindgen]
+   | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), BadType>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as IntoJsResult>
+             <Result<T, E> as IntoJsResult>
 note: required by `into_js_result`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn into_js_result(self) -> Result<JsValue, JsValue>;
-     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn into_js_result(self) -> Result<JsValue, JsValue>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `wasm_bindgen::JsValue: From<BadType>` is not satisfied
-    --> ui-tests/async-errors.rs:34:1
-     |
-34   | #[wasm_bindgen]
-     | ^^^^^^^^^^^^^^^ the trait `From<BadType>` is not implemented for `wasm_bindgen::JsValue`
-     |
-     = help: the following implementations were found:
-               <wasm_bindgen::JsValue as From<&'a String>>
-               <wasm_bindgen::JsValue as From<&'a T>>
-               <wasm_bindgen::JsValue as From<&'a str>>
-               <wasm_bindgen::JsValue as From<JsError>>
-             and 73 others
-     = note: required because of the requirements on the impl of `Into<wasm_bindgen::JsValue>` for `BadType`
-     = note: required because of the requirements on the impl of `IntoJsResult` for `BadType`
+  --> ui-tests/async-errors.rs:34:1
+   |
+34 | #[wasm_bindgen]
+   | ^^^^^^^^^^^^^^^ the trait `From<BadType>` is not implemented for `wasm_bindgen::JsValue`
+   |
+   = help: the following implementations were found:
+             <wasm_bindgen::JsValue as From<&'a String>>
+             <wasm_bindgen::JsValue as From<&'a T>>
+             <wasm_bindgen::JsValue as From<&'a str>>
+             <wasm_bindgen::JsValue as From<JsError>>
+           and $N others
+   = note: required because of the requirements on the impl of `Into<wasm_bindgen::JsValue>` for `BadType`
+   = note: required because of the requirements on the impl of `IntoJsResult` for `BadType`
 note: required by `into_js_result`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn into_js_result(self) -> Result<JsValue, JsValue>;
-     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn into_js_result(self) -> Result<JsValue, JsValue>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<BadType, wasm_bindgen::JsValue>: IntoJsResult` is not satisfied
-    --> ui-tests/async-errors.rs:36:1
-     |
-36   | #[wasm_bindgen]
-     | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<BadType, wasm_bindgen::JsValue>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as IntoJsResult>
-               <Result<T, E> as IntoJsResult>
+  --> ui-tests/async-errors.rs:36:1
+   |
+36 | #[wasm_bindgen]
+   | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<BadType, wasm_bindgen::JsValue>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as IntoJsResult>
+             <Result<T, E> as IntoJsResult>
 note: required by `into_js_result`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn into_js_result(self) -> Result<JsValue, JsValue>;
-     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn into_js_result(self) -> Result<JsValue, JsValue>;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/invalid-methods.stderr
+++ b/crates/macro/ui-tests/invalid-methods.stderr
@@ -1,59 +1,59 @@
 error: #[wasm_bindgen] default impls are not supported
- --> $DIR/invalid-methods.rs:7:1
+ --> ui-tests/invalid-methods.rs:7:1
   |
 7 | default impl A {
   | ^^^^^^^
 
 error: #[wasm_bindgen] unsafe impls are not supported
-  --> $DIR/invalid-methods.rs:11:1
+  --> ui-tests/invalid-methods.rs:11:1
    |
 11 | unsafe impl A {
    | ^^^^^^
 
 error: #[wasm_bindgen] trait impls are not supported
-  --> $DIR/invalid-methods.rs:15:6
+  --> ui-tests/invalid-methods.rs:15:6
    |
 15 | impl Clone for A {
    |      ^^^^^
 
 error: #[wasm_bindgen] generic impls aren't supported
-  --> $DIR/invalid-methods.rs:19:5
+  --> ui-tests/invalid-methods.rs:19:5
    |
 19 | impl<T> A {
    |     ^^^
 
 error: unsupported self type in #[wasm_bindgen] impl
-  --> $DIR/invalid-methods.rs:23:6
+  --> ui-tests/invalid-methods.rs:23:6
    |
 23 | impl &'static A {
    |      ^^^^^^^^^^
 
 error: const definitions aren't supported with #[wasm_bindgen]
-  --> $DIR/invalid-methods.rs:30:5
+  --> ui-tests/invalid-methods.rs:30:5
    |
 30 |     const X: u32 = 3;
    |     ^^^^^^^^^^^^^^^^^
 
 error: type definitions in impls aren't supported with #[wasm_bindgen]
-  --> $DIR/invalid-methods.rs:31:5
+  --> ui-tests/invalid-methods.rs:31:5
    |
 31 |     type Y = u32;
    |     ^^^^^^^^^^^^^
 
 error: macros in impls aren't supported
-  --> $DIR/invalid-methods.rs:32:5
+  --> ui-tests/invalid-methods.rs:32:5
    |
 32 |     x!();
    |     ^^^^^
 
 error: can only #[wasm_bindgen] non-const functions
-  --> $DIR/invalid-methods.rs:39:9
+  --> ui-tests/invalid-methods.rs:39:9
    |
 39 |     pub const fn foo() {}
    |         ^^^^^
 
 warning: unused macro definition
-  --> $DIR/invalid-methods.rs:26:1
+  --> ui-tests/invalid-methods.rs:26:1
    |
 26 | macro_rules! x { () => () }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -1,17 +1,17 @@
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: FromWasmAbi` is not satisfied
-  --> $DIR/missing-catch.rs:6:9
-   |
-6  |     pub fn foo() -> Result<JsValue, JsValue>;
-   |            ^^^ the trait `FromWasmAbi` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
-   |
+ --> ui-tests/missing-catch.rs:6:9
+  |
+6 |     pub fn foo() -> Result<JsValue, JsValue>;
+  |            ^^^ the trait `FromWasmAbi` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+  |
 note: required by a bound in `FromWasmAbi`
-  --> $DIR/traits.rs:23:1
-   |
-23 | / pub trait FromWasmAbi: WasmDescribe {
-24 | |     /// The wasm ABI type that this converts from when coming back out from the
-25 | |     /// ABI boundary.
-26 | |     type Abi: WasmAbi;
-...  |
-35 | |     unsafe fn from_abi(js: Self::Abi) -> Self;
-36 | | }
-   | |_^ required by this bound in `FromWasmAbi`
+ --> $WORKSPACE/src/convert/traits.rs
+  |
+  | / pub trait FromWasmAbi: WasmDescribe {
+  | |     /// The wasm ABI type that this converts from when coming back out from the
+  | |     /// ABI boundary.
+  | |     type Abi: WasmAbi;
+... |
+  | |     unsafe fn from_abi(js: Self::Abi) -> Self;
+  | | }
+  | |_^ required by this bound in `FromWasmAbi`

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -11,61 +11,61 @@ error: the start function cannot have generics
    |            ^^^
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:15:1
-     |
-15   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
+  --> ui-tests/start-function.rs:15:1
+   |
+15 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as wasm_bindgen::__rt::Start>
 note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn start(self);
+   |         ^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:18:1
-     |
-18   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
+  --> ui-tests/start-function.rs:18:1
+   |
+18 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as wasm_bindgen::__rt::Start>
 note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn start(self);
+   |         ^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:27:1
-     |
-27   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
+  --> ui-tests/start-function.rs:27:1
+   |
+27 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as wasm_bindgen::__rt::Start>
 note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn start(self);
+   |         ^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
-    --> ui-tests/start-function.rs:30:1
-     |
-30   | #[wasm_bindgen(start)]
-     | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
-     |
-     = help: the following implementations were found:
-               <Result<(), E> as wasm_bindgen::__rt::Start>
+  --> ui-tests/start-function.rs:30:1
+   |
+30 | #[wasm_bindgen(start)]
+   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+   |
+   = help: the following implementations were found:
+             <Result<(), E> as wasm_bindgen::__rt::Start>
 note: required by `start`
-    --> $WORKSPACE/src/lib.rs
-     |
-     |         fn start(self);
-     |         ^^^^^^^^^^^^^^^
-     = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> $WORKSPACE/src/lib.rs
+   |
+   |         fn start(self);
+   |         ^^^^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/traits-not-implemented.stderr
+++ b/crates/macro/ui-tests/traits-not-implemented.stderr
@@ -1,18 +1,18 @@
 error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
-  --> $DIR/traits-not-implemented.rs:5:1
-   |
-5  | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `A`
-   |
+ --> ui-tests/traits-not-implemented.rs:5:1
+  |
+5 | #[wasm_bindgen]
+  | ^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `A`
+  |
 note: required by a bound in `IntoWasmAbi`
-  --> $DIR/traits.rs:9:1
-   |
-9  | / pub trait IntoWasmAbi: WasmDescribe {
-10 | |     /// The wasm ABI type that this converts into when crossing the ABI
-11 | |     /// boundary.
-12 | |     type Abi: WasmAbi;
-...  |
-16 | |     fn into_abi(self) -> Self::Abi;
-17 | | }
-   | |_^ required by this bound in `IntoWasmAbi`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+ --> $WORKSPACE/src/convert/traits.rs
+  |
+  | / pub trait IntoWasmAbi: WasmDescribe {
+  | |     /// The wasm ABI type that this converts into when crossing the ABI
+  | |     /// boundary.
+  | |     type Abi: WasmAbi;
+... |
+  | |     fn into_abi(self) -> Self::Abi;
+  | | }
+  | |_^ required by this bound in `IntoWasmAbi`
+  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/unused-attributes.stderr
+++ b/crates/macro/ui-tests/unused-attributes.stderr
@@ -22,6 +22,12 @@ error: unused variable: `readonly`
 21 | #[wasm_bindgen(readonly)]
    |                ^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_readonly`
 
+error: unused variable: `typescript_type`
+  --> ui-tests/unused-attributes.rs:26:28
+   |
+26 |     #[wasm_bindgen(getter, typescript_type = "Thing[]")]
+   |                            ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_typescript_type`
+
 error: unused variable: `getter_with_clone`
   --> ui-tests/unused-attributes.rs:24:16
    |
@@ -33,9 +39,3 @@ error: unused variable: `final`
    |
 24 | #[wasm_bindgen(getter_with_clone, final)]
    |                                   ^^^^^ help: if this is intentional, prefix it with an underscore: `_final`
-
-error: unused variable: `typescript_type`
-  --> ui-tests/unused-attributes.rs:26:28
-   |
-26 |     #[wasm_bindgen(getter, typescript_type = "Thing[]")]
-   |                            ^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_typescript_type`

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-multi-value-xform"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/multi-value-xform"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared"

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -6,7 +6,7 @@ mod schema_hash_approval;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.83";
+pub const SCHEMA_VERSION: &str = "0.2.84";
 
 #[macro_export]
 macro_rules! shared_api {
@@ -17,7 +17,7 @@ macro_rules! shared_api {
             enums: Vec<Enum<'a>>,
             imports: Vec<Import<'a>>,
             structs: Vec<Struct<'a>>,
-            typescript_custom_sections: Vec<&'a str>,
+            typescript_custom_sections: Vec<LiteralOrExpression<'a>>,
             local_modules: Vec<LocalModule<'a>>,
             inline_js: Vec<&'a str>,
             unique_crate_identifier: &'a str,
@@ -138,6 +138,11 @@ macro_rules! shared_api {
         struct LocalModule<'a> {
             identifier: &'a str,
             contents: &'a str,
+        }
+
+        enum LiteralOrExpression<'a> {
+            Literal(&'a str),
+            Expression(&'a syn::Expr),
         }
         }
     }; // end of mac case

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &'static str = "17656911631008664055";
+const APPROVED_SCHEMA_FILE_HASH: &'static str = "1917474777926115096";
 
 #[test]
 fn schema_version() {

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 console_error_panic_hook = '0.1'
 js-sys = { path = '../js-sys', version = '0.3.60' }
 scoped-tls = "1.0"
-wasm-bindgen = { path = '../..', version = '0.2.83' }
+wasm-bindgen = { path = '../..', version = '0.2.84' }
 wasm-bindgen-futures = { path = '../futures', version = '0.4.33' }
 wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.33' }
 

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-threads-xform"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/threads-xform"
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 walrus = "0.19.0"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.83" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.84" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/typescript-tests/src/custom_section.rs
+++ b/crates/typescript-tests/src/custom_section.rs
@@ -5,7 +5,21 @@ const TS_INTERFACE_EXPORT: &'static str = r"
   interface Height { height: number; }
 ";
 
+#[wasm_bindgen(typescript_custom_section)]
+const TS_INTERFACE_EXPORT_NON_LITERAL: &'static str = std::concat!(
+    "interface Name { name: NameString; }\n",
+    std::include_str!("./data/custom_section_intf.ts")
+);
+
 #[wasm_bindgen]
 pub struct Person {
     pub height: u32,
+}
+
+#[wasm_bindgen]
+impl Person {
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        "Alice".into()
+    }
 }

--- a/crates/typescript-tests/src/custom_section.ts
+++ b/crates/typescript-tests/src/custom_section.ts
@@ -1,3 +1,3 @@
 import * as wbg from '../pkg/typescript_tests';
 
-const height: wbg.Height = new wbg.Person();
+const height: wbg.Height & wbg.Name = new wbg.Person();

--- a/crates/typescript-tests/src/data/custom_section_intf.ts
+++ b/crates/typescript-tests/src/data/custom_section_intf.ts
@@ -1,0 +1,1 @@
+type NameString = string;

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-wasm-conventions"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/wasm-conventions"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-bindgen-wasm-interpreter"
-version = "0.2.83"
+version = "0.2.84"
 authors = ["The wasm-bindgen Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/wasm-interpreter"
@@ -15,7 +15,7 @@ edition = '2018'
 anyhow = "1.0"
 log = "0.4"
 walrus = "0.19.0"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.83" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.84" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 test = false
 
 [dependencies]
-wasm-bindgen = { path = "../..", version = "0.2.83" }
+wasm-bindgen = { path = "../..", version = "0.2.84" }
 js-sys = { path = '../js-sys', version = '0.3.60' }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.1"
 proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '1.0', features = ['full'] }
-wasm-bindgen-backend = { version = "=0.2.83", path = "../backend" }
+wasm-bindgen-backend = { version = "=0.2.84", path = "../backend" }
 weedle = { git = "https://github.com/rustwasm/weedle.git" }
 once_cell = "1.12"
 sourcefile = "0.1"

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 js-sys = "0.3.60"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3.60"
 
 [dependencies.web-sys]

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 web-sys = { version = "0.3.60", features = ['console'] }

--- a/examples/deno/Cargo.toml
+++ b/examples/deno/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3.60"
 wasm-bindgen-futures = "0.4.33"
 

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3.60"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/import_js/crate/Cargo.toml
+++ b/examples/import_js/crate/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 js-sys = "0.3.60"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 humantime = "2"
 
 [dependencies.web-sys]

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -15,7 +15,7 @@ rayon-core = "1.5.0"
 raytracer = { git = 'https://github.com/alexcrichton/raytracer', branch = 'update-deps' }
 serde-wasm-bindgen = "0.4.3"
 futures-channel-preview = "0.3.0-alpha.18"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.33"
 
 [dependencies.web-sys]

--- a/examples/request-animation-frame/Cargo.toml
+++ b/examples/request-animation-frame/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/synchronous-instantiation/Cargo.toml
+++ b/examples/synchronous-instantiation/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -12,7 +12,7 @@ askama = "0.10.0"
 
 [dependencies]
 js-sys = "0.3.60"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 askama = "0.10.0"
 console_error_panic_hook = "0.1.5"
 

--- a/examples/wasm-audio-worklet/Cargo.toml
+++ b/examples/wasm-audio-worklet/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 console_log = "0.2.0"
 js-sys = "0.3.60"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.33"
 
 [dependencies.web-sys]

--- a/examples/wasm-in-wasm-imports/Cargo.toml
+++ b/examples/wasm-in-wasm-imports/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3.60"
 wasm-bindgen-futures = "0.4.33"

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3.60"
 wasm-bindgen-futures = "0.4.33"

--- a/examples/wasm-in-web-worker/Cargo.toml
+++ b/examples/wasm-in-web-worker/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
 [dependencies.web-sys]

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"

--- a/examples/weather_report/Cargo.toml
+++ b/examples/weather_report/Cargo.toml
@@ -15,7 +15,7 @@ chrono = "0.4.11"
 reqwest = "0.10.6"
 wasm-bindgen-futures = "0.4.1"
 json= "*"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 gloo = "0.2.1"
 
 [dependencies.web-sys]

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 js-sys = "0.3.60"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3"
 wasm-bindgen-futures = "0.4.33"
 

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 js-sys = "0.3"
 
 [dependencies.web-sys]

--- a/examples/webxr/Cargo.toml
+++ b/examples/webxr/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 futures = "0.3.4"
 js-sys = "0.3.60"
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.33"
 
 [dependencies.web-sys]

--- a/examples/without-a-bundler/Cargo.toml
+++ b/examples/without-a-bundler/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.84"
 
 [dependencies.web-sys]
 version = "0.3.4"

--- a/guide/src/contributing/testing.md
+++ b/guide/src/contributing/testing.md
@@ -35,7 +35,7 @@ These tests assert that we have reasonable error messages that point to the
 right source spans when the `#[wasm_bindgen]` proc-macro is misused.
 
 ```
-cargo test -p ui-tests
+cargo test -p wasm-bindgen-macro
 ```
 
 ## The `js-sys` Tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod prelude {
 
 pub mod convert;
 pub mod describe;
+pub mod macro_support;
 
 mod cast;
 pub use crate::cast::{JsCast, JsObject};

--- a/src/macro_support.rs
+++ b/src/macro_support.rs
@@ -1,0 +1,73 @@
+#![doc(hidden)]
+
+/// Returns the length of the buffer resulting from the concatenation of all the
+/// given byte buffers.
+pub const fn concat_len(strings: &[&[u8]]) -> usize {
+    let mut len = 0;
+    let mut i = 0;
+
+    while i < strings.len() {
+        len += strings[i].len();
+        i += 1;
+    }
+
+    len
+}
+
+/// Returns a byte buffer containing the concatenation of all the given byte
+/// buffers.
+pub const fn concat<const LEN: usize>(strings: &[&[u8]]) -> [u8; LEN] {
+    let mut buf = [0; LEN];
+
+    let mut buf_i = 0;
+    let mut strings_i = 0;
+
+    while strings_i < strings.len() {
+        let string = &strings[strings_i];
+        let mut string_i = 0;
+
+        while string_i < string.len() {
+            buf[buf_i] = string[string_i];
+            buf_i += 1;
+            string_i += 1;
+        }
+
+        strings_i += 1;
+    }
+
+    assert!(buf_i == LEN);
+
+    buf
+}
+
+/// Returns the length in bytes it takes to encode the given value using VLE.
+pub const fn vle_len(mut value: usize) -> usize {
+    let mut len = 1;
+
+    while (value >> 7) != 0 {
+        len += 1;
+        value >>= 7;
+    }
+
+    assert!(value >> 7 == 0);
+
+    len
+}
+
+/// Returns the VLE of the given value.
+pub const fn vle<const LEN: usize>(mut value: usize) -> [u8; LEN] {
+    let mut result = [0; LEN];
+    let mut result_i = 0;
+
+    while (value >> 7) != 0 {
+        result[result_i] = (value as u8) | 0x80;
+        result_i += 1;
+        value >>= 7;
+    }
+
+    assert!(value >> 7 == 0);
+    assert!(result_i + 1 == LEN);
+
+    result[result_i] = value as u8;
+    result
+}


### PR DESCRIPTION
Also:
- Bump version to 0.2.84, since the internal schema is changing.
- Bump MSRV for UI tests to 1.57 to allow `assert!` in `const fn`s.
- Update UI test outputs.

This will, among other things, allow `include_str!` in `#[wasm_bindgen(typescript_custom_section)]` (and fix #2828). This also opens the door for non-literal constants in `inline_js` (thus fixing #2787) with minimal changes.

This is a clone of #3115, which was closed by GitHub when I renamed the `main` branch.