### PR TITLE
add verbose name for internal `ptr` property

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -503,7 +503,7 @@ impl<'a, 'b> JsBuilder<'a, 'b> {
         }
         self.prelude(&format!(
             "\
-                if ({0}.ptr === 0) {{
+                if ({0}.__wbg_ptr === 0) {{
                     throw new Error('Attempt to use a moved value');
                 }}
             ",
@@ -731,7 +731,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
             let val = js.pop();
             js.assert_class(&val, &class);
             js.assert_not_moved(&val);
-            js.push(format!("{}.ptr", val));
+            js.push(format!("{}.__wbg_ptr", val));
         }
 
         Instruction::I32FromOptionRust { class } => {

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -134,14 +134,14 @@ impl<'a, 'b> Builder<'a, 'b> {
                 drop(params.next());
                 if js.cx.config.debug {
                     js.prelude(
-                        "if (this.ptr == 0) throw new Error('Attempt to use a moved value');",
+                        "if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');",
                     );
                 }
                 if consumes_self {
                     js.prelude("const ptr = this.__destroy_into_raw();");
                     js.args.push("ptr".into());
                 } else {
-                    js.args.push("this.ptr".into());
+                    js.args.push("this.__wbg_ptr".into());
                 }
             }
             None => {}

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -927,14 +927,14 @@ impl<'a> Context<'a> {
                 static __wrap(ptr) {{
                     ptr = ptr >>> 0;
                     const obj = Object.create({}.prototype);
-                    obj.ptr = ptr;
+                    obj.__wbg_ptr = ptr;
                     {}
                     return obj;
                 }}
                 ",
                 name,
                 if self.config.weak_refs {
-                    format!("{}Finalization.register(obj, obj.ptr, obj);", name)
+                    format!("{}Finalization.register(obj, obj.__wbg_ptr, obj);", name)
                 } else {
                     String::new()
                 },
@@ -1010,8 +1010,8 @@ impl<'a> Context<'a> {
         dst.push_str(&format!(
             "
             __destroy_into_raw() {{
-                const ptr = this.ptr;
-                this.ptr = 0;
+                const ptr = this.__wbg_ptr;
+                this.__wbg_ptr = 0;
                 {}
                 return ptr;
             }}

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -228,7 +228,7 @@ exports.js_test_inspectable_classes = () => {
     assert.strictEqual(not_inspectable.toJSON, undefined);
     assert.strictEqual(not_inspectable.toString(), '[object Object]');
     // Non-inspectable classes in Node.js have no special console.log formatting
-    assert.strictEqual(console_log_to_string(not_inspectable), `NotInspectable { ptr: ${not_inspectable.ptr} }`);
+    assert.strictEqual(console_log_to_string(not_inspectable), `NotInspectable { __wbg_ptr: ${not_inspectable.__wbg_ptr} }`);
     inspectable.free();
     not_inspectable.free();
 };


### PR DESCRIPTION
This PR changes the name of the `ptr` property to `__wbg_ptr` during the JS generation step this prevents clashes with public struct fields in Rust client code.

Fixes #3388