### PR TITLE
rename main -> start on `wasm-bindgen(start)` example

### DIFF
--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -6,7 +6,7 @@ soon as the wasm module is instantiated.
 
 ```rust
 #[wasm_bindgen(start)]
-fn main() {
+fn start() {
     // executed automatically ...
 }
 ```

--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -12,9 +12,9 @@ fn start() {
 ```
 
 The `start` section of the wasm executable will be configured to execute the
-`main` function here as soon as it can. Note that due to various practical
+`start` function here as soon as it can. Note that due to various practical
 limitations today the start section of the executable may not literally point to
-`main`, but the `main` function here should be started up automatically when the
+`start`, but the `start` function here should be started up automatically when the
 wasm module is loaded.
 
 There's a few caveats to be aware of when using the `start` attribute:

--- a/guide/src/reference/attributes/on-rust-exports/start.md
+++ b/guide/src/reference/attributes/on-rust-exports/start.md
@@ -1,6 +1,6 @@
 # `start`
 
-When attached to a `pub` function this attribute will configure the `start`
+When attached to a function this attribute will configure the `start`
 section of the wasm executable to be emitted, executing the tagged function as
 soon as the wasm module is instantiated.
 


### PR DESCRIPTION
I got error with this example.

```
error: entry symbol `main` declared multiple times
  |
  = help: did you use `#[no_mangle]` on `fn main`? Use `#[start]` instead
```

In this document, "main" is specified as the function name. However, compilation will fail due to the previously mentioned error if "main" is used. This is presumably because "main" is a function name reserved in Rust as the starting function for binaries.

rename to `start` then succeeded.
