### PR TITLE
`__wbindgen_thread_destroy` has optional params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,16 @@
 
 * Add additional constructor to `DataView` for `SharedArrayBuffer`.
   [#3695](https://github.com/rustwasm/wasm-bindgen/pull/3695)
-* Remove experimental status from `wasm_bindgen::module()` and update docs to say it works with `--target web`.
+
+* Stabilize `wasm_bindgen::module()`.
   [#3690](https://github.com/rustwasm/wasm-bindgen/pull/3690)
 
 ### Fixed
 
 * The DWARF section is now correctly modified instead of leaving it in a broken state.
   [#3483](https://github.com/rustwasm/wasm-bindgen/pull/3483)
-* Update the TypeScript signature of `__wbindgen_thread_destroy` to indicate that it has optional parameters.
+
+* Update the TypeScript signature of `__wbindgen_thread_destroy` to indicate that it's parameters are optional.
   [#3703](https://github.com/rustwasm/wasm-bindgen/pull/3703)
 
 ## [0.2.88](https://github.com/rustwasm/wasm-bindgen/compare/0.2.87...0.2.88)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@
 
 * Add additional constructor to `DataView` for `SharedArrayBuffer`.
   [#3695](https://github.com/rustwasm/wasm-bindgen/pull/3695)
+* Remove experimental status from `wasm_bindgen::module()` and update docs to say it works with `--target web`.
+  [#3690](https://github.com/rustwasm/wasm-bindgen/pull/3690)
 
 ### Fixed
 
 * The DWARF section is now correctly modified instead of leaving it in a broken state.
   [#3483](https://github.com/rustwasm/wasm-bindgen/pull/3483)
+* Update the TypeScript signature of `__wbindgen_thread_destroy` to indicate that it has optional parameters.
+  [#3703](https://github.com/rustwasm/wasm-bindgen/pull/3703)
 
 ## [0.2.88](https://github.com/rustwasm/wasm-bindgen/compare/0.2.87...0.2.88)
 

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -55,6 +55,10 @@ fn push_index_identifier(i: usize, s: &mut String) {
     }
 }
 
+fn args_are_optional(name: &str) -> bool {
+    name == "__wbindgen_thread_destroy"
+}
+
 pub fn interface(module: &Module) -> Result<String, Error> {
     let mut exports = String::new();
 
@@ -81,6 +85,9 @@ pub fn interface(module: &Module) -> Result<String, Error> {
             }
 
             push_index_identifier(i, &mut args);
+            if args_are_optional(&entry.name) {
+                args.push('?');
+            }
             args.push_str(": number");
         }
 


### PR DESCRIPTION
This PR updates the generated TypeScript to reflect the fact that `__wbindgen_thread_destroy` has optional params.

Ref: https://github.com/rustwasm/wasm-bindgen/blob/9fb3bca16876c756266274f78fcd0214e0581eaa/crates/threads-xform/src/lib.rs#L394-L395

Before:

```ts
export interface InitOutput {
  readonly start: () => void;
  readonly run: () => void;
  readonly child_entry_point: (a: number) => void;
  readonly memory: WebAssembly.Memory;
  readonly __wbindgen_malloc: (a: number, b: number) => number;
  readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
  readonly __wbindgen_exn_store: (a: number) => void;
  readonly __wbindgen_thread_destroy: (a: number, b: number) => void;
  readonly __wbindgen_start: () => void;
}
```

After:
```ts
export interface InitOutput {
  readonly start: () => void;
  readonly run: () => void;
  readonly child_entry_point: (a: number) => void;
  readonly memory: WebAssembly.Memory;
  readonly __wbindgen_malloc: (a: number, b: number) => number;
  readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
  readonly __wbindgen_exn_store: (a: number) => void;
  readonly __wbindgen_thread_destroy: (a?: number, b?: number) => void;
  readonly __wbindgen_start: () => void;
}
```

Ideally I'd like better names too (`a` and `b`) but for the life of me I can't tell if it's in the wasm or not. Maybe just hardcode it since I'm already doing `__wbindgen_thread_destroy`? 🤷‍♂️ Oh well this is a strict improvement.