### PR TITLE
Changed `write` functions of FileSystemSyncAccessHandle to accept immutable buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 * Replaced `curl` with `ureq`. By default we now use Rustls instead of OpenSSL.
   [#3511](https://github.com/rustwasm/wasm-bindgen/pull/3511)
 
+* Changed mutability of the argument `buffer` in `write` functions to immutable for `FileSystemSyncAccessHandle` and `FileSystemWritableFileStream`.
+  It was also automatically changed for `IdbFileHandle`, which is deprecated.
+  [#3537](https://github.com/rustwasm/wasm-bindgen/pull/3537)
+
 ### Fixed
 
 * Fixed bindings and comments for `Atomics.wait`.

--- a/crates/web-sys/src/features/gen_FileSystemSyncAccessHandle.rs
+++ b/crates/web-sys/src/features/gen_FileSystemSyncAccessHandle.rs
@@ -163,7 +163,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_with_u8_array(
         this: &FileSystemSyncAccessHandle,
-        buffer: &mut [u8],
+        buffer: &[u8],
     ) -> Result<f64, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "FileSystemReadWriteOptions")]
@@ -194,7 +194,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_with_u8_array_and_options(
         this: &FileSystemSyncAccessHandle,
-        buffer: &mut [u8],
+        buffer: &[u8],
         options: &FileSystemReadWriteOptions,
     ) -> Result<f64, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_FileSystemWritableFileStream.rs
+++ b/crates/web-sys/src/features/gen_FileSystemWritableFileStream.rs
@@ -98,7 +98,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn write_with_u8_array(
         this: &FileSystemWritableFileStream,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "Blob")]

--- a/crates/web-sys/src/features/gen_IdbFileHandle.rs
+++ b/crates/web-sys/src/features/gen_IdbFileHandle.rs
@@ -320,7 +320,7 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `IdbFileHandle`, `IdbFileRequest`*"]
     pub fn write_with_u8_array(
         this: &IdbFileHandle,
-        value: &mut [u8],
+        value: &[u8],
     ) -> Result<Option<IdbFileRequest>, JsValue>;
     #[cfg(all(feature = "Blob", feature = "IdbFileRequest",))]
     # [wasm_bindgen (catch , method , structural , js_class = "IDBFileHandle" , js_name = write)]

--- a/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
+++ b/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
@@ -12,7 +12,7 @@
 
 use wasm_bindgen::{JsCast, JsValue};
 #[cfg(web_sys_unstable_apis)]
-use web_sys::{FileSystemSyncAccessHandle, FileSystemWritableFileStream};
+use web_sys::{FileSystemSyncAccessHandle, FileSystemWritableFileStream, FileSystemReadWriteOptions};
 use web_sys::{WebGl2RenderingContext, WebGlRenderingContext, WebSocket};
 
 // Ensure that our whitelisted WebGlRenderingContext methods compile with immutable slices.

--- a/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
+++ b/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
@@ -11,6 +11,8 @@
 //! @see https://github.com/rustwasm/wasm-bindgen/issues/1005
 
 use wasm_bindgen::{JsCast, JsValue};
+#[cfg(web_sys_unstable_apis)]
+use web_sys::{FileSystemSyncAccessHandle, FileSystemWritableFileStream};
 use web_sys::{WebGl2RenderingContext, WebGlRenderingContext, WebSocket};
 
 // Ensure that our whitelisted WebGlRenderingContext methods compile with immutable slices.
@@ -69,6 +71,23 @@ fn test_webgl2_rendering_context_immutable_slices() {
 fn test_websocket_immutable_slices() {
     let ws = JsValue::null().unchecked_into::<WebSocket>();
     ws.send_with_u8_array(&[0]);
+}
+
+// Ensure that our whitelisted FileSystemSyncAccessHandle methods compile with immutable slices.
+#[cfg(web_sys_unstable_apis)]
+fn test_file_system_sync_access_handle_immutable_slices() {
+    let sa = JsValue::null().unchecked_into::<FileSystemSyncAccessHandle>();
+    let opt = JsValue::null().unchecked_into::<FileSystemReadWriteOptions>();
+
+    sa.write_with_u8_array(&[0]);
+    sa.write_with_u8_array_and_options(&[0], &opt);
+}
+
+// Ensure that our whitelisted FileSystemWritableFileStream methods compile with immutable slices.
+#[cfg(web_sys_unstable_apis)]
+fn test_file_system_writable_file_stream_immutable_slices() {
+    let wf = JsValue::null().unchecked_into::<FileSystemWritableFileStream>();
+    wf.write_with_u8_array(&[0]);
 }
 
 // TODO:

--- a/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
+++ b/crates/web-sys/tests/wasm/whitelisted_immutable_slices.rs
@@ -12,7 +12,9 @@
 
 use wasm_bindgen::{JsCast, JsValue};
 #[cfg(web_sys_unstable_apis)]
-use web_sys::{FileSystemSyncAccessHandle, FileSystemWritableFileStream, FileSystemReadWriteOptions};
+use web_sys::{
+    FileSystemReadWriteOptions, FileSystemSyncAccessHandle, FileSystemWritableFileStream,
+};
 use web_sys::{WebGl2RenderingContext, WebGlRenderingContext, WebSocket};
 
 // Ensure that our whitelisted WebGlRenderingContext methods compile with immutable slices.

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -92,6 +92,8 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "copyToChannel",
         // FontFace
         "FontFace", // TODO: Add another type's functions here. Leave a comment header with the type name
+        // FileSystemWritableFileStream and FileSystemWritableFileStream
+        "write",
     ])
 });
 

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -92,7 +92,7 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "copyToChannel",
         // FontFace
         "FontFace", // TODO: Add another type's functions here. Leave a comment header with the type name
-        // FileSystemWritableFileStream and FileSystemWritableFileStream
+        // FileSystemSyncAccessHandle and FileSystemWritableFileStream
         "write",
     ])
 });


### PR DESCRIPTION
Removed unnecessary `mut` for the write functions.

According to the MDN documentation, there should not be any modification applied to the buffer, so this should be completely fine.

Should resolve #3536