### PR TITLE
Bump MSRV to v1.57

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-bindgen-benchmark"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 wasm-bindgen = "0.2.43"

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Backend code generation of the wasm-bindgen tool
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [features]
 spans = []

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Shared support for the wasm-bindgen-cli package, an internal dependency
 """
 edition = '2018'
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ information see https://github.com/rustwasm/wasm-bindgen.
 """
 edition = '2018'
 default-run = 'wasm-bindgen'
-rust-version = "1.56"
+rust-version = "1.57"
 
 [package.metadata.binstall]
 pkg-url = "https://github.com/rustwasm/wasm-bindgen/releases/download/{ version }/wasm-bindgen-{ version }-{ target }{ archive-suffix }"

--- a/crates/example-tests/Cargo.toml
+++ b/crates/example-tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "example-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0.75"

--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Internal externref transformations for wasm-bindgen
 """
 edition = '2018'
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/future
 readme = "./README.md"
 version = "0.4.37"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 cfg-if = "1.0.0"

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -13,7 +13,7 @@ Node.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.
 """
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 test = false

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate
 """
 edition = '2018'
-rust-version = "1.56"
+rust-version = "1.57"
 
 [features]
 spans = ["wasm-bindgen-backend/spans"]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Definition of the `#[wasm_bindgen]` attribute, an internal dependency
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 proc-macro = true

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Internal multi-value transformations for wasm-bindgen
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -11,7 +11,7 @@ Shared support between wasm-bindgen and wasm-bindgen cli, an internal
 dependency.
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 # Because only a single `wasm_bindgen` version can be used in a dependency
 # graph, pretend we link a native library so that `cargo` will provide better

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -6,7 +6,7 @@ description = "Internal testing macro for wasm-bindgen"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 proc-macro = true

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -6,7 +6,7 @@ description = "Internal testing crate for wasm-bindgen"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 console_error_panic_hook = '0.1'

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Support for threading-related transformations in wasm-bindgen
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/typescript-tests/Cargo.toml
+++ b/crates/typescript-tests/Cargo.toml
@@ -3,7 +3,7 @@ name = "typescript-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 wasm-bindgen = { path = '../..' }

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://rustwasm.github.io/wasm-bindgen/"
 documentation = "https://docs.rs/wasm-bindgen-wasm-conventions"
 description = "Utilities for working with Wasm codegen conventions (usually established by LLVM/lld)"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 walrus = "0.19.0"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Micro-interpreter optimized for wasm-bindgen's use case
 """
 edition = '2018'
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -11,7 +11,7 @@ Bindings for all Web APIs, a procedurally generated crate from WebIDL
 """
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/webidl-tests/Cargo.toml
+++ b/crates/webidl-tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
 publish = false
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 test = false

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 Support for parsing WebIDL specific to wasm-bindgen
 """
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [dependencies]
 env_logger = "0.8.1"

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -3,7 +3,7 @@ name = "add"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -3,7 +3,7 @@ name = "canvas"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -3,7 +3,7 @@ name = "char"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -3,7 +3,7 @@ name = "closures"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -3,7 +3,7 @@ name = "console_log"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/deno/Cargo.toml
+++ b/examples/deno/Cargo.toml
@@ -3,7 +3,7 @@ name = "deno"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -3,7 +3,7 @@ name = "dom"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-duck-typed-interfaces"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -3,7 +3,7 @@ name = "fetch"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -3,7 +3,7 @@ name = "guide-supported-types-examples"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -3,7 +3,7 @@ name = "hello_world"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -3,7 +3,7 @@ name = "julia_set"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-bindgen-paint"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -3,7 +3,7 @@ name = "performance"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -3,7 +3,7 @@ name = "raytrace-parallel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/request-animation-frame/Cargo.toml
+++ b/examples/request-animation-frame/Cargo.toml
@@ -3,7 +3,7 @@ name = "request-animation-frame"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/synchronous-instantiation/Cargo.toml
+++ b/examples/synchronous-instantiation/Cargo.toml
@@ -3,7 +3,7 @@ name = "synchronous-instantiation"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -3,7 +3,7 @@ name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-audio-worklet/Cargo.toml
+++ b/examples/wasm-audio-worklet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-audio-worklet"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm-imports/Cargo.toml
+++ b/examples/wasm-in-wasm-imports/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-in-wasm-imports"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-in-wasm"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-web-worker/Cargo.toml
+++ b/examples/wasm-in-web-worker/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-in-web-worker"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm2js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/weather_report/Cargo.toml
+++ b/examples/weather_report/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Ayush <ayushmishra2005@gmail.com>"]
 categories = ["wasm"]
 readme = "README.md"
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -3,7 +3,7 @@ name = "webaudio"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -3,7 +3,7 @@ name = "webgl"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -3,7 +3,7 @@ name = "webrtc_datachannel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -3,7 +3,7 @@ name = "websockets"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webxr/Cargo.toml
+++ b/examples/webxr/Cargo.toml
@@ -3,7 +3,7 @@ name = "webxr"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler-no-modules/Cargo.toml
+++ b/examples/without-a-bundler-no-modules/Cargo.toml
@@ -3,7 +3,7 @@ name = "without-a-bundler-no-modules"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler/Cargo.toml
+++ b/examples/without-a-bundler/Cargo.toml
@@ -3,7 +3,7 @@ name = "without-a-bundler"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
https://github.com/rustwasm/wasm-bindgen/pull/3656 increased the `rust-version` of `wasm-bindgen` to v1.57, but all other crates were still at v1.56.

I didn't include any mention in the changelog because we don't actually have an MSRV policy in place. See #3114.