### PR TITLE
Stabilize `OffscreenCanvasRenderingContext2d`

### DIFF
--- a/crates/web-sys/src/features/gen_CanvasRenderingContext2d.rs
+++ b/crates/web-sys/src/features/gen_CanvasRenderingContext2d.rs
@@ -1031,23 +1031,6 @@ extern "C" {
         dirty_width: f64,
         dirty_height: f64,
     ) -> Result<(), JsValue>;
-    # [wasm_bindgen (method , structural , js_class = "CanvasRenderingContext2D" , js_name = getLineDash)]
-    #[doc = "The `getLineDash()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getLineDash)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
-    pub fn get_line_dash(this: &CanvasRenderingContext2d) -> ::js_sys::Array;
-    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = setLineDash)]
-    #[doc = "The `setLineDash()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
-    pub fn set_line_dash(
-        this: &CanvasRenderingContext2d,
-        segments: &::wasm_bindgen::JsValue,
-    ) -> Result<(), JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = arc)]
     #[doc = "The `arc()` method."]
     #[doc = ""]
@@ -1174,6 +1157,93 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
     pub fn rect(this: &CanvasRenderingContext2d, x: f64, y: f64, w: f64, h: f64);
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
+    pub fn round_rect(
+        this: &CanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
+    pub fn round_rect_with_f64(
+        this: &CanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "DomPointInit")]
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`, `DomPointInit`*"]
+    pub fn round_rect_with_dom_point_init(
+        this: &CanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &DomPointInit,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
+    pub fn round_rect_with_f64_sequence(
+        this: &CanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
+    pub fn round_rect_with_dom_point_init_sequence(
+        this: &CanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (method , structural , js_class = "CanvasRenderingContext2D" , js_name = getLineDash)]
+    #[doc = "The `getLineDash()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getLineDash)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
+    pub fn get_line_dash(this: &CanvasRenderingContext2d) -> ::js_sys::Array;
+    # [wasm_bindgen (catch , method , structural , js_class = "CanvasRenderingContext2D" , js_name = setLineDash)]
+    #[doc = "The `setLineDash()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `CanvasRenderingContext2d`*"]
+    pub fn set_line_dash(
+        this: &CanvasRenderingContext2d,
+        segments: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "CanvasRenderingContext2D" , js_name = clearRect)]
     #[doc = "The `clearRect()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_OffscreenCanvasRenderingContext2d.rs
+++ b/crates/web-sys/src/features/gen_OffscreenCanvasRenderingContext2d.rs
@@ -1,7 +1,6 @@
 #![allow(unused_imports)]
 use super::*;
 use wasm_bindgen::prelude::*;
-#[cfg(web_sys_unstable_apis)]
 #[wasm_bindgen]
 extern "C" {
     # [wasm_bindgen (extends = :: js_sys :: Object , js_name = OffscreenCanvasRenderingContext2D , typescript_type = "OffscreenCanvasRenderingContext2D")]
@@ -11,11 +10,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type OffscreenCanvasRenderingContext2d;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "OffscreenCanvas")]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = canvas)]
     #[doc = "Getter for the `canvas` field of this object."]
@@ -23,429 +18,270 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/canvas)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn canvas(this: &OffscreenCanvasRenderingContext2d) -> OffscreenCanvas;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = globalAlpha)]
     #[doc = "Getter for the `globalAlpha` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/globalAlpha)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn global_alpha(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = globalAlpha)]
     #[doc = "Setter for the `globalAlpha` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/globalAlpha)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_global_alpha(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , catch , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = globalCompositeOperation)]
     #[doc = "Getter for the `globalCompositeOperation` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/globalCompositeOperation)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn global_composite_operation(
         this: &OffscreenCanvasRenderingContext2d,
     ) -> Result<String, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , catch , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = globalCompositeOperation)]
     #[doc = "Setter for the `globalCompositeOperation` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/globalCompositeOperation)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_global_composite_operation(
         this: &OffscreenCanvasRenderingContext2d,
         value: &str,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = strokeStyle)]
     #[doc = "Getter for the `strokeStyle` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/strokeStyle)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn stroke_style(this: &OffscreenCanvasRenderingContext2d) -> ::wasm_bindgen::JsValue;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = strokeStyle)]
     #[doc = "Setter for the `strokeStyle` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/strokeStyle)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_stroke_style(
         this: &OffscreenCanvasRenderingContext2d,
         value: &::wasm_bindgen::JsValue,
     );
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fillStyle)]
     #[doc = "Getter for the `fillStyle` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fillStyle)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_style(this: &OffscreenCanvasRenderingContext2d) -> ::wasm_bindgen::JsValue;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fillStyle)]
     #[doc = "Setter for the `fillStyle` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fillStyle)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_fill_style(
         this: &OffscreenCanvasRenderingContext2d,
         value: &::wasm_bindgen::JsValue,
     );
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = filter)]
     #[doc = "Getter for the `filter` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/filter)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn filter(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = filter)]
     #[doc = "Setter for the `filter` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/filter)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_filter(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = imageSmoothingEnabled)]
     #[doc = "Getter for the `imageSmoothingEnabled` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/imageSmoothingEnabled)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn image_smoothing_enabled(this: &OffscreenCanvasRenderingContext2d) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = imageSmoothingEnabled)]
     #[doc = "Setter for the `imageSmoothingEnabled` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/imageSmoothingEnabled)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_image_smoothing_enabled(this: &OffscreenCanvasRenderingContext2d, value: bool);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineWidth)]
     #[doc = "Getter for the `lineWidth` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineWidth)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn line_width(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineWidth)]
     #[doc = "Setter for the `lineWidth` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineWidth)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_line_width(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineCap)]
     #[doc = "Getter for the `lineCap` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineCap)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn line_cap(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineCap)]
     #[doc = "Setter for the `lineCap` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineCap)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_line_cap(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineJoin)]
     #[doc = "Getter for the `lineJoin` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineJoin)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn line_join(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineJoin)]
     #[doc = "Setter for the `lineJoin` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineJoin)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_line_join(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = miterLimit)]
     #[doc = "Getter for the `miterLimit` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/miterLimit)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn miter_limit(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = miterLimit)]
     #[doc = "Setter for the `miterLimit` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/miterLimit)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_miter_limit(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineDashOffset)]
     #[doc = "Getter for the `lineDashOffset` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineDashOffset)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn line_dash_offset(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineDashOffset)]
     #[doc = "Setter for the `lineDashOffset` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineDashOffset)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_line_dash_offset(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowOffsetX)]
     #[doc = "Getter for the `shadowOffsetX` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowOffsetX)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn shadow_offset_x(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowOffsetX)]
     #[doc = "Setter for the `shadowOffsetX` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowOffsetX)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_shadow_offset_x(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowOffsetY)]
     #[doc = "Getter for the `shadowOffsetY` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowOffsetY)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn shadow_offset_y(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowOffsetY)]
     #[doc = "Setter for the `shadowOffsetY` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowOffsetY)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_shadow_offset_y(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowBlur)]
     #[doc = "Getter for the `shadowBlur` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowBlur)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn shadow_blur(this: &OffscreenCanvasRenderingContext2d) -> f64;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowBlur)]
     #[doc = "Setter for the `shadowBlur` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowBlur)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_shadow_blur(this: &OffscreenCanvasRenderingContext2d, value: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowColor)]
     #[doc = "Getter for the `shadowColor` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowColor)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn shadow_color(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = shadowColor)]
     #[doc = "Setter for the `shadowColor` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/shadowColor)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_shadow_color(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = font)]
     #[doc = "Getter for the `font` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/font)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn font(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = font)]
     #[doc = "Setter for the `font` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/font)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_font(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = textAlign)]
     #[doc = "Getter for the `textAlign` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/textAlign)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn text_align(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = textAlign)]
     #[doc = "Setter for the `textAlign` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/textAlign)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_text_align(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = textBaseline)]
     #[doc = "Getter for the `textBaseline` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/textBaseline)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn text_baseline(this: &OffscreenCanvasRenderingContext2d) -> String;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , setter , js_class = "OffscreenCanvasRenderingContext2D" , js_name = textBaseline)]
     #[doc = "Setter for the `textBaseline` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/textBaseline)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_text_baseline(this: &OffscreenCanvasRenderingContext2d, value: &str);
-    #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = commit)]
-    #[doc = "The `commit()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/commit)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn commit(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -453,16 +289,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_image_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlImageElement,
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "SvgImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -470,16 +302,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `SvgImageElement`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_svg_image_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &SvgImageElement,
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlCanvasElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -487,16 +315,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_canvas_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlCanvasElement,
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlVideoElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -504,16 +328,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_video_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlVideoElement,
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -521,16 +341,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_image_bitmap(
         this: &OffscreenCanvasRenderingContext2d,
         image: &ImageBitmap,
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "OffscreenCanvas")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -538,9 +354,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_offscreen_canvas(
         this: &OffscreenCanvasRenderingContext2d,
         image: &OffscreenCanvas,
@@ -564,7 +377,6 @@ extern "C" {
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -572,9 +384,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_image_element_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlImageElement,
@@ -583,7 +392,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "SvgImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -591,9 +399,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `SvgImageElement`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_svg_image_element_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &SvgImageElement,
@@ -602,7 +407,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlCanvasElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -610,9 +414,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_canvas_element_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlCanvasElement,
@@ -621,7 +422,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlVideoElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -629,9 +429,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_video_element_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlVideoElement,
@@ -640,7 +437,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -648,9 +444,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_image_bitmap_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &ImageBitmap,
@@ -659,7 +452,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "OffscreenCanvas")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -667,9 +459,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_offscreen_canvas_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &OffscreenCanvas,
@@ -697,7 +486,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -705,9 +493,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlImageElement,
@@ -720,7 +505,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "SvgImageElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -728,9 +512,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `SvgImageElement`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_svg_image_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &SvgImageElement,
@@ -743,7 +524,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlCanvasElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -751,9 +531,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlCanvasElement,
@@ -766,7 +543,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "HtmlVideoElement")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -774,9 +550,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_html_video_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlVideoElement,
@@ -789,7 +562,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -797,9 +569,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_image_bitmap_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &ImageBitmap,
@@ -812,7 +581,6 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "OffscreenCanvas")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = drawImage)]
     #[doc = "The `drawImage()` method."]
@@ -820,9 +588,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/drawImage)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn draw_image_with_offscreen_canvas_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
         this: &OffscreenCanvasRenderingContext2d,
         image: &OffscreenCanvas,
@@ -858,29 +623,20 @@ extern "C" {
         dw: f64,
         dh: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = beginPath)]
     #[doc = "The `beginPath()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/beginPath)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn begin_path(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = clip)]
     #[doc = "The `clip()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/clip)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clip(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "CanvasWindingRule")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = clip)]
     #[doc = "The `clip()` method."]
@@ -888,14 +644,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/clip)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clip_with_canvas_winding_rule(
         this: &OffscreenCanvasRenderingContext2d,
         winding: CanvasWindingRule,
     );
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Path2d")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = clip)]
     #[doc = "The `clip()` method."]
@@ -903,11 +655,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/clip)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clip_with_path_2d(this: &OffscreenCanvasRenderingContext2d, path: &Path2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasWindingRule", feature = "Path2d",))]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = clip)]
     #[doc = "The `clip()` method."]
@@ -915,26 +663,18 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/clip)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`, `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clip_with_path_2d_and_winding(
         this: &OffscreenCanvasRenderingContext2d,
         path: &Path2d,
         winding: CanvasWindingRule,
     );
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fill)]
     #[doc = "The `fill()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fill)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "CanvasWindingRule")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fill)]
     #[doc = "The `fill()` method."]
@@ -942,14 +682,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fill)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_with_canvas_winding_rule(
         this: &OffscreenCanvasRenderingContext2d,
         winding: CanvasWindingRule,
     );
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Path2d")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fill)]
     #[doc = "The `fill()` method."]
@@ -957,11 +693,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fill)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_with_path_2d(this: &OffscreenCanvasRenderingContext2d, path: &Path2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasWindingRule", feature = "Path2d",))]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fill)]
     #[doc = "The `fill()` method."]
@@ -969,30 +701,22 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fill)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`, `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_with_path_2d_and_winding(
         this: &OffscreenCanvasRenderingContext2d,
         path: &Path2d,
         winding: CanvasWindingRule,
     );
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = isPointInPath)]
     #[doc = "The `isPointInPath()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/isPointInPath)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_point_in_path_with_f64(
         this: &OffscreenCanvasRenderingContext2d,
         x: f64,
         y: f64,
     ) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "CanvasWindingRule")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = isPointInPath)]
     #[doc = "The `isPointInPath()` method."]
@@ -1000,16 +724,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/isPointInPath)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_point_in_path_with_f64_and_canvas_winding_rule(
         this: &OffscreenCanvasRenderingContext2d,
         x: f64,
         y: f64,
         winding: CanvasWindingRule,
     ) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Path2d")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = isPointInPath)]
     #[doc = "The `isPointInPath()` method."]
@@ -1017,16 +737,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/isPointInPath)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_point_in_path_with_path_2d_and_f64(
         this: &OffscreenCanvasRenderingContext2d,
         path: &Path2d,
         x: f64,
         y: f64,
     ) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasWindingRule", feature = "Path2d",))]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = isPointInPath)]
     #[doc = "The `isPointInPath()` method."]
@@ -1034,9 +750,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/isPointInPath)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`, `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_point_in_path_with_path_2d_and_f64_and_winding(
         this: &OffscreenCanvasRenderingContext2d,
         path: &Path2d,
@@ -1044,22 +757,17 @@ extern "C" {
         y: f64,
         winding: CanvasWindingRule,
     ) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = isPointInStroke)]
     #[doc = "The `isPointInStroke()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/isPointInStroke)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_point_in_stroke_with_x_and_y(
         this: &OffscreenCanvasRenderingContext2d,
         x: f64,
         y: f64,
     ) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Path2d")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = isPointInStroke)]
     #[doc = "The `isPointInStroke()` method."]
@@ -1067,27 +775,19 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/isPointInStroke)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_point_in_stroke_with_path_and_x_and_y(
         this: &OffscreenCanvasRenderingContext2d,
         path: &Path2d,
         x: f64,
         y: f64,
     ) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = stroke)]
     #[doc = "The `stroke()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/stroke)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn stroke(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Path2d")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = stroke)]
     #[doc = "The `stroke()` method."]
@@ -1095,11 +795,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/stroke)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `Path2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn stroke_with_path(this: &OffscreenCanvasRenderingContext2d, path: &Path2d);
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "CanvasGradient")]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createLinearGradient)]
     #[doc = "The `createLinearGradient()` method."]
@@ -1107,9 +803,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createLinearGradient)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasGradient`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_linear_gradient(
         this: &OffscreenCanvasRenderingContext2d,
         x0: f64,
@@ -1117,7 +810,6 @@ extern "C" {
         x1: f64,
         y1: f64,
     ) -> CanvasGradient;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "HtmlImageElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -1125,15 +817,11 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `HtmlImageElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_html_image_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlImageElement,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "SvgImageElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -1141,15 +829,11 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `OffscreenCanvasRenderingContext2d`, `SvgImageElement`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_svg_image_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &SvgImageElement,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "HtmlCanvasElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -1157,15 +841,11 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `HtmlCanvasElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_html_canvas_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlCanvasElement,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "HtmlVideoElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -1173,15 +853,11 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `HtmlVideoElement`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_html_video_element(
         this: &OffscreenCanvasRenderingContext2d,
         image: &HtmlVideoElement,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -1189,15 +865,11 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `ImageBitmap`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_image_bitmap(
         this: &OffscreenCanvasRenderingContext2d,
         image: &ImageBitmap,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "CanvasPattern", feature = "OffscreenCanvas",))]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createPattern)]
     #[doc = "The `createPattern()` method."]
@@ -1205,9 +877,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createPattern)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasPattern`, `OffscreenCanvas`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_pattern_with_offscreen_canvas(
         this: &OffscreenCanvasRenderingContext2d,
         image: &OffscreenCanvas,
@@ -1229,7 +898,6 @@ extern "C" {
         image: &VideoFrame,
         repetition: &str,
     ) -> Result<Option<CanvasPattern>, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "CanvasGradient")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createRadialGradient)]
     #[doc = "The `createRadialGradient()` method."]
@@ -1237,9 +905,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createRadialGradient)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `CanvasGradient`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_radial_gradient(
         this: &OffscreenCanvasRenderingContext2d,
         x0: f64,
@@ -1249,7 +914,6 @@ extern "C" {
         y1: f64,
         r1: f64,
     ) -> Result<CanvasGradient, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageData")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createImageData)]
     #[doc = "The `createImageData()` method."]
@@ -1257,15 +921,11 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createImageData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_image_data_with_sw_and_sh(
         this: &OffscreenCanvasRenderingContext2d,
         sw: f64,
         sh: f64,
     ) -> Result<ImageData, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageData")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = createImageData)]
     #[doc = "The `createImageData()` method."]
@@ -1273,14 +933,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/createImageData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn create_image_data_with_imagedata(
         this: &OffscreenCanvasRenderingContext2d,
         imagedata: &ImageData,
     ) -> Result<ImageData, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageData")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = getImageData)]
     #[doc = "The `getImageData()` method."]
@@ -1288,9 +944,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/getImageData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn get_image_data(
         this: &OffscreenCanvasRenderingContext2d,
         sx: f64,
@@ -1298,7 +951,6 @@ extern "C" {
         sw: f64,
         sh: f64,
     ) -> Result<ImageData, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageData")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = putImageData)]
     #[doc = "The `putImageData()` method."]
@@ -1306,16 +958,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/putImageData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn put_image_data(
         this: &OffscreenCanvasRenderingContext2d,
         imagedata: &ImageData,
         dx: f64,
         dy: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ImageData")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = putImageData)]
     #[doc = "The `putImageData()` method."]
@@ -1323,9 +971,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/putImageData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn put_image_data_with_dirty_x_and_dirty_y_and_dirty_width_and_dirty_height(
         this: &OffscreenCanvasRenderingContext2d,
         imagedata: &ImageData,
@@ -1336,112 +981,278 @@ extern "C" {
         dirty_width: f64,
         dirty_height: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = arc)]
+    #[doc = "The `arc()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/arc)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn arc(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        radius: f64,
+        start_angle: f64,
+        end_angle: f64,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = arc)]
+    #[doc = "The `arc()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/arc)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn arc_with_anticlockwise(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        radius: f64,
+        start_angle: f64,
+        end_angle: f64,
+        anticlockwise: bool,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = arcTo)]
+    #[doc = "The `arcTo()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/arcTo)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn arc_to(
+        this: &OffscreenCanvasRenderingContext2d,
+        x1: f64,
+        y1: f64,
+        x2: f64,
+        y2: f64,
+        radius: f64,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = bezierCurveTo)]
+    #[doc = "The `bezierCurveTo()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/bezierCurveTo)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn bezier_curve_to(
+        this: &OffscreenCanvasRenderingContext2d,
+        cp1x: f64,
+        cp1y: f64,
+        cp2x: f64,
+        cp2y: f64,
+        x: f64,
+        y: f64,
+    );
+    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = closePath)]
+    #[doc = "The `closePath()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/closePath)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn close_path(this: &OffscreenCanvasRenderingContext2d);
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = ellipse)]
+    #[doc = "The `ellipse()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/ellipse)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn ellipse(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        radius_x: f64,
+        radius_y: f64,
+        rotation: f64,
+        start_angle: f64,
+        end_angle: f64,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = ellipse)]
+    #[doc = "The `ellipse()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/ellipse)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn ellipse_with_anticlockwise(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        radius_x: f64,
+        radius_y: f64,
+        rotation: f64,
+        start_angle: f64,
+        end_angle: f64,
+        anticlockwise: bool,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = lineTo)]
+    #[doc = "The `lineTo()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/lineTo)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn line_to(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64);
+    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = moveTo)]
+    #[doc = "The `moveTo()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/moveTo)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn move_to(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64);
+    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = quadraticCurveTo)]
+    #[doc = "The `quadraticCurveTo()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/quadraticCurveTo)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn quadratic_curve_to(
+        this: &OffscreenCanvasRenderingContext2d,
+        cpx: f64,
+        cpy: f64,
+        x: f64,
+        y: f64,
+    );
+    # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = rect)]
+    #[doc = "The `rect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/rect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn rect(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64, w: f64, h: f64);
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn round_rect(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn round_rect_with_f64(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "DomPointInit")]
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomPointInit`, `OffscreenCanvasRenderingContext2d`*"]
+    pub fn round_rect_with_dom_point_init(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &DomPointInit,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn round_rect_with_f64_sequence(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
+    pub fn round_rect_with_dom_point_init_sequence(
+        this: &OffscreenCanvasRenderingContext2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = getLineDash)]
     #[doc = "The `getLineDash()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/getLineDash)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn get_line_dash(this: &OffscreenCanvasRenderingContext2d) -> ::js_sys::Array;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = setLineDash)]
     #[doc = "The `setLineDash()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/setLineDash)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_line_dash(
         this: &OffscreenCanvasRenderingContext2d,
         segments: &::wasm_bindgen::JsValue,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = clearRect)]
     #[doc = "The `clearRect()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/clearRect)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clear_rect(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64, w: f64, h: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fillRect)]
     #[doc = "The `fillRect()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fillRect)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_rect(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64, w: f64, h: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = strokeRect)]
     #[doc = "The `strokeRect()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/strokeRect)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn stroke_rect(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64, w: f64, h: f64);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = restore)]
     #[doc = "The `restore()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/restore)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn restore(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = save)]
     #[doc = "The `save()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/save)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn save(this: &OffscreenCanvasRenderingContext2d);
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fillText)]
     #[doc = "The `fillText()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fillText)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_text(
         this: &OffscreenCanvasRenderingContext2d,
         text: &str,
         x: f64,
         y: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = fillText)]
     #[doc = "The `fillText()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/fillText)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn fill_text_with_max_width(
         this: &OffscreenCanvasRenderingContext2d,
         text: &str,
@@ -1449,7 +1260,6 @@ extern "C" {
         y: f64,
         max_width: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "TextMetrics")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = measureText)]
     #[doc = "The `measureText()` method."]
@@ -1457,39 +1267,28 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/measureText)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`, `TextMetrics`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn measure_text(
         this: &OffscreenCanvasRenderingContext2d,
         text: &str,
     ) -> Result<TextMetrics, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = strokeText)]
     #[doc = "The `strokeText()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/strokeText)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn stroke_text(
         this: &OffscreenCanvasRenderingContext2d,
         text: &str,
         x: f64,
         y: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = strokeText)]
     #[doc = "The `strokeText()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/strokeText)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn stroke_text_with_max_width(
         this: &OffscreenCanvasRenderingContext2d,
         text: &str,
@@ -1497,7 +1296,6 @@ extern "C" {
         y: f64,
         max_width: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "DomMatrix")]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = getTransform)]
     #[doc = "The `getTransform()` method."]
@@ -1505,53 +1303,34 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/getTransform)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `DomMatrix`, `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn get_transform(this: &OffscreenCanvasRenderingContext2d) -> Result<DomMatrix, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = resetTransform)]
     #[doc = "The `resetTransform()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/resetTransform)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn reset_transform(this: &OffscreenCanvasRenderingContext2d) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = rotate)]
     #[doc = "The `rotate()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/rotate)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn rotate(this: &OffscreenCanvasRenderingContext2d, angle: f64) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = scale)]
     #[doc = "The `scale()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/scale)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn scale(this: &OffscreenCanvasRenderingContext2d, x: f64, y: f64) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = setTransform)]
     #[doc = "The `setTransform()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/setTransform)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn set_transform(
         this: &OffscreenCanvasRenderingContext2d,
         a: f64,
@@ -1561,16 +1340,12 @@ extern "C" {
         e: f64,
         f: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = transform)]
     #[doc = "The `transform()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/transform)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn transform(
         this: &OffscreenCanvasRenderingContext2d,
         a: f64,
@@ -1580,16 +1355,12 @@ extern "C" {
         e: f64,
         f: f64,
     ) -> Result<(), JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (catch , method , structural , js_class = "OffscreenCanvasRenderingContext2D" , js_name = translate)]
     #[doc = "The `translate()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D/translate)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvasRenderingContext2d`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn translate(
         this: &OffscreenCanvasRenderingContext2d,
         x: f64,

--- a/crates/web-sys/src/features/gen_Path2d.rs
+++ b/crates/web-sys/src/features/gen_Path2d.rs
@@ -173,4 +173,68 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Path2d`*"]
     pub fn rect(this: &Path2d, x: f64, y: f64, w: f64, h: f64);
+    # [wasm_bindgen (catch , method , structural , js_class = "Path2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Path2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Path2d`*"]
+    pub fn round_rect(this: &Path2d, x: f64, y: f64, w: f64, h: f64) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "Path2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Path2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Path2d`*"]
+    pub fn round_rect_with_f64(
+        this: &Path2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: f64,
+    ) -> Result<(), JsValue>;
+    #[cfg(feature = "DomPointInit")]
+    # [wasm_bindgen (catch , method , structural , js_class = "Path2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Path2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomPointInit`, `Path2d`*"]
+    pub fn round_rect_with_dom_point_init(
+        this: &Path2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &DomPointInit,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "Path2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Path2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Path2d`*"]
+    pub fn round_rect_with_f64_sequence(
+        this: &Path2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "Path2D" , js_name = roundRect)]
+    #[doc = "The `roundRect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Path2D/roundRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Path2d`*"]
+    pub fn round_rect_with_dom_point_init_sequence(
+        this: &Path2d,
+        x: f64,
+        y: f64,
+        w: f64,
+        h: f64,
+        radii: &::wasm_bindgen::JsValue,
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl
@@ -124,7 +124,7 @@ CanvasRenderingContext2D includes CanvasDrawImage;
 CanvasRenderingContext2D includes CanvasImageData;
 CanvasRenderingContext2D includes CanvasPathDrawingStyles;
 CanvasRenderingContext2D includes CanvasTextDrawingStyles;
-CanvasRenderingContext2D includes CanvasPathMethods;
+CanvasRenderingContext2D includes CanvasPath;
 CanvasRenderingContext2D includes CanvasHitRegions;
 
 interface mixin CanvasState {
@@ -201,7 +201,7 @@ interface mixin CanvasRect {
 };
 
 interface mixin CanvasDrawPath {
-  // path API (see also CanvasPathMethods)
+  // path API (see also CanvasPath)
   undefined beginPath();
   undefined fill(optional CanvasWindingRule winding = "nonzero");
   undefined fill(Path2D path, optional CanvasWindingRule winding = "nonzero");
@@ -286,31 +286,22 @@ interface mixin CanvasTextDrawingStyles {
   attribute DOMString textBaseline; // "top", "hanging", "middle", "alphabetic", "ideographic", "bottom" (default: "alphabetic")
 };
 
-interface mixin CanvasPathMethods {
+interface mixin CanvasPath {
   // shared path API methods
   undefined closePath();
-  [LenientFloat]
-  undefined moveTo(double x, double y);
-  [LenientFloat]
-  undefined lineTo(double x, double y);
-  [LenientFloat]
-  undefined quadraticCurveTo(double cpx, double cpy, double x, double y);
-
-  [LenientFloat]
-  undefined bezierCurveTo(double cp1x, double cp1y, double cp2x, double cp2y, double x, double y);
-
-  [Throws, LenientFloat]
-  undefined arcTo(double x1, double y1, double x2, double y2, double radius);
-// NOT IMPLEMENTED  [LenientFloat] undefined arcTo(double x1, double y1, double x2, double y2, double radiusX, double radiusY, double rotation);
-
-  [LenientFloat]
-  undefined rect(double x, double y, double w, double h);
-
-  [Throws, LenientFloat]
-  undefined arc(double x, double y, double radius, double startAngle, double endAngle, optional boolean anticlockwise = false);
-
-  [Throws, LenientFloat]
-  undefined ellipse(double x, double y, double radiusX, double radiusY, double rotation, double startAngle, double endAngle, optional boolean anticlockwise = false);
+  undefined moveTo(unrestricted double x, unrestricted double y);
+  undefined lineTo(unrestricted double x, unrestricted double y);
+  undefined quadraticCurveTo(unrestricted double cpx, unrestricted double cpy, unrestricted double x, unrestricted double y);
+  undefined bezierCurveTo(unrestricted double cp1x, unrestricted double cp1y, unrestricted double cp2x, unrestricted double cp2y, unrestricted double x, unrestricted double y);
+  [Throws]
+  undefined arcTo(unrestricted double x1, unrestricted double y1, unrestricted double x2, unrestricted double y2, unrestricted double radius); 
+  undefined rect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h);
+  [Throws]
+  undefined roundRect(unrestricted double x, unrestricted double y, unrestricted double w, unrestricted double h, optional (unrestricted double or DOMPointInit or sequence<(unrestricted double or DOMPointInit)>) radii = 0);
+  [Throws]
+  undefined arc(unrestricted double x, unrestricted double y, unrestricted double radius, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false); 
+  [Throws]
+  undefined ellipse(unrestricted double x, unrestricted double y, unrestricted double radiusX, unrestricted double radiusY, unrestricted double rotation, unrestricted double startAngle, unrestricted double endAngle, optional boolean anticlockwise = false);
 };
 
 interface mixin CanvasHitRegions {
@@ -371,4 +362,4 @@ interface Path2D
 {
   undefined addPath(Path2D path, optional SVGMatrix transformation);
 };
-Path2D includes CanvasPathMethods;
+Path2D includes CanvasPath;

--- a/crates/web-sys/webidls/enabled/OffscreenCanvasRenderingContext2D.webidl
+++ b/crates/web-sys/webidls/enabled/OffscreenCanvasRenderingContext2D.webidl
@@ -1,6 +1,7 @@
 [Exposed = (Window, Worker)]
 interface OffscreenCanvasRenderingContext2D {
-  undefined commit();
+  // `commit()` doesn't exist, spec has to be updated: <https://github.com/whatwg/html/pull/3872>
+  // undefined commit();
   readonly attribute OffscreenCanvas canvas;
 };
 


### PR DESCRIPTION
Implemented in all browsers now: https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#browser_compatibility.

See https://html.spec.whatwg.org/multipage/canvas.html#offscreencanvasrenderingcontext2d.

Follow-up to https://github.com/rustwasm/wasm-bindgen/pull/3319.