### PR TITLE
Add attribute for custom path to `wasm_bindgen`

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -5,12 +5,13 @@
 use crate::{util::ShortHash, Diagnostic};
 use proc_macro2::{Ident, Span};
 use std::hash::{Hash, Hasher};
+use syn::Path;
 use wasm_bindgen_shared as shared;
 
 /// An abstract syntax tree representing a rust program. Contains
 /// extra information for joining up this rust code with javascript.
 #[cfg_attr(feature = "extra-traits", derive(Debug))]
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Program {
     /// rust -> js interfaces
     pub exports: Vec<Export>,
@@ -26,6 +27,26 @@ pub struct Program {
     pub typescript_custom_sections: Vec<String>,
     /// Inline JS snippets
     pub inline_js: Vec<String>,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
+    /// Path to wasm_bindgen_futures
+    pub wasm_bindgen_futures: Path,
+}
+
+impl Default for Program {
+    fn default() -> Self {
+        Self {
+            exports: Default::default(),
+            imports: Default::default(),
+            linked_modules: Default::default(),
+            enums: Default::default(),
+            structs: Default::default(),
+            typescript_custom_sections: Default::default(),
+            inline_js: Default::default(),
+            wasm_bindgen: syn::parse_quote! { wasm_bindgen },
+            wasm_bindgen_futures: syn::parse_quote! { wasm_bindgen_futures },
+        }
+    }
 }
 
 impl Program {
@@ -77,6 +98,10 @@ pub struct Export {
     /// Whether or not this function should be flagged as the wasm start
     /// function.
     pub start: bool,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
+    /// Path to wasm_bindgen_futures
+    pub wasm_bindgen_futures: Path,
 }
 
 /// The 3 types variations of `self`.
@@ -166,6 +191,10 @@ pub struct ImportFunction {
     pub shim: Ident,
     /// The doc comment on this import, if one is provided
     pub doc_comment: String,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
+    /// Path to wasm_bindgen_futures
+    pub wasm_bindgen_futures: Path,
 }
 
 /// The type of a function being imported
@@ -237,6 +266,8 @@ pub struct ImportStatic {
     pub rust_name: Ident,
     /// The name of this static on the JS side
     pub js_name: String,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
 }
 
 /// The metadata for a type being imported
@@ -265,6 +296,8 @@ pub struct ImportType {
     pub vendor_prefixes: Vec<Ident>,
     /// If present, don't generate a `Deref` impl
     pub no_deref: bool,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
 }
 
 /// The metadata for an Enum being imported
@@ -281,6 +314,8 @@ pub struct ImportEnum {
     pub variant_values: Vec<String>,
     /// Attributes to apply to the Rust enum
     pub rust_attrs: Vec<syn::Attribute>,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
 }
 
 /// Information about a function being imported or exported
@@ -329,6 +364,8 @@ pub struct Struct {
     pub is_inspectable: bool,
     /// Whether to generate a typescript definition for this struct
     pub generate_typescript: bool,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
 }
 
 /// The field of a struct
@@ -361,6 +398,8 @@ pub struct StructField {
     /// If this is `Some`, the auto-generated getter for this field must clone
     /// the field instead of copying it.
     pub getter_with_clone: Option<Span>,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
 }
 
 /// Information about an Enum being exported
@@ -379,6 +418,8 @@ pub struct Enum {
     pub hole: u32,
     /// Whether to generate a typescript definition for this enum
     pub generate_typescript: bool,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
 }
 
 /// The variant of an enum

--- a/crates/macro/ui-tests/wasm-bindgen.rs
+++ b/crates/macro/ui-tests/wasm-bindgen.rs
@@ -1,0 +1,43 @@
+extern crate wasm_bindgen as extern_test;
+
+use wasm_bindgen::prelude::*;
+
+mod test {
+    pub use wasm_bindgen as test;
+    pub use wasm_bindgen;
+}
+
+#[wasm_bindgen(wasm_bindgen = wasm_bindgen)]
+pub fn good1() {}
+
+#[wasm_bindgen(wasm_bindgen = ::wasm_bindgen)]
+pub fn good2() {}
+
+#[wasm_bindgen(wasm_bindgen = test::wasm_bindgen)]
+pub fn good3() {}
+
+#[wasm_bindgen(wasm_bindgen = test::test)]
+pub fn good4() {}
+
+#[wasm_bindgen(wasm_bindgen = extern_test)]
+pub fn good5() {}
+
+#[wasm_bindgen(wasm_bindgen_futures = wasm_bindgen_futures)]
+pub fn good6() {}
+
+#[wasm_bindgen(wasm_bindgen = wasm_bindgen)]
+pub async fn good7() {}
+
+#[wasm_bindgen(wasm_bindgen_futures = wasm_bindgen_futures)]
+pub async fn good8() {}
+
+#[wasm_bindgen(wasm_bindgen = wasm_bindgen, wasm_bindgen_futures = wasm_bindgen_futures)]
+pub async fn good9() {}
+
+#[wasm_bindgen(wasm_bindgen = test)]
+pub fn bad1() {}
+
+#[wasm_bindgen(wasm_bindgen_futures = test)]
+pub async fn bad2() {}
+
+fn main() {}

--- a/crates/macro/ui-tests/wasm-bindgen.stderr
+++ b/crates/macro/ui-tests/wasm-bindgen.stderr
@@ -1,0 +1,19 @@
+error[E0433]: failed to resolve: could not find `convert` in `test`
+  --> ui-tests/wasm-bindgen.rs:37:1
+   |
+37 | #[wasm_bindgen(wasm_bindgen = test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `convert` in `test`
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0425]: cannot find function `future_to_promise` in module `test`
+  --> ui-tests/wasm-bindgen.rs:40:1
+   |
+40 | #[wasm_bindgen(wasm_bindgen_futures = test)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in `test`
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing this function
+   |
+3  | use wasm_bindgen_futures::future_to_promise;
+   |


### PR DESCRIPTION
This adds two new attributes: `wasm_bindgen` and `wasm_bindgen_futures`, which allow to specify the path to both crates if they were renamed or re-exported from a different crate.

This is analogous to [Tokio](https://docs.rs/tokio/1.26.0/tokio/attr.main.html#rename-package), [Serde](https://serde.rs/container-attrs.html#crate) or [Pollster](https://docs.rs/pollster/0.3.0/pollster/#macro).