### PR TITLE
Add workflow to bump versions and create releases

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,34 @@
+name: Bump packages
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+          description: 'bump or publish'
+          required: true
+          default: 'bump'
+          type: choice
+          options:
+            - bump
+            - publish
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'bump'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustc publish.rs
+      - run: git checkout -b bump
+      - run: printf "bump versions for release\n\n" > /tmp/bump
+      - run: ./publish bump >> /tmp/bump
+      - run: git add .
+      - run: git commit -m "bump"
+      - run: git push origin bump
+      - run: gh pr create --fill --body-file /tmp/bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -32,3 +32,16 @@ jobs:
       - run: gh pr create --fill --body-file /tmp/bump
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event.inputs.action == 'publish'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustc publish.rs
+      - name: assert we're on bump branch
+        run: test "$(git git branch --show-current)" = "bump"
+      - run: ./publish publish
+        env:
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
This PR adds a new workflow called bump. This workflow is to be triggered manually when a new release is to be published. The process of releases is as follows:

1. Run the bump flow from `master`
2. Review/merge the bump PR
3. Run the publish flow from `bump` branch
