### PR TITLE
Fixes #3259: use verbose names for load / init / getImports

### DIFF
--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -239,7 +239,7 @@ fn default_module_path_target_web() {
     let contents = fs::read_to_string(out_dir.join("default_module_path_target_web.js")).unwrap();
     assert!(contents.contains(
         "\
-async function init(input) {
+async function __wbg_init(input) {
     if (wasm !== undefined) return wasm;
 
     if (typeof input === 'undefined') {
@@ -268,7 +268,7 @@ fn default_module_path_target_no_modules() {
     ));
     assert!(contents.contains(
         "\
-    async function init(input) {
+    async function __wbg_init(input) {
         if (wasm !== undefined) return wasm;
 
         if (typeof input === 'undefined' && script_src !== 'undefined') {
@@ -291,11 +291,11 @@ fn omit_default_module_path_target_web() {
         fs::read_to_string(out_dir.join("omit_default_module_path_target_web.js")).unwrap();
     assert!(contents.contains(
         "\
-async function init(input) {
+async function __wbg_init(input) {
     if (wasm !== undefined) return wasm;
 
 
-    const imports = getImports();",
+    const imports = __wbg_get_imports();",
     ));
 }
 
@@ -313,11 +313,11 @@ fn omit_default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("omit_default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
-    async function init(input) {
+    async function __wbg_init(input) {
         if (wasm !== undefined) return wasm;
 
 
-        const imports = getImports();",
+        const imports = __wbg_get_imports();",
     ));
 }
 


### PR DESCRIPTION
`init` / `load` / `getImports` are common names for functions, and clash when generated with `--target web`. This adds verbose prefixes to them so there's a smaller chance of clashing with already defined functions.

Fixes https://github.com/rustwasm/wasm-bindgen/issues/3259.

--- 

Hi! This is my first pull request here, and I don't really know how to write rust, but I think I got this right. Happy to iterate if you'd like. 