### PR TITLE
Implemented compatibility mode with wasm32-wasi

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,3 +2,6 @@
 # that.
 [target.wasm32-unknown-unknown]
 runner = 'cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner --'
+
+[target.wasm32-wasi]
+runner = 'cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner --'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,50 @@ jobs:
         WASM_BINDGEN_EXTERNREF: 1
         NODE_ARGS: --experimental-wasm-reftypes
 
+  test_wasi_abi:
+    name: "Run wasm-bindgen crate tests with --wasi-abi (unix)"
+    runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+      TEST_WASI_ABI: 1
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-wasi
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '16'
+    - uses: ./.github/actions/setup-geckodriver
+    - run: cargo test --target wasm32-wasi
+      env:
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: ./tests/wasi/wasi_browser.js
+    - run: cargo test --target wasm32-wasi --features serde-serialize
+      env:
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: ./tests/wasi/wasi_browser.js
+    - run: cargo test --target wasm32-wasi --features enable-interning
+      env:
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: ./tests/wasi/wasi_browser.js
+    - run: cargo test --target wasm32-wasi -p no-std
+    # - run: cargo test --target wasm32-wasi -p wasm-bindgen-futures
+    - run: cargo test --target wasm32-wasi --test wasm
+      env:
+        WASM_BINDGEN_WEAKREF: 1
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: tests/wasi/wasi_node.js
+    - run: cargo test --target wasm32-wasi --test wasm
+      env:
+        WASM_BINDGEN_WEAKREF: 1
+        WASM_BINDGEN_NO_DEBUG: 1
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: tests/wasi/wasi_node.js
+    - run: cargo test --target wasm32-wasi --test wasm --features serde-serialize
+      env:
+        WASM_BINDGEN_WEAKREF: 1
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: tests/wasi/wasi_node.js
+    - run: cargo test --target wasm32-wasi
+      env:
+        WASM_BINDGEN_EXTERNREF: 1
+        NODE_ARGS: --experimental-wasm-reftypes
+        REROUTE_WASI_SNAPSHOT_PREVIEW1: tests/wasi/wasi_node.js
+
   test_threads:
     name: "Run wasm-bindgen crate tests with multithreading enabled"
     runs-on: ubuntu-latest

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -633,6 +633,114 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             js.string_to_memory(*mem, *malloc, *realloc)?;
         }
 
+        Instruction::PackSlice(mem) => {
+            js.cx.inject_stack_pointer_shim()?;
+
+            let len = js.pop();
+            let ptr = js.pop();
+
+            let i = js.tmp();
+            let mem = js.cx.expose_uint32_memory(*mem);
+
+            js.prelude(&format!("
+                const argPtr{i} = wasm.__wbindgen_add_to_stack_pointer(-16);
+                {mem}()[argPtr{i} / 4] = {ptr};
+                {mem}()[argPtr{i} / 4 + 1] = {len};
+            "));
+
+            js.push(format!("argPtr{i}"));
+
+            js.finally(&format!("wasm.__wbindgen_add_to_stack_pointer(16);"));
+        }
+        Instruction::PackMutSlice(mem) => {
+            js.cx.inject_stack_pointer_shim()?;
+
+            let idx = js.pop();
+            let len = js.pop();
+            let ptr = js.pop();
+
+            let i = js.tmp();
+            let mem = js.cx.expose_uint32_memory(*mem);
+
+            js.prelude(&format!("
+                const argPtr{i} = wasm.__wbindgen_add_to_stack_pointer(-16);
+                {mem}()[argPtr{i} / 4] = {ptr};
+                {mem}()[argPtr{i} / 4 + 1] = {len};
+                {mem}()[argPtr{i} / 4 + 2] = {idx};
+            "));
+
+            js.push(format!("argPtr{i}"));
+
+            js.finally(&format!("wasm.__wbindgen_add_to_stack_pointer(16);"));
+        }
+        Instruction::UnpackSlice(mem) => {
+            let mem = js.cx.expose_uint32_memory(*mem);
+
+            let arg_ptr = js.pop();
+            let i = js.tmp();
+
+            js.prelude(&format!("
+                var ptr{i} = {mem}()[{arg_ptr} / 4];
+                var len{i} = {mem}()[{arg_ptr} / 4 + 1];
+            "));
+
+            js.push(format!("ptr{i}"));
+            js.push(format!("len{i}"));
+        }
+
+        Instruction::PackOption(mem, ty) => {
+            js.cx.inject_stack_pointer_shim()?;
+
+            let content = js.pop();
+            let discriminant = js.pop();
+
+            let i = js.tmp();
+            let mem32 = js.cx.expose_uint32_memory(*mem);
+
+            let (content_mem, content_size) = match ty {
+                AdapterType::I32 => (js.cx.expose_int32_memory(*mem), 4),
+                AdapterType::U32 => (js.cx.expose_uint32_memory(*mem), 4),
+                AdapterType::F32 => (js.cx.expose_f32_memory(*mem), 4),
+                AdapterType::I64 => (js.cx.expose_int64_memory(*mem), 8),
+                AdapterType::U64 => (js.cx.expose_uint64_memory(*mem), 8),
+                AdapterType::F64 => (js.cx.expose_f64_memory(*mem), 8),
+                _ => bail!("Unexpected type passed to PackOption"),
+            };
+
+            js.prelude(&format!("
+                const argPtr{i} = wasm.__wbindgen_add_to_stack_pointer(-16);
+                {mem32}()[argPtr{i} / 4] = {discriminant};
+                {content_mem}()[argPtr{i} / {content_size} + 1] = {content};
+            "));
+
+            js.push(format!("argPtr{i}"));
+
+            js.finally(&format!("wasm.__wbindgen_add_to_stack_pointer(16);"));
+        }
+        Instruction::UnpackOption(mem, ty) => {
+            let mem32 = js.cx.expose_uint32_memory(*mem);
+            let (content_mem, content_size) = match ty {
+                AdapterType::I32 => (js.cx.expose_int32_memory(*mem), 4),
+                AdapterType::U32 => (js.cx.expose_uint32_memory(*mem), 4),
+                AdapterType::F32 => (js.cx.expose_f32_memory(*mem), 4),
+                AdapterType::I64 => (js.cx.expose_int64_memory(*mem), 8),
+                AdapterType::U64 => (js.cx.expose_uint64_memory(*mem), 8),
+                AdapterType::F64 => (js.cx.expose_f64_memory(*mem), 8),
+                _ => bail!("Unexpected type passed to PackOption"),
+            };
+
+            let arg_ptr = js.pop();
+            let i = js.tmp();
+
+            js.prelude(&format!("
+                var discriminant{i} = {mem32}()[{arg_ptr} / 4];
+                var content{i} = {content_mem}()[{arg_ptr} / {content_size} + 1];
+            "));
+
+            js.push(format!("discriminant{i}"));
+            js.push(format!("content{i}"));
+        }
+
         Instruction::Retptr { size } => {
             js.cx.inject_stack_pointer_shim()?;
             js.prelude(&format!(

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -47,6 +47,7 @@ pub struct Bindgen {
     wasm_interface_types: bool,
     encode_into: EncodeInto,
     split_linked_modules: bool,
+    wasi_abi: bool,
 }
 
 pub struct Output {
@@ -122,6 +123,7 @@ impl Bindgen {
             encode_into: EncodeInto::Test,
             omit_default_module_path: true,
             split_linked_modules: false,
+            wasi_abi: false,
         }
     }
 
@@ -311,6 +313,11 @@ impl Bindgen {
         self
     }
 
+    pub fn wasi_abi(&mut self, enable: bool) -> &mut Bindgen {
+        self.wasi_abi = enable;
+        self
+    }
+
     pub fn generate<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {
         self.generate_output()?.emit(path.as_ref())
     }
@@ -381,6 +388,13 @@ impl Bindgen {
         // sections.
         descriptors::execute(&mut module)?;
 
+        for import in module.imports.iter_mut() {
+            let env_name = format!("REROUTE_{}", import.module.to_uppercase());
+            if let Ok(reroute) = env::var(env_name) {
+                import.module = reroute;
+            }
+        }
+
         // Process the custom section we extracted earlier. In its stead insert
         // a forward-compatible wasm interface types section as well as an
         // auxiliary section for all sorts of miscellaneous information and
@@ -393,6 +407,7 @@ impl Bindgen {
             self.wasm_interface_types,
             thread_count,
             self.emit_start,
+            self.wasi_abi,
         )?;
 
         // Now that we've got type information from the webidl processing pass,

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -38,6 +38,7 @@ struct Context<'a> {
     wasm_interface_types: bool,
     thread_count: Option<ThreadCount>,
     support_start: bool,
+    wasi_abi: bool,
 }
 
 struct InstructionBuilder<'a, 'b> {
@@ -55,6 +56,7 @@ pub fn process(
     wasm_interface_types: bool,
     thread_count: Option<ThreadCount>,
     support_start: bool,
+    wasi_abi: bool,
 ) -> Result<(NonstandardWitSectionId, WasmBindgenAuxId), Error> {
     let mut cx = Context {
         adapters: Default::default(),
@@ -72,6 +74,7 @@ pub fn process(
         wasm_interface_types,
         thread_count,
         support_start,
+        wasi_abi,
     };
     cx.init()?;
 

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -236,6 +236,12 @@ fn translate_instruction(
             mem: *mem,
             malloc: *malloc,
         }),
+        PackSlice(_) | PackMutSlice(_) | UnpackSlice(_) => {
+            bail!("slices not supported in wasm interface types with wasi ABI");
+        }
+        PackOption(_, _) | UnpackOption(_, _) => {
+            bail!("Options with primitive types not supported in wasm interface types with wasi ABI");
+        }
         StoreRetptr { .. } | LoadRetptr { .. } | Retptr { .. } => {
             bail!("return pointers aren't supported in wasm interface types");
         }

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -94,6 +94,13 @@ pub enum Instruction {
     /// A known instruction in the "standard"
     Standard(wit_walrus::Instruction),
 
+    PackSlice(walrus::MemoryId),
+    PackMutSlice(walrus::MemoryId),
+    UnpackSlice(walrus::MemoryId),
+
+    PackOption(walrus::MemoryId, AdapterType),
+    UnpackOption(walrus::MemoryId, AdapterType),
+
     /// A call to one of our own defined adapters, similar to the standard
     /// call-adapter instruction
     CallAdapter(AdapterId),

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -171,6 +171,10 @@ integration test.\
         b.split_linked_modules(true);
     }
 
+    if env::var("TEST_WASI_ABI").is_ok() {
+        b.wasi_abi(true);
+    }
+
     b.debug(debug)
         .input_module(module, wasm)
         .keep_debug(false)

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -41,6 +41,7 @@ Options:
     --no-modules                 Deprecated, use `--target no-modules`
     --weak-refs                  Enable usage of the JS weak references proposal
     --reference-types            Enable usage of WebAssembly reference types
+    --wasi-abi                   Generate bindings for the wasm32-wasi target
     -V --version                 Print the version number of wasm-bindgen
 
 Additional documentation: https://rustwasm.github.io/wasm-bindgen/reference/cli.html
@@ -71,6 +72,7 @@ struct Args {
     flag_target: Option<String>,
     flag_omit_default_module_path: bool,
     flag_split_linked_modules: bool,
+    flag_wasi_abi: bool,
     arg_input: Option<PathBuf>,
 }
 
@@ -125,7 +127,8 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .typescript(typescript)
         .omit_imports(args.flag_omit_imports)
         .omit_default_module_path(args.flag_omit_default_module_path)
-        .split_linked_modules(args.flag_split_linked_modules);
+        .split_linked_modules(args.flag_split_linked_modules)
+        .wasi_abi(args.flag_wasi_abi);
     if let Some(true) = args.flag_weak_refs {
         b.weak_refs(true);
     }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -51,8 +51,10 @@ if_std! {
         fn drop(&mut self) {
             unsafe {
                 __wbindgen_copy_to_typed_array(
-                    self.contents.as_ptr() as *const u8,
-                    self.contents.len() * mem::size_of::<T>(),
+                    WasmSlice {
+                        ptr: self.contents.as_ptr() as u32,
+                        len: (self.contents.len() * mem::size_of::<T>()) as u32,
+                    },
                     self.js.idx
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl JsValue {
     /// be owned by the JS garbage collector.
     #[inline]
     pub fn from_str(s: &str) -> JsValue {
-        unsafe { JsValue::_new(__wbindgen_string_new(s.as_ptr(), s.len())) }
+        unsafe { JsValue::_new(__wbindgen_string_new(WasmSlice { ptr: s.as_ptr() as u32, len: s.len() as u32 })) }
     }
 
     /// Creates a new JS value which is a number.
@@ -158,7 +158,7 @@ impl JsValue {
     /// allocated large integer) and returns a handle to the JS version of it.
     #[inline]
     pub fn bigint_from_str(s: &str) -> JsValue {
-        unsafe { JsValue::_new(__wbindgen_bigint_from_str(s.as_ptr(), s.len())) }
+        unsafe { JsValue::_new(__wbindgen_bigint_from_str(WasmSlice { ptr: s.as_ptr() as u32, len: s.len() as u32  })) }
     }
 
     /// Creates a new JS value which is a boolean.
@@ -194,8 +194,10 @@ impl JsValue {
         unsafe {
             match description {
                 Some(description) => JsValue::_new(__wbindgen_symbol_named_new(
-                    description.as_ptr(),
-                    description.len(),
+                    WasmSlice {
+                        ptr: description.as_ptr() as u32,
+                        len: description.len() as u32,
+                    },
                 )),
                 None => JsValue::_new(__wbindgen_symbol_anonymous_new()),
             }
@@ -232,7 +234,7 @@ impl JsValue {
         T: serde::ser::Serialize + ?Sized,
     {
         let s = serde_json::to_string(t)?;
-        unsafe { Ok(JsValue::_new(__wbindgen_json_parse(s.as_ptr(), s.len()))) }
+        unsafe { Ok(JsValue::_new(__wbindgen_json_parse(WasmSlice { ptr: s.as_ptr() as u32, len: s.len() as u32 }))) }
     }
 
     /// Invokes `JSON.stringify` on this value and then parses the resulting
@@ -1010,14 +1012,14 @@ externs! {
         fn __wbindgen_object_clone_ref(idx: u32) -> u32;
         fn __wbindgen_object_drop_ref(idx: u32) -> ();
 
-        fn __wbindgen_string_new(ptr: *const u8, len: usize) -> u32;
+        fn __wbindgen_string_new(s: WasmSlice) -> u32;
         fn __wbindgen_number_new(f: f64) -> u32;
-        fn __wbindgen_bigint_from_str(ptr: *const u8, len: usize) -> u32;
+        fn __wbindgen_bigint_from_str(s: WasmSlice) -> u32;
         fn __wbindgen_bigint_from_i64(n: i64) -> u32;
         fn __wbindgen_bigint_from_u64(n: u64) -> u32;
         fn __wbindgen_bigint_from_i128(hi: i64, lo: u64) -> u32;
         fn __wbindgen_bigint_from_u128(hi: u64, lo: u64) -> u32;
-        fn __wbindgen_symbol_named_new(ptr: *const u8, len: usize) -> u32;
+        fn __wbindgen_symbol_named_new(name: WasmSlice) -> u32;
         fn __wbindgen_symbol_anonymous_new() -> u32;
 
         fn __wbindgen_externref_heap_live_count() -> u32;
@@ -1064,21 +1066,21 @@ externs! {
 
         fn __wbindgen_debug_string(ret: *mut [usize; 2], idx: u32) -> ();
 
-        fn __wbindgen_throw(a: *const u8, b: usize) -> !;
+        fn __wbindgen_throw(msg: WasmSlice) -> !;
         fn __wbindgen_rethrow(a: u32) -> !;
-        fn __wbindgen_error_new(a: *const u8, b: usize) -> u32;
+        fn __wbindgen_error_new(msg: WasmSlice) -> u32;
 
         fn __wbindgen_cb_drop(idx: u32) -> u32;
 
         fn __wbindgen_describe(v: u32) -> ();
         fn __wbindgen_describe_closure(a: u32, b: u32, c: u32) -> u32;
 
-        fn __wbindgen_json_parse(ptr: *const u8, len: usize) -> u32;
+        fn __wbindgen_json_parse(s: WasmSlice) -> u32;
         fn __wbindgen_json_serialize(idx: u32) -> WasmSlice;
         fn __wbindgen_jsval_eq(a: u32, b: u32) -> u32;
         fn __wbindgen_jsval_loose_eq(a: u32, b: u32) -> u32;
 
-        fn __wbindgen_copy_to_typed_array(ptr: *const u8, len: usize, idx: u32) -> ();
+        fn __wbindgen_copy_to_typed_array(buffer: WasmSlice, idx: u32) -> ();
 
         fn __wbindgen_not(idx: u32) -> u32;
 
@@ -1199,7 +1201,7 @@ pub fn throw(s: &str) -> ! {
 #[inline(never)]
 pub fn throw_str(s: &str) -> ! {
     unsafe {
-        __wbindgen_throw(s.as_ptr(), s.len());
+        __wbindgen_throw(WasmSlice { ptr: s.as_ptr() as u32, len: s.len() as u32 });
     }
 }
 
@@ -1825,7 +1827,7 @@ impl JsError {
     #[inline]
     pub fn new(s: &str) -> JsError {
         Self {
-            value: unsafe { JsValue::_new(crate::__wbindgen_error_new(s.as_ptr(), s.len())) },
+            value: unsafe { JsValue::_new(crate::__wbindgen_error_new(WasmSlice { ptr: s.as_ptr() as u32, len: s.len() as u32 })) },
         }
     }
 }

--- a/tests/wasi/wasi_browser.js
+++ b/tests/wasi/wasi_browser.js
@@ -1,0 +1,72 @@
+
+export function args_get() {
+    return 0;
+}
+
+export function args_sizes_get() {
+    return 0;
+}
+
+export function clock_time_get() {
+    return 0;
+}
+
+export function fd_filestat_get() {
+    return 0;
+}
+
+export function fd_read() {
+    return 0;
+}
+
+export function fd_seek() {
+    return 0;
+}
+
+export function fd_write() {
+    return 0;
+}
+
+export function path_filestat_get() {
+    return 0;
+}
+
+export function path_open() {
+    return 0;
+}
+
+export function sched_yield() {
+    return 0;
+}
+
+export function random_get() {
+    return 0;
+}
+
+export function environ_get() {
+    return 0;
+}
+
+export function environ_sizes_get() {
+    return 0;
+}
+
+export function fd_close() {
+    return 0;
+}
+
+export function fd_fdstat_get() {
+    return 0;
+}
+
+export function fd_prestat_get() {
+    return 8;
+}
+
+export function fd_prestat_dir_name() {
+    return 0;
+}
+
+export function proc_exit() {
+    throw "proc_exit";
+}

--- a/tests/wasi/wasi_node.js
+++ b/tests/wasi/wasi_node.js
@@ -1,0 +1,73 @@
+module.exports = {};
+
+module.exports.args_get = function() {
+    return 0;
+}
+
+module.exports.args_sizes_get = function() {
+    return 0;
+}
+
+module.exports.clock_time_get = function() {
+    return 0;
+}
+
+module.exports.fd_filestat_get = function() {
+    return 0;
+}
+
+module.exports.fd_read = function() {
+    return 0;
+}
+
+module.exports.fd_seek = function() {
+    return 0;
+}
+
+module.exports.fd_write = function() {
+    return 0;
+}
+
+module.exports.path_filestat_get = function() {
+    return 0;
+}
+
+module.exports.path_open = function() {
+    return 0;
+}
+
+module.exports.sched_yield = function() {
+    return 0;
+}
+
+module.exports.random_get = function() {
+    return 0;
+}
+
+module.exports.environ_get = function() {
+    return 0;
+}
+
+module.exports.environ_sizes_get = function() {
+    return 0;
+}
+
+module.exports.fd_close = function() {
+    return 0;
+}
+
+module.exports.fd_fdstat_get = function() {
+    return 0;
+}
+
+module.exports.fd_prestat_get = function() {
+    return 8;
+}
+
+module.exports.fd_prestat_dir_name = function() {
+    return 0;
+}
+
+module.exports.proc_exit = function() {
+    throw "proc_exit";
+}


### PR DESCRIPTION
This PR adds the new --wasi-abi flag to wasm-bindgen. With this flag, wasm-bindgen generates bindings that are compatible with the ABI used by the rust target wasm32-wasi.
The changes should not affect the behavior of wasm-bindgen when the flag is not specified.

For implementing the behavior of wasm32-wasi, I introduced a few new Instructions to the "Standard".
They are `PackSlice`, `UnpackSlice`, `PackOption` and `UnpackOption`. These instructions translate between the passed-by-pointer structs used in wasm32-wasi and the format expected by the rest of wasm-bindgen.

I am very open to suggestions on this.