### PR TITLE
Replace curl package into ureq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,6 @@
   [#3480](https://github.com/rustwasm/wasm-bindgen/pull/3480)
 
 * Replaced `curl` with `ureq`. By default we now use Rustls instead of OpenSSL.
-  The `openssl` is now out of the dependencies in `wasm-bindgen-cli` crates, so that
-  the `vendored-openssl` feature is now out of supported features.
   [#3511](https://github.com/rustwasm/wasm-bindgen/pull/3511)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   because required arguments occurring after optional arguments are currently not supported by the generator.
   [#3480](https://github.com/rustwasm/wasm-bindgen/pull/3480)
 
+* Replaced `curl` package into `ureq`.
+  [#3511](https://github.com/rustwasm/wasm-bindgen/pull/3511)
+
 ### Fixed
 
 * Fixed bindings and comments for `Atomics.wait`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
   [#3480](https://github.com/rustwasm/wasm-bindgen/pull/3480)
 
 * Replaced `curl` with `ureq`. By default we now use Rustls instead of OpenSSL.
+  The `openssl` is now out of the dependencies in `wasm-bindgen-cli` crates, so that
+  the `vendored-openssl` feature is now out of supported features.
   [#3511](https://github.com/rustwasm/wasm-bindgen/pull/3511)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   because required arguments occurring after optional arguments are currently not supported by the generator.
   [#3480](https://github.com/rustwasm/wasm-bindgen/pull/3480)
 
-* Replaced `curl` package into `ureq`.
+* Replaced `curl` with `ureq`. By default we now use Rustls instead of OpenSSL.
   [#3511](https://github.com/rustwasm/wasm-bindgen/pull/3511)
 
 ### Fixed

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,12 +20,15 @@ docopt = "1.0"
 env_logger = "0.8"
 anyhow = "1.0"
 log = "0.4"
-openssl = { version = '0.10.11', optional = true }
+native-tls = { version = "0.2", default-features = false, optional = true }
 rouille = { version = "3.0.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
-ureq = { version = "2.7", default-features = false, features = ["brotli", "gzip"] }
+ureq = { version = "2.7", default-features = false, features = [
+    "brotli",
+    "gzip",
+] }
 walrus = { version = "0.19.0", features = ['parallel'] }
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.87" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.87" }
@@ -46,11 +49,9 @@ harness = false
 [features]
 default = ["rustls-tls"]
 
-rustls-tls = ["ureq/tls"]
-
-# Enables native-tls specific functionality not available by default.
-native-tls = ["ureq/native-tls"]
-native-tls-vendored = ["native-tls", "native-tls/vendored"]
+native-tls = ["dep:native-tls", "ureq/native-tls"]
+rustls-tls = ["ureq/tls"]                          # ureq uses rustls by default.
 
 # Legacy support
-vendored-openssl = ['native-tls-vendored']
+openssl = ["native-tls"]
+vendored-openssl = ["openssl", "native-tls/vendored"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,7 +25,7 @@ rouille = { version = "3.0.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
-ureq = { version = "2.7", default-features = false, features = ["gzip"] }
+ureq = { version = "2.7", default-features = false, features = ["brotli", "gzip"] }
 walrus = { version = "0.19.0", features = ['parallel'] }
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.87" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.87" }
@@ -50,7 +50,7 @@ rustls-tls = ["ureq/tls"]
 
 # Enables native-tls specific functionality not available by default.
 native-tls = ["ureq/native-tls"]
-native-tls-vendored = ["native-tls", "openssl/vendored"]
+native-tls-vendored = ["native-tls", "native-tls/vendored"]
 
 # Legacy support
 vendored-openssl = ['native-tls-vendored']

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,7 +16,6 @@ default-run = 'wasm-bindgen'
 rust-version = "1.56"
 
 [dependencies]
-curl = "0.4.13"
 docopt = "1.0"
 env_logger = "0.8"
 anyhow = "1.0"
@@ -26,6 +25,7 @@ rouille = { version = "3.0.0", default-features = false }
 serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
+ureq = { version = "2.7", default-features = false, features = ["gzip"] }
 walrus = { version = "0.19.0", features = ['parallel'] }
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.87" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.87" }
@@ -44,4 +44,13 @@ name = "reference"
 harness = false
 
 [features]
-vendored-openssl = ['openssl/vendored']
+default = ["rustls-tls"]
+
+rustls-tls = ["ureq/tls"]
+
+# Enables native-tls specific functionality not available by default.
+native-tls = ["ureq/native-tls"]
+native-tls-vendored = ["native-tls", "openssl/vendored"]
+
+# Legacy support
+vendored-openssl = ['native-tls-vendored']

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -49,9 +49,9 @@ harness = false
 [features]
 default = ["rustls-tls"]
 
-native-tls = ["dep:native-tls", "ureq/native-tls"]
-rustls-tls = ["ureq/tls"]                          # ureq uses rustls by default.
+native-tls = ["ureq/native-tls"]
+rustls-tls = ["ureq/tls"]
 
 # Legacy support
-openssl = ["native-tls"]
+openssl = ["dep:native-tls"]
 vendored-openssl = ["openssl", "native-tls/vendored"]


### PR DESCRIPTION
When installing `wasm-bindgen-cli` in Alpine Linux, it's forced to install `openssl-sys` package.

But I found that the `openssl` dependency is only subject to `curl` package, which is used for headless operations.

So I think it's ok to adopt `rustls` instead, not installing the native openssl binaries by option.

And I replaced the old `curl` package into `ureq`, using `rustls` by default.

Therefore, this PR is a `rustls` support for `wasm-bindgen-cli`.