### PR TITLE
Add support for conditional ui detection and ff ctap2 detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Added
 
+* Add bindings for `PublicKeyCredential.isConditionalMediationAvailable`.
+  [#3489](https://github.com/rustwasm/wasm-bindgen/pull/3489)
+
 * Extend `AudioContext` with unstable features supporting audio sink configuration.
   [#3433](https://github.com/rustwasm/wasm-bindgen/pull/3433)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-* Add bindings for `PublicKeyCredential.isConditionalMediationAvailable`.
+* Add bindings for `PublicKeyCredential.isConditionalMediationAvailable()`.
   [#3489](https://github.com/rustwasm/wasm-bindgen/pull/3489)
 
 * Extend `AudioContext` with unstable features supporting audio sink configuration.

--- a/crates/web-sys/src/features/gen_PublicKeyCredential.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredential.rs
@@ -37,6 +37,17 @@ extern "C" {
     pub fn get_client_extension_results(
         this: &PublicKeyCredential,
     ) -> AuthenticationExtensionsClientOutputs;
+    #[cfg(web_sys_unstable_apis)]
+    # [wasm_bindgen (static_method_of = PublicKeyCredential , js_class = "PublicKeyCredential" , js_name = isConditionalMediationAvailable)]
+    #[doc = "The `isConditionalMediationAvailable()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `PublicKeyCredential`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn is_conditional_mediation_available() -> ::js_sys::Promise;
     # [wasm_bindgen (static_method_of = PublicKeyCredential , js_class = "PublicKeyCredential" , js_name = isUserVerifyingPlatformAuthenticatorAvailable)]
     #[doc = "The `isUserVerifyingPlatformAuthenticatorAvailable()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_PublicKeyCredential.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredential.rs
@@ -44,4 +44,16 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `PublicKeyCredential`*"]
     pub fn is_user_verifying_platform_authenticator_available() -> ::js_sys::Promise;
+    # [wasm_bindgen (static_method_of = PublicKeyCredential , js_class = "PublicKeyCredential" , js_name = isConditionalMediationAvailable)]
+    #[doc = "The `isConditionalMediationAvailable()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `PublicKeyCredential`*"]
+    pub fn is_conditional_mediation_available() -> ::js_sys::Promise;
+    # [wasm_bindgen (static_method_of = PublicKeyCredential , js_class = "PublicKeyCredential" , js_name = isExternalCTAP2SecurityKeySupported, catch)]
+    #[doc = "The `isExternalCTAP2SecurityKeySupported()` method."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `PublicKeyCredential`*"]
+    pub fn is_external_ctap2_securitykey_supported() -> Result<::js_sys::Promise, JsValue>;
 }

--- a/crates/web-sys/webidls/unstable/WebAuthentication.webidl
+++ b/crates/web-sys/webidls/unstable/WebAuthentication.webidl
@@ -1,0 +1,4 @@
+[SecureContext]
+partial interface PublicKeyCredential {
+    static Promise<boolean> isConditionalMediationAvailable();
+};


### PR DESCRIPTION
This adds two important API's for Webauthn to web_sys.

The first is `isConditionalMediationAvailable` which allows detection of this feature for resident key username autocompletion. 

The second is `isExternalCTAP2SecurityKeySupported` which is needed for interoperating with firefox. Sadly firefox in some cases does not support CTAP2 and introduced an undocumented api per https://bugzilla.mozilla.org/show_bug.cgi?id=1526023 and this was never added to MDN. It was discussed by w3c/webauthn and seen as temporary per https://github.com/w3c/webauthn/issues/1173

However like all good temporary things, it still exists and it's required to detect if CTAP2 support exists in firefox - which it still does not for many users meaning it needs to be possible to adjust work flows in this case. 