### PR TITLE
Feat: add support for Cloudflare Workers via `--workerd` option

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1477,6 +1477,7 @@ impl<'a> Context<'a> {
             }
             OutputMode::Bundler {
                 browser_only: false,
+                ..
             } => {
                 self.global(&format!(
                     "
@@ -1490,7 +1491,7 @@ impl<'a> Context<'a> {
             OutputMode::Deno
             | OutputMode::Web
             | OutputMode::NoModules { .. }
-            | OutputMode::Bundler { browser_only: true } => {
+            | OutputMode::Bundler { browser_only: true, .. } => {
                 self.global(&format!("const cached{0} = (typeof {0} !== 'undefined' ? new {0}{1} : {{ {2}: () => {{ throw Error('{0} not available') }} }} );", s, args, op))
             }
         };
@@ -1500,11 +1501,14 @@ impl<'a> Context<'a> {
                 OutputMode::Node { .. }
                 | OutputMode::Bundler {
                     browser_only: false,
+                    ..
                 } => self.global(init),
                 OutputMode::Deno
                 | OutputMode::Web
                 | OutputMode::NoModules { .. }
-                | OutputMode::Bundler { browser_only: true } => self.global(&format!(
+                | OutputMode::Bundler {
+                    browser_only: true, ..
+                } => self.global(&format!(
                     "if (typeof {} !== 'undefined') {{ {} }};",
                     s, init
                 )),

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,6 +22,7 @@ Options:
                                  and the default is [bundler]
     --no-modules-global VAR      Name of the global variable to initialize
     --browser                    Hint that JS should only be compatible with a browser
+    --workerd                    Hint that JS should only be compatible with a Cloudflare Worker
     --typescript                 Output a TypeScript definition file (on by default)
     --no-typescript              Don't emit a *.d.ts file
     --omit-imports               Don't emit imports in generated JavaScript
@@ -50,6 +51,7 @@ Additional documentation: https://rustwasm.github.io/wasm-bindgen/reference/cli.
 struct Args {
     flag_nodejs: bool,
     flag_browser: bool,
+    flag_workerd: bool,
     flag_web: bool,
     flag_no_modules: bool,
     flag_typescript: bool,
@@ -115,6 +117,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .nodejs(args.flag_nodejs)?
         .web(args.flag_web)?
         .browser(args.flag_browser)?
+        .workerd(args.flag_workerd)?
         .no_modules(args.flag_no_modules)?
         .debug(args.flag_debug)
         .demangle(!args.flag_no_demangle)

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -429,15 +429,8 @@ fn workerd_target_bundler() {
     assert!(contents.contains(
         r#"import * as imports from "./workerd_target_bundler_bg.js";
 import wkmod from "./workerd_target_bundler_bg.wasm";
-import * as nodemod from "./workerd_target_bundler_bg.wasm";
-
-if ((typeof process !== 'undefined') && (process.release.name === 'node')) {
-    imports.__wbg_set_wasm(nodemod);
-} else {
-    const instance = new WebAssembly.Instance(wkmod, { "./workerd_target_bundler_bg.js": imports });
-    imports.__wbg_set_wasm(instance.exports);
-}
-
+const instance = new WebAssembly.Instance(wkmod, { "./workerd_target_bundler_bg.js": imports });
+imports.__wbg_set_wasm(instance.exports);
 export * from "./workerd_target_bundler_bg.js";"#
     ));
 }
@@ -457,15 +450,8 @@ fn workerd_target_default() {
     assert!(contents.contains(
         r#"import * as imports from "./workerd_target_default_bg.js";
 import wkmod from "./workerd_target_default_bg.wasm";
-import * as nodemod from "./workerd_target_default_bg.wasm";
-
-if ((typeof process !== 'undefined') && (process.release.name === 'node')) {
-    imports.__wbg_set_wasm(nodemod);
-} else {
-    const instance = new WebAssembly.Instance(wkmod, { "./workerd_target_default_bg.js": imports });
-    imports.__wbg_set_wasm(instance.exports);
-}
-
+const instance = new WebAssembly.Instance(wkmod, { "./workerd_target_default_bg.js": imports });
+imports.__wbg_set_wasm(instance.exports);
 export * from "./workerd_target_default_bg.js";"#
     ));
 }
@@ -480,7 +466,7 @@ fn workerd_target_nodejs_should_fail() {
         )
         .wasm_bindgen("--target nodejs --workerd");
     cmd.assert().failure().stderr(predicates::str::contains(
-        "cannot specify `--workerd` with another output mode already specified",
+        "cannot specify `--workerd` with other output types",
     ));
 }
 

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -84,6 +84,12 @@ When generating bundler-compatible code (see the section on [deployment]) this
 indicates that the bundled code is always intended to go into a browser so a few
 checks for Node.js can be elided.
 
+### `--workerd`
+
+When generating bundler-compatible code (see the section on [deployment]) this
+indicates that the bundled code is always intended to go into a Cloudflare Worker so a few
+checks for Node.js can be elided.
+
 ### `--weak-refs`
 
 Enables usage of the [TC39 Weak References

--- a/guide/src/reference/deployment.md
+++ b/guide/src/reference/deployment.md
@@ -32,6 +32,10 @@ natively implemented in any JS implementation at this time. As a result, to
 consume the default output of `wasm-bindgen` you will need a bundler of some
 form.
 
+If the bundled code is intended to run in a browser, please specify the `--browser` option.
+If the bundled code is intended to run in a Cloudflare Worker, please specify the `--workerd` option.
+You can refer to the "Options" section on [cli](./cli.md#options).
+
 > **Note**: the choice of this default output was done to reflect the trends of
 > the JS ecosystem. While tools other than bundlers don't support wasm files as
 > native ES modules today they're all very much likely to in the future!


### PR DESCRIPTION
Currently, the bindings generated by `wasm-bindgen` cannot be used on Cloudflare Workers out of the box (see "JavaScript Plumbing" section in the [docs](https://developers.cloudflare.com/workers/platform/webassembly/rust/#javascript-plumbing-wasm-bindgen)). This is a pain for developers, as shown in https://github.com/rustwasm/wasm-bindgen/issues/2972.

This PR proposes a new `--workerd` option for `--target bundler` that closes https://github.com/rustwasm/wasm-bindgen/issues/2972.

Tests and markdown documentation updates are included.

## Example

Consider a `wasm32-unknown-unknown` crate called `cf-worker`.
The current `cf_worker.js` binding generated by `wasm-bindgen --target bundler` is:

```js
import * as wasm from "./cf_worker_bg.wasm";
import { __wbg_set_wasm } from "./cf_worker_bg.js";
__wbg_set_wasm(wasm);
export * from "./cf_worker_bg.js";
```

This PR, following Cloudflare's own documentation and using `wasm-bindgen --target bundler --workerd`, creates the following binding instead:

```js
import * as imports from "./cf_worker_bg.js";
import wkmod from "./cf_worker_bg.wasm";
const instance = new WebAssembly.Instance(wkmod, { "./cf_worker_bg.js": imports });
imports.__wbg_set_wasm(instance.exports);
export * from "./cf_worker_bg.js";
```

which is indeed compatible with Cloudflare Workers.