### PR TITLE
Removing [Throws] from FileSystemWritableFileStream functions which pass errors via the returned promise rather than throwing directly

### DIFF
--- a/crates/web-sys/src/features/gen_FileSystemWritableFileStream.rs
+++ b/crates/web-sys/src/features/gen_FileSystemWritableFileStream.rs
@@ -16,7 +16,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type FileSystemWritableFileStream;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = seek)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = seek)]
     #[doc = "The `seek()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/seek)"]
@@ -25,12 +25,9 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn seek_with_u32(
-        this: &FileSystemWritableFileStream,
-        position: u32,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    pub fn seek_with_u32(this: &FileSystemWritableFileStream, position: u32) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = seek)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = seek)]
     #[doc = "The `seek()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/seek)"]
@@ -39,12 +36,9 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn seek_with_f64(
-        this: &FileSystemWritableFileStream,
-        position: f64,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    pub fn seek_with_f64(this: &FileSystemWritableFileStream, position: f64) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = truncate)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = truncate)]
     #[doc = "The `truncate()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/truncate)"]
@@ -53,12 +47,9 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn truncate_with_u32(
-        this: &FileSystemWritableFileStream,
-        size: u32,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    pub fn truncate_with_u32(this: &FileSystemWritableFileStream, size: u32) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = truncate)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = truncate)]
     #[doc = "The `truncate()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/truncate)"]
@@ -67,12 +58,9 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn truncate_with_f64(
-        this: &FileSystemWritableFileStream,
-        size: f64,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    pub fn truncate_with_f64(this: &FileSystemWritableFileStream, size: f64) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
     #[doc = "The `write()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write)"]
@@ -84,9 +72,9 @@ extern "C" {
     pub fn write_with_buffer_source(
         this: &FileSystemWritableFileStream,
         data: &::js_sys::Object,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
     #[doc = "The `write()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write)"]
@@ -98,10 +86,10 @@ extern "C" {
     pub fn write_with_u8_array(
         this: &FileSystemWritableFileStream,
         data: &mut [u8],
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Blob")]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
     #[doc = "The `write()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write)"]
@@ -110,12 +98,9 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn write_with_blob(
-        this: &FileSystemWritableFileStream,
-        data: &Blob,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    pub fn write_with_blob(this: &FileSystemWritableFileStream, data: &Blob) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
     #[doc = "The `write()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write)"]
@@ -124,13 +109,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn write_with_str(
-        this: &FileSystemWritableFileStream,
-        data: &str,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    pub fn write_with_str(this: &FileSystemWritableFileStream, data: &str) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "WriteParams")]
-    # [wasm_bindgen (catch , method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
+    # [wasm_bindgen (method , structural , js_class = "FileSystemWritableFileStream" , js_name = write)]
     #[doc = "The `write()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemWritableFileStream/write)"]
@@ -142,5 +124,5 @@ extern "C" {
     pub fn write_with_write_params(
         this: &FileSystemWritableFileStream,
         data: &WriteParams,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> ::js_sys::Promise;
 }

--- a/crates/web-sys/webidls/unstable/FileSystemAccess.webidl
+++ b/crates/web-sys/webidls/unstable/FileSystemAccess.webidl
@@ -64,11 +64,8 @@ typedef (BufferSource or Blob or USVString or WriteParams) FileSystemWriteChunkT
 
 [Exposed=(Window,Worker), SecureContext]
 interface FileSystemWritableFileStream : WritableStream {
-  [Throws]
   Promise<undefined> write(FileSystemWriteChunkType data);
-  [Throws]
   Promise<undefined> seek(unsigned long long position);
-  [Throws]
   Promise<undefined> truncate(unsigned long long size);
 };
 


### PR DESCRIPTION
Based on https://github.com/rustwasm/wasm-bindgen/pull/3327#discussion_r1195730766

It seems these functions don't throw directly.
In the above linked comment thread @daxpedda mentioned:

> According to the spec all three can throw: https://streams.spec.whatwg.org/#writablestream-get-a-writer.

But when I tested it, the condition on which they would throw while getting a writer seems to result in the promise having an error, not the function throwing.

Here's a test one can run in developer tools to verify this:
```
const storage = await window.navigator.storage.getDirectory();
const fileHandle = await storage.getFileHandle('test', { create: true });
const writable = await fileHandle.createWritable();
const writer = writable.getWriter(); // lock the stream
try {
    console.log(writable.write('x')); // will fail to get a writer internally
} catch(e) {
    // this won't run, instead the above promise will fail
    console.log("CAUGHT");
}
try {
    console.log(writable.seek(0)); // will fail to get a writer internally
} catch(e) {
    // this won't run, instead the above promise will fail
    console.log("CAUGHT");
}
try {
    console.log(writable.truncate(0)); // will fail to get a writer internally
} catch(e) {
    // this won't run, instead the above promise will fail
    console.log("CAUGHT");
}
```
I ran it on Chrome and Edge, which never printed `CAUGHT` and logged failed promises.
Weirdly, Firefox has `Throws` only on `write`: https://searchfox.org/mozilla-central/source/dom/webidl/FileSystemWritableFileStream.webidl#23-25
I'm not familiar with which condition would throw directly rather than result in a promise with an error based on any documentation I could find.