### PR TITLE
`wasm-bindgen-futures`: use `queueMicrotask` for next tick runs (#3203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,6 @@
   This should avoid quirks, like exceptions thrown get now properly reported
   as normal exceptions rather than as rejected promises.
   [#3611](https://github.com/rustwasm/wasm-bindgen/pull/3611)
-  [#2392](https://github.com/rustwasm/wasm-bindgen/issues/2392)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@
   `#[repr(C)]` types.
   [#3595](https://github.com/rustwasm/wasm-bindgen/pull/3595)
 
+* Use `queueMicrotask` in `wasm-bindgen-futures` for scheduling tasks on the next tick.
+  If that is not available, use the previous `Promise.then` mechanism as a fallback.
+  This should avoid quirks, like exceptions thrown get now properly reported
+  as normal exceptions rather than as rejected promises.
+  [#3611](https://github.com/rustwasm/wasm-bindgen/pull/3611)
+  [#2392](https://github.com/rustwasm/wasm-bindgen/issues/2392)
+
 ### Fixed
 
 * Fixed bindings and comments for `Atomics.wait`.

--- a/crates/futures/src/queue.rs
+++ b/crates/futures/src/queue.rs
@@ -8,11 +8,9 @@ use wasm_bindgen::prelude::*;
 extern "C" {
     #[wasm_bindgen]
     fn queueMicrotask(closure: &Closure<dyn FnMut(JsValue)>);
-}
 
-#[wasm_bindgen]
-extern "C" {
     type Global;
+
     #[wasm_bindgen(method, getter, js_name = queueMicrotask)]
     fn hasQueueMicrotask(this: &Global) -> JsValue;
 }

--- a/crates/futures/src/queue.rs
+++ b/crates/futures/src/queue.rs
@@ -4,6 +4,19 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen]
+    fn queueMicrotask(closure: &Closure<dyn FnMut(JsValue)>);
+}
+
+#[wasm_bindgen]
+extern "C" {
+    type Global;
+    #[wasm_bindgen(method, getter, js_name = queueMicrotask)]
+    fn hasQueueMicrotask(this: &Global) -> JsValue;
+}
+
 struct QueueState {
     // The queue of Tasks which are to be run in order. In practice this is all the
     // synchronous work of futures, and each `Task` represents calling `poll` on
@@ -42,17 +55,21 @@ pub(crate) struct Queue {
     state: Rc<QueueState>,
     promise: Promise,
     closure: Closure<dyn FnMut(JsValue)>,
+    has_queue_microtask: bool,
 }
 
 impl Queue {
     // Schedule a task to run on the next tick
     pub(crate) fn schedule_task(&self, task: Rc<crate::task::Task>) {
         self.state.tasks.borrow_mut().push_back(task);
-        // Note that we currently use a promise and a closure to do this, but
-        // eventually we should probably use something like `queueMicrotask`:
-        // https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/queueMicrotask
+        // Use queueMicrotask to execute as soon as possible. If it does not exist
+        // fall back to the promise resolution
         if !self.state.is_scheduled.replace(true) {
-            let _ = self.promise.then(&self.closure);
+            if self.has_queue_microtask {
+                queueMicrotask(&self.closure);
+            } else {
+                let _ = self.promise.then(&self.closure);
+            }
         }
     }
     // Append a task to the currently running queue, or schedule it
@@ -70,6 +87,11 @@ impl Queue {
             tasks: RefCell::new(VecDeque::new()),
         });
 
+        let has_queue_microtask = js_sys::global()
+            .unchecked_into::<Global>()
+            .hasQueueMicrotask()
+            .is_function();
+
         Self {
             promise: Promise::resolve(&JsValue::undefined()),
 
@@ -82,6 +104,7 @@ impl Queue {
             },
 
             state,
+            has_queue_microtask,
         }
     }
 }


### PR DESCRIPTION
but use `catch` to wrap it in a Result to be able to fall back to the previous `Promsise.then` variant.

since this is my first pull request here, i hope the code is ok this way, but a few questions remain:

* i simply imported queueMicrotask in global scope, since this should work for both non workers (window) and workers AFAICT
* i tried to run the tests mentioned here: https://rustwasm.github.io/docs/wasm-bindgen/contributing/testing.html but 
   the first one failed (regardless of my changes) and `cargo test -p ui-tests` also did not work (the remaining tests worked, as well as the ones directly in `wasm-bindgen-futures`
 * i tested #2392 with this, and this now seems to work
 * is the way i fall back to the old implementation ok? i couldn't find a way to import bindings 'optionally' or test during runtime if a function exists?
 * also is embedding such functionality from javascript directly ok? orwould it better be to add that to web-sys/js-sys first and use that?

Fixes #2392.