### PR TITLE
Remove class wrap for constructors in Rust exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   bindgen placeholder.
   [#3233](https://github.com/rustwasm/wasm-bindgen/pull/3233)
 
+* Changed constructor implementation in generated JS bindings, it is now
+  possible to override methods from generated JS classes using inheritance.
+  When exported constructors return `Self`.
+  [#3562](https://github.com/rustwasm/wasm-bindgen/pull/3562)
+
 ### Fixed
 
 * Fixed bindings and comments for `Atomics.wait`.
@@ -65,6 +70,9 @@
 
 * Use fully qualified paths in the `wasm_bindgen_test` macro.
   [#3549](https://github.com/rustwasm/wasm-bindgen/pull/3549)
+
+* Fixed bug allowing JS primitives to be returned from exported constructors.
+  [#3562](https://github.com/rustwasm/wasm-bindgen/pull/3562)
 
 ## [0.2.87](https://github.com/rustwasm/wasm-bindgen/compare/0.2.86...0.2.87)
 

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -484,7 +484,29 @@ impl<'a> Context<'a> {
             Some(class) => {
                 let class = class.to_string();
                 match export.method_kind {
-                    decode::MethodKind::Constructor => AuxExportKind::Constructor(class),
+                    decode::MethodKind::Constructor => {
+                        let msg = "Trying to return JS primitive from constructor, return value will be ignored. Use a builder instead (remove `constructor` attribute).";
+                        match descriptor.ret {
+                            Descriptor::I8
+                            | Descriptor::U8
+                            | Descriptor::ClampedU8
+                            | Descriptor::I16
+                            | Descriptor::U16
+                            | Descriptor::I32
+                            | Descriptor::U32
+                            | Descriptor::F32
+                            | Descriptor::F64
+                            | Descriptor::I64
+                            | Descriptor::U64
+                            | Descriptor::Boolean
+                            | Descriptor::Char
+                            | Descriptor::CachedString
+                            | Descriptor::Option(_)
+                            | Descriptor::Unit => bail!(msg),
+                            _ => {}
+                        }
+                        AuxExportKind::Constructor(class)
+                    }
                     decode::MethodKind::Operation(op) => {
                         if !op.is_static {
                             // Make the first argument be the index of the receiver.

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -501,6 +501,7 @@ impl<'a> Context<'a> {
                             | Descriptor::Boolean
                             | Descriptor::Char
                             | Descriptor::CachedString
+                            | Descriptor::String
                             | Descriptor::Option(_)
                             | Descriptor::Unit => bail!(msg),
                             _ => {}

--- a/crates/cli/tests/reference/builder.d.ts
+++ b/crates/cli/tests/reference/builder.d.ts
@@ -1,0 +1,11 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+*/
+export class ClassBuilder {
+  free(): void;
+/**
+* @returns {ClassBuilder}
+*/
+  static builder(): ClassBuilder;
+}

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -1,0 +1,61 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8Memory0 = null;
+
+function getUint8Memory0() {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8Memory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+}
+/**
+*/
+export class ClassBuilder {
+
+    static __wrap(ptr) {
+        ptr = ptr >>> 0;
+        const obj = Object.create(ClassBuilder.prototype);
+        obj.__wbg_ptr = ptr;
+
+        return obj;
+    }
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_classbuilder_free(ptr);
+    }
+    /**
+    * @returns {ClassBuilder}
+    */
+    static builder() {
+        const ret = wasm.classbuilder_builder();
+        return ClassBuilder.__wrap(ret);
+    }
+}
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+

--- a/crates/cli/tests/reference/builder.rs
+++ b/crates/cli/tests/reference/builder.rs
@@ -1,0 +1,11 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct ClassBuilder(());
+
+#[wasm_bindgen]
+impl ClassBuilder {
+    pub fn builder() -> ClassBuilder {
+        ClassBuilder(())
+    }
+}

--- a/crates/cli/tests/reference/builder.wat
+++ b/crates/cli/tests/reference/builder.wat
@@ -1,0 +1,10 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32)))
+  (func $__wbg_classbuilder_free (;0;) (type 1) (param i32))
+  (func $classbuilder_builder (;1;) (type 0) (result i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "__wbg_classbuilder_free" (func $__wbg_classbuilder_free))
+  (export "classbuilder_builder" (func $classbuilder_builder))
+)

--- a/crates/cli/tests/reference/constructor.d.ts
+++ b/crates/cli/tests/reference/constructor.d.ts
@@ -1,0 +1,10 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+*/
+export class ClassConstructor {
+  free(): void;
+/**
+*/
+  constructor();
+}

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -43,6 +43,7 @@ export class ClassConstructor {
     constructor() {
         const ret = wasm.classconstructor_new();
         this.__wbg_ptr = ret >>> 0;
+        return this;
     }
 }
 

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -1,0 +1,52 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8Memory0 = null;
+
+function getUint8Memory0() {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8Memory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+}
+/**
+*/
+export class ClassConstructor {
+
+    __destroy_into_raw() {
+        const ptr = this.__wbg_ptr;
+        this.__wbg_ptr = 0;
+
+        return ptr;
+    }
+
+    free() {
+        const ptr = this.__destroy_into_raw();
+        wasm.__wbg_classconstructor_free(ptr);
+    }
+    /**
+    */
+    constructor() {
+        const ret = wasm.classconstructor_new();
+        this.__wbg_ptr = ret >>> 0;
+    }
+}
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+

--- a/crates/cli/tests/reference/constructor.rs
+++ b/crates/cli/tests/reference/constructor.rs
@@ -1,0 +1,13 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct ClassConstructor(());
+
+#[wasm_bindgen]
+impl ClassConstructor {
+
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> ClassConstructor {
+        ClassConstructor(())
+    }
+}

--- a/crates/cli/tests/reference/constructor.wat
+++ b/crates/cli/tests/reference/constructor.wat
@@ -1,0 +1,10 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32)))
+  (func $__wbg_classconstructor_free (;0;) (type 1) (param i32))
+  (func $classconstructor_new (;1;) (type 0) (result i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "__wbg_classconstructor_free" (func $__wbg_classconstructor_free))
+  (export "classconstructor_new" (func $classconstructor_new))
+)

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -431,3 +431,30 @@ fn function_table_preserved() {
         .wasm_bindgen("");
     cmd.assert().success();
 }
+
+#[test]
+fn constructor_cannot_return_foreign_struct() {
+    let (mut cmd, _out_dir) = Project::new("constructor_cannot_return_foreign_struct")
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                pub struct Foo(());
+                
+                #[wasm_bindgen]
+                pub struct Bar(());
+
+                #[wasm_bindgen]
+                impl Foo {
+                    #[wasm_bindgen(constructor)]
+                    pub fn new() -> Bar {
+                        Bar(())
+                    }
+                }
+            "#,
+        )
+        .wasm_bindgen("--target web");
+    cmd.assert().failure();
+}

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -433,8 +433,8 @@ fn function_table_preserved() {
 }
 
 #[test]
-fn constructor_cannot_return_foreign_struct() {
-    let (mut cmd, _out_dir) = Project::new("constructor_cannot_return_foreign_struct")
+fn constructor_cannot_return_option_struct() {
+    let (mut cmd, _out_dir) = Project::new("constructor_cannot_return_option_struct")
         .file(
             "src/lib.rs",
             r#"
@@ -444,13 +444,10 @@ fn constructor_cannot_return_foreign_struct() {
                 pub struct Foo(());
                 
                 #[wasm_bindgen]
-                pub struct Bar(());
-
-                #[wasm_bindgen]
                 impl Foo {
                     #[wasm_bindgen(constructor)]
-                    pub fn new() -> Bar {
-                        Bar(())
+                    pub fn new() -> Option<Foo> {
+                        Some(Foo(()))
                     }
                 }
             "#,

--- a/guide/src/reference/attributes/on-rust-exports/constructor.md
+++ b/guide/src/reference/attributes/on-rust-exports/constructor.md
@@ -32,3 +32,41 @@ import { Foo } from './my_module';
 const f = new Foo();
 console.log(f.get_contents());
 ```
+
+## Caveats
+
+Starting from v0.2.48 there is a bug in the `wasm-bindgen` which breaks inheritance of exported Rust structs from JavaScript side (see [#3213](https://github.com/rustwasm/wasm-bindgen/issues/3213)). If you want to inherit from a Rust struct such as:
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct Parent {
+    msg: String,
+}
+
+#[wasm_bindgen]
+impl Parent {
+    #[wasm_bindgen(constructor)]
+    fn new() -> Self {
+        Parent {
+            msg: String::from("Hello from Parent!"),
+        }
+    }
+}
+```
+
+You will need to reset the prototype of `this` back to the `Child` class prototype after calling the `Parent`'s constructor via `super`.
+
+```js
+import { Parent } from './my_module';
+
+class Child extends Parent {
+    constructor() {
+        super();
+        Object.setPrototypeOf(this, Child.prototype);
+    }
+}
+```
+
+This is no longer required as of v0.2.88.

--- a/guide/src/reference/attributes/on-rust-exports/constructor.md
+++ b/guide/src/reference/attributes/on-rust-exports/constructor.md
@@ -35,7 +35,7 @@ console.log(f.get_contents());
 
 ## Caveats
 
-Starting from v0.2.48 there is a bug in the `wasm-bindgen` which breaks inheritance of exported Rust structs from JavaScript side (see [#3213](https://github.com/rustwasm/wasm-bindgen/issues/3213)). If you want to inherit from a Rust struct such as:
+Starting from v0.2.48 there is a bug in `wasm-bindgen` which breaks inheritance of exported Rust structs from JavaScript side (see [#3213](https://github.com/rustwasm/wasm-bindgen/issues/3213)). If you want to inherit from a Rust struct such as:
 
 ```rust
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
After #1594 constructors of Rust exported structs started using class wrapping when generating JS shims. Wrapping erases prototype information from the object instance in JS and as a result it is not possible to override methods (via inheritance) of the generated class.

This PR is rebased from #3561, it passes the constructor information from the `Builder` into the instruction translation function which ensures that constructors returning `Self` no longer rely on `__wrap`.

Fixes #3213