### PR TITLE
Improved version mismatch error message

### DIFF
--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -1479,16 +1479,17 @@ version of wasm-bindgen that uses a different bindgen format than this binary:
      this binary schema version: {}
 
 Currently the bindgen format is unstable enough that these two schema versions
-must exactly match. You can accomplish this by either updating the wasm-bindgen
-dependency or this binary.
+must exactly match. You can accomplish this by either updating this binary or 
+the wasm-bindgen dependency in the Rust project.
 
 You should be able to update the wasm-bindgen dependency with:
 
-    cargo update -p wasm-bindgen
+    cargo update -p wasm-bindgen --precise {my_version}
 
-or you can update the binary with
+don't forget to recompile your wasm file! Alternatively, you can update the 
+binary with:
 
-    cargo install -f wasm-bindgen-cli
+    cargo install -f wasm-bindgen-cli --version {their_version}
 
 if this warning fails to go away though and you're not sure what to do feel free
 to open an issue at https://github.com/rustwasm/wasm-bindgen/issues!

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -1475,8 +1475,8 @@ pub fn extract_programs<'a>(
 it looks like the Rust project used to create this wasm file was linked against
 version of wasm-bindgen that uses a different bindgen format than this binary:
 
-  rust wasm file schema version: {}
-     this binary schema version: {}
+  rust wasm file schema version: {their_version}
+     this binary schema version: {my_version}
 
 Currently the bindgen format is unstable enough that these two schema versions
 must exactly match. You can accomplish this by either updating this binary or 
@@ -1493,9 +1493,7 @@ binary with:
 
 if this warning fails to go away though and you're not sure what to do feel free
 to open an issue at https://github.com/rustwasm/wasm-bindgen/issues!
-",
-                    their_version,
-                    my_version,
+"
                 );
             }
             let next = get_remaining(&mut payload).unwrap();


### PR DESCRIPTION
Improved suggested commands (and wording) for the error that shows up whenever there is a version mismatch between the `wasm-bindgen` version that is used by the CLI tool and a compiled wasm file.

Fixes #2619