### PR TITLE
try_reserve_exact has been stabilized nearly two years ago

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = """
 Easy support for interacting between JS and Rust.
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 features = ["serde-serialize"]


### PR DESCRIPTION
use Vec's try_reserve_exact method (stabilized in rust 1.57) instead of an ad-hoc reimplementation thereof