### PR TITLE
Implement `Into<JsValue>` for `Vec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ Released 2024-02-06
 * Add bindings for `USBDevice.forget()`.
   [#3821](https://github.com/rustwasm/wasm-bindgen/pull/3821)
 
+* Added support for returning `Vec`s from async functions.
+  [#3630](https://github.com/rustwasm/wasm-bindgen/pull/3630)
+
 ### Changed
 
 * Stabilize `ClipboardEvent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Add method `copy_within` for TypedArray, add methods `find_last`,`find_last_index` for Array.
   [#3888](https://github.com/rustwasm/wasm-bindgen/pull/3888)
 
+* Added support for returning `Vec`s from async functions.
+  [#3630](https://github.com/rustwasm/wasm-bindgen/pull/3630)
+
 ### Changed
 
 * Stabilize Web Share API.
@@ -81,9 +84,6 @@ Released 2024-02-06
 
 * Add bindings for `USBDevice.forget()`.
   [#3821](https://github.com/rustwasm/wasm-bindgen/pull/3821)
-
-* Added support for returning `Vec`s from async functions.
-  [#3630](https://github.com/rustwasm/wasm-bindgen/pull/3630)
 
 ### Changed
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -365,6 +365,12 @@ impl ToTokens for ast::Struct {
                     #wasm_bindgen::convert::js_value_vector_from_abi(js)
                 }
             }
+
+            impl #wasm_bindgen::__rt::VectorIntoJsValue for #name {
+                fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::std::boxed::Box<[#name]>) -> #wasm_bindgen::JsValue {
+                    #wasm_bindgen::__rt::js_value_vector_into_jsvalue(vector)
+                }
+            }
         })
         .to_tokens(tokens);
 
@@ -1507,6 +1513,12 @@ impl ToTokens for ast::Enum {
                     js: Self::Abi
                 ) -> #wasm_bindgen::__rt::std::boxed::Box<[#enum_name]> {
                     #wasm_bindgen::convert::js_value_vector_from_abi(js)
+                }
+            }
+
+            impl #wasm_bindgen::__rt::VectorIntoJsValue for #enum_name {
+                fn vector_into_jsvalue(vector: #wasm_bindgen::__rt::std::boxed::Box<[#enum_name]>) -> #wasm_bindgen::JsValue {
+                    #wasm_bindgen::__rt::js_value_vector_into_jsvalue(vector)
                 }
             }
         })

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -79,6 +79,10 @@ fn slice(contents: Descriptor) -> Descriptor {
     Descriptor::Ref(Box::new(Descriptor::Slice(Box::new(contents))))
 }
 
+fn vector(contents: Descriptor) -> Descriptor {
+    Descriptor::Vector(Box::new(contents))
+}
+
 intrinsics! {
     pub enum Intrinsic {
         #[symbol = "__wbindgen_jsval_eq"]
@@ -265,37 +269,37 @@ intrinsics! {
         #[signature = fn(slice(U8), ref_externref()) -> Unit]
         CopyToTypedArray,
         #[symbol = "__wbindgen_uint8_array_new"]
-        #[signature = fn(slice(U8)) -> Externref]
+        #[signature = fn(vector(U8)) -> Externref]
         Uint8ArrayNew,
         #[symbol = "__wbindgen_uint8_clamped_array_new"]
-        #[signature = fn(slice(ClampedU8)) -> Externref]
+        #[signature = fn(vector(ClampedU8)) -> Externref]
         Uint8ClampedArrayNew,
         #[symbol = "__wbindgen_uint16_array_new"]
-        #[signature = fn(slice(U16)) -> Externref]
+        #[signature = fn(vector(U16)) -> Externref]
         Uint16ArrayNew,
         #[symbol = "__wbindgen_uint32_array_new"]
-        #[signature = fn(slice(U32)) -> Externref]
+        #[signature = fn(vector(U32)) -> Externref]
         Uint32ArrayNew,
         #[symbol = "__wbindgen_biguint64_array_new"]
-        #[signature = fn(slice(U64)) -> Externref]
+        #[signature = fn(vector(U64)) -> Externref]
         BigUint64ArrayNew,
         #[symbol = "__wbindgen_int8_array_new"]
-        #[signature = fn(slice(I8)) -> Externref]
+        #[signature = fn(vector(I8)) -> Externref]
         Int8ArrayNew,
         #[symbol = "__wbindgen_int16_array_new"]
-        #[signature = fn(slice(I16)) -> Externref]
+        #[signature = fn(vector(I16)) -> Externref]
         Int16ArrayNew,
         #[symbol = "__wbindgen_int32_array_new"]
-        #[signature = fn(slice(I32)) -> Externref]
+        #[signature = fn(vector(I32)) -> Externref]
         Int32ArrayNew,
         #[symbol = "__wbindgen_bigint64_array_new"]
-        #[signature = fn(slice(I64)) -> Externref]
+        #[signature = fn(vector(I64)) -> Externref]
         BigInt64ArrayNew,
         #[symbol = "__wbindgen_float32_array_new"]
-        #[signature = fn(slice(F32)) -> Externref]
+        #[signature = fn(vector(F32)) -> Externref]
         Float32ArrayNew,
         #[symbol = "__wbindgen_float64_array_new"]
-        #[signature = fn(slice(F64)) -> Externref]
+        #[signature = fn(vector(F64)) -> Externref]
         Float64ArrayNew,
         #[symbol = "__wbindgen_array_new"]
         #[signature = fn() -> Externref]

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -264,6 +264,45 @@ intrinsics! {
         #[symbol = "__wbindgen_copy_to_typed_array"]
         #[signature = fn(slice(U8), ref_externref()) -> Unit]
         CopyToTypedArray,
+        #[symbol = "__wbindgen_uint8_array_new"]
+        #[signature = fn(slice(U8)) -> Externref]
+        Uint8ArrayNew,
+        #[symbol = "__wbindgen_uint8_clamped_array_new"]
+        #[signature = fn(slice(ClampedU8)) -> Externref]
+        Uint8ClampedArrayNew,
+        #[symbol = "__wbindgen_uint16_array_new"]
+        #[signature = fn(slice(U16)) -> Externref]
+        Uint16ArrayNew,
+        #[symbol = "__wbindgen_uint32_array_new"]
+        #[signature = fn(slice(U32)) -> Externref]
+        Uint32ArrayNew,
+        #[symbol = "__wbindgen_biguint64_array_new"]
+        #[signature = fn(slice(U64)) -> Externref]
+        BigUint64ArrayNew,
+        #[symbol = "__wbindgen_int8_array_new"]
+        #[signature = fn(slice(I8)) -> Externref]
+        Int8ArrayNew,
+        #[symbol = "__wbindgen_int16_array_new"]
+        #[signature = fn(slice(I16)) -> Externref]
+        Int16ArrayNew,
+        #[symbol = "__wbindgen_int32_array_new"]
+        #[signature = fn(slice(I32)) -> Externref]
+        Int32ArrayNew,
+        #[symbol = "__wbindgen_bigint64_array_new"]
+        #[signature = fn(slice(I64)) -> Externref]
+        BigInt64ArrayNew,
+        #[symbol = "__wbindgen_float32_array_new"]
+        #[signature = fn(slice(F32)) -> Externref]
+        Float32ArrayNew,
+        #[symbol = "__wbindgen_float64_array_new"]
+        #[signature = fn(slice(F64)) -> Externref]
+        Float64ArrayNew,
+        #[symbol = "__wbindgen_array_new"]
+        #[signature = fn() -> Externref]
+        ArrayNew,
+        #[symbol = "__wbindgen_array_push"]
+        #[signature = fn(ref_externref(), Externref) -> Unit]
+        ArrayPush,
         #[symbol = "__wbindgen_externref_heap_live_count"]
         #[signature = fn() -> I32]
         ExternrefHeapLiveCount,

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3577,6 +3577,31 @@ impl<'a> Context<'a> {
                 )
             }
 
+            Intrinsic::Uint8ArrayNew
+            | Intrinsic::Uint8ClampedArrayNew
+            | Intrinsic::Uint16ArrayNew
+            | Intrinsic::Uint32ArrayNew
+            | Intrinsic::BigUint64ArrayNew
+            | Intrinsic::Int8ArrayNew
+            | Intrinsic::Int16ArrayNew
+            | Intrinsic::Int32ArrayNew
+            | Intrinsic::BigInt64ArrayNew
+            | Intrinsic::Float32ArrayNew
+            | Intrinsic::Float64ArrayNew => {
+                assert_eq!(args.len(), 1);
+                args[0].clone()
+            }
+
+            Intrinsic::ArrayNew => {
+                assert_eq!(args.len(), 0);
+                "[]".to_string()
+            }
+
+            Intrinsic::ArrayPush => {
+                assert_eq!(args.len(), 2);
+                format!("{}.push({})", args[0], args[1])
+            }
+
             Intrinsic::ExternrefHeapLiveCount => {
                 assert_eq!(args.len(), 0);
                 self.expose_global_heap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1989,51 +1989,53 @@ macro_rules! typed_arrays {
     };
 }
 
-typed_arrays! {
-    u8 __wbindgen_uint8_array_new __wbindgen_uint8_clamped_array_new,
-    u16 __wbindgen_uint16_array_new __wbindgen_uint16_array_new,
-    u32 __wbindgen_uint32_array_new __wbindgen_uint32_array_new,
-    u64 __wbindgen_biguint64_array_new __wbindgen_biguint64_array_new,
-    i8 __wbindgen_int8_array_new __wbindgen_int8_array_new,
-    i16 __wbindgen_int16_array_new __wbindgen_int16_array_new,
-    i32 __wbindgen_int32_array_new __wbindgen_int32_array_new,
-    i64 __wbindgen_bigint64_array_new __wbindgen_bigint64_array_new,
-    f32 __wbindgen_float32_array_new __wbindgen_float32_array_new,
-    f64 __wbindgen_float64_array_new __wbindgen_float64_array_new,
-}
-
-impl __rt::VectorIntoJsValue for JsValue {
-    fn vector_into_jsvalue(vector: Box<[JsValue]>) -> JsValue {
-        __rt::js_value_vector_into_jsvalue::<JsValue>(vector)
+if_std! {
+    typed_arrays! {
+        u8 __wbindgen_uint8_array_new __wbindgen_uint8_clamped_array_new,
+        u16 __wbindgen_uint16_array_new __wbindgen_uint16_array_new,
+        u32 __wbindgen_uint32_array_new __wbindgen_uint32_array_new,
+        u64 __wbindgen_biguint64_array_new __wbindgen_biguint64_array_new,
+        i8 __wbindgen_int8_array_new __wbindgen_int8_array_new,
+        i16 __wbindgen_int16_array_new __wbindgen_int16_array_new,
+        i32 __wbindgen_int32_array_new __wbindgen_int32_array_new,
+        i64 __wbindgen_bigint64_array_new __wbindgen_bigint64_array_new,
+        f32 __wbindgen_float32_array_new __wbindgen_float32_array_new,
+        f64 __wbindgen_float64_array_new __wbindgen_float64_array_new,
     }
-}
 
-impl<T: JsObject> __rt::VectorIntoJsValue for T {
-    fn vector_into_jsvalue(vector: Box<[T]>) -> JsValue {
-        __rt::js_value_vector_into_jsvalue::<T>(vector)
+    impl __rt::VectorIntoJsValue for JsValue {
+        fn vector_into_jsvalue(vector: Box<[JsValue]>) -> JsValue {
+            __rt::js_value_vector_into_jsvalue::<JsValue>(vector)
+        }
     }
-}
 
-impl __rt::VectorIntoJsValue for String {
-    fn vector_into_jsvalue(vector: Box<[String]>) -> JsValue {
-        __rt::js_value_vector_into_jsvalue::<String>(vector)
+    impl<T: JsObject> __rt::VectorIntoJsValue for T {
+        fn vector_into_jsvalue(vector: Box<[T]>) -> JsValue {
+            __rt::js_value_vector_into_jsvalue::<T>(vector)
+        }
     }
-}
 
-impl<T> From<Vec<T>> for JsValue
-where
-    JsValue: From<Box<[T]>>,
-{
-    fn from(vector: Vec<T>) -> Self {
-        JsValue::from(vector.into_boxed_slice())
+    impl __rt::VectorIntoJsValue for String {
+        fn vector_into_jsvalue(vector: Box<[String]>) -> JsValue {
+            __rt::js_value_vector_into_jsvalue::<String>(vector)
+        }
     }
-}
 
-impl<T> From<Clamped<Vec<T>>> for JsValue
-where
-    JsValue: From<Clamped<Box<[T]>>>,
-{
-    fn from(vector: Clamped<Vec<T>>) -> Self {
-        JsValue::from(Clamped(vector.0.into_boxed_slice()))
+    impl<T> From<Vec<T>> for JsValue
+    where
+        JsValue: From<Box<[T]>>,
+    {
+        fn from(vector: Vec<T>) -> Self {
+            JsValue::from(vector.into_boxed_slice())
+        }
+    }
+
+    impl<T> From<Clamped<Vec<T>>> for JsValue
+    where
+        JsValue: From<Clamped<Box<[T]>>>,
+    {
+        fn from(vector: Clamped<Vec<T>>) -> Self {
+            JsValue::from(Clamped(vector.0.into_boxed_slice()))
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1970,18 +1970,18 @@ impl From<JsError> for JsValue {
 macro_rules! typed_arrays {
     ($($ty:ident $ctor:ident $clamped_ctor:ident,)*) => {
         $(
-            impl From<Vec<$ty>> for JsValue {
-                fn from(mut vec: Vec<$ty>) -> Self {
-                    let result = unsafe { JsValue::_new($ctor(vec.as_mut_ptr(), vec.len())) };
-                    mem::forget(vec);
+            impl From<Box<[$ty]>> for JsValue {
+                fn from(mut vector: Box<[$ty]>) -> Self {
+                    let result = unsafe { JsValue::_new($ctor(vector.as_mut_ptr(), vector.len())) };
+                    mem::forget(vector);
                     result
                 }
             }
 
-            impl From<Clamped<Vec<$ty>>> for JsValue {
-                fn from(mut vec: Clamped<Vec<$ty>>) -> Self {
-                    let result = unsafe { JsValue::_new($clamped_ctor(vec.as_mut_ptr(), vec.len())) };
-                    mem::forget(vec);
+            impl From<Clamped<Box<[$ty]>>> for JsValue {
+                fn from(mut vector: Clamped<Box<[$ty]>>) -> Self {
+                    let result = unsafe { JsValue::_new($clamped_ctor(vector.as_mut_ptr(), vector.len())) };
+                    mem::forget(vector);
                     result
                 }
             }
@@ -2026,5 +2026,14 @@ where
 {
     fn from(vector: Vec<T>) -> Self {
         JsValue::from(vector.into_boxed_slice())
+    }
+}
+
+impl<T> From<Clamped<Vec<T>>> for JsValue
+where
+    JsValue: From<Clamped<Box<[T]>>>,
+{
+    fn from(vector: Clamped<Vec<T>>) -> Self {
+        JsValue::from(Clamped(vector.0.into_boxed_slice()))
     }
 }

--- a/tests/wasm/async_vecs.js
+++ b/tests/wasm/async_vecs.js
@@ -2,10 +2,16 @@ const wasm = require('wasm-bindgen-test.js');
 const assert = require('assert');
 
 exports.js_works = async () => {
-    assert.deepStrictEqual(await wasm.async_number_vec(), new Int32Array([1, -3, 7, 12]));
     assert.deepStrictEqual(await wasm.async_jsvalue_vec(), [1, "hi", new Float64Array(), null]);
     assert.deepStrictEqual(await wasm.async_import_vec(), [/hi|bye/, /hello w[a-z]rld/]);
     assert.deepStrictEqual(await wasm.async_string_vec(), ["a", "b", "c"]);
     assert.strictEqual((await wasm.async_struct_vec()).length, 2);
     assert.deepStrictEqual(await wasm.async_enum_vec(), [wasm.AnotherEnum.C, wasm.AnotherEnum.A, wasm.AnotherEnum.B]);
+
+    const numberVec = await wasm.async_number_vec();
+    assert.deepStrictEqual(numberVec, new Int32Array([1, -3, 7, 12]));
+    // Make sure `numberVec` is a fresh `Int32Array`, not a view into Wasm memory,
+    // so that it can be GC'd without the whole Wasm module having to be GC'd as
+    // well.
+    assert.strictEqual(numberVec.byteLength, numberVec.buffer.byteLength);
 };

--- a/tests/wasm/async_vecs.js
+++ b/tests/wasm/async_vecs.js
@@ -1,0 +1,11 @@
+const wasm = require('wasm-bindgen-test.js');
+const assert = require('assert');
+
+exports.js_works = async () => {
+    assert.deepStrictEqual(await wasm.async_number_vec(), new Int32Array([1, -3, 7, 12]));
+    assert.deepStrictEqual(await wasm.async_jsvalue_vec(), [1, "hi", new Float64Array(), null]);
+    assert.deepStrictEqual(await wasm.async_import_vec(), [/hi|bye/, /hello w[a-z]rld/]);
+    assert.deepStrictEqual(await wasm.async_string_vec(), ["a", "b", "c"]);
+    assert.strictEqual((await wasm.async_struct_vec()).length, 2);
+    assert.deepStrictEqual(await wasm.async_enum_vec(), [wasm.AnotherEnum.C, wasm.AnotherEnum.A, wasm.AnotherEnum.B]);
+};

--- a/tests/wasm/async_vecs.rs
+++ b/tests/wasm/async_vecs.rs
@@ -1,0 +1,66 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen(module = "tests/wasm/async_vecs.js")]
+extern "C" {
+    async fn js_works();
+}
+
+#[wasm_bindgen]
+extern "C" {
+    pub type RegExp;
+    #[wasm_bindgen(constructor)]
+    fn new(re: &str) -> RegExp;
+}
+
+#[wasm_bindgen]
+pub async fn async_number_vec() -> Vec<i32> {
+    vec![1, -3, 7, 12]
+}
+
+#[wasm_bindgen]
+pub async fn async_jsvalue_vec() -> Vec<JsValue> {
+    vec![
+        1u32.into(),
+        "hi".into(),
+        Vec::<f64>::new().into(),
+        JsValue::NULL,
+    ]
+}
+
+#[wasm_bindgen]
+pub async fn async_import_vec() -> Vec<RegExp> {
+    vec![RegExp::new("hi|bye"), RegExp::new("hello w[a-z]rld")]
+}
+
+#[wasm_bindgen]
+pub async fn async_string_vec() -> Vec<String> {
+    vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub struct AnotherStruct;
+
+#[wasm_bindgen]
+pub async fn async_struct_vec() -> Vec<AnotherStruct> {
+    vec![AnotherStruct; 2]
+}
+
+#[wasm_bindgen]
+#[derive(Clone)]
+pub enum AnotherEnum {
+    A,
+    B,
+    C,
+}
+
+#[wasm_bindgen]
+pub async fn async_enum_vec() -> Vec<AnotherEnum> {
+    vec![AnotherEnum::C, AnotherEnum::A, AnotherEnum::B]
+}
+
+#[wasm_bindgen_test]
+async fn works() {
+    js_works().await;
+}

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -16,6 +16,7 @@ use wasm_bindgen::prelude::*;
 
 pub mod api;
 pub mod arg_names;
+pub mod async_vecs;
 pub mod bigint;
 pub mod char;
 pub mod classes;


### PR DESCRIPTION
This means that `Vec`s can now be returned from `async` functions.

Fixes #3155.

I had to add a new `VectorIntoJsValue` trait, since similarly to `VectorIntoWasmAbi` the orphan rule won't let us directly implement `From<Vec<T>>` for `JsValue` outside of `wasm-bindgen`.

I did some quick benchmarking, and it seems like the copy-into-a-new-`Vec` approach used to return `Vec`s from synchronous functions is faster:

```
cpu: Apple M1 Pro
runtime: deno 1.36.4 (aarch64-apple-darwin)

file:///Users/liam/src/wasm-bindgen-playground/bench.ts
benchmark             time (avg)        iter/s             (min … max)       p75       p99      p995
---------------------------------------------------------------------- -----------------------------
direct_enum_vec   121.87 µs/iter       8,205.6   (115.33 µs … 1.28 ms) 120.25 µs 189.42 µs 196.38 µs
jsvalue_enum_vec  359.78 µs/iter       2,779.5 (285.38 µs … 480.12 µs) 358.71 µs 444.92 µs 454.62 µs
```

So it might be a good idea to later change this to use a similar implementation. However I haven't checked if these results are the same in other JS runtimes so take that with a grain of salt.