### PR TITLE
Implement `requestAnimationFrame` for `DedicatedWorkerGlobalScope`

### DIFF
--- a/crates/web-sys/src/features/gen_DedicatedWorkerGlobalScope.rs
+++ b/crates/web-sys/src/features/gen_DedicatedWorkerGlobalScope.rs
@@ -77,4 +77,24 @@ extern "C" {
         message: &::wasm_bindgen::JsValue,
         transfer: &::wasm_bindgen::JsValue,
     ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "DedicatedWorkerGlobalScope" , js_name = cancelAnimationFrame)]
+    #[doc = "The `cancelAnimationFrame()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DedicatedWorkerGlobalScope`*"]
+    pub fn cancel_animation_frame(
+        this: &DedicatedWorkerGlobalScope,
+        handle: i32,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "DedicatedWorkerGlobalScope" , js_name = requestAnimationFrame)]
+    #[doc = "The `requestAnimationFrame()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DedicatedWorkerGlobalScope`*"]
+    pub fn request_animation_frame(
+        this: &DedicatedWorkerGlobalScope,
+        callback: &::js_sys::Function,
+    ) -> Result<i32, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_Window.rs
+++ b/crates/web-sys/src/features/gen_Window.rs
@@ -1966,13 +1966,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Window`*"]
     pub fn blur(this: &Window) -> Result<(), JsValue>;
-    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = cancelAnimationFrame)]
-    #[doc = "The `cancelAnimationFrame()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Window`*"]
-    pub fn cancel_animation_frame(this: &Window, handle: i32) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "Window" , js_name = cancelIdleCallback)]
     #[doc = "The `cancelIdleCallback()` method."]
     #[doc = ""]
@@ -2167,16 +2160,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Window`*"]
     pub fn release_events(this: &Window);
-    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = requestAnimationFrame)]
-    #[doc = "The `requestAnimationFrame()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Window`*"]
-    pub fn request_animation_frame(
-        this: &Window,
-        callback: &::js_sys::Function,
-    ) -> Result<i32, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = requestIdleCallback)]
     #[doc = "The `requestIdleCallback()` method."]
     #[doc = ""]
@@ -2293,6 +2276,23 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Window`*"]
     pub fn get(this: &Window, name: &str) -> Option<::js_sys::Object>;
+    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = cancelAnimationFrame)]
+    #[doc = "The `cancelAnimationFrame()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/cancelAnimationFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Window`*"]
+    pub fn cancel_animation_frame(this: &Window, handle: i32) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = requestAnimationFrame)]
+    #[doc = "The `requestAnimationFrame()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Window`*"]
+    pub fn request_animation_frame(
+        this: &Window,
+        callback: &::js_sys::Function,
+    ) -> Result<i32, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = atob)]
     #[doc = "The `atob()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/AnimationFrame.webidl
+++ b/crates/web-sys/webidls/enabled/AnimationFrame.webidl
@@ -1,0 +1,10 @@
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames
+
+callback FrameRequestCallback = undefined (DOMHighResTimeStamp time);
+
+interface mixin AnimationFrameProvider {
+  [Throws] long requestAnimationFrame(FrameRequestCallback callback);
+  [Throws] undefined cancelAnimationFrame(long handle);
+};
+Window includes AnimationFrameProvider;
+DedicatedWorkerGlobalScope includes AnimationFrameProvider;

--- a/crates/web-sys/webidls/enabled/Window.webidl
+++ b/crates/web-sys/webidls/enabled/Window.webidl
@@ -9,7 +9,6 @@
  * https://dvcs.w3.org/hg/IndexedDB/raw-file/tip/Overview.html
  * http://dev.w3.org/csswg/cssom/
  * http://dev.w3.org/csswg/cssom-view/
- * https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html
  * https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html
  * https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html
  * http://dvcs.w3.org/hg/speech-api/raw-file/tip/speechapi.html
@@ -195,13 +194,6 @@ partial interface Window {
   [Throws, NeedsCallerType] attribute any outerHeight;
   [Replaceable] readonly attribute double devicePixelRatio;
 };
-
-// https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/RequestAnimationFrame/Overview.html
-partial interface Window {
-  [Throws] long requestAnimationFrame(FrameRequestCallback callback);
-  [Throws] undefined cancelAnimationFrame(long handle);
-};
-callback FrameRequestCallback = undefined (DOMHighResTimeStamp time);
 
 // https://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html
 partial interface Window {


### PR DESCRIPTION
This follows the spec here: https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frames.

I added a new `webidl` file named after this section of the spec. Had to adjust the return type to prevent a breaking change.