### PR TITLE
Allow creating `Vec`s of exported enums

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1383,6 +1383,7 @@ impl ToTokens for ast::Enum {
                 }
             }
         });
+        let try_from_cast_clauses = cast_clauses.clone();
         let wasm_bindgen = &self.wasm_bindgen;
         (quote! {
             #[automatically_derived]
@@ -1443,13 +1444,13 @@ impl ToTokens for ast::Enum {
 
                 fn try_from(value: #wasm_bindgen::JsValue)
                     -> #wasm_bindgen::__rt::std::result::Result<Self, Self::Error> {
-                    let val = f64::try_from(value)? as u32;
+                    let js = f64::try_from(&value)? as u32;
 
-                    unsafe {
-                        #wasm_bindgen::__rt::std::result::Result::Ok(
-                            <Self as #wasm_bindgen::convert::FromWasmAbi>::from_abi(val)
-                        )
-                    }
+                    #wasm_bindgen::__rt::std::result::Result::Ok(
+                        #(#try_from_cast_clauses else)* {
+                            return #wasm_bindgen::__rt::std::result::Result::Err(value)
+                        }
+                    )
                 }
             }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1427,6 +1427,65 @@ impl ToTokens for ast::Enum {
                     inform(#hole);
                 }
             }
+
+            #[automatically_derived]
+            impl #wasm_bindgen::__rt::core::convert::From<#enum_name> for
+                #wasm_bindgen::JsValue
+            {
+                fn from(value: #enum_name) -> Self {
+                    #wasm_bindgen::JsValue::from_f64((value as u32).into())
+                }
+            }
+
+            #[allow(clippy::all)]
+            impl #wasm_bindgen::__rt::core::convert::TryFrom<#wasm_bindgen::JsValue> for #enum_name {
+                type Error = #wasm_bindgen::JsValue;
+
+                fn try_from(value: #wasm_bindgen::JsValue)
+                    -> #wasm_bindgen::__rt::std::result::Result<Self, Self::Error> {
+                    let val = f64::try_from(value)? as u32;
+
+                    unsafe {
+                        #wasm_bindgen::__rt::std::result::Result::Ok(
+                            <Self as #wasm_bindgen::convert::FromWasmAbi>::from_abi(val)
+                        )
+                    }
+                }
+            }
+
+            impl #wasm_bindgen::describe::WasmDescribeVector for #enum_name {
+                fn describe_vector() {
+                    use #wasm_bindgen::describe::*;
+                    inform(VECTOR);
+                    <#wasm_bindgen::JsValue as #wasm_bindgen::describe::WasmDescribe>::describe();
+                }
+            }
+
+            impl #wasm_bindgen::convert::VectorIntoWasmAbi for #enum_name {
+                type Abi = <
+                    #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
+                    as #wasm_bindgen::convert::IntoWasmAbi
+                >::Abi;
+
+                fn vector_into_abi(
+                    vector: #wasm_bindgen::__rt::std::boxed::Box<[#enum_name]>
+                ) -> Self::Abi {
+                    #wasm_bindgen::convert::js_value_vector_into_abi(vector)
+                }
+            }
+
+            impl #wasm_bindgen::convert::VectorFromWasmAbi for #enum_name {
+                type Abi = <
+                    #wasm_bindgen::__rt::std::boxed::Box<[#wasm_bindgen::JsValue]>
+                    as #wasm_bindgen::convert::FromWasmAbi
+                >::Abi;
+
+                unsafe fn vector_from_abi(
+                    js: Self::Abi
+                ) -> #wasm_bindgen::__rt::std::boxed::Box<[#enum_name]> {
+                    #wasm_bindgen::convert::js_value_vector_from_abi(js)
+                }
+            }
         })
         .to_tokens(into);
     }

--- a/tests/wasm/enum_vecs.js
+++ b/tests/wasm/enum_vecs.js
@@ -1,0 +1,23 @@
+const wasm = require('wasm-bindgen-test.js');
+const assert = require('assert');
+
+exports.pass_enum_vec = () => {
+    const el1 = wasm.EnumArrayElement.Unit;
+    const el2 = wasm.EnumArrayElement.Unit;
+    const ret = wasm.consume_enum_vec([el1, el2]);
+    assert.strictEqual(ret.length, 3);
+
+    const ret2 = wasm.consume_optional_enum_vec(ret);
+    assert.strictEqual(ret2.length, 4);
+
+    assert.strictEqual(wasm.consume_optional_enum_vec(undefined), undefined);
+};
+
+exports.pass_invalid_enum_vec = () => {
+    try {
+        wasm.consume_enum_vec(['not an enum value']);
+    } catch (e) {
+        assert.match(e.message, /invalid enum value passed/)
+        assert.match(e.stack, /consume_enum_vec/)
+    }
+};

--- a/tests/wasm/enum_vecs.rs
+++ b/tests/wasm/enum_vecs.rs
@@ -1,0 +1,36 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/enum_vecs.js")]
+extern "C" {
+    fn pass_enum_vec();
+    fn pass_invalid_enum_vec();
+}
+
+#[wasm_bindgen]
+pub enum EnumArrayElement {
+    Unit,
+}
+
+#[wasm_bindgen]
+pub fn consume_enum_vec(mut vec: Vec<EnumArrayElement>) -> Vec<EnumArrayElement> {
+    vec.push(EnumArrayElement::Unit);
+    vec
+}
+
+#[wasm_bindgen]
+pub fn consume_optional_enum_vec(
+    vec: Option<Vec<EnumArrayElement>>,
+) -> Option<Vec<EnumArrayElement>> {
+    vec.map(consume_enum_vec)
+}
+
+#[wasm_bindgen_test]
+fn test_valid() {
+    pass_enum_vec();
+}
+
+#[wasm_bindgen_test]
+fn test_invalid() {
+    pass_invalid_enum_vec();
+}

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -23,6 +23,7 @@ pub mod closures;
 pub mod comments;
 pub mod duplicate_deps;
 pub mod duplicates;
+pub mod enum_vecs;
 pub mod enums;
 #[path = "final.rs"]
 pub mod final_;


### PR DESCRIPTION
Also implements `TryFrom<JsValue>` and `Into<JsValue>` for them.

Enums were left behind in #3554. This adds the missing bits.