### PR TITLE
Remove class wrap for constructors in Rust exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
   bindgen placeholder.
   [#3233](https://github.com/rustwasm/wasm-bindgen/pull/3233)
 
+* Changed inheritance behavior in generated JS bindings, it is now possible to
+  override methods from generated JS classes using inheritance.
+  [#3561](https://github.com/rustwasm/wasm-bindgen/pull/3561)
+
 ### Fixed
 
 * Fixed bindings and comments for `Atomics.wait`.
@@ -52,6 +56,10 @@
 
 * Fixed `wasm_bindgen_test` macro to handle raw identifiers in test names.
   [#3541](https://github.com/rustwasm/wasm-bindgen/pull/3541)
+
+* Fixed bug where constructors of exported Rust structs are allowed to return
+  other exported Rust structs (i.e. not `Self`).
+  [#3561](https://github.com/rustwasm/wasm-bindgen/pull/3561)
 
 ## [0.2.87](https://github.com/rustwasm/wasm-bindgen/compare/0.2.86...0.2.87)
 

--- a/crates/cli-support/src/externref.rs
+++ b/crates/cli-support/src/externref.rs
@@ -137,7 +137,7 @@ fn find_call_export(instrs: &[InstructionData]) -> Option<Export> {
         .iter()
         .enumerate()
         .filter_map(|(i, instr)| match instr.instr {
-            Instruction::CallExport(e) => Some(Export::Export(e)),
+            Instruction::CallExport(e, _) => Some(Export::Export(e)),
             Instruction::CallTableElement(e) => Some(Export::TableElement {
                 idx: e,
                 call_idx: i,
@@ -267,7 +267,7 @@ fn export_xform(cx: &mut Context, export: Export, instrs: &mut Vec<InstructionDa
     // also maintain indices of the instructions to delete.
     for (i, instr) in iter.by_ref() {
         match instr.instr {
-            Instruction::CallExport(_) | Instruction::CallTableElement(_) => break,
+            Instruction::CallExport(_, _) | Instruction::CallTableElement(_) => break,
             Instruction::I32FromExternrefOwned => {
                 args.pop();
                 args.push(Some(true));

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -989,7 +989,7 @@ fn instruction(js: &mut JsBuilder, instr: &Instruction, log_error: &mut bool) ->
         Instruction::SelfFromI32 => {
             let val = js.pop();
             js.prelude(&format!("this.__wbg_ptr = {} >>> 0;", val));
-            js.push(format!("this"));
+            js.push("this".to_string());
         }
 
         Instruction::RustFromI32 { class } => {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2749,7 +2749,7 @@ impl<'a> Context<'a> {
                         call = Some(id);
                     }
                 }
-                Instruction::CallExport(_)
+                Instruction::CallExport(_, _)
                 | Instruction::CallTableElement(_)
                 | Instruction::CallCore(_) => return Ok(false),
                 _ => {}

--- a/crates/cli-support/src/multivalue.rs
+++ b/crates/cli-support/src/multivalue.rs
@@ -81,7 +81,7 @@ fn extract_xform<'a>(
             .iter_mut()
             .find_map(|i| match &mut i.instr {
                 Instruction::CallCore(f) => Some(Slot::Id(f)),
-                Instruction::CallExport(e) => Some(Slot::Export(*e)),
+                Instruction::CallExport(e, _) => Some(Slot::Export(*e)),
                 Instruction::CallTableElement(index) => Some(Slot::TableElement(*index)),
                 _ => None,
             })

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -1289,7 +1289,7 @@ impl<'a> Context<'a> {
                     &[AdapterType::Struct(class.clone())],
                 );
             } else {
-                bail!("constructor for `{}` does not return `Self`", class);
+                ret.outgoing(&signature.ret)?;
             }
         } else {
             ret.outgoing(&signature.ret)?;

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -101,7 +101,7 @@ pub struct AuxExport {
 /// sort of webidl import to customize behavior or something like that. In any
 /// case this doesn't feel quite right in terms of privilege separation, so
 /// we'll want to work on this. For now though it works.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AuxExportKind {
     /// A free function that's just listed on the exported module
     Function(String),

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -1,5 +1,5 @@
 use crate::descriptor::VectorKind;
-use crate::wit::{AuxImport, WasmBindgenAux, AuxExportKind};
+use crate::wit::{AuxExportKind, AuxImport, WasmBindgenAux};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use walrus::{FunctionId, ImportId, TypedCustomSectionId};

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -1,5 +1,5 @@
 use crate::descriptor::VectorKind;
-use crate::wit::{AuxImport, WasmBindgenAux};
+use crate::wit::{AuxImport, WasmBindgenAux, AuxExportKind};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use walrus::{FunctionId, ImportId, TypedCustomSectionId};
@@ -102,7 +102,7 @@ pub enum Instruction {
     /// call-adapter instruction
     CallAdapter(AdapterId),
     /// Call an exported function in the core module
-    CallExport(walrus::ExportId),
+    CallExport(walrus::ExportId, AuxExportKind),
     /// Call an element in the function table of the core module
     CallTableElement(u32),
 
@@ -249,6 +249,8 @@ pub enum Instruction {
     },
     /// pops `i32`, pushes string from that `char`
     StringFromChar,
+    /// pops `i32`, pushed an externref for rust class without wrapping
+    SelfFromI32,
     /// pops `i32`, pushes an externref for the wrapped rust class
     RustFromI32 {
         class: String,

--- a/crates/cli/tests/reference/builder.d.ts
+++ b/crates/cli/tests/reference/builder.d.ts
@@ -1,0 +1,11 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+*/
+export class ClassBuilder {
+  free(): void;
+/**
+* @returns {ClassBuilder}
+*/
+  static builder(): ClassBuilder;
+}

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -1,0 +1,61 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8Memory0 = null;
+
+function getUint8Memory0() {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8Memory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+}
+/**
+*/
+export class ClassBuilder {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(ClassBuilder.prototype);
+        obj.__wbg_ptr = ptr;
+
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_classbuilder_free(ptr);
+    }
+    /**
+    * @returns {ClassBuilder}
+    */
+    static builder() {
+        const ret = wasm.classbuilder_builder();
+        return ClassBuilder.__wrap(ret);
+    }
+}
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+

--- a/crates/cli/tests/reference/builder.rs
+++ b/crates/cli/tests/reference/builder.rs
@@ -1,0 +1,11 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct ClassBuilder(String);
+
+#[wasm_bindgen]
+impl ClassBuilder {
+    pub fn builder() -> Self {
+        ClassBuilder(String::from("Test"))
+    }
+}

--- a/crates/cli/tests/reference/builder.wat
+++ b/crates/cli/tests/reference/builder.wat
@@ -1,0 +1,10 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32)))
+  (func $classbuilder_builder (;0;) (type 0) (result i32))
+  (func $__wbg_classbuilder_free (;1;) (type 1) (param i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "__wbg_classbuilder_free" (func $__wbg_classbuilder_free))
+  (export "classbuilder_builder" (func $classbuilder_builder))
+)

--- a/crates/cli/tests/reference/constructor.d.ts
+++ b/crates/cli/tests/reference/constructor.d.ts
@@ -1,0 +1,10 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+*/
+export class ClassConstructor {
+  free(): void;
+/**
+*/
+  constructor();
+}

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -1,0 +1,53 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8Memory0 = null;
+
+function getUint8Memory0() {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8Memory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+}
+/**
+*/
+export class ClassConstructor {
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_classconstructor_free(ptr);
+    }
+    /**
+    */
+    constructor() {
+        const ret = wasm.classconstructor_new();
+        this.__wbg_ptr = ret >>> 0;
+        return this;
+    }
+}
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+

--- a/crates/cli/tests/reference/constructor.rs
+++ b/crates/cli/tests/reference/constructor.rs
@@ -1,0 +1,13 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct ClassConstructor(());
+
+#[wasm_bindgen]
+impl ClassConstructor {
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        ClassConstructor(())
+    }
+}

--- a/crates/cli/tests/reference/constructor.wat
+++ b/crates/cli/tests/reference/constructor.wat
@@ -1,0 +1,10 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32)))
+  (func $__wbg_classconstructor_free (;0;) (type 1) (param i32))
+  (func $classconstructor_new (;1;) (type 0) (result i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "__wbg_classconstructor_free" (func $__wbg_classconstructor_free))
+  (export "classconstructor_new" (func $classconstructor_new))
+)

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -431,3 +431,27 @@ fn function_table_preserved() {
         .wasm_bindgen("");
     cmd.assert().success();
 }
+
+#[test]
+fn constructor_without_self_does_not_work() {
+    let (mut cmd, _out_dir) = Project::new("constructor_without_self_does_not_work")
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                pub struct Foo(());
+
+                #[wasm_bindgen]
+                impl Foo {
+                    #[wasm_bindgen(constructor)]
+                    pub fn new() -> i32 {
+                        0
+                    }
+                }
+            "#,
+        )
+        .wasm_bindgen("--target web");
+    cmd.assert().failure();
+}

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -433,8 +433,8 @@ fn function_table_preserved() {
 }
 
 #[test]
-fn constructor_without_self_does_not_work() {
-    let (mut cmd, _out_dir) = Project::new("constructor_without_self_does_not_work")
+fn constructor_cannot_return_foreign_struct() {
+    let (mut cmd, _out_dir) = Project::new("constructor_cannot_return_foreign_struct")
         .file(
             "src/lib.rs",
             r#"
@@ -444,10 +444,13 @@ fn constructor_without_self_does_not_work() {
                 pub struct Foo(());
 
                 #[wasm_bindgen]
+                pub struct Bar(());
+
+                #[wasm_bindgen]
                 impl Foo {
                     #[wasm_bindgen(constructor)]
-                    pub fn new() -> i32 {
-                        0
+                    pub fn new() -> Bar {
+                        Bar(())
                     }
                 }
             "#,

--- a/guide/src/reference/attributes/on-rust-exports/constructor.md
+++ b/guide/src/reference/attributes/on-rust-exports/constructor.md
@@ -32,3 +32,41 @@ import { Foo } from './my_module';
 const f = new Foo();
 console.log(f.get_contents());
 ```
+
+## Caveats
+
+Starting from v0.2.48 there is a bug in the `wasm-bindgen-cli-support` crate which breaks inheritance of exported Rust structs from JavaScript side (see [#3213](https://github.com/rustwasm/wasm-bindgen/issues/3213)). If you want to inherit a Rust struct such as:
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct Parent {
+    msg: String,
+}
+
+#[wasm_bindgen]
+impl Parent {
+    #[wasm_bindgen(constructor)]
+    fn new() -> Self {
+        Parent {
+            msg: String::from("Hello from Parent!"),
+        }
+    }
+}
+```
+
+You will need to reset the prototype of `this` back to the `Child` class prototype after calling the `Parent`'s constructor via `super`.
+
+```js
+import { Parent } from './my_module';
+
+class Child extends Parent {
+    constructor() {
+        super();
+        Object.setPrototypeOf(this, Child.prototype);
+    }
+}
+```
+
+This is no longer required as of v0.2.88.


### PR DESCRIPTION
After #1594 constructors of Rust exported structs started using class wrapping when generating JS shims. Wrapping erases prototype information from the object instance in JS and as a result it is not possible to override methods (via inheritance) of the generated class.

Additionally, some checks to ensure constructors always return an instance of `Self` were lost.

This PR fixes the above two issues by embedding the kind of export into the `CallExport` instruction and monitoring for constructor exports calls during the export adapter creation.

Once a constructor export call is detected and validated a new instruction `SelfFromI32` is pushed into the stack that avoids class wrapping.

Fixes #3213