### PR TITLE
Mark inform function as unsafe

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -180,8 +180,8 @@ impl ToTokens for ast::Struct {
                         }
                     }
                     use #wasm_bindgen::describe::*;
-                    inform(RUST_STRUCT);
-                    inform(#name_len);
+                    unsafe { inform(RUST_STRUCT) };
+                    unsafe { inform(#name_len) };
                     #(inform(#name_chars);)*
                 }
             }
@@ -611,7 +611,7 @@ impl TryToTokens for ast::Export {
                 {
                     let inner = &reference.elem;
                     quote! {
-                        inform(LONGREF);
+                        unsafe { inform(LONGREF) };
                         <#inner as WasmDescribe>::describe();
                     }
                 }
@@ -639,9 +639,9 @@ impl TryToTokens for ast::Export {
         Descriptor {
             ident: &export,
             inner: quote! {
-                inform(FUNCTION);
-                inform(0);
-                inform(#nargs);
+                unsafe { inform(FUNCTION) };
+                unsafe { inform(0) };
+                unsafe { inform(#nargs) };
                 #describe_args
                 #describe_ret
             },
@@ -693,8 +693,8 @@ impl ToTokens for ast::ImportType {
             let typescript_type_chars = typescript_type.chars().map(|c| c as u32);
             quote! {
                 use #wasm_bindgen::describe::*;
-                inform(NAMED_EXTERNREF);
-                inform(#typescript_type_len);
+                unsafe { inform(NAMED_EXTERNREF) };
+                unsafe { inform(#typescript_type_len) };
                 #(inform(#typescript_type_chars);)*
             }
         } else {
@@ -1268,9 +1268,9 @@ impl<'a> ToTokens for DescribeImport<'a> {
         Descriptor {
             ident: &f.shim,
             inner: quote! {
-                inform(FUNCTION);
-                inform(0);
-                inform(#nargs);
+                unsafe { inform(FUNCTION);
+                unsafe { inform(0) };
+                unsafe { inform(#nargs) };
                 #(<#argtys as WasmDescribe>::describe();)*
                 #inform_ret
                 #inform_ret
@@ -1334,8 +1334,8 @@ impl ToTokens for ast::Enum {
             impl #wasm_bindgen::describe::WasmDescribe for #enum_name {
                 fn describe() {
                     use #wasm_bindgen::describe::*;
-                    inform(ENUM);
-                    inform(#hole);
+                    unsafe { inform(ENUM) };
+                    unsafe { inform(#hole) };
                 }
             }
         })
@@ -1469,7 +1469,7 @@ fn extern_fn(
 }
 
 /// Converts `span` into a stream of tokens, and attempts to ensure that `input`
-/// has all the appropriate span information so errors in it point to `span`.
+/// has all the appropriate span ation so errors in it point to `span`.
 fn respan(input: TokenStream, span: &dyn ToTokens) -> TokenStream {
     let mut first_span = Span::call_site();
     let mut last_span = Span::call_site();

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -329,7 +329,7 @@ where
         // about what's going on here.
 
         extern "C" fn describe<T: WasmClosure + ?Sized>() {
-            inform(CLOSURE);
+            unsafe { inform(CLOSURE) };
             T::describe()
         }
 
@@ -464,7 +464,7 @@ where
     T: WasmClosure + ?Sized,
 {
     fn describe() {
-        inform(EXTERNREF);
+        unsafe { inform(EXTERNREF) };
     }
 }
 
@@ -587,7 +587,7 @@ macro_rules! doit {
                     ret.return_abi()
                 }
 
-                inform(invoke::<$($var,)* R> as u32);
+                unsafe { inform(invoke::<$($var,)* R> as u32) };
 
                 unsafe extern fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
@@ -605,7 +605,7 @@ macro_rules! doit {
                         fields: (a, b)
                     }.ptr));
                 }
-                inform(destroy::<$($var,)* R> as u32);
+                unsafe { inform(destroy::<$($var,)* R> as u32) };
 
                 <&Self>::describe();
             }
@@ -640,7 +640,7 @@ macro_rules! doit {
                     ret.return_abi()
                 }
 
-                inform(invoke::<$($var,)* R> as u32);
+                unsafe { inform(invoke::<$($var,)* R> as u32) };
 
                 unsafe extern fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
@@ -654,7 +654,7 @@ macro_rules! doit {
                         fields: (a, b)
                     }.ptr));
                 }
-                inform(destroy::<$($var,)* R> as u32);
+                unsafe { inform(destroy::<$($var,)* R> as u32) };
 
                 <&mut Self>::describe();
             }
@@ -772,7 +772,7 @@ where
             ret.return_abi()
         }
 
-        inform(invoke::<A, R> as u32);
+        unsafe { inform(invoke::<A, R> as u32) };
 
         unsafe extern "C" fn destroy<A: RefFromWasmAbi, R: ReturnWasmAbi>(a: usize, b: usize) {
             // See `Fn()` above for why we simply return
@@ -783,7 +783,7 @@ where
                 FatPtr::<dyn Fn(&A) -> R> { fields: (a, b) }.ptr,
             ));
         }
-        inform(destroy::<A, R> as u32);
+        unsafe { inform(destroy::<A, R> as u32) };
 
         <&Self>::describe();
     }
@@ -816,7 +816,7 @@ where
             ret.return_abi()
         }
 
-        inform(invoke::<A, R> as u32);
+        unsafe { inform(invoke::<A, R> as u32) };
 
         unsafe extern "C" fn destroy<A: RefFromWasmAbi, R: ReturnWasmAbi>(a: usize, b: usize) {
             // See `Fn()` above for why we simply return
@@ -827,7 +827,7 @@ where
                 FatPtr::<dyn FnMut(&A) -> R> { fields: (a, b) }.ptr,
             ));
         }
-        inform(destroy::<A, R> as u32);
+        unsafe { inform(destroy::<A, R> as u32) };
 
         <&mut Self>::describe();
     }

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -48,9 +48,9 @@ macro_rules! stack_closures {
                   R: ReturnWasmAbi
         {
             fn describe() {
-                inform(FUNCTION);
-                inform($invoke::<$($var,)* R> as u32);
-                inform($cnt);
+                unsafe { inform(FUNCTION) };
+                unsafe { inform($invoke::<$($var,)* R> as u32) };
+                unsafe { inform($cnt) };
                 $(<$var as WasmDescribe>::describe();)*
                 <R as WasmDescribe>::describe();
                 <R as WasmDescribe>::describe();
@@ -97,9 +97,9 @@ macro_rules! stack_closures {
                   R: ReturnWasmAbi
         {
             fn describe() {
-                inform(FUNCTION);
-                inform($invoke_mut::<$($var,)* R> as u32);
-                inform($cnt);
+                unsafe { inform(FUNCTION) };
+                unsafe { inform($invoke_mut::<$($var,)* R> as u32) };
+                unsafe { inform($cnt) };
                 $(<$var as WasmDescribe>::describe();)*
                 <R as WasmDescribe>::describe();
                 <R as WasmDescribe>::describe();
@@ -163,9 +163,9 @@ where
     R: ReturnWasmAbi,
 {
     fn describe() {
-        inform(FUNCTION);
-        inform(invoke1_ref::<A, R> as u32);
-        inform(1);
+        unsafe { inform(FUNCTION) };
+        unsafe { inform(invoke1_ref::<A, R> as u32) };
+        unsafe { inform(1) };
         <&A as WasmDescribe>::describe();
         <R as WasmDescribe>::describe();
         <R as WasmDescribe>::describe();
@@ -215,9 +215,9 @@ where
     R: ReturnWasmAbi,
 {
     fn describe() {
-        inform(FUNCTION);
-        inform(invoke1_mut_ref::<A, R> as u32);
-        inform(1);
+        unsafe { inform(FUNCTION) };
+        unsafe { inform(invoke1_mut_ref::<A, R> as u32) };
+        unsafe { inform(1) };
         <&A as WasmDescribe>::describe();
         <R as WasmDescribe>::describe();
         <R as WasmDescribe>::describe();

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -49,7 +49,7 @@ tys! {
 }
 
 #[inline(always)] // see the wasm-interpreter crate
-pub fn inform(a: u32) {
+pub unsafe fn inform(a: u32) {
     unsafe { super::__wbindgen_describe(a) }
 }
 
@@ -60,7 +60,7 @@ pub trait WasmDescribe {
 macro_rules! simple {
     ($($t:ident => $d:ident)*) => ($(
         impl WasmDescribe for $t {
-            fn describe() { inform($d) }
+            fn describe() { unsafe { inform($d) } }
         }
     )*)
 }
@@ -98,33 +98,33 @@ cfg_if! {
 
 impl<T> WasmDescribe for *const T {
     fn describe() {
-        inform(I32)
+        unsafe { inform(I32) }
     }
 }
 
 impl<T> WasmDescribe for *mut T {
     fn describe() {
-        inform(I32)
+        unsafe { inform(I32) }
     }
 }
 
 impl<T: WasmDescribe> WasmDescribe for [T] {
     fn describe() {
-        inform(SLICE);
+        unsafe { inform(SLICE) };
         T::describe();
     }
 }
 
 impl<'a, T: WasmDescribe + ?Sized> WasmDescribe for &'a T {
     fn describe() {
-        inform(REF);
+        unsafe { inform(REF) };
         T::describe();
     }
 }
 
 impl<'a, T: WasmDescribe + ?Sized> WasmDescribe for &'a mut T {
     fn describe() {
-        inform(REFMUT);
+        unsafe { inform(REFMUT) };
         T::describe();
     }
 }
@@ -147,7 +147,7 @@ if_std! {
 
     impl<T: WasmDescribe> WasmDescribe for Box<[T]> {
         fn describe() {
-            inform(VECTOR);
+            unsafe { inform(VECTOR) };
             T::describe();
         }
     }
@@ -161,27 +161,27 @@ if_std! {
 
 impl<T: WasmDescribe> WasmDescribe for Option<T> {
     fn describe() {
-        inform(OPTIONAL);
+        unsafe { inform(OPTIONAL) };
         T::describe();
     }
 }
 
 impl WasmDescribe for () {
     fn describe() {
-        inform(UNIT)
+        unsafe { inform(UNIT) }
     }
 }
 
 impl<T: WasmDescribe, E: Into<JsValue>> WasmDescribe for Result<T, E> {
     fn describe() {
-        inform(RESULT);
+        unsafe { inform(RESULT) };
         T::describe();
     }
 }
 
 impl<T: WasmDescribe> WasmDescribe for Clamped<T> {
     fn describe() {
-        inform(CLAMPED);
+        unsafe { inform(CLAMPED) };
         T::describe();
     }
 }


### PR DESCRIPTION
https://github.com/rustwasm/wasm-bindgen/blob/153a6aa9c7a989c1865df7f93b2ddbca1113a175/src/describe.rs#L52-L54
Hello, in the above test case, the function has a 'function not implemented on non-wasm32 targets'.
```rust
let _ = inform(10);
``` 
`thread 'main' panicked at 'function not implemented on non-wasm32 targets'`
This function should be marked as unsafe, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately