### PR TITLE
Conditionally enable bindings for `wasm32-wasi` with `--wasi` flag

### DIFF
--- a/crates/backend/build.rs
+++ b/crates/backend/build.rs
@@ -1,6 +1,4 @@
-// This `build.rs` makes `[package] links = ...` work in `Cargo.toml`.
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
     let enable_wasi_env_var = std::env::var("WASM_BINDGEN_ENABLE_WASI").unwrap_or_default();
     if enable_wasi_env_var == "1" {
         println!("cargo:rustc-cfg=enable_wasi");

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1380,7 +1380,7 @@ impl<'a> ToTokens for DescribeImport<'a> {
 }
 
 impl ToTokens for ast::Enum {
-    fn to_tokens(&self, into: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let enum_name = &self.rust_name;
         let name_str = self.js_name.to_string();
         let name_len = name_str.len() as u32;
@@ -1501,12 +1501,12 @@ impl ToTokens for ast::Enum {
                 }
             }
         })
-        .to_tokens(into);
+        .to_tokens(tokens);
     }
 }
 
 impl ToTokens for ast::ImportStatic {
-    fn to_tokens(&self, into: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = &self.rust_name;
         let ty = &self.ty;
         let shim_name = &self.shim;
@@ -1541,7 +1541,7 @@ impl ToTokens for ast::ImportStatic {
                 }
             };
         })
-        .to_tokens(into);
+        .to_tokens(tokens);
 
         Descriptor {
             ident: shim_name,
@@ -1551,7 +1551,7 @@ impl ToTokens for ast::ImportStatic {
             attrs: vec![],
             wasm_bindgen: &self.wasm_bindgen,
         }
-        .to_tokens(into);
+        .to_tokens(tokens);
     }
 }
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -223,12 +223,12 @@ impl ToTokens for ast::Struct {
                     let ptr = #wasm_bindgen::convert::IntoWasmAbi::into_abi(value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
                     extern "C" {
                         fn #new_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi)))))]
                     unsafe fn #new_fn(_: u32) -> u32 {
                         panic!("cannot convert to JsValue outside of the wasm target")
                     }
@@ -240,7 +240,7 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
             #[automatically_derived]
             const _: () = {
                 #[no_mangle]
@@ -305,12 +305,12 @@ impl ToTokens for ast::Struct {
                     let idx = #wasm_bindgen::convert::IntoWasmAbi::into_abi(&value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
                     extern "C" {
                         fn #unwrap_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi)))))]
                     unsafe fn #unwrap_fn(_: u32) -> u32 {
                         panic!("cannot convert from JsValue outside of the wasm target")
                     }
@@ -399,7 +399,7 @@ impl ToTokens for ast::StructField {
         (quote! {
             #[automatically_derived]
             const _: () = {
-                #[cfg_attr(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))), no_mangle)]
+                #[cfg_attr(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))), no_mangle)]
                 #[doc(hidden)]
                 pub unsafe extern "C" fn #getter(js: u32)
                     -> #wasm_bindgen::convert::WasmRet<<#ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi>
@@ -437,7 +437,7 @@ impl ToTokens for ast::StructField {
         let (args, names) = splat(wasm_bindgen, &Ident::new("val", rust_name.span()), &abi);
 
         (quote! {
-            #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
             #[automatically_derived]
             const _: () = {
                 #[no_mangle]
@@ -683,7 +683,7 @@ impl TryToTokens for ast::Export {
             const _: () = {
                 #(#attrs)*
                 #[cfg_attr(
-                    all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))),
+                    all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))),
                     export_name = #export_name,
                 )]
                 pub unsafe extern "C" fn #generated_name(#(#args),*) -> #wasm_bindgen::convert::WasmRet<#projection::Abi> {
@@ -933,11 +933,11 @@ impl ToTokens for ast::ImportType {
                 impl JsCast for #rust_name {
                     fn instanceof(val: &JsValue) -> bool {
                         #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                        #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
                         extern "C" {
                             fn #instanceof_shim(val: u32) -> u32;
                         }
-                        #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi)))))]
                         unsafe fn #instanceof_shim(_: u32) -> u32 {
                             panic!("cannot check instanceof on non-wasm targets");
                         }
@@ -1521,12 +1521,12 @@ impl ToTokens for ast::ImportStatic {
             #vis static #name: #wasm_bindgen::JsStatic<#ty> = {
                 fn init() -> #ty {
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
                     extern "C" {
                         fn #shim_name() -> #abi_ret;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi)))))]
                     unsafe fn #shim_name() -> #abi_ret {
                         panic!("cannot access imported statics on non-wasm targets")
                     }
@@ -1591,7 +1591,7 @@ impl<'a, T: ToTokens> ToTokens for Descriptor<'a, T> {
         let attrs = &self.attrs;
         let wasm_bindgen = &self.wasm_bindgen;
         (quote! {
-            #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
             #[automatically_derived]
             const _: () = {
                 #(#attrs)*
@@ -1617,14 +1617,14 @@ fn extern_fn(
     abi_ret: TokenStream,
 ) -> TokenStream {
     quote! {
-        #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
         #(#attrs)*
         #[link(wasm_import_module = "__wbindgen_placeholder__")]
         extern "C" {
             fn #import_name(#(#abi_arguments),*) -> #abi_ret;
         }
 
-        #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi)))))]
         unsafe fn #import_name(#(#abi_arguments),*) -> #abi_ret {
             #(
                 drop(#abi_argument_names);

--- a/crates/backend/src/error.rs
+++ b/crates/backend/src/error.rs
@@ -108,26 +108,26 @@ fn extract_spans(node: &dyn ToTokens) -> Option<(Span, Span)> {
 }
 
 impl ToTokens for Diagnostic {
-    fn to_tokens(&self, dst: &mut TokenStream) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         match &self.inner {
             Repr::Single { text, span } => {
                 let cs2 = (Span::call_site(), Span::call_site());
                 let (start, end) = span.unwrap_or(cs2);
-                dst.append(Ident::new("compile_error", start));
-                dst.append(Punct::new('!', Spacing::Alone));
+                tokens.append(Ident::new("compile_error", start));
+                tokens.append(Punct::new('!', Spacing::Alone));
                 let mut message = TokenStream::new();
                 message.append(Literal::string(text));
                 let mut group = Group::new(Delimiter::Brace, message);
                 group.set_span(end);
-                dst.append(group);
+                tokens.append(group);
             }
             Repr::Multi { diagnostics } => {
                 for diagnostic in diagnostics {
-                    diagnostic.to_tokens(dst);
+                    diagnostic.to_tokens(tokens);
                 }
             }
             Repr::SynError(err) => {
-                err.to_compile_error().to_tokens(dst);
+                err.to_compile_error().to_tokens(tokens);
             }
         }
     }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -45,6 +45,7 @@ pub struct Bindgen {
     multi_value: bool,
     encode_into: EncodeInto,
     split_linked_modules: bool,
+    wasi: bool,
 }
 
 pub struct Output {
@@ -113,6 +114,7 @@ impl Bindgen {
             encode_into: EncodeInto::Test,
             omit_default_module_path: true,
             split_linked_modules: false,
+            wasi: false,
         }
     }
 
@@ -244,6 +246,11 @@ impl Bindgen {
 
     pub fn debug(&mut self, debug: bool) -> &mut Bindgen {
         self.debug = debug;
+        self
+    }
+
+    pub fn wasi(&mut self, wasi: bool) -> &mut Bindgen {
+        self.wasi = wasi;
         self
     }
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Error};
 use docopt::Docopt;
 use serde::Deserialize;
+use std::env;
 use std::path::PathBuf;
 use std::process;
 use wasm_bindgen_cli_support::{Bindgen, EncodeInto};
@@ -154,6 +155,12 @@ fn rmain(args: &Args) -> Result<(), Error> {
         Some(ref p) => p,
         None => bail!("the `--out-dir` argument is now required"),
     };
+
+    if args.flag_wasi {
+        env::set_var("WASM_BINDGEN_ENABLE_WASI", "1");
+    } else {
+        env::set_var("WASM_BINDGEN_ENABLE_WASI", "0");
+    }
 
     b.generate(out_dir)
 }

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -41,6 +41,7 @@ Options:
     --no-modules                 Deprecated, use `--target no-modules`
     --weak-refs                  Enable usage of the JS weak references proposal
     --reference-types            Enable usage of WebAssembly reference types
+    --wasi                       Enable binding on `wasm32-wasi` target
     -V --version                 Print the version number of wasm-bindgen
 
 Additional documentation: https://rustwasm.github.io/wasm-bindgen/reference/cli.html
@@ -71,6 +72,7 @@ struct Args {
     flag_target: Option<String>,
     flag_omit_default_module_path: bool,
     flag_split_linked_modules: bool,
+    flag_wasi: bool,
     arg_input: Option<PathBuf>,
 }
 
@@ -117,6 +119,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .browser(args.flag_browser)?
         .no_modules(args.flag_no_modules)?
         .debug(args.flag_debug)
+        .wasi(args.flag_wasi)
         .demangle(!args.flag_no_demangle)
         .keep_lld_exports(args.flag_keep_lld_exports)
         .keep_debug(args.flag_keep_debug)

--- a/crates/wasm-interpreter/tests/smoke.rs
+++ b/crates/wasm-interpreter/tests/smoke.rs
@@ -3,7 +3,7 @@ use wasm_bindgen_wasm_interpreter::Interpreter;
 
 fn interpret(wat: &str, name: &str, result: Option<&[u32]>) {
     let wasm = wat::parse_str(wat).unwrap();
-    let mut module = ModuleConfig::new()
+    let module = ModuleConfig::new()
         .generate_producers_section(false)
         .parse(&wasm)
         .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,14 @@ macro_rules! if_std {
 
 macro_rules! externs {
     ($(#[$attr:meta])* extern "C" { $(fn $name:ident($($args:tt)*) -> $ret:ty;)* }) => (
-        #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi))))]
         $(#[$attr])*
         extern "C" {
             $(fn $name($($args)*) -> $ret;)*
         }
 
         $(
-            #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+            #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", all(target_os = "wasi", enable_wasi)))))]
             #[allow(unused_variables)]
             unsafe extern fn $name($($args)*) -> $ret {
                 panic!("function not implemented on non-wasm32 targets")
@@ -1336,7 +1336,7 @@ impl<T> UnwrapThrowExt<T> for Option<T> {
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(
             target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
+            any(target_os = "unknown", all(target_os = "wasi", enable_wasi))
         )) {
             match self {
                 Some(val) => val,
@@ -1356,7 +1356,7 @@ where
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(
             target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
+            any(target_os = "unknown", all(target_os = "wasi", enable_wasi))
         )) {
             match self {
                 Ok(val) => val,


### PR DESCRIPTION
With #3233(Jan 2023), generating bindings for WASI was disabled.

- #3233

However, with #3595(Sep 2023) `wasm-bindgen` gained compatibility with `wasm32-wasi`'s standard C ABI. It was stated in #3454 by @Liamolucko that `wasm-bindgen` already supports the standard C ABI that `wasm32-wasi` uses.

- #3595 
- https://github.com/rustwasm/wasm-bindgen/issues/3454#issuecomment-1782638916

This PR aims to enable bindings for `wasm32-wasi` under the new `--wasi` flag. This will allow ecosystem around `wasm-bindgen` such as `wasm-pack` to make use of `wasm32-wasi`.

I'm very open to feedback, so please tag me if there's room for improvements. I should perhaps add or modify some tests for now.