### PR TITLE
Lower the ES target for instanceof code

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3023,7 +3023,7 @@ impl<'a> Context<'a> {
                     let result;
                     try {{
                         result = {} instanceof {};
-                    }} catch {{
+                    }} catch (_) {{
                         result = false;
                     }}
                     ",


### PR DESCRIPTION
Since #3053 the code makes use of the ES2019 optional catch binding syntax, while generated code in general seems to be compatible with ES2015.