### PR TITLE
Update docs to say that `wasm_bindgen::module()` is also available with `--target web`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1368,13 +1368,9 @@ where
     }
 }
 
-/// Returns a handle to this wasm instance's `WebAssembly.Module`
-///
-/// Note that this is only available when the final wasm app is built with
-/// `--target no-modules` or `--target web`, it's not recommended to rely on this
-/// API yet! This is largely just an experimental addition to enable threading demos.
-/// Using this may prevent your wasm module from building down the road.
-#[doc(hidden)]
+/// Returns a handle to this Wasm instance's `WebAssembly.Module`.
+/// This is only available when the final Wasm app is built with
+/// `--target no-modules` or `--target web`.
 pub fn module() -> JsValue {
     unsafe { JsValue::_new(__wbindgen_module()) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1371,9 +1371,9 @@ where
 /// Returns a handle to this wasm instance's `WebAssembly.Module`
 ///
 /// Note that this is only available when the final wasm app is built with
-/// `--target no-modules`, it's not recommended to rely on this API yet! This is
-/// largely just an experimental addition to enable threading demos. Using this
-/// may prevent your wasm module from building down the road.
+/// `--target no-modules` or `--target web`, it's not recommended to rely on this
+/// API yet! This is largely just an experimental addition to enable threading demos.
+/// Using this may prevent your wasm module from building down the road.
 #[doc(hidden)]
 pub fn module() -> JsValue {
     unsafe { JsValue::_new(__wbindgen_module()) }


### PR DESCRIPTION
The docs were originally written in [this commit](https://github.com/rustwasm/wasm-bindgen/commit/25b26f41e78aeb4924719681848b75aadfbebfb5#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R637-R649) with [a corresponding runtime check](https://github.com/rustwasm/wasm-bindgen/commit/25b26f41e78aeb4924719681848b75aadfbebfb5#diff-072222e984a549efeebf98f26d0c59a69d88abe246db7e0958654fc32471313eR392-R395). The runtime check was updated [here](https://github.com/rustwasm/wasm-bindgen/commit/b762948456617ee263de8e43b3636bd3a4d1da75#diff-072222e984a549efeebf98f26d0c59a69d88abe246db7e0958654fc32471313eL532-R587)* , but the corresponding doc was not updated. This PR updates that doc.

> \* Click to expand the `mod.rs` diff since Github doesn't load it because it's too large, then ctrl-f `is currently only supported`.

---

Separately, what would it take to graduate this API to a non-experiment?