### PR TITLE
use fully qualified names in `wasm_bindgen_test` for items exported from std prelude

### DIFF
--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -76,9 +76,11 @@ pub fn wasm_bindgen_test(
     let mut tokens = Vec::<TokenTree>::new();
 
     let should_panic = match should_panic {
-        Some(Some(lit)) => quote! { Some(Some(#lit)) },
-        Some(None) => quote! { Some(None) },
-        None => quote! { None },
+        Some(Some(lit)) => {
+            quote! { ::core::option::Option::Some(::core::option::Option::Some(#lit)) }
+        }
+        Some(None) => quote! { ::core::option::Option::Some(::core::option::Option::None) },
+        None => quote! { ::core::option::Option::None },
     };
 
     let test_body = if r#async {

--- a/crates/test-macro/ui-tests/should_panic.rs
+++ b/crates/test-macro/ui-tests/should_panic.rs
@@ -1,3 +1,7 @@
+#![no_implicit_prelude]
+
+extern crate wasm_bindgen_test_macro;
+
 use wasm_bindgen_test_macro::wasm_bindgen_test;
 
 #[wasm_bindgen_test]

--- a/crates/test-macro/ui-tests/should_panic.stderr
+++ b/crates/test-macro/ui-tests/should_panic.stderr
@@ -1,59 +1,59 @@
 error: malformed `#[should_panic = "..."]` attribute
-  --> ui-tests/should_panic.rs:28:15
+  --> ui-tests/should_panic.rs:32:15
    |
-28 | #[should_panic::error]
+32 | #[should_panic::error]
    |               ^
 
 error: malformed `#[should_panic]` attribute
-  --> ui-tests/should_panic.rs:32:18
+  --> ui-tests/should_panic.rs:36:18
    |
-32 | #[should_panic = 42]
+36 | #[should_panic = 42]
    |                  ^^
 
 error: malformed `#[should_panic = "..."]` attribute
-  --> ui-tests/should_panic.rs:36:15
-   |
-36 | #[should_panic[]]
-   |               ^^
-
-error: malformed `#[should_panic(...)]` attribute
   --> ui-tests/should_panic.rs:40:15
    |
-40 | #[should_panic(42)]
-   |               ^^^^
+40 | #[should_panic[]]
+   |               ^^
 
 error: malformed `#[should_panic(...)]` attribute
   --> ui-tests/should_panic.rs:44:15
    |
-44 | #[should_panic(test)]
-   |               ^^^^^^
+44 | #[should_panic(42)]
+   |               ^^^^
 
 error: malformed `#[should_panic(...)]` attribute
   --> ui-tests/should_panic.rs:48:15
    |
-48 | #[should_panic(expected)]
-   |               ^^^^^^^^^^
+48 | #[should_panic(test)]
+   |               ^^^^^^
 
 error: malformed `#[should_panic(...)]` attribute
   --> ui-tests/should_panic.rs:52:15
    |
-52 | #[should_panic(expected::error)]
+52 | #[should_panic(expected)]
+   |               ^^^^^^^^^^
+
+error: malformed `#[should_panic(...)]` attribute
+  --> ui-tests/should_panic.rs:56:15
+   |
+56 | #[should_panic(expected::error)]
    |               ^^^^^^^^^^^^^^^^^
 
 error: malformed `#[should_panic]` attribute
-  --> ui-tests/should_panic.rs:56:3
+  --> ui-tests/should_panic.rs:60:3
    |
-56 | #[should_panic(expected =)]
+60 | #[should_panic(expected =)]
    |   ^^^^^^^^^^^^
 
 error: malformed `#[should_panic]` attribute
-  --> ui-tests/should_panic.rs:60:27
+  --> ui-tests/should_panic.rs:64:27
    |
-60 | #[should_panic(expected = 5)]
+64 | #[should_panic(expected = 5)]
    |                           ^
 
 error: duplicate `should_panic` attribute
-  --> ui-tests/should_panic.rs:65:3
+  --> ui-tests/should_panic.rs:69:3
    |
-65 | #[should_panic = "test"]
+69 | #[should_panic = "test"]
    |   ^^^^^^^^^^^^


### PR DESCRIPTION
## Motivation

Currently, the `wasm_bindgen_test` macro dooes not use fully qualified names for items exported from the prelude. This means that naming collisions (`struct Some`) or the removal of the std library prelude will cause compilation errors.

## Solution

- Identify and use fully qualified names in macros were we previously assumed the Rust std prelude. We use `::core` rather than `::std`.
- Add [`no_implicit_prelude`](https://doc.rust-lang.org/reference/names/preludes.html#the-no_implicit_prelude-attribute) to `crates/test-macro/ui-tests/should_panic.rs`.