### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sy
 description = """
 Bindings for all Web APIs, a procedurally generated crate from WebIDL
 """
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = "2018"
 rust-version = "1.56"
 


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly.

Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields