### PR TITLE
Fix `TextEncoder` stub name

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1438,7 +1438,7 @@ impl<'a> Context<'a> {
         if !self.should_write_global("text_encoder") {
             return Ok(());
         }
-        self.expose_text_processor("TextEncoder", "('utf-8')", None)
+        self.expose_text_processor("TextEncoder", "encode", "('utf-8')", None)
     }
 
     fn expose_text_decoder(&mut self) -> Result<(), Error> {
@@ -1454,6 +1454,7 @@ impl<'a> Context<'a> {
         // `fatal` is needed to catch any weird encoding bugs when sending a string from Rust to JS
         self.expose_text_processor(
             "TextDecoder",
+            "decode",
             "('utf-8', { ignoreBOM: true, fatal: true })",
             init,
         )?;
@@ -1464,6 +1465,7 @@ impl<'a> Context<'a> {
     fn expose_text_processor(
         &mut self,
         s: &str,
+        op: &str,
         args: &str,
         init: Option<&str>,
     ) -> Result<(), Error> {
@@ -1494,7 +1496,7 @@ impl<'a> Context<'a> {
             | OutputMode::Web
             | OutputMode::NoModules { .. }
             | OutputMode::Bundler { browser_only: true } => {
-                self.global(&format!("const cached{0} = (typeof {0} !== 'undefined' ? new {0}{1} : {{ decode: () => {{ throw Error('{0} not available') }} }} );", s, args))
+                self.global(&format!("const cached{0} = (typeof {0} !== 'undefined' ? new {0}{1} : {{ {2}: () => {{ throw Error('{0} not available') }} }} );", s, args, op))
             }
         };
 


### PR DESCRIPTION
When changing `wasm_audio_worklet` so that `cachedTextEncoder.encode` is used:

```
wasm_audio_worklet.js:61 Uncaught TypeError: cachedTextEncoder.encode is not a function
    at encodeString (wasm_audio_worklet.js:61:35)
    at passStringToWasm0 (wasm_audio_worklet.js:98:21)
```