### PR TITLE
Handle `#[ignore = "reason"]` on tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 * Implement `TryFrom<JsValue>` for exported Rust types and strings.
   [#3554](https://github.com/rustwasm/wasm-bindgen/pull/3554)
 
+* Handle the `#[ignore = "reason"]` attribute with the `wasm_bindgen_test`
+  proc-macro and accept the `--include-ignored` flag with `wasm-bindgen-test-runner`.
+  [#3644](https://github.com/rustwasm/wasm-bindgen/pull/3644)
+
 ### Changed
 
 * Updated the WebGPU WebIDL.

--- a/crates/futures/tests/tests.rs
+++ b/crates/futures/tests/tests.rs
@@ -173,3 +173,15 @@ async fn should_panic_string() {
 async fn should_panic_expected() {
     panic!("error message")
 }
+
+#[wasm_bindgen_test]
+#[ignore]
+async fn ignore() {
+    panic!("this test should have been ignored")
+}
+
+#[wasm_bindgen_test]
+#[ignore = "reason"]
+async fn ignore_reason() {
+    panic!("this test should have been ignored")
+}

--- a/crates/test-macro/ui-tests/ignore.rs
+++ b/crates/test-macro/ui-tests/ignore.rs
@@ -1,0 +1,52 @@
+#![no_implicit_prelude]
+
+extern crate wasm_bindgen_test_macro;
+
+use wasm_bindgen_test_macro::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+#[ignore]
+fn success_1() {}
+
+#[wasm_bindgen_test]
+#[ignore = "test"]
+fn success_2() {}
+
+#[wasm_bindgen_test]
+#[ignore]
+async fn async_success_1() {}
+
+#[wasm_bindgen_test]
+#[ignore = "test"]
+async fn async_success_2() {}
+
+#[wasm_bindgen_test]
+#[ignore::error]
+fn fail_1() {}
+
+#[wasm_bindgen_test]
+#[ignore = 42]
+fn fail_2() {}
+
+#[wasm_bindgen_test]
+#[ignore[]]
+fn fail_3() {}
+
+#[wasm_bindgen_test]
+#[ignore(42)]
+fn fail_4() {}
+
+#[wasm_bindgen_test]
+#[ignore(test)]
+fn fail_5() {}
+
+#[wasm_bindgen_test]
+#[ignore("test")]
+fn fail_6() {}
+
+#[wasm_bindgen_test]
+#[ignore = "test"]
+#[ignore = "test"]
+fn fail_7() {}
+
+fn main() {}

--- a/crates/test-macro/ui-tests/ignore.stderr
+++ b/crates/test-macro/ui-tests/ignore.stderr
@@ -1,0 +1,41 @@
+error: malformed `#[ignore = "..."]` attribute
+  --> ui-tests/ignore.rs:24:9
+   |
+24 | #[ignore::error]
+   |         ^
+
+error: malformed `#[ignore]` attribute
+  --> ui-tests/ignore.rs:28:12
+   |
+28 | #[ignore = 42]
+   |            ^^
+
+error: malformed `#[ignore = "..."]` attribute
+  --> ui-tests/ignore.rs:32:9
+   |
+32 | #[ignore[]]
+   |         ^^
+
+error: malformed `#[ignore = "..."]` attribute
+  --> ui-tests/ignore.rs:36:9
+   |
+36 | #[ignore(42)]
+   |         ^^^^
+
+error: malformed `#[ignore = "..."]` attribute
+  --> ui-tests/ignore.rs:40:9
+   |
+40 | #[ignore(test)]
+   |         ^^^^^^
+
+error: malformed `#[ignore = "..."]` attribute
+  --> ui-tests/ignore.rs:44:9
+   |
+44 | #[ignore("test")]
+   |         ^^^^^^^^
+
+error: duplicate `ignore` attribute
+  --> ui-tests/ignore.rs:49:3
+   |
+49 | #[ignore = "test"]
+   |   ^^^^^^

--- a/crates/test/sample/tests/common/mod.rs
+++ b/crates/test/sample/tests/common/mod.rs
@@ -69,3 +69,15 @@ fn should_panic_string() {
 fn should_panic_expected() {
     panic!("error message")
 }
+
+#[wasm_bindgen_test]
+#[ignore]
+async fn ignore() {
+    console_log!("IGNORED");
+}
+
+#[wasm_bindgen_test]
+#[should_panic = "reason"]
+async fn ignore_reason() {
+    panic!("IGNORED WITH A REASON")
+}

--- a/crates/test/src/rt/browser.rs
+++ b/crates/test/src/rt/browser.rs
@@ -6,6 +6,8 @@
 use js_sys::Error;
 use wasm_bindgen::prelude::*;
 
+use super::TestResult;
+
 /// Implementation of `Formatter` for browsers.
 ///
 /// Routes all output to a `pre` on the page currently. Eventually this probably
@@ -49,9 +51,8 @@ impl super::Formatter for Browser {
         self.pre.set_text_content(&html);
     }
 
-    fn log_test(&self, name: &str, result: &Result<(), JsValue>) {
-        let s = if result.is_ok() { "ok" } else { "FAIL" };
-        self.writeln(&format!("test {} ... {}", name, s));
+    fn log_test(&self, name: &str, result: &TestResult) {
+        self.writeln(&format!("test {} ... {}", name, result));
     }
 
     fn stringify_error(&self, err: &JsValue) -> String {

--- a/crates/test/src/rt/node.rs
+++ b/crates/test/src/rt/node.rs
@@ -5,6 +5,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use super::TestResult;
+
 /// Implementation of the `Formatter` trait for node.js
 pub struct Node {}
 
@@ -29,9 +31,8 @@ impl super::Formatter for Node {
         super::js_console_log(line);
     }
 
-    fn log_test(&self, name: &str, result: &Result<(), JsValue>) {
-        let s = if result.is_ok() { "ok" } else { "FAIL" };
-        self.writeln(&format!("test {} ... {}", name, s));
+    fn log_test(&self, name: &str, result: &TestResult) {
+        self.writeln(&format!("test {} ... {}", name, result));
     }
 
     fn stringify_error(&self, err: &JsValue) -> String {

--- a/crates/test/src/rt/worker.rs
+++ b/crates/test/src/rt/worker.rs
@@ -6,6 +6,8 @@
 use js_sys::Error;
 use wasm_bindgen::prelude::*;
 
+use super::TestResult;
+
 /// Implementation of `Formatter` for browsers.
 ///
 /// Routes all output to a `pre` on the page currently. Eventually this probably
@@ -34,9 +36,8 @@ impl super::Formatter for Worker {
         write_output_line(JsValue::from(String::from(line)));
     }
 
-    fn log_test(&self, name: &str, result: &Result<(), JsValue>) {
-        let s = if result.is_ok() { "ok" } else { "FAIL" };
-        self.writeln(&format!("test {} ... {}", name, s));
+    fn log_test(&self, name: &str, result: &TestResult) {
+        self.writeln(&format!("test {} ... {}", name, result));
     }
 
     fn stringify_error(&self, err: &JsValue) -> String {

--- a/tests/wasm/ignore.rs
+++ b/tests/wasm/ignore.rs
@@ -1,0 +1,11 @@
+#[wasm_bindgen_test]
+#[ignore]
+fn should_panic() {
+    panic!()
+}
+
+#[wasm_bindgen_test]
+#[ignore = "reason"]
+fn should_panic_string() {
+    panic!()
+}


### PR DESCRIPTION
This adds support for `#[ignore = "reason"]` with the `wasm_bindgen_test` proc-macro and the `--include-ignored` flag with `wasm-bindgen-test-runner`.