### PR TITLE
Don't rely on the name section for detecting `main`

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,6 +35,7 @@ diff = "0.1"
 predicates = "1.0.0"
 rayon = "1.0"
 tempfile = "3.0"
+wasmparser = "0.102.0"
 wasmprinter = "0.2, <=0.2.33" # pinned for wit-printer
 wit-printer = "0.2"
 wit-text = "0.8"


### PR DESCRIPTION
Fixes #3362

In some cases, the name section can fail to be parsed because one of the names is too long, which then causes the main function to not be detected because we don't know what any functions' names are.

However, `main` is also exported with the name `main`, so we can look for an export named `main` instead to avoid relying on the name section.