### PR TITLE
add .sha256 checksums to binary distribution tarballs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -486,7 +486,7 @@ jobs:
             tmp/$name/
           chmod +x tmp/$name/wasm*
           tar czvf gh-release/$name.tar.gz -C tmp $name
-          sha256sum gh-release/$name.tar.gz > gh-release/$name.tar.gz.sha256
+          sha256sum gh-release/$name.tar.gz > gh-release/$name.tar.gz.sha256sum
         }
         mk x86_64-unknown-linux-musl dist_linux_x86_64_musl
         mk aarch64-unknown-linux-gnu dist_linux_aarch64_gnu

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -486,6 +486,7 @@ jobs:
             tmp/$name/
           chmod +x tmp/$name/wasm*
           tar czvf gh-release/$name.tar.gz -C tmp $name
+          sha256sum gh-release/$name.tar.gz > gh-release/$name.tar.gz.sha256
         }
         mk x86_64-unknown-linux-musl dist_linux_x86_64_musl
         mk aarch64-unknown-linux-gnu dist_linux_aarch64_gnu
@@ -517,4 +518,4 @@ jobs:
     - uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: "gh-release/*.tar.gz"
+        files: "gh-release/*.tar.gz*"


### PR DESCRIPTION
Hiya. This adds a `*.tar.gz.sha256` file alongside each tarball pushed to GitHub Releases. Having a hash available does not magically add much in terms of supply chain security, it just enables tools like Bazel and Buck to pull binaries and ensure they're the same one as last time. The concrete need is to generate a JSON manifest of a GitHub release including sha256 hashes, without actually downloading the tarballs and hashing them at generation time. I have not tested the pipeline, but note that:

1. GitHub's ubuntu-latest builder includes coreutils, so the sha256sum command should be available.
2. I checked that the `*` at the end of the glob will match those .sha256 suffixes as well as the tarballs, against the glob package in use. `npm i -g glob; sha256sum CHANGELOG.md > CHANGELOG.md.sha256; glob '*.md*'`

So I think that will work. This is not a blocker because scripts for generating manifests can always fall back on downloading the tarballs to /tmp and hashing them there. So no need to push a release just for this.
