### PR TITLE
Add `cargo-binstall` support to `wasm-bindgen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Add bindings for `WorkerGlobalScope.performance`.
   [#3506](https://github.com/rustwasm/wasm-bindgen/pull/3506)
 
+* Add support for installing pre-built artifacts of `wasm-bindgen-cli`
+  via `cargo binstall wasm-bindgen-cli`.
+
 ### Changed
 
 * Updated the WebGPU WebIDL.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@
   <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
 </div>
 
+## Install `wasm-bindgen-cli`
+
+You can install it using `cargo-install`:
+
+```
+cargo install wasm-bindgen-cli
+```
+
+Or, you can either download it from the
+[release](https://github.com/rustwasm/wasm-bindgen/releases) page or run:
+
+If you have [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) installed,
+then you can install the pre-built artifacts by running:
+
+```
+cargo binstall wasm-bindgen-cli
+```
+
 ## Example
 
 Import JavaScript things into Rust and export Rust things to JavaScript.

--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@
 
 ## Install `wasm-bindgen-cli`
 
-You can install it using `cargo-install`:
+You can install it using `cargo install`:
 
 ```
 cargo install wasm-bindgen-cli
 ```
 
-Or, you can either download it from the
-[release](https://github.com/rustwasm/wasm-bindgen/releases) page or run:
+Or, you can download it from the
+[release page](https://github.com/rustwasm/wasm-bindgen/releases).
 
-If you have [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) installed,
+If you have [`cargo-binstall`](https://crates.io/crates/cargo-binstall) installed,
 then you can install the pre-built artifacts by running:
 
 ```

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,10 @@ edition = '2018'
 default-run = 'wasm-bindgen'
 rust-version = "1.56"
 
+[package.metadata.binstall]
+pkg-url = "https://github.com/rustwasm/wasm-bindgen/releases/download/{ version }/wasm-bindgen-{ version }-{ target }{ archive-suffix }"
+bin-dir = "wasm-bindgen-{ version }-{ target }/{ bin }{ binary-ext }"
+
 [dependencies]
 docopt = "1.0"
 env_logger = "0.8"


### PR DESCRIPTION
This would enable `cargo-binstall` to install the pre-built binaries from release artifacts.

How to test this:

```
cargo binstall --manifest-path crates/cli wasm-bindgen-cli
```