### PR TITLE
Add a test runner to two of the typescript tests to actually run them

### DIFF
--- a/crates/typescript-tests/Cargo.toml
+++ b/crates/typescript-tests/Cargo.toml
@@ -10,6 +10,8 @@ wasm-bindgen = { path = '../..' }
 wasm-bindgen-futures = { path = '../futures' }
 web-sys = { path = '../web-sys', features = [ 'HtmlElement', 'Node', 'Document' ] }
 js-sys = { path = '../js-sys' }
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
 
 [lib]
 crate-type = ['cdylib']

--- a/crates/typescript-tests/jest.config.cjs
+++ b/crates/typescript-tests/jest.config.cjs
@@ -5,6 +5,7 @@ module.exports = {
   extensionsToTreatAsEsm: [".ts"],
   verbose: true,
   testMatch: ['**/src/simple_struct.ts', '**/src/typescript_type.ts'],
+  injectGlobals: false,
   globals: {
     'ts-jest':
     {

--- a/crates/typescript-tests/jest.config.cjs
+++ b/crates/typescript-tests/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: [".ts"],
   verbose: true,
+  // TODO: match all test files
   testMatch: ['**/src/simple_struct.ts', '**/src/typescript_type.ts'],
   injectGlobals: false,
   globals: {

--- a/crates/typescript-tests/jest.config.cjs
+++ b/crates/typescript-tests/jest.config.cjs
@@ -1,0 +1,15 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: [".ts"],
+  verbose: true,
+  testMatch: ['**/src/simple_struct.ts'],
+  globals: {
+    'ts-jest':
+    {
+      useESM: true,
+      isolatedModules: true
+    }
+  }
+};

--- a/crates/typescript-tests/jest.config.cjs
+++ b/crates/typescript-tests/jest.config.cjs
@@ -4,7 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: [".ts"],
   verbose: true,
-  testMatch: ['**/src/simple_struct.ts'],
+  testMatch: ['**/src/simple_struct.ts', '**/src/typescript_type.ts'],
   globals: {
     'ts-jest':
     {

--- a/crates/typescript-tests/no_modules.tsconfig.json
+++ b/crates/typescript-tests/no_modules.tsconfig.json
@@ -4,6 +4,7 @@
         "noImplicitAny": true,
         "sourceMap": true,
         "outDir": "dist_no_modules",
+        "moduleResolution":"node"
     },
     "include": [
         "pkg/no_modules/*.d.ts",

--- a/crates/typescript-tests/package.json
+++ b/crates/typescript-tests/package.json
@@ -1,8 +1,12 @@
 {
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --config ./jest.config.cjs"
   },
   "devDependencies": {
-    "typescript": "^3.3.3333"
-  }
+    "@types/jest": "^29.5.8",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.2.2"
+  },
+  "type": "module"
 }

--- a/crates/typescript-tests/run.sh
+++ b/crates/typescript-tests/run.sh
@@ -57,3 +57,5 @@ cd ..
 
 # Then try to build the typescript in the src_no_modules folder against the pkg/no_modules build.
 npm run tsc -- -p no_modules.tsconfig.json
+
+npm test

--- a/crates/typescript-tests/src/simple_struct.ts
+++ b/crates/typescript-tests/src/simple_struct.ts
@@ -1,4 +1,5 @@
 import * as wbg from "../pkg/typescript_tests";
+import { expect, jest, test } from "@jest/globals";
 
 test("member function (void) -> void", () => {
   const a = new wbg.A();

--- a/crates/typescript-tests/src/simple_struct.ts
+++ b/crates/typescript-tests/src/simple_struct.ts
@@ -1,9 +1,19 @@
-import * as wbg from '../pkg/typescript_tests';
+import * as wbg from "../pkg/typescript_tests";
 
-const a = new wbg.A();
-wbg.A.other();
-a.foo();
-a.free();
-const b: boolean = a.ret_bool()
-a.take_bool(b);
-a.take_many(b, 1, 2);
+test("member function (void) -> void", () => {
+  const a = new wbg.A();
+  wbg.A.other();
+  a.foo();
+  a.free();
+  expect(() => {
+    a.ret_bool();
+  }).toThrow(/null pointer passed to rust/);
+});
+
+test("function with parameters", () => {
+  const a = new wbg.A();
+  const b: boolean = a.ret_bool();
+  expect(b).toStrictEqual(true);
+  a.take_bool(b);
+  a.take_many(b, 1, 2);
+});

--- a/crates/typescript-tests/src/typescript_type.rs
+++ b/crates/typescript-tests/src/typescript_type.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -16,7 +17,7 @@ extern "C" {
 }
 
 #[wasm_bindgen]
-#[derive(Default)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct TextStyle {
     pub bold: bool,
     pub italic: bool,
@@ -26,13 +27,12 @@ pub struct TextStyle {
 #[wasm_bindgen]
 impl TextStyle {
     #[wasm_bindgen(constructor)]
-    pub fn new(_i: ITextStyle) -> TextStyle {
-        // parse JsValue
-        TextStyle::default()
+    pub fn new(i: ITextStyle) -> TextStyle {
+        let js_value: JsValue = i.into();
+        serde_wasm_bindgen::from_value(js_value).unwrap()
     }
 
-    pub fn optional_new(_i: Option<ITextStyle>) -> TextStyle {
-        // parse JsValue
-        TextStyle::default()
+    pub fn optional_new(i: Option<ITextStyle>) -> TextStyle {
+        i.map(Self::new).unwrap_or_default()
     }
 }

--- a/crates/typescript-tests/src/typescript_type.ts
+++ b/crates/typescript-tests/src/typescript_type.ts
@@ -1,4 +1,5 @@
 import * as wbg from "../pkg/typescript_tests";
+import { expect, jest, test } from "@jest/globals";
 
 test("constructor", () => {
   const style: wbg.TextStyle = new wbg.TextStyle({
@@ -21,7 +22,7 @@ test("optional parameter constructor", () => {
   const optional_style: wbg.TextStyle = wbg.TextStyle.optional_new({
     italic: true,
     bold: false,
-    size: 0
+    size: 0,
   });
   expect(optional_style.bold).toStrictEqual(false);
   expect(optional_style.italic).toStrictEqual(true);

--- a/crates/typescript-tests/src/typescript_type.ts
+++ b/crates/typescript-tests/src/typescript_type.ts
@@ -1,9 +1,29 @@
-import * as wbg from '../pkg/typescript_tests';
+import * as wbg from "../pkg/typescript_tests";
 
-const style: wbg.TextStyle = new wbg.TextStyle({
-  bold: true,
-  italic: true,
-  size: 42,
+test("constructor", () => {
+  const style: wbg.TextStyle = new wbg.TextStyle({
+    bold: true,
+    italic: false,
+    size: 42,
+  });
+
+  expect(style.bold).toStrictEqual(true);
+  expect(style.italic).toStrictEqual(false);
+  expect(style.size).toStrictEqual(42);
 });
 
-const optional_style: wbg.TextStyle = wbg.TextStyle.optional_new();
+test("optional parameter constructor", () => {
+  const default_constructed: wbg.TextStyle = wbg.TextStyle.optional_new();
+  expect(default_constructed.bold).toStrictEqual(false);
+  expect(default_constructed.italic).toStrictEqual(false);
+  expect(default_constructed.size).toStrictEqual(0);
+
+  const optional_style: wbg.TextStyle = wbg.TextStyle.optional_new({
+    italic: true,
+    bold: false,
+    size: 0
+  });
+  expect(optional_style.bold).toStrictEqual(false);
+  expect(optional_style.italic).toStrictEqual(true);
+  expect(optional_style.size).toStrictEqual(0);
+});


### PR DESCRIPTION
This adds Jest as the test runner framework.
I have chosen this framework because it was the framework I managed to get running and because it seems reasonably popular:
https://2022.stateofjs.com/en-US/libraries/testing/

This uncovers that some of the tests are unrealistic code which would crash at runtime.

Before this PR, these tests were just compiled with tsc, but never run.

This PR also adds the new test script to the `crates/typescript-tests/run.sh` file which makes them run in the CI.