### PR TITLE
Fix wrong `null` check on `document.currentScript`

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -383,7 +383,7 @@ impl<'a> Context<'a> {
                 js.push_str("let script_src;\n");
                 js.push_str(
                     "\
-                    if (typeof document !== 'undefined' && typeof document.currentScript !== 'null') {
+                    if (typeof document !== 'undefined' && document.currentScript !== null) {
                         script_src = new URL(document.currentScript.src, location.href).toString();
                     }\n",
                 );

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -355,7 +355,7 @@ fn default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
-    if (typeof document !== 'undefined' && typeof document.currentScript !== 'null') {
+    if (typeof document !== 'undefined' && document.currentScript !== null) {
         script_src = new URL(document.currentScript.src, location.href).toString();
     }",
     ));


### PR DESCRIPTION
Checking for `null` shouldn't use `typeof`, that just returns `'object'`.

Follow-up to #3402.
Fixes #3398.