### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-bindgen-shared"
 version = "0.2.87"
 authors = ["The wasm-bindgen Developers"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared"
 homepage = "https://rustwasm.github.io/wasm-bindgen/"
 documentation = "https://docs.rs/wasm-bindgen-shared"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly.

Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields