### PR TITLE
Export JsValue from js-sys

### DIFF
--- a/crates/js-sys/CHANGELOG.md
+++ b/crates/js-sys/CHANGELOG.md
@@ -9,6 +9,7 @@ Released YYYY-MM-DD.
 ### Added
 
 * Added a re-export of `wasm-bindgen`.
+  [#3466](https://github.com/rustwasm/wasm-bindgen/pull/3466)
 
 ### Changed
 

--- a/crates/js-sys/CHANGELOG.md
+++ b/crates/js-sys/CHANGELOG.md
@@ -8,7 +8,10 @@ Released YYYY-MM-DD.
 
 ### Added
 
-* Added a re-export of `wasm-bindgen`.
+* Re-export `wasm-bindgen` from `js-sys` and `web-sys`.
+  [#3466](https://github.com/rustwasm/wasm-bindgen/pull/3466)
+
+* Re-export `js-sys` from `web-sys`.
   [#3466](https://github.com/rustwasm/wasm-bindgen/pull/3466)
 
 ### Changed

--- a/crates/js-sys/CHANGELOG.md
+++ b/crates/js-sys/CHANGELOG.md
@@ -8,7 +8,7 @@ Released YYYY-MM-DD.
 
 ### Added
 
-* TODO (or remove section if none)
+* Added a re-export of `wasm-bindgen`.
 
 ### Changed
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -50,6 +50,8 @@ use wasm_bindgen::prelude::*;
 // * Arguments that are `JsValue`s or imported JavaScript types should be taken
 //   by reference.
 
+pub use wasm_bindgen::prelude::JsValue;
+
 macro_rules! forward_deref_unop {
     (impl $imp:ident, $method:ident for $t:ty) => {
         impl $imp for $t {

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -28,6 +28,7 @@ use std::mem;
 use std::str;
 use std::str::FromStr;
 
+pub use wasm_bindgen;
 use wasm_bindgen::prelude::*;
 
 // When adding new imports:
@@ -49,8 +50,6 @@ use wasm_bindgen::prelude::*;
 //
 // * Arguments that are `JsValue`s or imported JavaScript types should be taken
 //   by reference.
-
-pub use wasm_bindgen::prelude::JsValue;
 
 macro_rules! forward_deref_unop {
     (impl $imp:ident, $method:ident for $t:ty) => {

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -17,6 +17,9 @@
 mod features;
 pub use features::*;
 
+pub use js_sys;
+pub use wasm_bindgen;
+
 /// Getter for the `Window` object
 ///
 /// [MDN Documentation]


### PR DESCRIPTION
This way, you can name the `JsValue` type without adding a dependency on `wasm-bindgen`.

On the other hand `js-sys` already depends on `wasm-bindgen`, so it's not that bad. Still, returning a type (or requiring it as an argument) that your crate doesn't provide simply feels wrong.