### PR TITLE
Allow creating `Vec`s of and implement `TryFrom<JsValue>` for strings and exported Rust types

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -164,7 +164,7 @@ impl ToTokens for ast::Struct {
         let name = &self.rust_name;
         let name_str = self.js_name.to_string();
         let name_len = name_str.len() as u32;
-        let name_chars = name_str.chars().map(|c| c as u32);
+        let name_chars: Vec<u32> = name_str.chars().map(|c| c as u32).collect();
         let new_fn = Ident::new(&shared::new_function(&name_str), Span::call_site());
         let free_fn = Ident::new(&shared::free_function(&name_str), Span::call_site());
         let unwrap_fn = Ident::new(&shared::unwrap_function(&name_str), Span::call_site());
@@ -331,8 +331,11 @@ impl ToTokens for ast::Struct {
 
             impl #wasm_bindgen::describe::WasmDescribeVector for #name {
                 fn describe_vector() {
-                    use #wasm_bindgen::__rt::std::boxed::Box;
-                    <Box<[#wasm_bindgen::JsValue]> as #wasm_bindgen::describe::WasmDescribe>::describe();
+                    use #wasm_bindgen::describe::*;
+                    inform(VECTOR);
+                    inform(NAMED_EXTERNREF);
+                    inform(#name_len);
+                    #(inform(#name_chars);)*
                 }
             }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -296,12 +296,12 @@ impl ToTokens for ast::Struct {
             }
 
             #[allow(clippy::all)]
-            impl wasm_bindgen::__rt::core::convert::TryFrom<wasm_bindgen::JsValue> for #name {
+            impl #wasm_bindgen::__rt::core::convert::TryFrom<#wasm_bindgen::JsValue> for #name {
                 type Error = ();
 
-                fn try_from(value: wasm_bindgen::JsValue)
-                    -> wasm_bindgen::__rt::std::result::Result<Self, Self::Error> {
-                    let js_ptr = wasm_bindgen::convert::IntoWasmAbi::into_abi(value);
+                fn try_from(value: #wasm_bindgen::JsValue)
+                    -> #wasm_bindgen::__rt::std::result::Result<Self, Self::Error> {
+                    let js_ptr = #wasm_bindgen::convert::IntoWasmAbi::into_abi(value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
                     #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
@@ -320,48 +320,48 @@ impl ToTokens for ast::Struct {
                     }
 
                     if(ptr == 0) {
-                        wasm_bindgen::__rt::std::result::Result::Err(())
+                        #wasm_bindgen::__rt::std::result::Result::Err(())
                     } else {
                         unsafe {
-                            wasm_bindgen::__rt::std::result::Result::Ok(
-                                <Self as wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr)
+                            #wasm_bindgen::__rt::std::result::Result::Ok(
+                                <Self as #wasm_bindgen::convert::FromWasmAbi>::from_abi(ptr)
                             )
                         }
                     }
                 }
             }
 
-            impl wasm_bindgen::describe::WasmDescribeVector for #name {
+            impl #wasm_bindgen::describe::WasmDescribeVector for #name {
                 fn describe_vector() {
-                    use wasm_bindgen::__rt::std::boxed::Box;
+                    use #wasm_bindgen::__rt::std::boxed::Box;
                     <Box<[#wasm_bindgen::JsValue]> as #wasm_bindgen::describe::WasmDescribe>::describe();
                 }
             }
 
-            impl wasm_bindgen::convert::VectorIntoWasmAbi for #name {
+            impl #wasm_bindgen::convert::VectorIntoWasmAbi for #name {
                 type Abi = <
                     #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
                     as #wasm_bindgen::convert::IntoWasmAbi
                 >::Abi;
 
                 fn vector_into_abi(
-                    vector: wasm_bindgen::__rt::std::boxed::Box<[#name]>
+                    vector: #wasm_bindgen::__rt::std::boxed::Box<[#name]>
                 ) -> Self::Abi {
                     #wasm_bindgen::convert::js_value_vector_into_abi(vector)
                 }
             }
 
-            impl wasm_bindgen::convert::OptionVectorIntoWasmAbi for #name {
+            impl #wasm_bindgen::convert::OptionVectorIntoWasmAbi for #name {
                 fn vector_none() -> <
                     #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
                     as #wasm_bindgen::convert::IntoWasmAbi
                 >::Abi {
-                    use wasm_bindgen::__rt::std::boxed::Box;
+                    use #wasm_bindgen::__rt::std::boxed::Box;
                     <Box<[#wasm_bindgen::JsValue]> as #wasm_bindgen::convert::OptionIntoWasmAbi>::none()
                 }
             }
 
-            impl wasm_bindgen::convert::VectorFromWasmAbi for #name {
+            impl #wasm_bindgen::convert::VectorFromWasmAbi for #name {
                 type Abi = <
                     #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
                     as #wasm_bindgen::convert::FromWasmAbi
@@ -369,7 +369,7 @@ impl ToTokens for ast::Struct {
 
                 unsafe fn vector_from_abi(
                     js: Self::Abi
-                ) -> wasm_bindgen::__rt::std::boxed::Box<[#name]> {
+                ) -> #wasm_bindgen::__rt::std::boxed::Box<[#name]> {
                     #wasm_bindgen::convert::js_value_vector_from_abi(js)
                 }
             }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -304,12 +304,12 @@ impl ToTokens for ast::Struct {
                     let idx = #wasm_bindgen::convert::IntoWasmAbi::into_abi(&value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
                     extern "C" {
                         fn #unwrap_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
+                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
                     unsafe fn #unwrap_fn(_: u32) -> u32 {
                         panic!("cannot convert from JsValue outside of the wasm target")
                     }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -332,37 +332,48 @@ impl ToTokens for ast::Struct {
             }
 
             impl wasm_bindgen::describe::WasmDescribeVector for #name {
-                use wasm_bindgen::__rt::std::boxed::Box;
-
                 fn describe_vector() {
+                    use wasm_bindgen::__rt::std::boxed::Box;
                     <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::describe();
                 }
             }
 
             impl wasm_bindgen::convert::VectorIntoWasmAbi for #name {
-                use wasm_bindgen::__rt::std::boxed::Box;
+                type Abi = <
+                    wasm_bindgen::__rt::std::boxed::Box<[#name]>
+                    as wasm_bindgen::convert::JsValueVector
+                >::ToAbi;
 
-                type Abi = <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::ToAbi;
+                fn vector_into_abi(
+                    vector: wasm_bindgen::__rt::std::boxed::Box<[#name]>
+                ) -> Self::Abi {
+                    use wasm_bindgen::__rt::std::boxed::Box;
 
-                fn vector_into_abi(vector: Box<[#name]>) -> Self::Abi {
                     <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::into_abi(vector)
                 }
             }
 
             impl wasm_bindgen::convert::OptionVectorIntoWasmAbi for #name {
-                use wasm_bindgen::__rt::std::boxed::Box;
-
-                fn vector_none() -> <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::ToAbi {
+                fn vector_none() -> <
+                    wasm_bindgen::__rt::std::boxed::Box<[#name]>
+                    as wasm_bindgen::convert::JsValueVector
+                >::ToAbi {
+                    use wasm_bindgen::__rt::std::boxed::Box;
                     <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::none()
                 }
             }
 
             impl wasm_bindgen::convert::VectorFromWasmAbi for #name {
-                use wasm_bindgen::__rt::std::boxed::Box;
+                type Abi = <
+                    wasm_bindgen::__rt::std::boxed::Box<[#name]>
+                    as wasm_bindgen::convert::JsValueVector
+                >::FromAbi;
 
-                type Abi = <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::FromAbi;
+                unsafe fn vector_from_abi(
+                    js: Self::Abi
+                ) -> wasm_bindgen::__rt::std::boxed::Box<[#name]> {
+                    use wasm_bindgen::__rt::std::boxed::Box;
 
-                unsafe fn vector_from_abi(js: Self::Abi) -> Box<[#name]> {
                     <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::from_abi(js)
                 }
             }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -334,47 +334,43 @@ impl ToTokens for ast::Struct {
             impl wasm_bindgen::describe::WasmDescribeVector for #name {
                 fn describe_vector() {
                     use wasm_bindgen::__rt::std::boxed::Box;
-                    <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::describe();
+                    <Box<[#wasm_bindgen::JsValue]> as #wasm_bindgen::describe::WasmDescribe>::describe();
                 }
             }
 
             impl wasm_bindgen::convert::VectorIntoWasmAbi for #name {
                 type Abi = <
-                    wasm_bindgen::__rt::std::boxed::Box<[#name]>
-                    as wasm_bindgen::convert::JsValueVector
-                >::ToAbi;
+                    #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
+                    as #wasm_bindgen::convert::IntoWasmAbi
+                >::Abi;
 
                 fn vector_into_abi(
                     vector: wasm_bindgen::__rt::std::boxed::Box<[#name]>
                 ) -> Self::Abi {
-                    use wasm_bindgen::__rt::std::boxed::Box;
-
-                    <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::into_abi(vector)
+                    #wasm_bindgen::convert::js_value_vector_into_abi(vector)
                 }
             }
 
             impl wasm_bindgen::convert::OptionVectorIntoWasmAbi for #name {
                 fn vector_none() -> <
-                    wasm_bindgen::__rt::std::boxed::Box<[#name]>
-                    as wasm_bindgen::convert::JsValueVector
-                >::ToAbi {
+                    #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
+                    as #wasm_bindgen::convert::IntoWasmAbi
+                >::Abi {
                     use wasm_bindgen::__rt::std::boxed::Box;
-                    <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::none()
+                    <Box<[#wasm_bindgen::JsValue]> as #wasm_bindgen::convert::OptionIntoWasmAbi>::none()
                 }
             }
 
             impl wasm_bindgen::convert::VectorFromWasmAbi for #name {
                 type Abi = <
-                    wasm_bindgen::__rt::std::boxed::Box<[#name]>
-                    as wasm_bindgen::convert::JsValueVector
-                >::FromAbi;
+                    #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
+                    as #wasm_bindgen::convert::FromWasmAbi
+                >::Abi;
 
                 unsafe fn vector_from_abi(
                     js: Self::Abi
                 ) -> wasm_bindgen::__rt::std::boxed::Box<[#name]> {
-                    use wasm_bindgen::__rt::std::boxed::Box;
-
-                    <Box<[#name]> as wasm_bindgen::convert::JsValueVector>::from_abi(js)
+                    #wasm_bindgen::convert::js_value_vector_from_abi(js)
                 }
             }
         })

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -349,16 +349,6 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            impl #wasm_bindgen::convert::OptionVectorIntoWasmAbi for #name {
-                fn vector_none() -> <
-                    #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
-                    as #wasm_bindgen::convert::IntoWasmAbi
-                >::Abi {
-                    use #wasm_bindgen::__rt::std::boxed::Box;
-                    <Box<[#wasm_bindgen::JsValue]> as #wasm_bindgen::convert::OptionIntoWasmAbi>::none()
-                }
-            }
-
             impl #wasm_bindgen::convert::VectorFromWasmAbi for #name {
                 type Abi = <
                     #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3238,7 +3238,6 @@ impl<'a> Context<'a> {
                 assert!(!variadic);
                 assert_eq!(args.len(), 1);
                 self.require_class_unwrap(class);
-                self.expose_take_object();
                 Ok(format!("{}.__unwrap({})", class, args[0]))
             }
         }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -75,6 +75,7 @@ pub struct ExportedClass {
     generate_typescript: bool,
     has_constructor: bool,
     wrap_needed: bool,
+    unwrap_needed: bool,
     /// Whether to generate helper methods for inspecting the class
     is_inspectable: bool,
     /// All readable properties of the class
@@ -932,6 +933,20 @@ impl<'a> Context<'a> {
                 } else {
                     String::new()
                 },
+            ));
+        }
+
+        if class.unwrap_needed {
+            dst.push_str(&format!(
+                "
+                static __unwrap(jsValue) {{
+                    if (!(jsValue instanceof {})) {{
+                        return 0;
+                    }}
+                    return jsValue.__destroy_into_raw();
+                }}
+                ",
+                name,
             ));
         }
 
@@ -2247,6 +2262,10 @@ impl<'a> Context<'a> {
         require_class(&mut self.exported_classes, name).wrap_needed = true;
     }
 
+    fn require_class_unwrap(&mut self, name: &str) {
+        require_class(&mut self.exported_classes, name).unwrap_needed = true;
+    }
+
     fn add_module_import(&mut self, module: String, name: &str, actual: &str) {
         let rename = if name == actual {
             None
@@ -3212,6 +3231,15 @@ impl<'a> Context<'a> {
                     Err(anyhow!("wasm-bindgen needs to be invoked with `--split-linked-modules`, because \"{}\" cannot be embedded.\n\
                         See https://rustwasm.github.io/wasm-bindgen/reference/cli.html#--split-linked-modules for details.", path))
                 }
+            }
+
+            AuxImport::UnwrapExportedClass(class) => {
+                assert!(kind == AdapterJsImportKind::Normal);
+                assert!(!variadic);
+                assert_eq!(args.len(), 1);
+                self.require_class_unwrap(class);
+                self.expose_take_object();
+                Ok(format!("{}.__unwrap({})", class, args[0]))
             }
         }
     }

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -336,6 +336,11 @@ pub enum AuxImport {
     /// The Option may contain the contents of the linked file, so it can be
     /// embedded.
     LinkTo(String, Option<String>),
+
+    /// This import is a generated shim which will attempt to unwrap JsValue to an
+    /// instance of the given exported class. The class name is one that is
+    /// exported from the Rust/wasm.
+    UnwrapExportedClass(String),
 }
 
 /// Values that can be imported verbatim to hook up to an import.

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -273,6 +273,9 @@ fn check_standard_import(import: &AuxImport) -> Result<(), Error> {
             format!("wasm-bindgen specific link function for `{}`", path)
         }
         AuxImport::Closure { .. } => format!("creating a `Closure` wrapper"),
+        AuxImport::UnwrapExportedClass(name) => {
+            format!("unwrapping a pointer from a `{}` js class wrapper", name)
+        }
     };
     bail!("import of {} requires JS glue", item);
 }

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -8,9 +8,9 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             *const T
             *mut T
             Box<[T]>
-            Box<[f32]>
-            Box<[f64]>
-            Box<[i16]>
-            Box<[i32]>
-            Box<[i64]>
-          and 35 others
+            Clamped<T>
+            Option<T>
+            Option<f32>
+            Option<f64>
+            Option<i32>
+          and $N others

--- a/crates/macro/ui-tests/traits-not-implemented.stderr
+++ b/crates/macro/ui-tests/traits-not-implemented.stderr
@@ -13,5 +13,5 @@ error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
             &'a (dyn Fn(A, B, C, D, E) -> R + 'b)
             &'a (dyn Fn(A, B, C, D, E, F) -> R + 'b)
             &'a (dyn Fn(A, B, C, D, E, F, G) -> R + 'b)
-          and 84 others
+          and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -166,10 +166,10 @@ pub fn free_function(struct_name: &str) -> String {
 }
 
 pub fn unwrap_function(struct_name: &str) -> String {
-    let mut name = format!("__wbg_");
+    let mut name = "__wbg_".to_string();
     name.extend(struct_name.chars().flat_map(|s| s.to_lowercase()));
     name.push_str("_unwrap");
-    return name;
+    name
 }
 
 pub fn free_function_export_name(function_name: &str) -> String {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -165,6 +165,13 @@ pub fn free_function(struct_name: &str) -> String {
     name
 }
 
+pub fn unwrap_function(struct_name: &str) -> String {
+    let mut name = format!("__wbg_");
+    name.extend(struct_name.chars().flat_map(|s| s.to_lowercase()));
+    name.push_str("_unwrap");
+    return name;
+}
+
 pub fn free_function_export_name(function_name: &str) -> String {
     function_name.to_string()
 }

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "12040133795598472740";
+const APPROVED_SCHEMA_FILE_HASH: &str = "5679641936258023729";
 
 #[test]
 fn schema_version() {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -52,7 +52,7 @@
     - [Imported JavaScript Types](./reference/types/imported-js-types.md)
     - [Exported Rust Types](./reference/types/exported-rust-types.md)
     - [`JsValue`](./reference/types/jsvalue.md)
-    - [`Box<[JsValue]>`](./reference/types/boxed-jsvalue-slice.md)
+    - [`Box<[T]>` and `Vec<T>`](./reference/types/boxed-slices.md)
     - [`*const T` and `*mut T`](./reference/types/pointers.md)
     - [Numbers](./reference/types/numbers.md)
     - [`bool`](./reference/types/bool.md)

--- a/guide/src/reference/types/boxed-slices.md
+++ b/guide/src/reference/types/boxed-slices.md
@@ -1,10 +1,19 @@
-# `Box<[JsValue]>`
+# `Box<[T]>` and `Vec<T>`
 
 | `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value | `Option<T>` parameter | `Option<T>` return value | JavaScript representation |
 |:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | Yes | No | No | Yes | Yes | Yes | A JavaScript `Array` object |
 
-Boxed slices of imported JS types and exported Rust types are also supported. `Vec<T>` is supported wherever `Box<[T]>` is.
+You can pass boxed slices and `Vec`s of several different types to and from JS:
+
+- `JsValue`s.
+- Imported JavaScript types.
+- Exported Rust types.
+- `String`s.
+
+[You can also pass boxed slices of numbers to JS](boxed-number-slices.html),
+except that they're converted to typed arrays (`Uint8Array`, `Int32Array`, etc.)
+instead of regular arrays.
 
 ## Example Rust Usage
 

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -9,8 +9,8 @@ use crate::{Clamped, JsError, JsValue, UnwrapThrowExt};
 if_std! {
     use std::boxed::Box;
     use std::convert::{TryFrom, TryInto};
-    use std::vec::Vec;
     use std::fmt::Debug;
+    use std::vec::Vec;
 }
 
 unsafe impl WasmAbi for () {}
@@ -395,8 +395,10 @@ impl IntoWasmAbi for JsError {
 }
 
 if_std! {
+    // Note: this can't take `&[T]` because the `Into<JsValue>` impl needs
+    // ownership of `T`.
     pub fn js_value_vector_into_abi<T: Into<JsValue>>(vector: Box<[T]>) -> <Box<[JsValue]> as IntoWasmAbi>::Abi {
-        let js_vals: Box::<[JsValue]> = vector
+        let js_vals: Box<[JsValue]> = vector
             .into_vec()
             .into_iter()
             .map(|x| x.into())

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -18,7 +18,8 @@ use cfg_if::cfg_if;
 if_std! {
     use core::mem;
     use std::convert::TryFrom;
-    use crate::convert::{OptionFromWasmAbi, JsValueVector};
+    use crate::convert::OptionFromWasmAbi;
+    use crate::convert::{js_value_vector_from_abi, js_value_vector_into_abi};
 }
 
 #[repr(C)]
@@ -204,30 +205,30 @@ macro_rules! js_value_vectors {
         if_std! {
             impl WasmDescribeVector for $t {
                 fn describe_vector() {
-                    <Box<[$t]> as JsValueVector>::describe();
+                    <Box<[JsValue]>>::describe();
                 }
             }
 
             // Can't use VectorIntoWasmAbi etc. because $t isn't necessarily Sized
             impl IntoWasmAbi for Box<[$t]> {
-                type Abi = <Self as JsValueVector>::ToAbi;
+                type Abi = <Box<[JsValue]> as IntoWasmAbi>::Abi;
 
                 fn into_abi(self) -> Self::Abi {
-                    <Self as JsValueVector>::into_abi(self)
+                    js_value_vector_into_abi(self)
                 }
             }
 
             impl OptionIntoWasmAbi for Box<[$t]> {
-                fn none() -> <Self as JsValueVector>::ToAbi {
-                    <Self as JsValueVector>::none()
+                fn none() -> <Box<[JsValue]> as IntoWasmAbi>::Abi {
+                    <Box<[JsValue]> as OptionIntoWasmAbi>::none()
                 }
             }
 
             impl FromWasmAbi for Box<[$t]> {
-                type Abi = <Self as JsValueVector>::FromAbi;
+                type Abi = <Box<[JsValue]> as FromWasmAbi>::Abi;
 
                 unsafe fn from_abi(js: Self::Abi) -> Self {
-                    <Self as JsValueVector>::from_abi(js)
+                    js_value_vector_from_abi(js)
                 }
             }
         }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -151,7 +151,7 @@ macro_rules! vectors {
 
             #[inline]
             unsafe fn ref_from_abi(js: WasmSlice) -> Box<[$t]> {
-                <Box<[$t]> as FromWasmAbi>::from_abi(js)
+                <Box<[$t]>>::from_abi(js)
             }
         }
 
@@ -161,7 +161,7 @@ macro_rules! vectors {
 
             #[inline]
             unsafe fn ref_mut_from_abi(js: WasmMutSlice) -> MutSlice<$t> {
-                let contents = <Box<[$t]> as FromWasmAbi>::from_abi(js.slice);
+                let contents = <Box<[$t]>>::from_abi(js.slice);
                 let js = JsValue::from_abi(js.idx);
                 MutSlice { contents, js }
             }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -1,3 +1,4 @@
+use std::convert::{TryFrom, TryInto};
 #[cfg(feature = "std")]
 use std::prelude::v1::*;
 
@@ -10,6 +11,8 @@ use crate::convert::OptionIntoWasmAbi;
 use crate::convert::{
     FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, RefFromWasmAbi, RefMutFromWasmAbi, WasmAbi,
 };
+use crate::describe;
+use crate::describe::WasmDescribe;
 use cfg_if::cfg_if;
 
 if_std! {
@@ -77,6 +80,13 @@ if_std! {
 macro_rules! vectors {
     ($($t:ident)*) => ($(
         if_std! {
+            impl WasmDescribe for Box<[$t]> {
+                fn describe() {
+                    describe::inform(describe::VECTOR);
+                    $t::describe();
+                }
+            }
+
             impl IntoWasmAbi for Box<[$t]> {
                 type Abi = WasmSlice;
 
@@ -151,7 +161,7 @@ macro_rules! vectors {
 
             #[inline]
             unsafe fn ref_from_abi(js: WasmSlice) -> Box<[$t]> {
-                <Box<[$t]>>::from_abi(js)
+                <Box<[$t]> as FromWasmAbi>::from_abi(js)
             }
         }
 
@@ -161,7 +171,7 @@ macro_rules! vectors {
 
             #[inline]
             unsafe fn ref_mut_from_abi(js: WasmMutSlice) -> MutSlice<$t> {
-                let contents = <Box<[$t]>>::from_abi(js.slice);
+                let contents = <Box<[$t]> as FromWasmAbi>::from_abi(js.slice);
                 let js = JsValue::from_abi(js.idx);
                 MutSlice { contents, js }
             }
@@ -181,6 +191,115 @@ macro_rules! vectors {
 
 vectors! {
     u8 i8 u16 i16 u32 i32 u64 i64 usize isize f32 f64
+}
+
+/// Enables blanket implementations of `WasmDescribe`, `IntoWasmAbi`,
+/// `FromWasmAbi` and `OptionIntoWasmAbi` functionality on boxed slices of
+/// types which can be converted to and from `JsValue` without conflicting
+/// implementations of those traits.
+///
+/// Implementing these traits directly with blanket implementations would
+/// be much more elegant, but unfortunately that's impossible because it
+/// conflicts with the implementations for `Box<[T]> where T: JsObject`.
+pub trait JsValueVector {
+    type ToAbi;
+    type FromAbi;
+
+    fn describe();
+    fn into_abi(self) -> Self::ToAbi;
+    fn none() -> Self::ToAbi;
+    unsafe fn from_abi(js: Self::FromAbi) -> Self;
+}
+
+/*
+ * Generates implementations for traits necessary for passing types to and from
+ * JavaScript on boxed slices of values which can be converted to and from
+ * `JsValue`.
+ */
+macro_rules! js_value_vectors {
+    ($($t:ident)*) => ($(
+        if_std! {
+            impl WasmDescribe for Box<[$t]> {
+                fn describe() {
+                    <Self as JsValueVector>::describe();
+                }
+            }
+
+            impl IntoWasmAbi for Box<[$t]> {
+                type Abi = <Self as JsValueVector>::ToAbi;
+
+                fn into_abi(self) -> Self::Abi {
+                    <Self as JsValueVector>::into_abi(self)
+                }
+            }
+
+            impl OptionIntoWasmAbi for Box<[$t]> {
+                fn none() -> Self::Abi {
+                    <Self as JsValueVector>::none()
+                }
+            }
+
+            impl FromWasmAbi for Box<[$t]> {
+                type Abi = <Self as JsValueVector>::FromAbi;
+
+                unsafe fn from_abi(js: Self::Abi) -> Self {
+                    <Self as JsValueVector>::from_abi(js)
+                }
+            }
+        }
+    )*)
+}
+
+if_std! {
+    impl<T> JsValueVector for Box<[T]> where
+        T: Into<JsValue> + TryFrom<JsValue>,
+        <T as TryFrom<JsValue>>::Error: core::fmt::Debug {
+        type ToAbi = <Box<[JsValue]> as IntoWasmAbi>::Abi;
+        type FromAbi = <Box<[JsValue]> as FromWasmAbi>::Abi;
+
+        fn describe() {
+            describe::inform(describe::VECTOR);
+            JsValue::describe();
+        }
+
+        fn into_abi(self) -> Self::ToAbi {
+            let js_vals: Box::<[JsValue]> = self
+                .into_vec()
+                .into_iter()
+                .map(|x| x.into())
+                .collect();
+
+            IntoWasmAbi::into_abi(js_vals)
+        }
+
+        fn none() -> Self::ToAbi {
+            <Box<[JsValue]> as OptionIntoWasmAbi>::none()
+        }
+
+        unsafe fn from_abi(js: Self::FromAbi) -> Self {
+            let js_vals = <Vec<JsValue> as FromWasmAbi>::from_abi(js);
+
+            js_vals
+                .into_iter()
+                .map(|x| x.try_into().expect("Array element of wrong type"))
+                .collect()
+        }
+    }
+
+    impl TryFrom<JsValue> for String {
+        type Error = ();
+
+        fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+            match value.as_string() {
+                Some(s) => Ok(s),
+                None => Err(()),
+            }
+        }
+    }
+}
+
+js_value_vectors! {
+    String
 }
 
 cfg_if! {

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -237,12 +237,12 @@ macro_rules! js_value_vectors {
 
 if_std! {
     impl TryFrom<JsValue> for String {
-        type Error = ();
+        type Error = JsValue;
 
         fn try_from(value: JsValue) -> Result<Self, Self::Error> {
             match value.as_string() {
                 Some(s) => Ok(s),
-                None => Err(()),
+                None => Err(value),
             }
         }
     }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -16,7 +16,7 @@ use crate::describe::{self, WasmDescribe, WasmDescribeVector};
 use cfg_if::cfg_if;
 
 if_std! {
-    use core::{mem};
+    use core::mem;
     use std::convert::TryFrom;
     use crate::convert::{OptionFromWasmAbi, JsValueVector};
 }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -11,7 +11,7 @@ use crate::convert::{
     FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, RefFromWasmAbi, RefMutFromWasmAbi, WasmAbi,
 };
 use crate::convert::{VectorFromWasmAbi, VectorIntoWasmAbi};
-use crate::describe::{self, WasmDescribe, WasmDescribeVector};
+use crate::describe::*;
 use cfg_if::cfg_if;
 
 if_std! {
@@ -82,7 +82,7 @@ macro_rules! vectors {
         if_std! {
             impl WasmDescribeVector for $t {
                 fn describe_vector() {
-                    describe::inform(describe::VECTOR);
+                    inform(VECTOR);
                     $t::describe();
                 }
             }
@@ -186,7 +186,16 @@ vectors! {
 if_std! {
     impl WasmDescribeVector for String {
         fn describe_vector() {
-            <Box<[JsValue]>>::describe();
+            inform(VECTOR);
+            inform(NAMED_EXTERNREF);
+            // Trying to use an actual loop for this breaks the wasm interpreter.
+            inform(6);
+            inform('s' as u32);
+            inform('t' as u32);
+            inform('r' as u32);
+            inform('i' as u32);
+            inform('n' as u32);
+            inform('g' as u32);
         }
     }
 

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -181,22 +181,30 @@ if_std! {
     use std::boxed::Box;
     use core::marker::Sized;
 
+    /// Trait for element types to implement IntoWasmAbi for vectors of
+    /// themselves.
     pub trait VectorIntoWasmAbi: WasmDescribeVector + Sized {
         type Abi: WasmAbi;
 
         fn vector_into_abi(vector: Box<[Self]>) -> Self::Abi;
     }
 
+    /// Trait for element types to implement OptionIntoWasmAbi for vectors
+    /// of themselves.
     pub trait OptionVectorIntoWasmAbi: VectorIntoWasmAbi {
         fn vector_none() -> Self::Abi;
     }
 
+    /// Trait for element types to implement FromWasmAbi for vectors of
+    /// themselves.
     pub trait VectorFromWasmAbi: WasmDescribeVector + Sized {
         type Abi: WasmAbi;
 
         unsafe fn vector_from_abi(js: Self::Abi) -> Box<[Self]>;
     }
 
+    /// Trait for element types to implement OptionFromWasmAbi for vectors
+    /// of themselves.
     pub trait OptionVectorFromWasmAbi: VectorFromWasmAbi {
         fn vector_is_none(abi: &Self::Abi) -> bool;
     }

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -160,8 +160,8 @@ impl<T: IntoWasmAbi> ReturnWasmAbi for T {
 }
 
 if_std! {
-    use std::boxed::Box;
     use core::marker::Sized;
+    use std::boxed::Box;
 
     /// Trait for element types to implement IntoWasmAbi for vectors of
     /// themselves.

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -159,24 +159,6 @@ impl<T: IntoWasmAbi> ReturnWasmAbi for T {
     }
 }
 
-/// Enables blanket implementations of `WasmDescribe`, `IntoWasmAbi`,
-/// `FromWasmAbi` and `OptionIntoWasmAbi` functionality on boxed slices of
-/// types which can be converted to and from `JsValue` without conflicting
-/// implementations of those traits.
-///
-/// Implementing these traits directly with blanket implementations would
-/// be much more elegant, but unfortunately that's impossible because it
-/// conflicts with the implementations for `Box<[T]> where T: JsObject`.
-pub trait JsValueVector {
-    type ToAbi;
-    type FromAbi;
-
-    fn describe();
-    fn into_abi(self) -> Self::ToAbi;
-    fn none() -> Self::ToAbi;
-    unsafe fn from_abi(js: Self::FromAbi) -> Self;
-}
-
 if_std! {
     use std::boxed::Box;
     use core::marker::Sized;

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -171,23 +171,11 @@ if_std! {
         fn vector_into_abi(vector: Box<[Self]>) -> Self::Abi;
     }
 
-    /// Trait for element types to implement OptionIntoWasmAbi for vectors
-    /// of themselves.
-    pub trait OptionVectorIntoWasmAbi: VectorIntoWasmAbi {
-        fn vector_none() -> Self::Abi;
-    }
-
     /// Trait for element types to implement FromWasmAbi for vectors of
     /// themselves.
     pub trait VectorFromWasmAbi: WasmDescribeVector + Sized {
         type Abi: WasmAbi;
 
         unsafe fn vector_from_abi(js: Self::Abi) -> Box<[Self]>;
-    }
-
-    /// Trait for element types to implement OptionFromWasmAbi for vectors
-    /// of themselves.
-    pub trait OptionVectorFromWasmAbi: VectorFromWasmAbi {
-        fn vector_is_none(abi: &Self::Abi) -> bool;
     }
 }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -158,16 +158,16 @@ if_std! {
         }
     }
 
-    impl<T: WasmDescribeVector> WasmDescribe for Box<[T]> {
-        fn describe() {
-            T::describe_vector();
-        }
-    }
-
     impl<T: JsObject> WasmDescribeVector for T {
         fn describe_vector() {
             inform(VECTOR);
             T::describe();
+        }
+    }
+
+    impl<T: WasmDescribeVector> WasmDescribe for Box<[T]> {
+        fn describe() {
+            T::describe_vector();
         }
     }
 

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -3,7 +3,7 @@
 
 #![doc(hidden)]
 
-use crate::{Clamped, JsError, JsValue};
+use crate::{Clamped, JsError, JsObject, JsValue};
 use cfg_if::cfg_if;
 
 macro_rules! tys {
@@ -145,7 +145,14 @@ if_std! {
         }
     }
 
-    impl<T: WasmDescribe> WasmDescribe for Box<[T]> {
+    impl WasmDescribe for Box<[JsValue]> {
+        fn describe() {
+            inform(VECTOR);
+            JsValue::describe();
+        }
+    }
+
+    impl<T> WasmDescribe for Box<[T]> where T: JsObject {
         fn describe() {
             inform(VECTOR);
             T::describe();

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -57,7 +57,7 @@ pub trait WasmDescribe {
     fn describe();
 }
 
-/// Trait for element types to implement IntoWasmAbi for vectors of
+/// Trait for element types to implement WasmDescribe for vectors of
 /// themselves.
 pub trait WasmDescribeVector {
     fn describe_vector();

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -57,6 +57,10 @@ pub trait WasmDescribe {
     fn describe();
 }
 
+pub trait WasmDescribeVector {
+    fn describe_vector();
+}
+
 macro_rules! simple {
     ($($t:ident => $d:ident)*) => ($(
         impl WasmDescribe for $t {
@@ -145,15 +149,21 @@ if_std! {
         }
     }
 
-    impl WasmDescribe for Box<[JsValue]> {
-        fn describe() {
+    impl WasmDescribeVector for JsValue {
+        fn describe_vector() {
             inform(VECTOR);
             JsValue::describe();
         }
     }
 
-    impl<T> WasmDescribe for Box<[T]> where T: JsObject {
+    impl<T: WasmDescribeVector> WasmDescribe for Box<[T]> {
         fn describe() {
+            T::describe_vector();
+        }
+    }
+
+    impl<T: JsObject> WasmDescribeVector for T {
+        fn describe_vector() {
             inform(VECTOR);
             T::describe();
         }

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -57,6 +57,8 @@ pub trait WasmDescribe {
     fn describe();
 }
 
+/// Trait for element types to implement IntoWasmAbi for vectors of
+/// themselves.
 pub trait WasmDescribeVector {
     fn describe_vector();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,6 +805,17 @@ if_std! {
             JsValue::from_str(&s)
         }
     }
+
+    impl TryFrom<JsValue> for String {
+        type Error = JsValue;
+
+        fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+            match value.as_string() {
+                Some(s) => Ok(s),
+                None => Err(value),
+            }
+        }
+    }
 }
 
 impl From<bool> for JsValue {

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -46,6 +46,7 @@ pub mod result_jserror;
 pub mod rethrow;
 pub mod simple;
 pub mod slice;
+pub mod string_vecs;
 pub mod struct_vecs;
 pub mod structural;
 pub mod truthy_falsy;

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -46,6 +46,7 @@ pub mod result_jserror;
 pub mod rethrow;
 pub mod simple;
 pub mod slice;
+pub mod struct_vecs;
 pub mod structural;
 pub mod truthy_falsy;
 pub mod usize;

--- a/tests/wasm/slice.js
+++ b/tests/wasm/slice.js
@@ -6,39 +6,60 @@ exports.js_export = () => {
     i8[0] = 1;
     i8[1] = 2;
     assert.deepStrictEqual(wasm.export_i8(i8), i8);
+    assert.deepStrictEqual(wasm.export_optional_i8(i8), i8);
     const u8 = new Uint8Array(2);
     u8[0] = 1;
     u8[1] = 2;
     assert.deepStrictEqual(wasm.export_u8(u8), u8);
+    assert.deepStrictEqual(wasm.export_optional_u8(u8), u8);
 
     const i16 = new Int16Array(2);
     i16[0] = 1;
     i16[1] = 2;
     assert.deepStrictEqual(wasm.export_i16(i16), i16);
+    assert.deepStrictEqual(wasm.export_optional_i16(i16), i16);
     const u16 = new Uint16Array(2);
     u16[0] = 1;
     u16[1] = 2;
     assert.deepStrictEqual(wasm.export_u16(u16), u16);
+    assert.deepStrictEqual(wasm.export_optional_u16(u16), u16);
 
     const i32 = new Int32Array(2);
     i32[0] = 1;
     i32[1] = 2;
     assert.deepStrictEqual(wasm.export_i32(i32), i32);
+    assert.deepStrictEqual(wasm.export_optional_i32(i32), i32);
     assert.deepStrictEqual(wasm.export_isize(i32), i32);
+    assert.deepStrictEqual(wasm.export_optional_isize(i32), i32);
     const u32 = new Uint32Array(2);
     u32[0] = 1;
     u32[1] = 2;
     assert.deepStrictEqual(wasm.export_u32(u32), u32);
+    assert.deepStrictEqual(wasm.export_optional_u32(u32), u32);
     assert.deepStrictEqual(wasm.export_usize(u32), u32);
+    assert.deepStrictEqual(wasm.export_optional_usize(u32), u32);
 
     const f32 = new Float32Array(2);
     f32[0] = 1;
     f32[1] = 2;
     assert.deepStrictEqual(wasm.export_f32(f32), f32);
+    assert.deepStrictEqual(wasm.export_optional_f32(f32), f32);
     const f64 = new Float64Array(2);
     f64[0] = 1;
     f64[1] = 2;
     assert.deepStrictEqual(wasm.export_f64(f64), f64);
+    assert.deepStrictEqual(wasm.export_optional_f64(f64), f64);
+
+    assert.strictEqual(wasm.export_optional_i8(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_u8(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_i16(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_u16(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_i32(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_isize(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_u32(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_usize(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_f32(undefined), undefined);
+    assert.strictEqual(wasm.export_optional_f64(undefined), undefined);
 };
 
 const test_import = (a, b, c) => {

--- a/tests/wasm/slice.rs
+++ b/tests/wasm/slice.rs
@@ -22,7 +22,7 @@ extern "C" {
 }
 
 macro_rules! export_macro {
-    ($(($i:ident, $n:ident))*) => ($(
+    ($(($i:ident, $n:ident, $optional_n:ident))*) => ($(
         #[wasm_bindgen]
         pub fn $n(a: &[$i]) -> Vec<$i> {
             assert_eq!(a.len(), 2);
@@ -30,20 +30,30 @@ macro_rules! export_macro {
             assert_eq!(a[1], 2 as $i);
             a.to_vec()
         }
+
+        #[wasm_bindgen]
+        pub fn $optional_n(a: Option<Vec<$i>>) -> Option<Vec<$i>> {
+            a.map(|a| {
+                assert_eq!(a.len(), 2);
+                assert_eq!(a[0], 1 as $i);
+                assert_eq!(a[1], 2 as $i);
+                a.to_vec()
+            })
+        }
     )*)
 }
 
 export_macro! {
-    (i8, export_i8)
-    (u8, export_u8)
-    (i16, export_i16)
-    (u16, export_u16)
-    (i32, export_i32)
-    (u32, export_u32)
-    (isize, export_isize)
-    (usize, export_usize)
-    (f32, export_f32)
-    (f64, export_f64)
+    (i8, export_i8, export_optional_i8)
+    (u8, export_u8, export_optional_u8)
+    (i16, export_i16, export_optional_i16)
+    (u16, export_u16, export_optional_u16)
+    (i32, export_i32, export_optional_i32)
+    (u32, export_u32, export_optional_u32)
+    (isize, export_isize, export_optional_isize)
+    (usize, export_usize, export_optional_usize)
+    (f32, export_f32, export_optional_f32)
+    (f64, export_f64, export_optional_f64)
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/string_vecs.js
+++ b/tests/wasm/string_vecs.js
@@ -1,0 +1,15 @@
+const wasm = require('wasm-bindgen-test.js');
+const assert = require('assert');
+
+exports.pass_string_vec = () => {
+    wasm.consume_string_vec(["hello", "world"]);
+};
+
+exports.pass_invalid_string_vec = () => {
+    try {
+        wasm.consume_string_vec([42]);
+    } catch (e) {
+        assert.match(e.message, /array contains a value of the wrong type/)
+        assert.match(e.stack, /consume_string_vec/)
+    }
+};

--- a/tests/wasm/string_vecs.js
+++ b/tests/wasm/string_vecs.js
@@ -2,7 +2,15 @@ const wasm = require('wasm-bindgen-test.js');
 const assert = require('assert');
 
 exports.pass_string_vec = () => {
-    wasm.consume_string_vec(["hello", "world"]);
+    assert.deepStrictEqual(
+        wasm.consume_string_vec(["hello", "world"]),
+        ["hello", "world", "Hello from Rust!"],
+    );
+    assert.deepStrictEqual(
+        wasm.consume_optional_string_vec(["hello", "world"]),
+        ["hello", "world", "Hello from Rust!"],
+    );
+    assert.strictEqual(wasm.consume_optional_string_vec(undefined), undefined);
 };
 
 exports.pass_invalid_string_vec = () => {

--- a/tests/wasm/string_vecs.rs
+++ b/tests/wasm/string_vecs.rs
@@ -1,0 +1,21 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/string_vecs.js")]
+extern "C" {
+    fn pass_string_vec();
+    fn pass_invalid_string_vec();
+}
+
+#[wasm_bindgen]
+pub fn consume_string_vec(_: Vec<String>) {}
+
+#[wasm_bindgen_test]
+fn test_valid() {
+    pass_string_vec();
+}
+
+#[wasm_bindgen_test]
+fn test_invalid() {
+    pass_invalid_string_vec();
+}

--- a/tests/wasm/string_vecs.rs
+++ b/tests/wasm/string_vecs.rs
@@ -8,7 +8,15 @@ extern "C" {
 }
 
 #[wasm_bindgen]
-pub fn consume_string_vec(_: Vec<String>) {}
+pub fn consume_string_vec(mut vec: Vec<String>) -> Vec<String> {
+    vec.push("Hello from Rust!".to_owned());
+    vec
+}
+
+#[wasm_bindgen]
+pub fn consume_optional_string_vec(vec: Option<Vec<String>>) -> Option<Vec<String>> {
+    vec.map(consume_string_vec)
+}
 
 #[wasm_bindgen_test]
 fn test_valid() {

--- a/tests/wasm/struct_vecs.js
+++ b/tests/wasm/struct_vecs.js
@@ -1,0 +1,17 @@
+const wasm = require('wasm-bindgen-test.js');
+const assert = require('assert');
+
+exports.pass_struct_vec = () => {
+    const el1 = new wasm.ArrayElement();
+    const el2 = new wasm.ArrayElement();
+    wasm.consume_struct_vec([el1, el2]);
+};
+
+exports.pass_invalid_struct_vec = () => {
+    try {
+        wasm.consume_struct_vec(['not a struct']);
+    } catch (e) {
+        assert.match(e.message, /array contains a value of the wrong type/)
+        assert.match(e.stack, /consume_struct_vec/)
+    }
+};

--- a/tests/wasm/struct_vecs.js
+++ b/tests/wasm/struct_vecs.js
@@ -4,7 +4,13 @@ const assert = require('assert');
 exports.pass_struct_vec = () => {
     const el1 = new wasm.ArrayElement();
     const el2 = new wasm.ArrayElement();
-    wasm.consume_struct_vec([el1, el2]);
+    const ret = wasm.consume_struct_vec([el1, el2]);
+    assert.deepStrictEqual(ret.length, 3);
+
+    const ret2 = wasm.consume_optional_struct_vec(ret);
+    assert.deepStrictEqual(ret2.length, 4);
+
+    assert.strictEqual(wasm.consume_optional_struct_vec(undefined), undefined);
 };
 
 exports.pass_invalid_struct_vec = () => {

--- a/tests/wasm/struct_vecs.js
+++ b/tests/wasm/struct_vecs.js
@@ -5,10 +5,10 @@ exports.pass_struct_vec = () => {
     const el1 = new wasm.ArrayElement();
     const el2 = new wasm.ArrayElement();
     const ret = wasm.consume_struct_vec([el1, el2]);
-    assert.deepStrictEqual(ret.length, 3);
+    assert.strictEqual(ret.length, 3);
 
     const ret2 = wasm.consume_optional_struct_vec(ret);
-    assert.deepStrictEqual(ret2.length, 4);
+    assert.strictEqual(ret2.length, 4);
 
     assert.strictEqual(wasm.consume_optional_struct_vec(undefined), undefined);
 };

--- a/tests/wasm/struct_vecs.rs
+++ b/tests/wasm/struct_vecs.rs
@@ -1,0 +1,32 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/struct_vecs.js")]
+extern "C" {
+    fn pass_struct_vec();
+    fn pass_invalid_struct_vec();
+}
+
+#[wasm_bindgen]
+pub struct ArrayElement;
+
+#[wasm_bindgen]
+impl ArrayElement {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> ArrayElement {
+        ArrayElement
+    }
+}
+
+#[wasm_bindgen]
+pub fn consume_struct_vec(_: Vec<ArrayElement>) {}
+
+#[wasm_bindgen_test]
+fn test_valid() {
+    pass_struct_vec();
+}
+
+#[wasm_bindgen_test]
+fn test_invalid() {
+    pass_invalid_struct_vec();
+}

--- a/tests/wasm/struct_vecs.rs
+++ b/tests/wasm/struct_vecs.rs
@@ -19,7 +19,15 @@ impl ArrayElement {
 }
 
 #[wasm_bindgen]
-pub fn consume_struct_vec(_: Vec<ArrayElement>) {}
+pub fn consume_struct_vec(mut vec: Vec<ArrayElement>) -> Vec<ArrayElement> {
+    vec.push(ArrayElement);
+    vec
+}
+
+#[wasm_bindgen]
+pub fn consume_optional_struct_vec(vec: Option<Vec<ArrayElement>>) -> Option<Vec<ArrayElement>> {
+    vec.map(consume_struct_vec)
+}
 
 #[wasm_bindgen_test]
 fn test_valid() {


### PR DESCRIPTION
This is a rebase of #2734 along with some fixes and tweaks. Sorry it took me so long to get to it!

This PR:
- Adds support for passing `Vec`s of Rust structs to/from JS.
- Adds support for passing `Vec<String>`s to/from JS.
- Implements `TryFrom<JsValue>` for Rust structs and strings.

The `Vec` impls are little inefficient, since they work by passing `Vec<JsValue>`s to/from JS like normal, and then translating them to the desired `Vec` with `TryFrom` / `Into<JsValue>`, which requires throwing away the first allocation and making a second one.

Fixes #111
Fixes #2452
Fixes #168
Fixes #2231

This also mostly supersedes #3088. That PR does support slightly more functionality (getting access to `&Struct` instead of forcing you to take ownership of it and invalidate JS's handle), but it also does so by exposing the internal `Anchor` type used by `RefFromWasmAbi`, which I'm not a huge fan of.

I haven't bumped the schema version, since the actual schema hasn't changed and so older versions of the CLI are mostly still compatible, although they do give this cryptic error message if you try and use the new `TryFrom<JsValue>` impl for Rust structs:

```
error: import of `__wbg_foo_unwrap` doesn't have an adapter listed
```

(where `foo` is the name of the struct.)

So maybe it's worth bumping it anyway, not sure.