### PR TITLE
Don't install `wasm-opt` in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,10 +231,6 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     - run: |
-        curl -L https://github.com/WebAssembly/binaryen/releases/download/version_109/binaryen-version_109-x86_64-linux.tar.gz -sSf > binaryen-version_109-x86_64-linux.tar.gz
-        tar -xz -f binaryen-version_109-x86_64-linux.tar.gz
-        echo "$PWD/binaryen-version_109/bin" >> $GITHUB_PATH
-    - run: |
         cargo build -p wasm-bindgen-cli
         ln -snf `pwd`/target/debug/wasm-bindgen $(dirname `which cargo`)/wasm-bindgen
     - run: mv _package.json package.json && npm install && rm package.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,6 +231,10 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     - run: |
+        curl -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz -sSf > binaryen-version_112-x86_64-linux.tar.gz
+        tar -xz -f binaryen-version_112-x86_64-linux.tar.gz binaryen-version_112/bin/wasm2js
+        echo "$PWD/binaryen-version_112/bin" >> $GITHUB_PATH
+    - run: |
         cargo build -p wasm-bindgen-cli
         ln -snf `pwd`/target/debug/wasm-bindgen $(dirname `which cargo`)/wasm-bindgen
     - run: mv _package.json package.json && npm install && rm package.json


### PR DESCRIPTION
This is a workaround for rustwasm/wasm-pack#1247, which causes `wasm-pack` to fail to run if a local version of `wasm-opt` is installed. That in turn caused the `build_examples` CI job to break.

This PR fixes that by not having it download binaryen, instead letting `wasm-pack` install it itself, which still works.