### PR TITLE
Add async variants of Atomics.wait

### DIFF
--- a/crates/js-sys/CHANGELOG.md
+++ b/crates/js-sys/CHANGELOG.md
@@ -8,6 +8,9 @@ Released YYYY-MM-DD.
 
 ### Added
 
+* Add bindings for async variants of `Atomics.wait`.
+  [#3504](https://github.com/rustwasm/wasm-bindgen/pull/3504)
+
 * Re-export `wasm-bindgen` from `js-sys` and `web-sys`.
   [#3466](https://github.com/rustwasm/wasm-bindgen/pull/3466)
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1209,7 +1209,7 @@ pub mod Atomics {
         /// You should use `wait_async_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
-        #[wasm_bindgen(js_namespace = Atomics, catch)]
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
         pub fn wait_async(typed_array: &Int32Array, index: u32, value: i32) -> Result<Object, JsValue>;
 
         /// The static `Atomics.waitAsync()` method verifies that a given position in an
@@ -1224,7 +1224,7 @@ pub mod Atomics {
         /// You should use `wait_async_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
-        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
         pub fn wait_async_bigint(
             typed_array: &Int32Array,
             index: u32,
@@ -1236,7 +1236,7 @@ pub mod Atomics {
         /// You should use `wait_with_timeout_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
-        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
         pub fn wait_async_with_timeout(
             typed_array: &Int32Array,
             index: u32,
@@ -1249,7 +1249,7 @@ pub mod Atomics {
         /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
-        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
         pub fn wait_async_with_timeout_bigint(
             typed_array: &Int32Array,
             index: u32,

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1213,7 +1213,7 @@ pub mod Atomics {
         pub fn wait_async(
             typed_array: &Int32Array,
             index: u32,
-            value: i32
+            value: i32,
         ) -> Result<Object, JsValue>;
 
         /// The static `Atomics.waitAsync()` method verifies that a given position in an

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1197,6 +1197,66 @@ pub mod Atomics {
             timeout: f64,
         ) -> Result<JsString, JsValue>;
 
+        /// The static `Atomics.waitAsync()` method verifies that a given position in an
+        /// `Int32Array` still contains a given value and if so sleeps, awaiting a
+        /// wakeup or a timeout. It returns an object with two properties. The first 
+        /// property `async` is a boolean which if true indicates that the second
+        /// property `value` is a promise. If `async` is false then value is a string 
+        /// whether equal to either "not-equal" or "timed-out".
+        /// Note: This operation only works with a shared `Int32Array` and may be used
+        /// on the main thread.
+        ///
+        /// You should use `wait_async_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
+        #[wasm_bindgen(js_namespace = Atomics, catch)]
+        pub fn wait_async(typed_array: &Int32Array, index: u32, value: i32) -> Result<Object, JsValue>;
+
+        /// The static `Atomics.waitAsync()` method verifies that a given position in an
+        /// `Int32Array` still contains a given value and if so sleeps, awaiting a
+        /// wakeup or a timeout. It returns an object with two properties. The first 
+        /// property `async` is a boolean which if true indicates that the second
+        /// property `value` is a promise. If `async` is false then value is a string 
+        /// whether equal to either "not-equal" or "timed-out".
+        /// Note: This operation only works with a shared `Int32Array` and may be used
+        /// on the main thread.
+        ///
+        /// You should use `wait_async_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        pub fn wait_async_bigint(
+            typed_array: &Int32Array,
+            index: u32,
+            value: i64,
+        ) -> Result<Object, JsValue>;
+
+        /// Like `waitAsync()`, but with timeout
+        ///
+        /// You should use `wait_with_timeout_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        pub fn wait_async_with_timeout(
+            typed_array: &Int32Array,
+            index: u32,
+            value: i32,
+            timeout: f64,
+        ) -> Result<Object, JsValue>;
+
+        /// Like `waitAsync()`, but with timeout
+        ///
+        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        ///
+        /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
+        #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
+        pub fn wait_async_with_timeout_bigint(
+            typed_array: &Int32Array,
+            index: u32,
+            value: i64,
+            timeout: f64,
+        ) -> Result<Object, JsValue>;
+
         /// The static `Atomics.xor()` method computes a bitwise XOR
         /// with a given value at a given position in the array,
         /// and returns the old value at that position.

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1199,9 +1199,9 @@ pub mod Atomics {
 
         /// The static `Atomics.waitAsync()` method verifies that a given position in an
         /// `Int32Array` still contains a given value and if so sleeps, awaiting a
-        /// wakeup or a timeout. It returns an object with two properties. The first 
+        /// wakeup or a timeout. It returns an object with two properties. The first
         /// property `async` is a boolean which if true indicates that the second
-        /// property `value` is a promise. If `async` is false then value is a string 
+        /// property `value` is a promise. If `async` is false then value is a string
         /// whether equal to either "not-equal" or "timed-out".
         /// Note: This operation only works with a shared `Int32Array` and may be used
         /// on the main thread.
@@ -1210,13 +1210,17 @@ pub mod Atomics {
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
-        pub fn wait_async(typed_array: &Int32Array, index: u32, value: i32) -> Result<Object, JsValue>;
+        pub fn wait_async(
+            typed_array: &Int32Array,
+            index: u32,
+            value: i32
+        ) -> Result<Object, JsValue>;
 
         /// The static `Atomics.waitAsync()` method verifies that a given position in an
         /// `Int32Array` still contains a given value and if so sleeps, awaiting a
-        /// wakeup or a timeout. It returns an object with two properties. The first 
+        /// wakeup or a timeout. It returns an object with two properties. The first
         /// property `async` is a boolean which if true indicates that the second
-        /// property `value` is a promise. If `async` is false then value is a string 
+        /// property `value` is a promise. If `async` is false then value is a string
         /// whether equal to either "not-equal" or "timed-out".
         /// Note: This operation only works with a shared `Int32Array` and may be used
         /// on the main thread.

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1206,7 +1206,7 @@ pub mod Atomics {
         /// Note: This operation only works with a shared `Int32Array` and may be used
         /// on the main thread.
         ///
-        /// You should use `wait_async_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_async_bigint` to operate on a `BigInt64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
@@ -1222,22 +1222,22 @@ pub mod Atomics {
         /// property `async` is a boolean which if true indicates that the second
         /// property `value` is a promise. If `async` is false then value is a string
         /// whether equal to either "not-equal" or "timed-out".
-        /// Note: This operation only works with a shared `Int32Array` and may be used
+        /// Note: This operation only works with a shared `BigInt64Array` and may be used
         /// on the main thread.
         ///
-        /// You should use `wait_async_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_async` to operate on a `Int32Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
         pub fn wait_async_bigint(
-            typed_array: &Int32Array,
+            typed_array: &BigInt64Array,
             index: u32,
             value: i64,
         ) -> Result<Object, JsValue>;
 
         /// Like `waitAsync()`, but with timeout
         ///
-        /// You should use `wait_with_timeout_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_async_with_timeout_bigint` to operate on a `BigInt64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
@@ -1250,12 +1250,12 @@ pub mod Atomics {
 
         /// Like `waitAsync()`, but with timeout
         ///
-        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_async_with_timeout` to operate on a `Int32Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = waitAsync)]
         pub fn wait_async_with_timeout_bigint(
-            typed_array: &Int32Array,
+            typed_array: &BigInt64Array,
             index: u32,
             value: i64,
             timeout: f64,


### PR DESCRIPTION
`Atomics.waitAsync` now has reasonable [support in most browsers](https://caniuse.com/mdn-javascript_builtins_atomics_waitasync) with Firefox being the notable exception, however they have a [bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=1467846) for implementing it.

I used the binding for `Atomics.wait` as a reference and one thing that seems off to me is that the `typed_array` argument for the bigint varieties of these functions take an `Int32Array`, instead of a `BigInt64Array`/`BigUint64Array`. It seems to me that the most correct thing to do here is two make further variants of this function, e.g., add the `*_biguint` variants, which also take u64 as their value argument. If there is a consensus on this, I can add the variants and we can rename this PR to something like "Clean up Atomics.wait and Atomics.waitAsync".