### PR TITLE
Fixed document.currentScript is null #3398

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -377,13 +377,14 @@ impl<'a> Context<'a> {
             // In `--target no-modules` mode we need to both expose a name on
             // the global object as well as generate our own custom start
             // function.
+            // `document.currentScript` property can be null in browser extensions
             OutputMode::NoModules { global } => {
                 js.push_str("const __exports = {};\n");
                 js.push_str("let script_src;\n");
                 js.push_str(
                     "\
                     if (typeof document !== 'undefined') {
-                        script_src = new URL(document.currentScript.src, location.href).toString();
+                        script_src = new URL((document.currentScript && document.currentScript.src) ? document.currentScript.src : '', location.href).toString();
                     }\n",
                 );
                 js.push_str("let wasm = undefined;\n");

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -356,7 +356,7 @@ fn default_module_path_target_no_modules() {
     assert!(contents.contains(
         "\
     if (typeof document !== 'undefined') {
-        script_src = new URL(document.currentScript.src, location.href).toString();
+        script_src = new URL((document.currentScript && document.currentScript.src) ? document.currentScript.src : '', location.href).toString();
     }",
     ));
     assert!(contents.contains(


### PR DESCRIPTION
This is a fix for https://github.com/rustwasm/wasm-bindgen/issues/3398 where `document.currentScript` can be null in a browser extension. It is a rough solution, probably not good enough to be merged, but I hope it saves time for maintainers coming up with a proper fix. 

### Changes: 

Check if document.currentScript or document.currentScript.src is null and replace it with an empty string so that the URL is set from `location.href`.

I do not know under what conditions `.src` property can be null and if it's right to replace it with an empty string. Maybe it should be a hard fail in that case. 

### Testing

* manually fixed the code in the output to see if it works for an extension
* ran `cargo test`
* __no tests with wasm-pack were done__


