### PR TITLE
Update the node version in the GitHub workflows from 16 to 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --target wasm32-unknown-unknown
     - run: cargo test --target wasm32-unknown-unknown --features serde-serialize
@@ -101,7 +101,6 @@ jobs:
     - run: cargo test --target wasm32-unknown-unknown
       env:
         WASM_BINDGEN_EXTERNREF: 1
-        NODE_ARGS: --experimental-wasm-reftypes
     - run: cargo test --target wasm32-unknown-unknown
       env:
         WASM_BINDGEN_MULTI_VALUE: 1
@@ -130,7 +129,7 @@ jobs:
   #   - run: rustup target add wasm32-unknown-unknown
   #   - uses: actions/setup-node@v3
   #     with:
-  #       node-version: '16'
+  #       node-version: '20'
   #   - uses: ./.github/actions/setup-geckodriver
   #   - run: cargo test --target wasm32-unknown-unknown
   #     env:
@@ -151,7 +150,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - run: cargo test
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli
@@ -171,7 +170,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features Node
@@ -200,7 +199,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo test -p js-sys --target wasm32-unknown-unknown
     - run: cargo test -p js-sys --target wasm32-unknown-unknown
@@ -216,7 +215,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - run: cargo test -p wasm-bindgen-webidl
     - run: cargo test -p webidl-tests --target wasm32-unknown-unknown
       env:
@@ -234,7 +233,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '20'
     - run: cd crates/typescript-tests && ./run.sh
 
   test_deno:


### PR DESCRIPTION
This required removing the --experimental-wasm-reftypes flag since it was removed from v8 in
https://github.com/v8/v8/commit/1771e4aaa3f285b3829539c1f80dbde01500fc21 which is included in Node `>= 18`