### PR TITLE
Replace`filter_map().next()` with `find_map`

### DIFF
--- a/crates/cli-support/src/externref.rs
+++ b/crates/cli-support/src/externref.rs
@@ -136,7 +136,7 @@ fn find_call_export(instrs: &[InstructionData]) -> Option<Export> {
     instrs
         .iter()
         .enumerate()
-        .filter_map(|(i, instr)| match instr.instr {
+        .find_map(|(i, instr)| match instr.instr {
             Instruction::CallExport(e) => Some(Export::Export(e)),
             Instruction::CallTableElement(e) => Some(Export::TableElement {
                 idx: e,
@@ -144,7 +144,6 @@ fn find_call_export(instrs: &[InstructionData]) -> Option<Export> {
             }),
             _ => None,
         })
-        .next()
 }
 
 enum Export {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -143,14 +143,13 @@ macro_rules! methods {
         fn $name(&self) -> Option<(&str, Span)> {
             self.attrs
                 .iter()
-                .filter_map(|a| match &a.1 {
+                .find_map(|a| match &a.1 {
                     BindgenAttr::$variant(_, s, span) => {
                         a.0.set(true);
                         Some((&s[..], *span))
                     }
                     _ => None,
                 })
-                .next()
         }
     };
 
@@ -158,14 +157,13 @@ macro_rules! methods {
         fn $name(&self) -> Option<(&[String], &[Span])> {
             self.attrs
                 .iter()
-                .filter_map(|a| match &a.1 {
+                .find_map(|a| match &a.1 {
                     BindgenAttr::$variant(_, ss, spans) => {
                         a.0.set(true);
                         Some((&ss[..], &spans[..]))
                     }
                     _ => None,
                 })
-                .next()
         }
     };
 
@@ -174,14 +172,13 @@ macro_rules! methods {
         fn $name(&self) -> Option<&$($other)*> {
             self.attrs
                 .iter()
-                .filter_map(|a| match &a.1 {
+                .find_map(|a| match &a.1 {
                     BindgenAttr::$variant(_, s) => {
                         a.0.set(true);
                         Some(s)
                     }
                     _ => None,
                 })
-                .next()
         }
     };
 
@@ -190,14 +187,13 @@ macro_rules! methods {
         fn $name(&self) -> Option<&$($other)*> {
             self.attrs
                 .iter()
-                .filter_map(|a| match &a.1 {
+                .find_map(|a| match &a.1 {
                     BindgenAttr::$variant(s) => {
                         a.0.set(true);
                         Some(s)
                     }
                     _ => None,
                 })
-                .next()
         }
     };
 }
@@ -1355,14 +1351,13 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
         values.sort();
         let hole = values
             .windows(2)
-            .filter_map(|window| {
+            .find_map(|window| {
                 if window[0] + 1 != window[1] {
                     Some(window[0] + 1)
                 } else {
                     None
                 }
             })
-            .next()
             .unwrap_or(*values.last().unwrap() + 1);
         for value in values {
             assert!(hole != value);

--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -249,11 +249,10 @@ fn allocate_static_data(
         .exports
         .iter()
         .filter(|e| e.name == "__heap_base")
-        .filter_map(|e| match e.item {
+        .find_map(|e| match e.item {
             ExportItem::Global(id) => Some(id),
             _ => None,
-        })
-        .next();
+        });
     let heap_base = match heap_base {
         Some(idx) => idx,
         None => bail!("failed to find `__heap_base` for injecting thread id"),

--- a/crates/wasm-interpreter/tests/smoke.rs
+++ b/crates/wasm-interpreter/tests/smoke.rs
@@ -12,11 +12,10 @@ fn interpret(wat: &str, name: &str, result: Option<&[u32]>) {
         .exports
         .iter()
         .filter(|e| e.name == name)
-        .filter_map(|e| match e.item {
+        .find_map(|e| match e.item {
             walrus::ExportItem::Function(f) => Some(f),
             _ => None,
         })
-        .next()
         .unwrap();
     assert_eq!(i.interpret_descriptor(id, &module), result);
 }

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -602,11 +602,10 @@ pub fn get_rust_deprecated<'a>(ext_attrs: &Option<ExtendedAttributeList<'a>>) ->
             _ => None,
         })
         .filter(|attr| attr.lhs_identifier.0 == "RustDeprecated")
-        .filter_map(|ident| match ident.rhs {
+        .find_map(|ident| match ident.rhs {
             IdentifierOrString::String(s) => Some(s),
             IdentifierOrString::Identifier(_) => None,
         })
-        .next()
         .map(|s| s.0)
 }
 


### PR DESCRIPTION
`rust-analyzer` emits a weak warning for this which leads to unnecessary noise in some editors.