### PR TITLE
fix ABI for raw pointers

### DIFF
--- a/crates/cli/tests/reference/pointers.d.ts
+++ b/crates/cli/tests/reference/pointers.d.ts
@@ -1,0 +1,12 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+* @param {number} input
+* @returns {number}
+*/
+export function const_pointer(input: number): number;
+/**
+* @param {number} input
+* @returns {number}
+*/
+export function mut_pointer(input: number): number;

--- a/crates/cli/tests/reference/pointers.js
+++ b/crates/cli/tests/reference/pointers.js
@@ -1,0 +1,23 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+/**
+* @param {number} input
+* @returns {number}
+*/
+export function const_pointer(input) {
+    const ret = wasm.const_pointer(input);
+    return ret >>> 0;
+}
+
+/**
+* @param {number} input
+* @returns {number}
+*/
+export function mut_pointer(input) {
+    const ret = wasm.mut_pointer(input);
+    return ret >>> 0;
+}
+

--- a/crates/cli/tests/reference/pointers.rs
+++ b/crates/cli/tests/reference/pointers.rs
@@ -1,0 +1,11 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn const_pointer(input: *const u8) -> *const u8 {
+    u32::MAX as *const _
+}
+
+#[wasm_bindgen]
+pub fn mut_pointer(input: *mut u8) -> *mut u8 {
+    u32::MAX as *mut _
+}

--- a/crates/cli/tests/reference/pointers.wat
+++ b/crates/cli/tests/reference/pointers.wat
@@ -1,0 +1,9 @@
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (func $const_pointer (;0;) (type 0) (param i32) (result i32))
+  (func $mut_pointer (;1;) (type 0) (param i32) (result i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "const_pointer" (func $const_pointer))
+  (export "mut_pointer" (func $mut_pointer))
+)

--- a/src/describe.rs
+++ b/src/describe.rs
@@ -104,13 +104,13 @@ cfg_if! {
 
 impl<T> WasmDescribe for *const T {
     fn describe() {
-        inform(I32)
+        inform(U32)
     }
 }
 
 impl<T> WasmDescribe for *mut T {
     fn describe() {
-        inform(I32)
+        inform(U32)
     }
 }
 


### PR DESCRIPTION
:wave: Hello from Stackblitz

We've noticed very buggy behavior when our Rust code requires a sizable amount of memory (above 2 GiB!). I've traced it back to `__wbindgen_malloc` returning negative pointers (!!), which screams "`i32` overflow" :grimacing: 

From what I can gather, changing the `WasmDescribe` impl. for raw pointers (so they follow `u32` ABI conventions instead of `i32`'s) should fix it. I've added a `references` test to `wasm-bindgen-cli`, not sure how appropriate/useful is.
