### PR TITLE
Add `sendEncodings` in `RTCRtpTransceiverInit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Added
 
+* Add bindings for `RTCRtpTransceiverInit.sendEncodings`.
+  [#3642](https://github.com/rustwasm/wasm-bindgen/pull/3642)
+
 * Add bindings for the Web Locks API to `web-sys`.
   [#3604](https://github.com/rustwasm/wasm-bindgen/pull/3604)
 

--- a/crates/web-sys/src/features/gen_RtcRtpTransceiverInit.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpTransceiverInit.rs
@@ -38,6 +38,23 @@ impl RtcRtpTransceiverInit {
         let _ = r;
         self
     }
+    #[doc = "Change the `sendEncodings` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `RtcRtpTransceiverInit`*"]
+    pub fn send_encodings(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(
+            self.as_ref(),
+            &JsValue::from("sendEncodings"),
+            &JsValue::from(val),
+        );
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
     #[doc = "Change the `streams` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `RtcRtpTransceiverInit`*"]

--- a/crates/web-sys/webidls/enabled/RTCRtpTransceiver.webidl
+++ b/crates/web-sys/webidls/enabled/RTCRtpTransceiver.webidl
@@ -17,8 +17,7 @@ enum RTCRtpTransceiverDirection {
 dictionary RTCRtpTransceiverInit {
     RTCRtpTransceiverDirection         direction = "sendrecv";
     sequence<MediaStream>              streams = [];
-    // TODO: bug 1396918
-    // sequence<RTCRtpEncodingParameters> sendEncodings;
+    sequence<RTCRtpEncodingParameters> sendEncodings = [];
 };
 
 [Pref="media.peerconnection.enabled",


### PR DESCRIPTION
This PR adds [spec compliant](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverinit-sendencodings) `sendEncodings` field in `RTCRtpTransceiverInit`.