### PR TITLE
Clippy: Fixes and CI for examples and tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,9 @@ jobs:
     - run: cargo clippy --no-deps --all-features -p webidl-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p web-sys -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings
+    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown --tests -- -D warnings
+    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-benchmark -- -D warnings
+    - run: for i in examples/*/; do cd "$i"; cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings || exit 1; cd ../..; done
 
   test_wasm_bindgen:
     name: "Run wasm-bindgen crate tests (unix)"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-bindgen-benchmark"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2.43"

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -59,7 +59,7 @@ pub fn fibonacci(n: i32) -> i32 {
     unsafe {
         FIB_HIGH = (a >> 32) as i32;
     }
-    return a as i32;
+    a as i32
 }
 
 #[wasm_bindgen]

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -68,16 +68,16 @@ pub fn fibonacci_high() -> i32 {
 }
 
 #[wasm_bindgen]
-pub fn call_foo_bar_final_n_times(n: usize, foo: &Foo) {
+pub fn call_foo_bar_final_n_times(n: usize, js_foo: &Foo) {
     for _ in 0..n {
-        foo.bar_final();
+        js_foo.bar_final();
     }
 }
 
 #[wasm_bindgen]
-pub fn call_foo_bar_structural_n_times(n: usize, foo: &Foo) {
+pub fn call_foo_bar_structural_n_times(n: usize, js_foo: &Foo) {
     for _ in 0..n {
-        foo.bar_structural();
+        js_foo.bar_structural();
     }
 }
 

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -3,6 +3,7 @@ name = "add"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -3,6 +3,7 @@ name = "canvas"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -3,6 +3,7 @@ name = "char"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/char/src/lib.rs
+++ b/examples/char/src/lib.rs
@@ -23,8 +23,8 @@ impl Counter {
     pub fn new(key: char, count: i32) -> Counter {
         log(&format!("Counter::new({}, {})", key, count));
         Counter {
-            key: key,
-            count: count,
+            key,
+            count,
         }
     }
 

--- a/examples/char/src/lib.rs
+++ b/examples/char/src/lib.rs
@@ -22,10 +22,7 @@ impl Counter {
     }
     pub fn new(key: char, count: i32) -> Counter {
         log(&format!("Counter::new({}, {})", key, count));
-        Counter {
-            key,
-            count,
-        }
+        Counter { key, count }
     }
 
     pub fn key(&self) -> char {

--- a/examples/char/src/lib.rs
+++ b/examples/char/src/lib.rs
@@ -16,10 +16,6 @@ pub struct Counter {
 
 #[wasm_bindgen]
 impl Counter {
-    pub fn default() -> Counter {
-        log("Counter::default");
-        Self::new('a', 0)
-    }
     pub fn new(key: char, count: i32) -> Counter {
         log(&format!("Counter::new({}, {})", key, count));
         Counter { key, count }

--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -3,6 +3,7 @@ name = "closures"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -3,6 +3,7 @@ name = "console_log"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/deno/Cargo.toml
+++ b/examples/deno/Cargo.toml
@@ -3,6 +3,7 @@ name = "deno"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -3,6 +3,7 @@ name = "dom"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-duck-typed-interfaces"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -3,6 +3,7 @@ name = "fetch"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "guide-supported-types-examples"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guide-supported-types-examples/src/lib.rs
+++ b/examples/guide-supported-types-examples/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unused_variables, dead_code)]
+#![allow(unused_variables, dead_code, clippy::boxed_local)]
 
 pub mod bool;
 pub mod boxed_js_value_slice;

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -3,6 +3,7 @@ name = "hello_world"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -3,6 +3,7 @@ name = "julia_set"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/julia_set/src/lib.rs
+++ b/examples/julia_set/src/lib.rs
@@ -13,8 +13,8 @@ pub fn draw(
 ) -> Result<(), JsValue> {
     // The real workhorse of this algorithm, generating pixel data
     let c = Complex { real, imaginary };
-    let mut data = get_julia_set(width, height, c);
-    let data = ImageData::new_with_u8_clamped_array_and_sh(Clamped(&mut data), width, height)?;
+    let data = get_julia_set(width, height, c);
+    let data = ImageData::new_with_u8_clamped_array_and_sh(Clamped(&data), width, height)?;
     ctx.put_image_data(&data, 0.0, 0.0)
 }
 

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm-bindgen-paint"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -44,8 +44,8 @@ fn start() -> Result<(), JsValue> {
         closure.forget();
     }
     {
-        let context = context.clone();
-        let pressed = pressed.clone();
+        let context = context;
+        let pressed = pressed;
         let closure = Closure::<dyn FnMut(_)>::new(move |event: web_sys::MouseEvent| {
             pressed.set(false);
             context.line_to(event.offset_x() as f64, event.offset_y() as f64);

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -44,8 +44,6 @@ fn start() -> Result<(), JsValue> {
         closure.forget();
     }
     {
-        let context = context;
-        let pressed = pressed;
         let closure = Closure::<dyn FnMut(_)>::new(move |event: web_sys::MouseEvent| {
             pressed.set(false);
             context.line_to(event.offset_x() as f64, event.offset_y() as f64);

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -3,6 +3,7 @@ name = "performance"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -3,6 +3,7 @@ name = "raytrace-parallel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/raytrace-parallel/src/lib.rs
+++ b/examples/raytrace-parallel/src/lib.rs
@@ -59,7 +59,10 @@ impl Scene {
         // `pool`.
         let thread_pool = rayon::ThreadPoolBuilder::new()
             .num_threads(concurrency)
-            .spawn_handler(|thread| Ok(pool.run(|| thread.run()).unwrap()))
+            .spawn_handler(|thread| {
+                pool.run(|| thread.run()).unwrap();
+                Ok(())
+            })
             .build()
             .unwrap();
 

--- a/examples/request-animation-frame/Cargo.toml
+++ b/examples/request-animation-frame/Cargo.toml
@@ -3,6 +3,7 @@ name = "request-animation-frame"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/synchronous-instantiation/Cargo.toml
+++ b/examples/synchronous-instantiation/Cargo.toml
@@ -3,6 +3,7 @@ name = "synchronous-instantiation"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -3,7 +3,7 @@ name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.65"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -3,7 +3,7 @@ name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.65"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -3,6 +3,7 @@ name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/src/controller.rs
+++ b/examples/todomvc/src/controller.rs
@@ -104,8 +104,7 @@ impl Controller {
         if let Some(data) = self.store.find(ItemQuery::Id { id: id.clone() }) {
             if let Some(todo) = data.get(0) {
                 let title = todo.title.to_string();
-                let citem = id;
-                message = Some(ViewMessage::EditItemDone(citem, title));
+                message = Some(ViewMessage::EditItemDone(id, title));
             }
         }
         if let Some(message) = message {
@@ -140,11 +139,9 @@ impl Controller {
     /// Set all items to complete or active.
     fn toggle_all(&mut self, completed: bool) {
         let mut vals = Vec::new();
-        self.store.find(ItemQuery::EmptyItemQuery).map(|data| {
-            for item in data.iter() {
-                vals.push(item.id.clone());
-            }
-        });
+        if let Some(data) = self.store.find(ItemQuery::EmptyItemQuery) {
+            vals.extend(data.iter().map(|item| item.id.clone()));
+        }
         for id in vals.iter() {
             self.toggle_completed(id.to_string(), completed);
         }

--- a/examples/todomvc/src/controller.rs
+++ b/examples/todomvc/src/controller.rs
@@ -92,7 +92,7 @@ impl Controller {
                 id: id.clone(),
                 title: title.clone(),
             });
-            self.add_message(ViewMessage::EditItemDone(id.to_string(), title.to_string()));
+            self.add_message(ViewMessage::EditItemDone(id.to_string(), title));
         } else {
             self.remove_item(&id);
         }
@@ -104,7 +104,7 @@ impl Controller {
         if let Some(data) = self.store.find(ItemQuery::Id { id: id.clone() }) {
             if let Some(todo) = data.get(0) {
                 let title = todo.title.to_string();
-                let citem = id.to_string();
+                let citem = id;
                 message = Some(ViewMessage::EditItemDone(citem, title));
             }
         }
@@ -133,7 +133,7 @@ impl Controller {
             id: id.clone(),
             completed,
         });
-        let tid = id.to_string();
+        let tid = id;
         self.add_message(ViewMessage::SetItemComplete(tid, completed));
     }
 
@@ -155,7 +155,7 @@ impl Controller {
     fn _filter(&mut self, force: bool) {
         let route = &self.active_route;
 
-        if force || self.last_active_route != "" || &self.last_active_route != route {
+        if force || !self.last_active_route.is_empty() || &self.last_active_route != route {
             let query = match route.as_str() {
                 "completed" => ItemQuery::Completed { completed: true },
                 "active" => ItemQuery::Completed { completed: false },

--- a/examples/todomvc/src/element.rs
+++ b/examples/todomvc/src/element.rs
@@ -21,28 +21,20 @@ impl From<web_sys::EventTarget> for Element {
 
 impl From<Element> for Option<web_sys::Node> {
     fn from(obj: Element) -> Option<web_sys::Node> {
-        if let Some(el) = obj.el {
-            Some(el.into())
-        } else {
-            None
-        }
+        obj.el.map(|el| el.into())
     }
 }
 
 impl From<Element> for Option<EventTarget> {
     fn from(obj: Element) -> Option<EventTarget> {
-        if let Some(el) = obj.el {
-            Some(el.into())
-        } else {
-            None
-        }
+        obj.el.map(|el| el.into())
     }
 }
 
 impl Element {
     // Create an element from a tag name
     pub fn create_element(tag: &str) -> Option<Element> {
-        if let Some(el) = web_sys::window()?.document()?.create_element(tag).ok() {
+        if let Ok(el) = web_sys::window()?.document()?.create_element(tag) {
             Some(el.into())
         } else {
             None
@@ -81,7 +73,7 @@ impl Element {
         mut handler: T,
         use_capture: bool,
     ) where
-        T: 'static + FnMut(web_sys::Event) -> (),
+        T: 'static + FnMut(web_sys::Event),
     {
         let el = match self.el.take() {
             Some(e) => e,
@@ -154,7 +146,7 @@ impl Element {
     pub fn set_text_content(&mut self, value: &str) {
         if let Some(el) = self.el.as_ref() {
             if let Some(node) = &el.dyn_ref::<web_sys::Node>() {
-                node.set_text_content(Some(&value));
+                node.set_text_content(Some(value));
             }
         }
     }
@@ -204,14 +196,14 @@ impl Element {
     /// ```
     pub fn class_list_remove(&mut self, value: &str) {
         if let Some(el) = self.el.take() {
-            el.class_list().remove_1(&value).unwrap();
+            el.class_list().remove_1(value).unwrap();
             self.el = Some(el);
         }
     }
 
     pub fn class_list_add(&mut self, value: &str) {
         if let Some(el) = self.el.take() {
-            el.class_list().add_1(&value).unwrap();
+            el.class_list().add_1(value).unwrap();
             self.el = Some(el);
         }
     }
@@ -233,7 +225,7 @@ impl Element {
     /// Sets the whole class value for `self.el`
     pub fn set_class_name(&mut self, class_name: &str) {
         if let Some(el) = self.el.take() {
-            el.set_class_name(&class_name);
+            el.set_class_name(class_name);
             self.el = Some(el);
         }
     }
@@ -307,7 +299,7 @@ impl Element {
     pub fn set_value(&mut self, value: &str) {
         if let Some(el) = self.el.take() {
             if let Some(el) = wasm_bindgen::JsCast::dyn_ref::<web_sys::HtmlInputElement>(&el) {
-                el.set_value(&value);
+                el.set_value(value);
             }
             self.el = Some(el);
         }

--- a/examples/todomvc/src/element.rs
+++ b/examples/todomvc/src/element.rs
@@ -21,24 +21,21 @@ impl From<web_sys::EventTarget> for Element {
 
 impl From<Element> for Option<web_sys::Node> {
     fn from(obj: Element) -> Option<web_sys::Node> {
-        obj.el.map(|el| el.into())
+        obj.el.map(Into::into)
     }
 }
 
 impl From<Element> for Option<EventTarget> {
     fn from(obj: Element) -> Option<EventTarget> {
-        obj.el.map(|el| el.into())
+        obj.el.map(Into::into)
     }
 }
 
 impl Element {
     // Create an element from a tag name
     pub fn create_element(tag: &str) -> Option<Element> {
-        if let Ok(el) = web_sys::window()?.document()?.create_element(tag) {
-            Some(el.into())
-        } else {
-            None
-        }
+        let el = web_sys::window()?.document()?.create_element(tag).ok()?;
+        Some(el.into())
     }
 
     pub fn qs(selector: &str) -> Option<Element> {

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -32,10 +32,10 @@ pub enum Message {
 }
 
 /// Used for debugging to the console
-pub fn exit(message: &str) -> ! {
+pub fn exit(message: &str) {
     let v = wasm_bindgen::JsValue::from_str(message);
     web_sys::console::exception_1(&v);
-    std::process::abort()
+    std::process::abort();
 }
 
 fn app(name: &str) {

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -33,7 +33,7 @@ pub enum Message {
 
 /// Used for debugging to the console
 pub fn exit(message: &str) {
-    let v = wasm_bindgen::JsValue::from_str(&message.to_string());
+    let v = wasm_bindgen::JsValue::from_str(message);
     web_sys::console::exception_1(&v);
     std::process::abort();
 }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -32,10 +32,10 @@ pub enum Message {
 }
 
 /// Used for debugging to the console
-pub fn exit(message: &str) {
+pub fn exit(message: &str) -> ! {
     let v = wasm_bindgen::JsValue::from_str(message);
     web_sys::console::exception_1(&v);
-    std::process::abort();
+    std::process::abort()
 }
 
 fn app(name: &str) {

--- a/examples/todomvc/src/scheduler.rs
+++ b/examples/todomvc/src/scheduler.rs
@@ -13,10 +13,6 @@ pub struct Scheduler {
     running: RefCell<bool>,
 }
 
-fn deadlock() -> ! {
-    exit("This might be a deadlock");
-}
-
 impl Scheduler {
     /// Construct a new `Scheduler`
     pub fn new() -> Scheduler {
@@ -29,13 +25,19 @@ impl Scheduler {
     }
 
     pub fn set_controller(&self, controller: Controller) {
-        let Ok(mut controller_data) = self.controller.try_borrow_mut() else { deadlock() };
-        *controller_data = Some(controller);
+        if let Ok(mut controller_data) = self.controller.try_borrow_mut() {
+            *controller_data = Some(controller);
+        } else {
+            exit("This might be a deadlock");
+        }
     }
 
     pub fn set_view(&self, view: View) {
-        let Ok(mut view_data) = self.view.try_borrow_mut() else { deadlock() };
-        *view_data = Some(view);
+        if let Ok(mut view_data) = self.view.try_borrow_mut() {
+            *view_data = Some(view);
+        } else {
+            exit("This might be a deadlock");
+        }
     }
 
     /// Add a new message onto the event stack
@@ -43,12 +45,19 @@ impl Scheduler {
     /// Triggers running the event loop if it's not already running
     pub fn add_message(&self, message: Message) {
         let running = {
-            let Ok(running) = self.running.try_borrow() else { deadlock() };
-            *running
+            if let Ok(running) = self.running.try_borrow() {
+                *running
+            } else {
+                exit("This might be a deadlock");
+                false
+            }
         };
         {
-            let Ok(mut events) = self.events.try_borrow_mut() else { deadlock() };
-            events.push(message);
+            if let Ok(mut events) = self.events.try_borrow_mut() {
+                events.push(message);
+            } else {
+                exit("This might be a deadlock");
+            }
         }
         if !running {
             self.run();
@@ -57,17 +66,27 @@ impl Scheduler {
 
     /// Start the event loop, taking messages from the stack to run
     fn run(&self) {
-        let events_len = {
-            let Ok(events) = self.events.try_borrow() else { deadlock() };
-            events.len()
-        };
+        let mut events_len = 0;
+        {
+            if let Ok(events) = self.events.try_borrow() {
+                events_len = events.len();
+            } else {
+                exit("This might be a deadlock");
+            }
+        }
         if events_len == 0 {
-            let Ok(mut running) = self.running.try_borrow_mut() else { deadlock() };
-            *running = false;
+            if let Ok(mut running) = self.running.try_borrow_mut() {
+                *running = false;
+            } else {
+                exit("This might be a deadlock");
+            }
         } else {
             {
-                let Ok(mut running) = self.running.try_borrow_mut() else { deadlock() };
-                *running = true;
+                if let Ok(mut running) = self.running.try_borrow_mut() {
+                    *running = true;
+                } else {
+                    exit("This might be a deadlock");
+                }
             }
             self.next_message();
         }
@@ -75,28 +94,39 @@ impl Scheduler {
 
     fn next_message(&self) {
         let event = {
-            let Ok(mut events) = self.events.try_borrow_mut() else { deadlock() };
-            events.pop()
+            if let Ok(mut events) = self.events.try_borrow_mut() {
+                Some(events.pop())
+            } else {
+                exit("This might be a deadlock");
+                None
+            }
         };
-        if let Some(event) = event {
+        if let Some(Some(event)) = event {
             match event {
                 Message::Controller(e) => {
-                    let Ok(mut controller) = self.controller.try_borrow_mut() else { deadlock() };
-                    if let Some(ref mut ag) = *controller {
-                        ag.call(e);
+                    if let Ok(mut controller) = self.controller.try_borrow_mut() {
+                        if let Some(ref mut ag) = *controller {
+                            ag.call(e);
+                        }
+                    } else {
+                        exit("This might be a deadlock");
                     }
                 }
                 Message::View(e) => {
-                    let Ok(mut view) = self.view.try_borrow_mut() else { deadlock() };
-                    if let Some(ref mut ag) = *view {
-                        ag.call(e);
+                    if let Ok(mut view) = self.view.try_borrow_mut() {
+                        if let Some(ref mut ag) = *view {
+                            ag.call(e);
+                        }
+                    } else {
+                        exit("This might be a deadlock");
                     }
                 }
             }
             self.run();
-        } else {
-            let Ok(mut running) = self.running.try_borrow_mut() else { deadlock() };
+        } else if let Ok(mut running) = self.running.try_borrow_mut() {
             *running = false;
+        } else {
+            exit("This might be a deadlock");
         }
     }
 }

--- a/examples/todomvc/src/scheduler.rs
+++ b/examples/todomvc/src/scheduler.rs
@@ -13,6 +13,10 @@ pub struct Scheduler {
     running: RefCell<bool>,
 }
 
+fn deadlock() -> ! {
+    exit("This might be a deadlock");
+}
+
 impl Scheduler {
     /// Construct a new `Scheduler`
     pub fn new() -> Scheduler {
@@ -28,7 +32,7 @@ impl Scheduler {
         if let Ok(mut controller_data) = self.controller.try_borrow_mut() {
             *controller_data = Some(controller);
         } else {
-            exit("This might be a deadlock");
+            deadlock()
         }
     }
 
@@ -36,7 +40,7 @@ impl Scheduler {
         if let Ok(mut view_data) = self.view.try_borrow_mut() {
             *view_data = Some(view);
         } else {
-            exit("This might be a deadlock");
+            deadlock()
         }
     }
 
@@ -44,20 +48,15 @@ impl Scheduler {
     ///
     /// Triggers running the event loop if it's not already running
     pub fn add_message(&self, message: Message) {
-        let running = {
-            if let Ok(running) = self.running.try_borrow() {
-                *running
-            } else {
-                exit("This might be a deadlock");
-                false
-            }
+        let running = if let Ok(running) = self.running.try_borrow() {
+            *running
+        } else {
+            deadlock()
         };
-        {
-            if let Ok(mut events) = self.events.try_borrow_mut() {
-                events.push(message);
-            } else {
-                exit("This might be a deadlock");
-            }
+        if let Ok(mut events) = self.events.try_borrow_mut() {
+            events.push(message);
+        } else {
+            deadlock()
         }
         if !running {
             self.run();
@@ -66,42 +65,34 @@ impl Scheduler {
 
     /// Start the event loop, taking messages from the stack to run
     fn run(&self) {
-        let mut events_len = 0;
-        {
-            if let Ok(events) = self.events.try_borrow() {
-                events_len = events.len();
-            } else {
-                exit("This might be a deadlock");
-            }
-        }
+        let events_len = if let Ok(events) = self.events.try_borrow() {
+            events.len()
+        } else {
+            deadlock()
+        };
         if events_len == 0 {
             if let Ok(mut running) = self.running.try_borrow_mut() {
                 *running = false;
             } else {
-                exit("This might be a deadlock");
+                deadlock()
             }
         } else {
-            {
-                if let Ok(mut running) = self.running.try_borrow_mut() {
-                    *running = true;
-                } else {
-                    exit("This might be a deadlock");
-                }
+            if let Ok(mut running) = self.running.try_borrow_mut() {
+                *running = true;
+            } else {
+                deadlock()
             }
             self.next_message();
         }
     }
 
     fn next_message(&self) {
-        let event = {
-            if let Ok(mut events) = self.events.try_borrow_mut() {
-                Some(events.pop())
-            } else {
-                exit("This might be a deadlock");
-                None
-            }
+        let event = if let Ok(mut events) = self.events.try_borrow_mut() {
+            events.pop()
+        } else {
+            deadlock()
         };
-        if let Some(Some(event)) = event {
+        if let Some(event) = event {
             match event {
                 Message::Controller(e) => {
                     if let Ok(mut controller) = self.controller.try_borrow_mut() {
@@ -109,7 +100,7 @@ impl Scheduler {
                             ag.call(e);
                         }
                     } else {
-                        exit("This might be a deadlock");
+                        deadlock()
                     }
                 }
                 Message::View(e) => {
@@ -118,7 +109,7 @@ impl Scheduler {
                             ag.call(e);
                         }
                     } else {
-                        exit("This might be a deadlock");
+                        deadlock()
                     }
                 }
             }
@@ -126,7 +117,7 @@ impl Scheduler {
         } else if let Ok(mut running) = self.running.try_borrow_mut() {
             *running = false;
         } else {
-            exit("This might be a deadlock");
+            deadlock()
         }
     }
 }

--- a/examples/todomvc/src/scheduler.rs
+++ b/examples/todomvc/src/scheduler.rs
@@ -46,7 +46,7 @@ impl Scheduler {
     pub fn add_message(&self, message: Message) {
         let running = {
             if let Ok(running) = self.running.try_borrow() {
-                running.clone()
+                *running
             } else {
                 exit("This might be a deadlock");
                 false
@@ -69,7 +69,7 @@ impl Scheduler {
         let mut events_len = 0;
         {
             if let Ok(events) = self.events.try_borrow() {
-                events_len = events.len().clone();
+                events_len = events.len();
             } else {
                 exit("This might be a deadlock");
             }

--- a/examples/todomvc/src/store.rs
+++ b/examples/todomvc/src/store.rs
@@ -79,7 +79,7 @@ impl Store {
     ///
     /// ```
     ///  let data = db.find(ItemQuery::Completed {completed: true});
-    ///	 // data will contain items whose completed properties are true
+    ///  // data will contain items whose completed properties are true
     /// ```
     pub fn find(&mut self, query: ItemQuery) -> Option<ItemListSlice<'_>> {
         Some(
@@ -194,7 +194,7 @@ impl ItemListTrait<Item> for ItemList {
     }
 }
 use std::iter::FromIterator;
-impl<'a> FromIterator<Item> for ItemList {
+impl FromIterator<Item> for ItemList {
     fn from_iter<I: IntoIterator<Item = Item>>(iter: I) -> Self {
         let mut c = ItemList::new();
         for i in iter {
@@ -238,10 +238,10 @@ impl<'a> FromIterator<&'a Item> for ItemListSlice<'a> {
     }
 }
 
-impl<'a> Into<ItemList> for ItemListSlice<'a> {
-    fn into(self) -> ItemList {
+impl From<ItemListSlice<'_>> for ItemList {
+    fn from(s: ItemListSlice<'_>) -> Self {
         let mut i = ItemList::new();
-        let items = self.list.into_iter();
+        let items = s.list.into_iter();
         for j in items {
             // TODO neaten this cloning?
             let item = Item {

--- a/examples/todomvc/src/view.rs
+++ b/examples/todomvc/src/view.rs
@@ -417,7 +417,6 @@ impl View {
 
 impl Drop for View {
     fn drop(&mut self) {
-        exit("calling drop on view");
         let callbacks: Vec<(web_sys::EventTarget, String, Closure<dyn FnMut()>)> =
             self.callbacks.drain(..).collect();
         for callback in callbacks {
@@ -429,5 +428,6 @@ impl Drop for View {
                 )
                 .unwrap();
         }
+        exit("calling drop on view");
     }
 }

--- a/examples/todomvc/src/view.rs
+++ b/examples/todomvc/src/view.rs
@@ -417,9 +417,7 @@ impl View {
 
 impl Drop for View {
     fn drop(&mut self) {
-        let callbacks: Vec<(web_sys::EventTarget, String, Closure<dyn FnMut()>)> =
-            self.callbacks.drain(..).collect();
-        for callback in callbacks {
+        for callback in self.callbacks.drain(..) {
             callback
                 .0
                 .remove_event_listener_with_callback(

--- a/examples/todomvc/src/view.rs
+++ b/examples/todomvc/src/view.rs
@@ -30,12 +30,10 @@ fn item_id(mut element: Element) -> Option<String> {
     element.parent_element().map(|mut parent| {
         let mut res = None;
         let parent_id = parent.dataset_get("id");
-        if parent_id != "" {
+        if !parent_id.is_empty() {
             res = Some(parent_id);
-        } else {
-            if let Some(mut ep) = parent.parent_element() {
-                res = Some(ep.dataset_get("id"));
-            }
+        } else if let Some(mut ep) = parent.parent_element() {
+            res = Some(ep.dataset_get("id"));
         }
         res.unwrap()
     })
@@ -260,7 +258,7 @@ impl View {
                 {
                     let v = input_el.value(); // TODO remove with nll
                     let title = v.trim();
-                    if title != "" {
+                    if !title.is_empty() {
                         if let Ok(sched) = &(sched.try_borrow_mut()) {
                             sched.add_message(Message::Controller(ControllerMessage::AddItem(
                                 String::from(title),
@@ -427,7 +425,7 @@ impl Drop for View {
                 .0
                 .remove_event_listener_with_callback(
                     callback.1.as_str(),
-                    &callback.2.as_ref().unchecked_ref(),
+                    callback.2.as_ref().unchecked_ref(),
                 )
                 .unwrap();
         }

--- a/examples/wasm-audio-worklet/Cargo.toml
+++ b/examples/wasm-audio-worklet/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-audio-worklet"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-audio-worklet/src/dependent_module.rs
+++ b/examples/wasm-audio-worklet/src/dependent_module.rs
@@ -25,7 +25,7 @@ pub fn on_the_fly(code: &str) -> Result<String, JsValue> {
 
     Url::create_object_url_with_blob(&Blob::new_with_str_sequence_and_options(
         &Array::of2(&JsValue::from(header.as_str()), &JsValue::from(code)),
-        &BlobPropertyBag::new().type_("text/javascript"),
+        BlobPropertyBag::new().type_("text/javascript"),
     )?)
 }
 
@@ -40,6 +40,6 @@ pub fn on_the_fly(code: &str) -> Result<String, JsValue> {
 #[macro_export]
 macro_rules! dependent_module {
     ($file_name:expr) => {
-        crate::dependent_module::on_the_fly(include_str!($file_name))
+        $crate::dependent_module::on_the_fly(include_str!($file_name))
     };
 }

--- a/examples/wasm-audio-worklet/src/lib.rs
+++ b/examples/wasm-audio-worklet/src/lib.rs
@@ -11,8 +11,8 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub async fn web_main() {
     // On the application level, audio worklet internals are abstracted by wasm_audio:
-    let params: &'static Params = Box::leak(Box::new(Params::default()));
-    let mut osc = Oscillator::new(&params);
+    let params: &'static Params = Box::leak(Box::default());
+    let mut osc = Oscillator::new(params);
     let ctx = wasm_audio(Box::new(move |buf| osc.process(buf)))
         .await
         .unwrap();

--- a/examples/wasm-audio-worklet/src/wasm_audio.rs
+++ b/examples/wasm-audio-worklet/src/wasm_audio.rs
@@ -42,9 +42,9 @@ pub fn wasm_audio_node(
     process: Box<dyn FnMut(&mut [f32]) -> bool>,
 ) -> Result<AudioWorkletNode, JsValue> {
     AudioWorkletNode::new_with_options(
-        &ctx,
+        ctx,
         "WasmProcessor",
-        &AudioWorkletNodeOptions::new().processor_options(Some(&js_sys::Array::of3(
+        AudioWorkletNodeOptions::new().processor_options(Some(&js_sys::Array::of3(
             &wasm_bindgen::module(),
             &wasm_bindgen::memory(),
             &WasmAudioProcessor(process).pack().into(),

--- a/examples/wasm-in-wasm-imports/Cargo.toml
+++ b/examples/wasm-in-wasm-imports/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm-in-wasm-imports"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm-in-wasm"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-web-worker/Cargo.toml
+++ b/examples/wasm-in-web-worker/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm-in-web-worker"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-web-worker/src/lib.rs
+++ b/examples/wasm-in-web-worker/src/lib.rs
@@ -118,8 +118,6 @@ fn setup_input_oninput_callback(worker: Rc<RefCell<web_sys::Worker>>) {
 
 /// Create a closure to act on the message returned by the worker
 fn get_on_msg_callback() -> Closure<dyn FnMut(MessageEvent)> {
-    
-
     Closure::new(move |event: MessageEvent| {
         console::log_2(&"Received response: ".into(), &event.data());
 

--- a/examples/wasm-in-web-worker/src/lib.rs
+++ b/examples/wasm-in-web-worker/src/lib.rs
@@ -28,10 +28,7 @@ impl NumberEval {
     /// * `number` - The number to be checked for being even/odd.
     pub fn is_even(&mut self, number: i32) -> bool {
         self.number = number;
-        match self.number % 2 {
-            0 => true,
-            _ => false,
-        }
+        self.number % 2 == 0
     }
 
     /// Get last number that was checked - this method is added to work with

--- a/examples/wasm-in-web-worker/src/lib.rs
+++ b/examples/wasm-in-web-worker/src/lib.rs
@@ -52,7 +52,7 @@ pub fn startup() {
     console::log_1(&"Created a new worker from within WASM".into());
 
     // Pass the worker to the function which sets up the `oninput` callback.
-    setup_input_oninput_callback(worker_handle.clone());
+    setup_input_oninput_callback(worker_handle);
 }
 
 fn setup_input_oninput_callback(worker: Rc<RefCell<web_sys::Worker>>) {
@@ -118,8 +118,10 @@ fn setup_input_oninput_callback(worker: Rc<RefCell<web_sys::Worker>>) {
 
 /// Create a closure to act on the message returned by the worker
 fn get_on_msg_callback() -> Closure<dyn FnMut(MessageEvent)> {
-    let callback = Closure::new(move |event: MessageEvent| {
-        console::log_2(&"Received response: ".into(), &event.data().into());
+    
+
+    Closure::new(move |event: MessageEvent| {
+        console::log_2(&"Received response: ".into(), &event.data());
 
         let result = match event.data().as_bool().unwrap() {
             true => "even",
@@ -133,7 +135,5 @@ fn get_on_msg_callback() -> Closure<dyn FnMut(MessageEvent)> {
             .dyn_ref::<HtmlElement>()
             .expect("#resultField should be a HtmlInputElement")
             .set_inner_text(result);
-    });
-
-    callback
+    })
 }

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -3,6 +3,7 @@ name = "wasm2js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/weather_report/Cargo.toml
+++ b/examples/weather_report/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Ayush <ayushmishra2005@gmail.com>"]
 categories = ["wasm"]
 readme = "README.md"
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/weather_report/src/lib.rs
+++ b/examples/weather_report/src/lib.rs
@@ -152,11 +152,11 @@ fn run() -> Result<(), JsValue> {
         let sunset = suns_s_td_div.clone();
         let geo = geo_shtd_div.clone();
         let input_value: &'static _ = Box::leak(Box::new(input_value));
-        let response = get_response(&input_value);
+        let response = get_response(input_value);
         spawn_local(async move {
             let parsed = response.await;
-            let lon = (&parsed["coord"]["lon"]).to_owned().as_f64().unwrap();
-            let lat = (&parsed["coord"]["lat"]).to_owned().as_f64().unwrap();
+            let lon = parsed["coord"]["lon"].to_owned().as_f64().unwrap();
+            let lat = parsed["coord"]["lat"].to_owned().as_f64().unwrap();
             initialize(lat, lon);
             let city_name: &str = &parsed["name"].to_owned().to_string();
             let country_name: &str = &parsed["sys"]["country"].to_owned().to_string();
@@ -169,13 +169,13 @@ fn run() -> Result<(), JsValue> {
                 "  ",
             ]
             .concat();
-            let temp = ((&parsed["main"]["temp"]).to_owned().as_f64().unwrap() - 273.15) as i64;
+            let temp = (parsed["main"]["temp"].to_owned().as_f64().unwrap() - 273.15) as i64;
 
             let content = [src, temp.to_string()].concat();
             let p: &str = &parsed["main"]["pressure"].to_owned().to_string();
             let h: &str = &parsed["main"]["humidity"].to_owned().to_string();
-            let sun_r = ((&parsed["sys"]["sunrise"]).to_owned().as_f64().unwrap()) as u64;
-            let sun_s = ((&parsed["sys"]["sunset"]).to_owned().as_f64().unwrap()) as u64;
+            let sun_r = (parsed["sys"]["sunrise"].to_owned().as_f64().unwrap()) as u64;
+            let sun_s = (parsed["sys"]["sunset"].to_owned().as_f64().unwrap()) as u64;
 
             temp_d
                 .set_attribute("style", "display: block")

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -3,6 +3,7 @@ name = "webaudio"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -3,6 +3,7 @@ name = "webgl"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -3,6 +3,7 @@ name = "webrtc_datachannel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -3,7 +3,7 @@ name = "webrtc_datachannel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.65"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -3,7 +3,7 @@ name = "webrtc_datachannel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.65"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/src/lib.rs
+++ b/examples/webrtc_datachannel/src/lib.rs
@@ -42,14 +42,11 @@ async fn start() -> Result<(), JsValue> {
     console_log!("dc1 created: label {:?}", dc1.label());
 
     let dc1_clone = dc1.clone();
-    let onmessage_callback =
-        Closure::<dyn FnMut(_)>::new(move |ev: MessageEvent| match ev.data().as_string() {
-            Some(message) => {
-                console_warn!("{:?}", message);
-                dc1_clone.send_with_str("Pong from pc1.dc!").unwrap();
-            }
-            None => {}
-        });
+    let onmessage_callback = Closure::<dyn FnMut(_)>::new(move |ev: MessageEvent| {
+        let Some(message) = ev.data().as_string() else { return };
+        console_warn!("{:?}", message);
+        dc1_clone.send_with_str("Pong from pc1.dc!").unwrap();
+    });
     dc1.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
     onmessage_callback.forget();
 
@@ -61,11 +58,10 @@ async fn start() -> Result<(), JsValue> {
         let dc2 = ev.channel();
         console_log!("pc2.ondatachannel!: {:?}", dc2.label());
 
-        let onmessage_callback =
-            Closure::<dyn FnMut(_)>::new(move |ev: MessageEvent| match ev.data().as_string() {
-                Some(message) => console_warn!("{:?}", message),
-                None => {}
-            });
+        let onmessage_callback = Closure::<dyn FnMut(_)>::new(move |ev: MessageEvent| {
+            let Some(message) = ev.data().as_string() else { return };
+            console_warn!("{:?}", message);
+        });
         dc2.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
         onmessage_callback.forget();
 
@@ -85,24 +81,20 @@ async fn start() -> Result<(), JsValue> {
      */
     let pc2_clone = pc2.clone();
     let onicecandidate_callback1 =
-        Closure::<dyn FnMut(_)>::new(move |ev: RtcPeerConnectionIceEvent| match ev.candidate() {
-            Some(candidate) => {
-                console_log!("pc1.onicecandidate: {:#?}", candidate.candidate());
-                let _ = pc2_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
-            }
-            None => {}
+        Closure::<dyn FnMut(_)>::new(move |ev: RtcPeerConnectionIceEvent| {
+            let Some(candidate) = ev.candidate() else { return };
+            console_log!("pc1.onicecandidate: {:#?}", candidate.candidate());
+            let _ = pc2_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
         });
     pc1.set_onicecandidate(Some(onicecandidate_callback1.as_ref().unchecked_ref()));
     onicecandidate_callback1.forget();
 
     let pc1_clone = pc1.clone();
     let onicecandidate_callback2 =
-        Closure::<dyn FnMut(_)>::new(move |ev: RtcPeerConnectionIceEvent| match ev.candidate() {
-            Some(candidate) => {
-                console_log!("pc2.onicecandidate: {:#?}", candidate.candidate());
-                let _ = pc1_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
-            }
-            None => {}
+        Closure::<dyn FnMut(_)>::new(move |ev: RtcPeerConnectionIceEvent| {
+            let Some(candidate) = ev.candidate() else { return };
+            console_log!("pc2.onicecandidate: {:#?}", candidate.candidate());
+            let _ = pc1_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
         });
     pc2.set_onicecandidate(Some(onicecandidate_callback2.as_ref().unchecked_ref()));
     onicecandidate_callback2.forget();

--- a/examples/webrtc_datachannel/src/lib.rs
+++ b/examples/webrtc_datachannel/src/lib.rs
@@ -43,9 +43,10 @@ async fn start() -> Result<(), JsValue> {
 
     let dc1_clone = dc1.clone();
     let onmessage_callback = Closure::<dyn FnMut(_)>::new(move |ev: MessageEvent| {
-        let Some(message) = ev.data().as_string() else { return };
-        console_warn!("{:?}", message);
-        dc1_clone.send_with_str("Pong from pc1.dc!").unwrap();
+        if let Some(message) = ev.data().as_string() {
+            console_warn!("{:?}", message);
+            dc1_clone.send_with_str("Pong from pc1.dc!").unwrap();
+        }
     });
     dc1.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
     onmessage_callback.forget();
@@ -59,8 +60,9 @@ async fn start() -> Result<(), JsValue> {
         console_log!("pc2.ondatachannel!: {:?}", dc2.label());
 
         let onmessage_callback = Closure::<dyn FnMut(_)>::new(move |ev: MessageEvent| {
-            let Some(message) = ev.data().as_string() else { return };
-            console_warn!("{:?}", message);
+            if let Some(message) = ev.data().as_string() {
+                console_warn!("{:?}", message);
+            }
         });
         dc2.set_onmessage(Some(onmessage_callback.as_ref().unchecked_ref()));
         onmessage_callback.forget();
@@ -82,9 +84,10 @@ async fn start() -> Result<(), JsValue> {
     let pc2_clone = pc2.clone();
     let onicecandidate_callback1 =
         Closure::<dyn FnMut(_)>::new(move |ev: RtcPeerConnectionIceEvent| {
-            let Some(candidate) = ev.candidate() else { return };
-            console_log!("pc1.onicecandidate: {:#?}", candidate.candidate());
-            let _ = pc2_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
+            if let Some(candidate) = ev.candidate() {
+                console_log!("pc1.onicecandidate: {:#?}", candidate.candidate());
+                let _ = pc2_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
+            }
         });
     pc1.set_onicecandidate(Some(onicecandidate_callback1.as_ref().unchecked_ref()));
     onicecandidate_callback1.forget();
@@ -92,9 +95,10 @@ async fn start() -> Result<(), JsValue> {
     let pc1_clone = pc1.clone();
     let onicecandidate_callback2 =
         Closure::<dyn FnMut(_)>::new(move |ev: RtcPeerConnectionIceEvent| {
-            let Some(candidate) = ev.candidate() else { return };
-            console_log!("pc2.onicecandidate: {:#?}", candidate.candidate());
-            let _ = pc1_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
+            if let Some(candidate) = ev.candidate() {
+                console_log!("pc2.onicecandidate: {:#?}", candidate.candidate());
+                let _ = pc1_clone.add_ice_candidate_with_opt_rtc_ice_candidate(Some(&candidate));
+            }
         });
     pc2.set_onicecandidate(Some(onicecandidate_callback2.as_ref().unchecked_ref()));
     onicecandidate_callback2.forget();

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -3,6 +3,7 @@ name = "websockets"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/websockets/src/lib.rs
+++ b/examples/websockets/src/lib.rs
@@ -29,7 +29,7 @@ fn start_websocket() -> Result<(), JsValue> {
             // here you can for example use Serde Deserialize decode the message
             // for demo purposes we switch back to Blob-type and send off another binary message
             cloned_ws.set_binary_type(web_sys::BinaryType::Blob);
-            match cloned_ws.send_with_u8_array(&vec![5, 6, 7, 8]) {
+            match cloned_ws.send_with_u8_array(&[5, 6, 7, 8]) {
                 Ok(_) => console_log!("binary message successfully sent"),
                 Err(err) => console_log!("error sending message: {:?}", err),
             }
@@ -73,7 +73,7 @@ fn start_websocket() -> Result<(), JsValue> {
             Err(err) => console_log!("error sending message: {:?}", err),
         }
         // send off binary message
-        match cloned_ws.send_with_u8_array(&vec![0, 1, 2, 3]) {
+        match cloned_ws.send_with_u8_array(&[0, 1, 2, 3]) {
             Ok(_) => console_log!("binary message successfully sent"),
             Err(err) => console_log!("error sending message: {:?}", err),
         }

--- a/examples/webxr/Cargo.toml
+++ b/examples/webxr/Cargo.toml
@@ -3,6 +3,7 @@ name = "webxr"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler-no-modules/Cargo.toml
+++ b/examples/without-a-bundler-no-modules/Cargo.toml
@@ -3,6 +3,7 @@ name = "without-a-bundler-no-modules"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler/Cargo.toml
+++ b/examples/without-a-bundler/Cargo.toml
@@ -3,6 +3,7 @@ name = "without-a-bundler"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/non_wasm.rs
+++ b/tests/non_wasm.rs
@@ -14,7 +14,7 @@ impl A {
     }
 
     pub fn foo(&self) {
-        drop(self.x);
+        assert_eq!(self.x, 3);
     }
 }
 

--- a/tests/wasm/api.rs
+++ b/tests/wasm/api.rs
@@ -82,14 +82,14 @@ pub fn api_mk_symbol() -> JsValue {
     let a = JsValue::symbol(None);
     assert!(a.is_symbol());
     assert_eq!(format!("{:?}", a), "JsValue(Symbol)");
-    return a;
+    a
 }
 
 #[wasm_bindgen]
 pub fn api_mk_symbol2(s: &str) -> JsValue {
     let a = JsValue::symbol(Some(s));
     assert!(a.is_symbol());
-    return a;
+    a
 }
 
 #[wasm_bindgen]
@@ -121,6 +121,7 @@ pub fn eq_test(a: &JsValue, b: &JsValue) -> bool {
 }
 
 #[wasm_bindgen]
+#[allow(clippy::eq_op)]
 pub fn eq_test1(a: &JsValue) -> bool {
     a == a
 }
@@ -132,8 +133,8 @@ pub fn api_completely_variadic(args: &JsValue) -> JsValue {
 
 #[wasm_bindgen(variadic)]
 pub fn api_variadic_with_prefixed_params(
-    first: &JsValue,
-    second: &JsValue,
+    _first: &JsValue,
+    _second: &JsValue,
     args: &JsValue,
 ) -> JsValue {
     args.into()

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -599,12 +599,12 @@ impl OverriddenInspectable {
     }
 
     #[wasm_bindgen(js_name = toJSON)]
-    pub fn to_json(&self) -> String {
+    pub fn js_to_json(&self) -> String {
         String::from("JSON was overwritten")
     }
 
     #[wasm_bindgen(js_name = toString)]
-    pub fn to_string(&self) -> String {
+    pub fn js_to_string(&self) -> String {
         String::from("string was overwritten")
     }
 }

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -510,7 +510,7 @@ fn test_closure_returner() {
         Reflect::set(
             &o,
             &JsValue::from("someKey"),
-            &some_fn.as_ref().unchecked_ref(),
+            some_fn.as_ref().unchecked_ref(),
         )
         .unwrap();
         Reflect::set(

--- a/tests/wasm/futures.rs
+++ b/tests/wasm/futures.rs
@@ -93,9 +93,9 @@ pub struct AsyncCustomError {
     pub val: JsValue,
 }
 
-impl Into<JsValue> for AsyncCustomError {
-    fn into(self) -> JsValue {
-        self.val
+impl From<AsyncCustomError> for JsValue {
+    fn from(e: AsyncCustomError) -> Self {
+        e.val
     }
 }
 

--- a/tests/wasm/import_class.rs
+++ b/tests/wasm/import_class.rs
@@ -1,6 +1,7 @@
 //! dox
 
 #![deny(missing_docs)] // test that documenting public bindings is enough
+#![allow(clippy::redundant_clone)] // test specifically with cloned objects
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -33,6 +33,7 @@ extern "C" {
     #[wasm_bindgen(js_name = pub)]
     fn js_function_named_rust_keyword() -> u32;
 
+    #[allow(non_camel_case_types)]
     type bar;
     #[wasm_bindgen(js_namespace = bar, js_name = foo)]
     static FOO: JsValue;

--- a/tests/wasm/js_keywords.rs
+++ b/tests/wasm/js_keywords.rs
@@ -25,7 +25,7 @@ pub fn arg_is_keyword(class: u8) -> u8 {
 }
 
 #[wasm_bindgen]
-struct Class {
+pub struct Class {
     name: String,
 }
 #[wasm_bindgen]

--- a/tests/wasm/js_keywords.rs
+++ b/tests/wasm/js_keywords.rs
@@ -50,6 +50,6 @@ impl Class {
 fn compile() {
     js_keywords_compile();
     assert_eq!(test_keyword_1_as_fn_name(1), 1);
-    assert_eq!(test_keyword_2_as_fn_name(1, 2), false);
+    assert!(!test_keyword_2_as_fn_name(1, 2));
     assert_eq!(test_keyword_as_fn_arg(1), 1);
 }

--- a/tests/wasm/js_objects.rs
+++ b/tests/wasm/js_objects.rs
@@ -173,12 +173,12 @@ fn serde() {
         .unwrap(),
     );
 
-    let foo = ret.into_serde::<SerdeFoo>().unwrap();
-    assert_eq!(foo.a, 2);
-    assert_eq!(foo.b, "bar");
-    assert!(foo.c.is_some());
-    assert_eq!(foo.c.as_ref().unwrap().a, 3);
-    assert_eq!(foo.d.a, 4);
+    let result = ret.into_serde::<SerdeFoo>().unwrap();
+    assert_eq!(result.a, 2);
+    assert_eq!(result.b, "bar");
+    assert!(result.c.is_some());
+    assert_eq!(result.c.as_ref().unwrap().a, 3);
+    assert_eq!(result.d.a, 4);
 
     assert_eq!(JsValue::from("bar").into_serde::<String>().unwrap(), "bar");
     assert_eq!(JsValue::undefined().into_serde::<i32>().ok(), None);

--- a/tests/wasm/js_objects.rs
+++ b/tests/wasm/js_objects.rs
@@ -145,6 +145,7 @@ fn another_vector_string_return() {
 
 #[cfg(feature = "serde-serialize")]
 #[wasm_bindgen_test]
+#[allow(deprecated)]
 fn serde() {
     #[derive(Deserialize, Serialize)]
     pub struct SerdeFoo {

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -1,5 +1,6 @@
 #![cfg(target_arch = "wasm32")]
-#![allow(drop_ref, clippy::drop_non_drop)]
+#![allow(renamed_and_removed_lints)] // clippy::drop_ref will be renamed to drop_ref
+#![allow(clippy::drop_ref, clippy::drop_non_drop)]
 
 extern crate js_sys;
 extern crate wasm_bindgen;

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -1,4 +1,5 @@
 #![cfg(target_arch = "wasm32")]
+#![allow(drop_ref, clippy::drop_non_drop)]
 
 extern crate js_sys;
 extern crate wasm_bindgen;

--- a/tests/wasm/no_shims.rs
+++ b/tests/wasm/no_shims.rs
@@ -22,7 +22,7 @@ use wasm_bindgen_test::*;
     module.exports.incoming_u32 = function () { return 4294967295; };
     module.exports.incoming_i32 = function () { return 0; };
     module.exports.incoming_f32 = function () { return 1.5; };
-    module.exports.incoming_f64 = function () { return 13.37; };
+    module.exports.incoming_f64 = function () { return Math.PI; };
 
     module.exports.outgoing_u8 = function (k) { assert_eq(k, 255); };
     module.exports.outgoing_i8 = function (i) { assert_eq(i, -127); };
@@ -30,12 +30,12 @@ use wasm_bindgen_test::*;
     module.exports.outgoing_i16 = function (j) { assert_eq(j, 32767); };
     module.exports.outgoing_i32 = function (x) { assert_eq(x, 0); };
     module.exports.outgoing_f32 = function (y) { assert_eq(y, 1.5); };
-    module.exports.outgoing_f64 = function (z) { assert_eq(z, 13.37); };
+    module.exports.outgoing_f64 = function (z) { assert_eq(z, Math.PI); };
 
     module.exports.many = function (x, y, z) {
         assert_eq(x, 0);
         assert_eq(y, 1.5);
-        assert_eq(z, 13.37);
+        assert_eq(z, Math.PI);
         return 42;
     };
 
@@ -45,8 +45,8 @@ use wasm_bindgen_test::*;
     };
 
     module.exports.MyNamespace = {};
-    module.exports.MyNamespace.incoming_namespaced = function () { return 3.14; };
-    module.exports.MyNamespace.outgoing_namespaced = function (pi) { assert_eq(3.14, pi); };
+    module.exports.MyNamespace.incoming_namespaced = function () { return 13.37; };
+    module.exports.MyNamespace.outgoing_namespaced = function (pi) { assert_eq(13.37, pi); };
 ")]
 extern "C" {
     #[wasm_bindgen(assert_no_shim)]
@@ -133,14 +133,14 @@ fn no_shims() {
     outgoing_f32(y);
 
     let z = incoming_f64();
-    assert_eq!(z, 13.37);
+    assert_eq!(z, std::f64::consts::PI);
     outgoing_f64(z);
 
     let w = many(x, y, z);
     assert_eq!(w, 42);
 
     let pi = incoming_namespaced();
-    assert_eq!(pi, 3.14);
+    assert_eq!(pi, 13.37);
     outgoing_namespaced(pi);
 
     let b = incoming_bool();

--- a/tests/wasm/no_shims.rs
+++ b/tests/wasm/no_shims.rs
@@ -30,12 +30,12 @@ use wasm_bindgen_test::*;
     module.exports.outgoing_i16 = function (j) { assert_eq(j, 32767); };
     module.exports.outgoing_i32 = function (x) { assert_eq(x, 0); };
     module.exports.outgoing_f32 = function (y) { assert_eq(y, 1.5); };
-    module.exports.outgoing_f64 = function (z) { assert_eq(z, Math.PI); };
+    module.exports.outgoing_f64 = function (pi) { assert_eq(pi, Math.PI); };
 
-    module.exports.many = function (x, y, z) {
+    module.exports.many = function (x, y, pi) {
         assert_eq(x, 0);
         assert_eq(y, 1.5);
-        assert_eq(z, Math.PI);
+        assert_eq(pi, Math.PI);
         return 42;
     };
 
@@ -46,7 +46,7 @@ use wasm_bindgen_test::*;
 
     module.exports.MyNamespace = {};
     module.exports.MyNamespace.incoming_namespaced = function () { return 13.37; };
-    module.exports.MyNamespace.outgoing_namespaced = function (pi) { assert_eq(13.37, pi); };
+    module.exports.MyNamespace.outgoing_namespaced = function (w) { assert_eq(13.37, w); };
 ")]
 extern "C" {
     #[wasm_bindgen(assert_no_shim)]
@@ -134,10 +134,10 @@ fn no_shims() {
 
     let pi = incoming_f64();
     assert_eq!(pi, std::f64::consts::PI);
-    outgoing_f64(z);
+    outgoing_f64(pi);
 
     let z = many(x, y, pi);
-    assert_eq!(w, 42);
+    assert_eq!(z, 42);
 
     let w = incoming_namespaced();
     assert_eq!(w, 13.37);

--- a/tests/wasm/no_shims.rs
+++ b/tests/wasm/no_shims.rs
@@ -132,16 +132,16 @@ fn no_shims() {
     assert_eq!(y, 1.5);
     outgoing_f32(y);
 
-    let z = incoming_f64();
-    assert_eq!(z, std::f64::consts::PI);
+    let pi = incoming_f64();
+    assert_eq!(pi, std::f64::consts::PI);
     outgoing_f64(z);
 
-    let w = many(x, y, z);
+    let z = many(x, y, pi);
     assert_eq!(w, 42);
 
-    let pi = incoming_namespaced();
-    assert_eq!(pi, 13.37);
-    outgoing_namespaced(pi);
+    let w = incoming_namespaced();
+    assert_eq!(w, 13.37);
+    outgoing_namespaced(w);
 
     let b = incoming_bool();
     assert!(b);

--- a/tests/wasm/owned.rs
+++ b/tests/wasm/owned.rs
@@ -13,6 +13,7 @@ impl OwnedValue {
         Self { n }
     }
 
+    #[allow(clippy::should_implement_trait)] // traits unsupported by wasm_bindgen
     pub fn add(self, other: OwnedValue) -> Self {
         Self {
             n: self.n + other.n,

--- a/tests/wasm/result.rs
+++ b/tests/wasm/result.rs
@@ -87,7 +87,7 @@ impl Struct {
 
     #[wasm_bindgen]
     pub fn new_err() -> Result<Struct, MyError> {
-        Err(MyError::Variant.into())
+        Err(MyError::Variant)
     }
 
     #[wasm_bindgen]

--- a/tests/wasm/result.rs
+++ b/tests/wasm/result.rs
@@ -20,9 +20,9 @@ extern "C" {
     fn error_new(message: &str) -> JsValue;
 }
 
-impl Into<JsValue> for MyError {
-    fn into(self) -> JsValue {
-        error_new(&format!("{}", self))
+impl From<MyError> for JsValue {
+    fn from(e: MyError) -> Self {
+        error_new(&format!("{}", e))
     }
 }
 

--- a/tests/wasm/result_jserror.rs
+++ b/tests/wasm/result_jserror.rs
@@ -45,7 +45,7 @@ call_test!(test_ok, call_ok);
 
 #[wasm_bindgen]
 pub fn make_an_error() -> JsError {
-    JsError::new("un-thrown error").into()
+    JsError::new("un-thrown error")
 }
 call_test!(test_make_an_error, call_make_an_error);
 

--- a/tests/wasm/simple.rs
+++ b/tests/wasm/simple.rs
@@ -57,11 +57,9 @@ pub fn simple_return_and_take_bool(a: bool, b: bool) -> bool {
 }
 
 #[wasm_bindgen]
-pub fn simple_raw_pointers_work(a: *mut u32, b: *const u8) -> *const u32 {
-    unsafe {
-        (*a) = (*b) as u32;
-        a
-    }
+pub unsafe fn simple_raw_pointers_work(a: *mut u32, b: *const u8) -> *const u32 {
+    (*a) = (*b) as u32;
+    a
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/simple.rs
+++ b/tests/wasm/simple.rs
@@ -60,7 +60,7 @@ pub fn simple_return_and_take_bool(a: bool, b: bool) -> bool {
 pub fn simple_raw_pointers_work(a: *mut u32, b: *const u8) -> *const u32 {
     unsafe {
         (*a) = (*b) as u32;
-        return a;
+        a
     }
 }
 
@@ -220,7 +220,7 @@ pub fn do_string_roundtrip(s: String) -> String {
 #[wasm_bindgen_test]
 fn externref_heap_live_count() {
     let x = wasm_bindgen::externref_heap_live_count();
-    let y = JsValue::null().clone();
+    let y = JsValue::null();
     assert!(wasm_bindgen::externref_heap_live_count() > x);
     drop(y);
     assert_eq!(x, wasm_bindgen::externref_heap_live_count());

--- a/tests/wasm/simple.rs
+++ b/tests/wasm/simple.rs
@@ -216,9 +216,10 @@ pub fn do_string_roundtrip(s: String) -> String {
 }
 
 #[wasm_bindgen_test]
+#[allow(clippy::redundant_clone)] // clone to increase heap live count
 fn externref_heap_live_count() {
     let x = wasm_bindgen::externref_heap_live_count();
-    let y = JsValue::null();
+    let y = JsValue::null().clone();
     assert!(wasm_bindgen::externref_heap_live_count() > x);
     drop(y);
     assert_eq!(x, wasm_bindgen::externref_heap_live_count());

--- a/tests/wasm/slice.rs
+++ b/tests/wasm/slice.rs
@@ -211,6 +211,7 @@ pub struct ReturnVecApplication {
 
 #[wasm_bindgen]
 impl ReturnVecApplication {
+    #[allow(clippy::vec_init_then_push)]
     pub fn new() -> ReturnVecApplication {
         let mut thing = vec![];
         thing.push(0);

--- a/tests/wasm/truthy_falsy.rs
+++ b/tests/wasm/truthy_falsy.rs
@@ -3,26 +3,26 @@ use wasm_bindgen_test::*;
 
 #[wasm_bindgen_test]
 fn test_is_truthy() {
-    assert_eq!(JsValue::from(0).is_truthy(), false);
-    assert_eq!(JsValue::from("".to_string()).is_truthy(), false);
-    assert_eq!(JsValue::from(false).is_truthy(), false);
-    assert_eq!(JsValue::NULL.is_truthy(), false);
-    assert_eq!(JsValue::UNDEFINED.is_truthy(), false);
+    assert!(!JsValue::from(0).is_truthy());
+    assert!(!JsValue::from("".to_string()).is_truthy());
+    assert!(!JsValue::from(false).is_truthy());
+    assert!(!JsValue::NULL.is_truthy());
+    assert!(!JsValue::UNDEFINED.is_truthy());
 
-    assert_eq!(JsValue::from(10).is_truthy(), true);
-    assert_eq!(JsValue::from("null".to_string()).is_truthy(), true);
-    assert_eq!(JsValue::from(true).is_truthy(), true);
+    assert!(JsValue::from(10).is_truthy());
+    assert!(JsValue::from("null".to_string()).is_truthy());
+    assert!(JsValue::from(true).is_truthy());
 }
 
 #[wasm_bindgen_test]
 fn test_is_falsy() {
-    assert_eq!(JsValue::from(0).is_falsy(), true);
-    assert_eq!(JsValue::from("".to_string()).is_falsy(), true);
-    assert_eq!(JsValue::from(false).is_falsy(), true);
-    assert_eq!(JsValue::NULL.is_falsy(), true);
-    assert_eq!(JsValue::UNDEFINED.is_falsy(), true);
+    assert!(JsValue::from(0).is_falsy());
+    assert!(JsValue::from("".to_string()).is_falsy());
+    assert!(JsValue::from(false).is_falsy());
+    assert!(JsValue::NULL.is_falsy());
+    assert!(JsValue::UNDEFINED.is_falsy());
 
-    assert_eq!(JsValue::from(10).is_falsy(), false);
-    assert_eq!(JsValue::from("null".to_string()).is_falsy(), false);
-    assert_eq!(JsValue::from(true).is_falsy(), false);
+    assert!(!JsValue::from(10).is_falsy());
+    assert!(!JsValue::from("null".to_string()).is_falsy());
+    assert!(!JsValue::from(true).is_falsy());
 }

--- a/tests/worker/main.rs
+++ b/tests/worker/main.rs
@@ -5,7 +5,7 @@ extern crate wasm_bindgen;
 extern crate wasm_bindgen_test;
 
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_worker);
 


### PR DESCRIPTION
@daxpedda

This also sets rust-version to 1.56 for most examples to prevent unnecessary changes. Where let else chains come handy, I upgraded to 1.65.