### PR TITLE
Fix `pkg` not being uploaded for non-Webpack examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,7 +277,7 @@ jobs:
         for dir in `ls examples | grep -v README | grep -v raytrace | grep -v deno | grep -v wasm-audio-worklet`; do
           (cd examples/$dir &&
             (npm run build -- --output-path ../../exbuild/$dir ||
-              (./build.sh && mkdir -p ../../exbuild/$dir && cp -r ./* ../../exbuild/$dir))
+              (./build.sh && mkdir -p ../../exbuild/$dir && cp -r ./* ../../exbuild/$dir && rm ../../exbuild/$dir/**/.gitignore))
           ) || exit 1;
         done
       env:


### PR DESCRIPTION
I noticed that none of the examples that compile using `wasm-pack` were working properly in https://rustwasm.github.io/wasm-bindgen/exbuild. I think this is happening because `wasm-pack` generates a `.gitignore` for everything in the `pkg` folder, which the GitHub Pages uploader is interpreting to mean 'don't upload this'.

This PR makes CI delete those `.gitignore`s to try and fix that. It's still a draft because I don't know if it's actually going to work.

This isn't _that_ severe, since the only broken example which is actually linked to from the guide is the WebSockets example. Once I've seen whether this has worked I might go ahead and add links for the rest of the `wasm-pack`-built examples as well.