### PR TITLE
feat: add RTCDataChannel id

### DIFF
--- a/crates/web-sys/src/features/gen_RtcDataChannel.rs
+++ b/crates/web-sys/src/features/gen_RtcDataChannel.rs
@@ -25,7 +25,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/id)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `RtcDataChannel`*"]
-    pub fn id(this: &RtcDataChannel) -> u16;
+    pub fn id(this: &RtcDataChannel) -> Option<u16>;
     # [wasm_bindgen (structural , method , getter , js_class = "RTCDataChannel" , js_name = reliable)]
     #[doc = "Getter for the `reliable` field of this object."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_RtcDataChannel.rs
+++ b/crates/web-sys/src/features/gen_RtcDataChannel.rs
@@ -19,6 +19,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `RtcDataChannel`*"]
     pub fn label(this: &RtcDataChannel) -> String;
+    # [wasm_bindgen (structural , method , getter , js_class = "RTCDataChannel" , js_name = id)]
+    #[doc = "Getter for the `id` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/id)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `RtcDataChannel`*"]
+    pub fn id(this: &RtcDataChannel) -> u16;
     # [wasm_bindgen (structural , method , getter , js_class = "RTCDataChannel" , js_name = reliable)]
     #[doc = "Getter for the `reliable` field of this object."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/RTCDataChannel.webidl
+++ b/crates/web-sys/webidls/enabled/RTCDataChannel.webidl
@@ -17,6 +17,7 @@ enum RTCDataChannelType {
 interface RTCDataChannel : EventTarget
 {
   readonly attribute DOMString label;
+  readonly attribute unsigned short id;
   readonly attribute boolean reliable;
   readonly attribute unsigned short? maxPacketLifeTime;
   readonly attribute unsigned short? maxRetransmits;

--- a/crates/web-sys/webidls/enabled/RTCDataChannel.webidl
+++ b/crates/web-sys/webidls/enabled/RTCDataChannel.webidl
@@ -17,7 +17,7 @@ enum RTCDataChannelType {
 interface RTCDataChannel : EventTarget
 {
   readonly attribute DOMString label;
-  readonly attribute unsigned short id;
+  readonly attribute unsigned short? id;
   readonly attribute boolean reliable;
   readonly attribute unsigned short? maxPacketLifeTime;
   readonly attribute unsigned short? maxRetransmits;


### PR DESCRIPTION
Adds [`RTCDataChannel` readonly attribute `id`](https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/id)

Set as type `unsigned short` compiles to `u16` which is the size of `id` (`0` to `65,534`)

fixes https://github.com/rustwasm/wasm-bindgen/issues/3542 