### PR TITLE
Fix bindings and comments for Atomics.wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 
 ### Changed
 
+* Fixed bindings and comments for `Atomics.wait`.
+  [#3509](https://github.com/rustwasm/wasm-bindgen/pull/3509)
+
 * Updated the WebGPU WebIDL.
   The optional `message` argument of [`GPUPipelineError`](https://www.w3.org/TR/webgpu/#gpupipelineerror)'s constructor has been manually specified as a required argument,
   because required arguments occurring after optional arguments are currently not supported by the generator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,15 @@
 
 ### Changed
 
-* Fixed bindings and comments for `Atomics.wait`.
-  [#3509](https://github.com/rustwasm/wasm-bindgen/pull/3509)
-
 * Updated the WebGPU WebIDL.
   The optional `message` argument of [`GPUPipelineError`](https://www.w3.org/TR/webgpu/#gpupipelineerror)'s constructor has been manually specified as a required argument,
   because required arguments occurring after optional arguments are currently not supported by the generator.
   [#3480](https://github.com/rustwasm/wasm-bindgen/pull/3480)
+
+### Fixed
+
+* Fixed bindings and comments for `Atomics.wait`.
+  [#3509](https://github.com/rustwasm/wasm-bindgen/pull/3509)
 
 ## [0.2.87](https://github.com/rustwasm/wasm-bindgen/compare/0.2.86...0.2.87)
 

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1148,32 +1148,32 @@ pub mod Atomics {
         /// Note: This operation only works with a shared `Int32Array`
         /// and may not be allowed on the main thread.
         ///
-        /// You should use `wait_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_bigint` to operate on a `BigInt64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch)]
         pub fn wait(typed_array: &Int32Array, index: u32, value: i32) -> Result<JsString, JsValue>;
 
         /// The static `Atomics.wait()` method verifies that a given
-        /// position in an `Int32Array` still contains a given value
+        /// position in an `BigInt64Array` still contains a given value
         /// and if so sleeps, awaiting a wakeup or a timeout.
         /// It returns a string which is either "ok", "not-equal", or "timed-out".
-        /// Note: This operation only works with a shared `Int32Array`
+        /// Note: This operation only works with a shared `BigInt64Array`
         /// and may not be allowed on the main thread.
         ///
-        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait` to operate on a `Int32Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
         pub fn wait_bigint(
-            typed_array: &Int32Array,
+            typed_array: &BigInt64Array,
             index: u32,
             value: i64,
         ) -> Result<JsString, JsValue>;
 
         /// Like `wait()`, but with timeout
         ///
-        /// You should use `wait_with_timeout_bigint` to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_with_timeout_bigint` to operate on a `BigInt64Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
@@ -1186,12 +1186,12 @@ pub mod Atomics {
 
         /// Like `wait()`, but with timeout
         ///
-        /// This method is used to operate on a `BigInt64Array` or a `BigUint64Array`.
+        /// You should use `wait_with_timeout` to operate on a `Int32Array`.
         ///
         /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait)
         #[wasm_bindgen(js_namespace = Atomics, catch, js_name = wait)]
         pub fn wait_with_timeout_bigint(
-            typed_array: &Int32Array,
+            typed_array: &BigInt64Array,
             index: u32,
             value: i64,
             timeout: f64,


### PR DESCRIPTION
@daxpedda @hamza1311 as discussed in #3504, this PR fixes the bindings and comments for `Atomics.wait`.