### PR TITLE
Update node from 16 to 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '17'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --target wasm32-unknown-unknown
     - run: cargo test --target wasm32-unknown-unknown --features serde-serialize
@@ -130,7 +130,7 @@ jobs:
   #   - run: rustup target add wasm32-unknown-unknown
   #   - uses: actions/setup-node@v3
   #     with:
-  #       node-version: '16'
+  #       node-version: '17'
   #   - uses: ./.github/actions/setup-geckodriver
   #   - run: cargo test --target wasm32-unknown-unknown
   #     env:
@@ -151,7 +151,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '17'
     - run: cargo test
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli
@@ -171,7 +171,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '17'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features Node
@@ -200,7 +200,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '17'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo test -p js-sys --target wasm32-unknown-unknown
     - run: cargo test -p js-sys --target wasm32-unknown-unknown
@@ -216,7 +216,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '17'
     - run: cargo test -p wasm-bindgen-webidl
     - run: cargo test -p webidl-tests --target wasm32-unknown-unknown
       env:
@@ -234,7 +234,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '17'
     - run: cd crates/typescript-tests && ./run.sh
 
   test_deno:


### PR DESCRIPTION
This seems to be the last version which "just works" by bumping the version number.

`18` fails with 
```
     Running `target/debug/wasm-bindgen-test-runner /home/runner/work/wasm-bindgen/wasm-bindgen/target/wasm32-unknown-unknown/debug/deps/wasm-3858e35c736746aa.wasm`
                                                  
Set timeout to 20 seconds...
Executing bindgen...                              
node: bad option: --experimental-wasm-reftypes
error: test failed, to rerun pass `--test wasm`

Caused by:
  process didn't exit successfully: `cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner -- /home/runner/work/wasm-bindgen/wasm-bindgen/target/wasm32-unknown-unknown/debug/deps/wasm-3858e35c736746aa.wasm` (exit status: 9)
note: test exited abnormally; to see the full output pass --nocapture to the harness.
                                                  
Error: Process completed with exit code 9.
```
https://github.com/thomasetter/wasm-bindgen/actions/runs/6611564031/job/17955697825?pr=4