### PR TITLE
Remove `ReadableStreamByobReader::read_with_u8_array()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@
 * Fixed optional parameters in JSDoc.
   [#3577](https://github.com/rustwasm/wasm-bindgen/pull/3577)
 
+### Removed
+
+* Removed `ReadableStreamByobReader::read_with_u8_array()` because it doesn't work with Wasm.
+  [#3582](https://github.com/rustwasm/wasm-bindgen/pull/3582)
+
 ## [0.2.87](https://github.com/rustwasm/wasm-bindgen/compare/0.2.86...0.2.87)
 
 Released 2023-06-12.

--- a/crates/web-sys/src/features/gen_ReadableStreamByobReader.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamByobReader.rs
@@ -37,16 +37,6 @@ extern "C" {
         this: &ReadableStreamByobReader,
         view: &::js_sys::Object,
     ) -> ::js_sys::Promise;
-    # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBReader" , js_name = read)]
-    #[doc = "The `read()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader/read)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ReadableStreamByobReader`*"]
-    pub fn read_with_u8_array(
-        this: &ReadableStreamByobReader,
-        view: &mut [u8],
-    ) -> ::js_sys::Promise;
     # [wasm_bindgen (method , structural , js_class = "ReadableStreamBYOBReader" , js_name = releaseLock)]
     #[doc = "The `releaseLock()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/Streams.webidl
+++ b/crates/web-sys/webidls/enabled/Streams.webidl
@@ -91,6 +91,7 @@ dictionary ReadableStreamReadResult {
 interface ReadableStreamBYOBReader {
   [Throws] constructor(ReadableStream stream);
 
+  [RustNotWasmMemory]
   Promise<ReadableStreamReadResult> read(ArrayBufferView view);
   undefined releaseLock();
 };

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -140,5 +140,9 @@ pub(crate) static FIXED_INTERFACES: Lazy<
             "OffscreenCanvasRenderingContext2d",
             canvas_rendering_context,
         ),
+        (
+            "ReadableStreamByobReader",
+            BTreeMap::from_iter([("read", "read_with_array_buffer_view")]),
+        ),
     ])
 });

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -266,7 +266,11 @@ impl<'src> FirstPassRecord<'src> {
                 // in-place, but all other flattened types will cause new
                 // signatures to be created.
                 let cur = actual_signatures.len();
-                for (j, idl_type) in idl_type.flatten().into_iter().enumerate() {
+                for (j, idl_type) in idl_type
+                    .flatten(signature.attrs.as_ref())
+                    .into_iter()
+                    .enumerate()
+                {
                     for k in start..cur {
                         if j == 0 {
                             actual_signatures[k].args.push(idl_type.clone());


### PR DESCRIPTION
See #3579.

This is technically a breaking change, but seeing as this would always fail it seems fine to me. We could always deprecate it instead.
@Liamolucko WDYT?