### PR TITLE
Handle raw identifiers in wasm_bindgen_test macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 * Fixed bindings and comments for `Atomics.wait`.
   [#3509](https://github.com/rustwasm/wasm-bindgen/pull/3509)
 
+* Fixed `wasm_bindgen_test` macro to handle raw identifiers in test names.
+  [#3541](https://github.com/rustwasm/wasm-bindgen/pull/3541)
+
 ## [0.2.87](https://github.com/rustwasm/wasm-bindgen/compare/0.2.86...0.2.87)
 
 Released 2023-06-12.

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -89,7 +89,10 @@ pub fn wasm_bindgen_test(
     // We generate a `#[no_mangle]` with a known prefix so the test harness can
     // later slurp up all of these functions and pass them as arguments to the
     // main test harness. This is the entry point for all tests.
-    let name = format!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
+    let internal_id = ident.to_string()
+        .strip_prefix("r#")
+        .map_or(ident.clone(), |s| Ident::new(s, Span::call_site()));
+    let name = format!("__wbgt_{}_{}", internal_id, CNT.fetch_add(1, Ordering::SeqCst));
     let name = Ident::new(&name, Span::call_site());
     tokens.extend(
         (quote! {

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate proc_macro;
 
 use proc_macro2::*;
+use quote::format_ident;
 use quote::quote;
 use quote::quote_spanned;
 use std::sync::atomic::*;
@@ -89,16 +90,7 @@ pub fn wasm_bindgen_test(
     // We generate a `#[no_mangle]` with a known prefix so the test harness can
     // later slurp up all of these functions and pass them as arguments to the
     // main test harness. This is the entry point for all tests.
-    let internal_id = ident
-        .to_string()
-        .strip_prefix("r#")
-        .map_or(ident.clone(), |s| Ident::new(s, Span::call_site()));
-    let name = format!(
-        "__wbgt_{}_{}",
-        internal_id,
-        CNT.fetch_add(1, Ordering::SeqCst)
-    );
-    let name = Ident::new(&name, Span::call_site());
+    let name = format_ident!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
     tokens.extend(
         (quote! {
             #[no_mangle]

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -89,10 +89,15 @@ pub fn wasm_bindgen_test(
     // We generate a `#[no_mangle]` with a known prefix so the test harness can
     // later slurp up all of these functions and pass them as arguments to the
     // main test harness. This is the entry point for all tests.
-    let internal_id = ident.to_string()
+    let internal_id = ident
+        .to_string()
         .strip_prefix("r#")
         .map_or(ident.clone(), |s| Ident::new(s, Span::call_site()));
-    let name = format!("__wbgt_{}_{}", internal_id, CNT.fetch_add(1, Ordering::SeqCst));
+    let name = format!(
+        "__wbgt_{}_{}",
+        internal_id,
+        CNT.fetch_add(1, Ordering::SeqCst)
+    );
     let name = Ident::new(&name, Span::call_site());
     tokens.extend(
         (quote! {


### PR DESCRIPTION
Currently the use of raw identifiers in test names produces an invalid function name. `Ident::new` panics whenever it encounters the `r#` prefix, instead `Ident::new_raw` should be used.

However, the `__wbgt` prefix we append forms a valid identifier already. So removing the raw ident prefix ("r#") is the only thing required to create a valid function name.

Fixes #3288