### PR TITLE
chore: run audit on examples

### DIFF
--- a/examples/add/package.json
+++ b/examples/add/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
@@ -9,6 +9,6 @@
     "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/char/package.json
+++ b/examples/char/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/closures/package.json
+++ b/examples/closures/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/console_log/package.json
+++ b/examples/console_log/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/dom/package.json
+++ b/examples/dom/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/duck-typed-interfaces/package.json
+++ b/examples/duck-typed-interfaces/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/guide-supported-types-examples/package.json
+++ b/examples/guide-supported-types-examples/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/hello_world/package.json
+++ b/examples/hello_world/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/import_js/package.json
+++ b/examples/import_js/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/julia_set/package.json
+++ b/examples/julia_set/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/paint/package.json
+++ b/examples/paint/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/performance/package.json
+++ b/examples/performance/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/wasm-in-wasm-imports/package.json
+++ b/examples/wasm-in-wasm-imports/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/wasm-in-wasm/package.json
+++ b/examples/wasm-in-wasm/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/weather_report/package.json
+++ b/examples/weather_report/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/webaudio/package.json
+++ b/examples/webaudio/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/webgl/package.json
+++ b/examples/webgl/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/webrtc_datachannel/package.json
+++ b/examples/webrtc_datachannel/package.json
@@ -1,14 +1,14 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }

--- a/examples/webxr/package.json
+++ b/examples/webxr/package.json
@@ -1,17 +1,17 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "dependencies": {
     "webxr": "./pkg"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
+    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^4.15.1"
   }
 }


### PR DESCRIPTION
If this PR is merged, it will update and cleanup the `package.json` files in the examples.

More specifically, I ran `for d in $(ls); do cd $d; npm i; npm audit fix --force; cd -; done` from the `examples` folder.

The command not only updated `webpack-dev-server` but also seemed to have reordered the entries (sorting them alphabetically) and did a minor reformatting (dropped a superfluous whitespace), but that looks ok IMO.

I did run `npm run build` followed by `npm run serve` on the `add` example to verify that it's still working as expected.