### PR TITLE
Don't throw a TypeError if module.headers is undefined.

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -800,7 +800,7 @@ impl<'a> Context<'a> {
                                 return await WebAssembly.instantiateStreaming(module, imports);
 
                             }} catch (e) {{
-                                if (!module.headers || module.headers.get('Content-Type') !== 'application/wasm') {{
+                                if (typeof module.headers === 'undefined' || module.headers.get('Content-Type') !== 'application/wasm') {{
                                     console.warn(\"`WebAssembly.instantiateStreaming` failed \
                                                     because your server does not serve wasm with \
                                                     `application/wasm` MIME type. Falling back to \

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -800,7 +800,7 @@ impl<'a> Context<'a> {
                                 return await WebAssembly.instantiateStreaming(module, imports);
 
                             }} catch (e) {{
-                                if (module.headers.get('Content-Type') != 'application/wasm') {{
+                                if (!module.headers || module.headers.get('Content-Type') !== 'application/wasm') {{
                                     console.warn(\"`WebAssembly.instantiateStreaming` failed \
                                                     because your server does not serve wasm with \
                                                     `application/wasm` MIME type. Falling back to \


### PR DESCRIPTION
See https://github.com/ruffle-rs/ruffle/issues/11504 and https://github.com/ruffle-rs/ruffle/pull/11505#issuecomment-1587946906.