### PR TITLE
Fix race condition in reference tests

### DIFF
--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -11,7 +11,6 @@
 
 use anyhow::{bail, Result};
 use assert_cmd::prelude::*;
-use rayon::prelude::*;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -37,7 +36,7 @@ fn main() -> Result<()> {
     tests.sort();
 
     let errs = tests
-        .par_iter()
+        .iter()
         .filter_map(|t| runtest(t).err().map(|e| (t, e)))
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
The reference test runner was attempting to compile all of them in parallel, with all of their outputs being written to `target/wasm32-unknown-unknown/debug/reference_test.wasm`. That led to a race condition if this happened:

* test a finishes compiling, emits `reference_test.wasm`
* test b finishes compiling, emits `reference_test.wasm`
* test a runs `wasm-bindgen` on the `reference_test.wasm` that test b just emitted.

This led to the results of reference tests getting mixed up.

For whatever reason, this only happens on my Mac laptop and not my Linux desktop. It could be an OS difference, or just because the laptop's a lot faster, I don't know.

I solved it by just not running them in parallel, since parallelising them didn't do much anyway thanks to `cargo` locking the build directory.