### PR TITLE
docs: add and hello_world switched to direct import

### DIFF
--- a/examples/add/index.js
+++ b/examples/add/index.js
@@ -1,6 +1,5 @@
 // For more comments about what's going on here, check out the `hello_world`
 // example
-const rust = import('./pkg');
-rust
-  .then(m => alert('1 + 2 = ' + m.add(1, 2)))
-  .catch(console.error);
+import { add } from './pkg';
+
+alert('1 + 2 = ' + add(1, 2))

--- a/examples/hello_world/index.js
+++ b/examples/hello_world/index.js
@@ -1,8 +1,3 @@
-// Note that a dynamic `import` statement here is required due to
-// webpack/webpack#6615, but in theory `import { greet } from './pkg';`
-// will work here one day as well!
-const rust = import('./pkg');
+import { greet } from './pkg';
 
-rust
-  .then(m => m.greet('World!'))
-  .catch(console.error);
+greet('World');


### PR DESCRIPTION
If this PR is merged, it will update examples to use static import instead of dynamic ones (see #2759)

I just switched the **hello_world** and **add** examples, if ok I could just as well run through the other examples as well.

As a sidenote, npm is complaining about vulnerabilities due to the use of an older version of **webpack-dev-server** - bumping this to `4.15.1` fixes it. I'd just commit that also?