### PR TITLE
Allow SharedArrayBuffer to be passed to DataView constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
+## [Unreleased](https://github.com/rustwasm/wasm-bindgen/compare/0.2.88...main)
+
+### Added
+
+* Allow SharedArrayBuffer to be passed to DataView constructor
+  [#3695](https://github.com/rustwasm/wasm-bindgen/pull/3695)
+
 ## [0.2.88](https://github.com/rustwasm/wasm-bindgen/compare/0.2.87...0.2.88)
 
 Released 2023-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-* Allow SharedArrayBuffer to be passed to DataView constructor
+* Add additional constructor to `DataView` for `SharedArrayBuffer`.
   [#3695](https://github.com/rustwasm/wasm-bindgen/pull/3695)
 
 ## [0.2.88](https://github.com/rustwasm/wasm-bindgen/compare/0.2.87...0.2.88)

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1596,7 +1596,15 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)
     #[wasm_bindgen(constructor)]
-    pub fn new(buffer: &JsValue, byteOffset: usize, byteLength: usize) -> DataView;
+    pub fn new(buffer: &ArrayBuffer, byteOffset: usize, byteLength: usize) -> DataView;
+
+    /// The `DataView` view provides a low-level interface for reading and
+    /// writing multiple number types in an `ArrayBuffer` irrespective of the
+    /// platform's endianness.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)
+    #[wasm_bindgen(constructor)]
+    pub fn new_with_shared_array_buffer(buffer: &SharedArrayBuffer, byteOffset: usize, byteLength: usize) -> DataView;
 
     /// The ArrayBuffer referenced by this view. Fixed at construction time and thus read only.
     ///

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1604,7 +1604,11 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)
     #[wasm_bindgen(constructor)]
-    pub fn new_with_shared_array_buffer(buffer: &SharedArrayBuffer, byteOffset: usize, byteLength: usize) -> DataView;
+    pub fn new_with_shared_array_buffer(
+        buffer: &SharedArrayBuffer,
+        byteOffset: usize,
+        byteLength: usize,
+    ) -> DataView;
 
     /// The ArrayBuffer referenced by this view. Fixed at construction time and thus read only.
     ///

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -1596,7 +1596,7 @@ extern "C" {
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView)
     #[wasm_bindgen(constructor)]
-    pub fn new(buffer: &ArrayBuffer, byteOffset: usize, byteLength: usize) -> DataView;
+    pub fn new(buffer: &JsValue, byteOffset: usize, byteLength: usize) -> DataView;
 
     /// The ArrayBuffer referenced by this view. Fixed at construction time and thus read only.
     ///


### PR DESCRIPTION
Fixes #3694 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView#buffer