### PR TITLE
web-sys: Add `HtmlElement` `inert` property

### DIFF
--- a/crates/web-sys/src/features/gen_HtmlElement.rs
+++ b/crates/web-sys/src/features/gen_HtmlElement.rs
@@ -118,6 +118,20 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlElement`*"]
     pub fn set_hidden(this: &HtmlElement, value: bool);
+    # [wasm_bindgen (structural , method , getter , js_class = "HTMLElement" , js_name = inert)]
+    #[doc = "Getter for the `inert` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlElement`*"]
+    pub fn inert(this: &HtmlElement) -> bool;
+    # [wasm_bindgen (structural , method , setter , js_class = "HTMLElement" , js_name = inert)]
+    #[doc = "Setter for the `inert` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlElement`*"]
+    pub fn set_inert(this: &HtmlElement, value: bool);
     # [wasm_bindgen (structural , method , getter , js_class = "HTMLElement" , js_name = tabIndex)]
     #[doc = "Getter for the `tabIndex` field of this object."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/HTMLElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLElement.webidl
@@ -35,6 +35,8 @@ interface HTMLElement : Element {
   // user interaction
   [CEReactions, SetterThrows, Pure]
            attribute boolean hidden;
+  [CEReactions]
+           attribute boolean inert;
   [NeedsCallerType]
   undefined click();
   [CEReactions, SetterThrows, Pure]


### PR DESCRIPTION
This PR adds the `inert` property of `HtmlElement`. From what I can see it seems to be stable so I assume the fact that it is missing is simply an oversight.

See:
- https://html.spec.whatwg.org/multipage/interaction.html#inert
- https://html.spec.whatwg.org/multipage/dom.html#htmlelement
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert