### PR TITLE
Replace TryFrom with custom TryFromJsValue trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@
 
 * The DWARF section is now correctly modified instead of leaving it in a broken state.
   [#3483](https://github.com/rustwasm/wasm-bindgen/pull/3483)
-* Custom TryFromJsValue Trait: Fixed an issue where #[wasm_bindgen] automatically derived the TryFrom trait for any struct, preventing custom TryFrom<JsValue> implementations. The wasm-bindgen derive macro has been updated to utilize the new TryFromJsValue trait.    [#3709](https://github.com/rustwasm/wasm-bindgen/pull/3709)
 
+* Fixed an issue where `#[wasm_bindgen]` automatically derived the `TryFrom` trait for any struct, preventing custom `TryFrom<JsValue>` implementations. It has been updated to utilize a new `TryFromJsValue` trait instead.
+  [#3709](https://github.com/rustwasm/wasm-bindgen/pull/3709)
 
 * Update the TypeScript signature of `__wbindgen_thread_destroy` to indicate that it's parameters are optional.
   [#3703](https://github.com/rustwasm/wasm-bindgen/pull/3703)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 * The DWARF section is now correctly modified instead of leaving it in a broken state.
   [#3483](https://github.com/rustwasm/wasm-bindgen/pull/3483)
+* Custom TryFromJsValue Trait: Fixed an issue where #[wasm_bindgen] automatically derived the TryFrom trait for any struct, preventing custom TryFrom<JsValue> implementations. The wasm-bindgen derive macro has been updated to utilize the new TryFromJsValue trait.    [#3709](https://github.com/rustwasm/wasm-bindgen/pull/3709)
+
 
 * Update the TypeScript signature of `__wbindgen_thread_destroy` to indicate that it's parameters are optional.
   [#3703](https://github.com/rustwasm/wasm-bindgen/pull/3703)

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -297,7 +297,7 @@ impl ToTokens for ast::Struct {
             }
 
             #[allow(clippy::all)]
-            impl #wasm_bindgen::TryFromJsValue for #name {
+            impl #wasm_bindgen::convert::TryFromJsValue for #name {
                 type Error = #wasm_bindgen::JsValue;
 
                 fn try_from_js_value(value: #wasm_bindgen::JsValue)
@@ -819,11 +819,12 @@ impl ToTokens for ast::ImportType {
 
             #[automatically_derived]
             const _: () = {
+                use #wasm_bindgen::convert::TryFromJsValue;
                 use #wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
                 use #wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
                 use #wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
                 use #wasm_bindgen::describe::WasmDescribe;
-                use #wasm_bindgen::{JsValue, JsCast, JsObject, TryFromJsValue};
+                use #wasm_bindgen::{JsValue, JsCast, JsObject};
                 use #wasm_bindgen::__rt::core;
 
                 impl WasmDescribe for #rust_name {
@@ -1452,11 +1453,11 @@ impl ToTokens for ast::Enum {
             }
 
             #[allow(clippy::all)]
-            impl #wasm_bindgen::TryFromJsValue for #enum_name {
+            impl #wasm_bindgen::convert::TryFromJsValue for #enum_name {
                 type Error = #wasm_bindgen::JsValue;
 
                 fn try_from_js_value(value: #wasm_bindgen::JsValue)
-                    -> #wasm_bindgen::__rt::std::result::Result<Self, <#enum_name as #wasm_bindgen::TryFromJsValue>::Error> {
+                    -> #wasm_bindgen::__rt::std::result::Result<Self, <#enum_name as #wasm_bindgen::convert::TryFromJsValue>::Error> {
                     use #wasm_bindgen::__rt::core::convert::TryFrom;
                     let js = f64::try_from(&value)? as u32;
 

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -297,10 +297,10 @@ impl ToTokens for ast::Struct {
             }
 
             #[allow(clippy::all)]
-            impl #wasm_bindgen::__rt::core::convert::TryFrom<#wasm_bindgen::JsValue> for #name {
+            impl #wasm_bindgen::convert::TryFromJsValue for #name {
                 type Error = #wasm_bindgen::JsValue;
 
-                fn try_from(value: #wasm_bindgen::JsValue)
+                fn try_from_js_value(value: #wasm_bindgen::JsValue)
                     -> #wasm_bindgen::__rt::std::result::Result<Self, Self::Error> {
                     let idx = #wasm_bindgen::convert::IntoWasmAbi::into_abi(&value);
 
@@ -822,6 +822,7 @@ impl ToTokens for ast::ImportType {
                 use #wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
                 use #wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
                 use #wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
+                use #wasm_bindgen::convert::TryFromJsValue;
                 use #wasm_bindgen::describe::WasmDescribe;
                 use #wasm_bindgen::{JsValue, JsCast, JsObject};
                 use #wasm_bindgen::__rt::core;
@@ -1452,11 +1453,12 @@ impl ToTokens for ast::Enum {
             }
 
             #[allow(clippy::all)]
-            impl #wasm_bindgen::__rt::core::convert::TryFrom<#wasm_bindgen::JsValue> for #enum_name {
+            impl #wasm_bindgen::convert::TryFromJsValue for #enum_name {
                 type Error = #wasm_bindgen::JsValue;
 
-                fn try_from(value: #wasm_bindgen::JsValue)
-                    -> #wasm_bindgen::__rt::std::result::Result<Self, <#enum_name as #wasm_bindgen::__rt::core::convert::TryFrom<JsValue>>::Error> {
+                fn try_from_js_value(value: #wasm_bindgen::JsValue)
+                    -> #wasm_bindgen::__rt::std::result::Result<Self, <#enum_name as #wasm_bindgen::convert::TryFromJsValue>::Error> {
+                    use #wasm_bindgen::__rt::core::convert::TryFrom;
                     let js = f64::try_from(&value)? as u32;
 
                     #wasm_bindgen::__rt::std::result::Result::Ok(

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -297,7 +297,7 @@ impl ToTokens for ast::Struct {
             }
 
             #[allow(clippy::all)]
-            impl #wasm_bindgen::convert::TryFromJsValue for #name {
+            impl #wasm_bindgen::TryFromJsValue for #name {
                 type Error = #wasm_bindgen::JsValue;
 
                 fn try_from_js_value(value: #wasm_bindgen::JsValue)
@@ -822,9 +822,8 @@ impl ToTokens for ast::ImportType {
                 use #wasm_bindgen::convert::{IntoWasmAbi, FromWasmAbi};
                 use #wasm_bindgen::convert::{OptionIntoWasmAbi, OptionFromWasmAbi};
                 use #wasm_bindgen::convert::{RefFromWasmAbi, LongRefFromWasmAbi};
-                use #wasm_bindgen::convert::TryFromJsValue;
                 use #wasm_bindgen::describe::WasmDescribe;
-                use #wasm_bindgen::{JsValue, JsCast, JsObject};
+                use #wasm_bindgen::{JsValue, JsCast, JsObject, TryFromJsValue};
                 use #wasm_bindgen::__rt::core;
 
                 impl WasmDescribe for #rust_name {
@@ -1453,11 +1452,11 @@ impl ToTokens for ast::Enum {
             }
 
             #[allow(clippy::all)]
-            impl #wasm_bindgen::convert::TryFromJsValue for #enum_name {
+            impl #wasm_bindgen::TryFromJsValue for #enum_name {
                 type Error = #wasm_bindgen::JsValue;
 
                 fn try_from_js_value(value: #wasm_bindgen::JsValue)
-                    -> #wasm_bindgen::__rt::std::result::Result<Self, <#enum_name as #wasm_bindgen::convert::TryFromJsValue>::Error> {
+                    -> #wasm_bindgen::__rt::std::result::Result<Self, <#enum_name as #wasm_bindgen::TryFromJsValue>::Error> {
                     use #wasm_bindgen::__rt::core::convert::TryFrom;
                     let js = f64::try_from(&value)? as u32;
 

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -2,13 +2,13 @@ use core::char;
 use core::mem::{self, ManuallyDrop};
 
 use crate::convert::traits::{WasmAbi, WasmPrimitive};
+use crate::convert::TryFromJsValue;
 use crate::convert::{FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, RefFromWasmAbi};
 use crate::convert::{OptionFromWasmAbi, OptionIntoWasmAbi, ReturnWasmAbi};
 use crate::{Clamped, JsError, JsValue, UnwrapThrowExt};
 
 if_std! {
     use std::boxed::Box;
-    use std::convert::{TryFrom, TryInto};
     use std::fmt::Debug;
     use std::vec::Vec;
 }
@@ -415,7 +415,7 @@ if_std! {
         js_vals.into_abi()
     }
 
-    pub unsafe fn js_value_vector_from_abi<T: TryFrom<JsValue>>(js: <Box<[JsValue]> as FromWasmAbi>::Abi) -> Box<[T]> where T::Error: Debug {
+    pub unsafe fn js_value_vector_from_abi<T: TryFromJsValue>(js: <Box<[JsValue]> as FromWasmAbi>::Abi) -> Box<[T]> where T::Error: Debug {
         let js_vals = <Vec<JsValue> as FromWasmAbi>::from_abi(js);
 
         let mut result = Vec::with_capacity(js_vals.len());
@@ -430,7 +430,7 @@ if_std! {
             // we're talking about, it can only see functions that actually make it to the
             // final wasm binary (i.e., not inlined functions). All of those internal
             // iterator functions get inlined in release mode, and so they don't show up.
-            result.push(value.try_into().expect_throw("array contains a value of the wrong type"));
+            result.push(T::try_from_js_value(value).expect_throw("array contains a value of the wrong type"));
         }
         result.into_boxed_slice()
     }

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -2,9 +2,9 @@ use core::char;
 use core::mem::{self, ManuallyDrop};
 
 use crate::convert::traits::{WasmAbi, WasmPrimitive};
-use crate::convert::TryFromJsValue;
 use crate::convert::{FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, RefFromWasmAbi};
 use crate::convert::{OptionFromWasmAbi, OptionIntoWasmAbi, ReturnWasmAbi};
+use crate::TryFromJsValue;
 use crate::{Clamped, JsError, JsValue, UnwrapThrowExt};
 
 if_std! {

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -2,9 +2,9 @@ use core::char;
 use core::mem::{self, ManuallyDrop};
 
 use crate::convert::traits::{WasmAbi, WasmPrimitive};
+use crate::convert::TryFromJsValue;
 use crate::convert::{FromWasmAbi, IntoWasmAbi, LongRefFromWasmAbi, RefFromWasmAbi};
 use crate::convert::{OptionFromWasmAbi, OptionIntoWasmAbi, ReturnWasmAbi};
-use crate::TryFromJsValue;
 use crate::{Clamped, JsError, JsValue, UnwrapThrowExt};
 
 if_std! {

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -2,6 +2,7 @@ use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use crate::describe::*;
+use crate::JsValue;
 
 /// A trait for anything that can be converted into a type that can cross the
 /// wasm ABI directly, eg `u32` or `f64`.
@@ -248,4 +249,12 @@ impl<T: WasmAbi> WasmRet<T> {
     pub fn join(self) -> T {
         T::join(self.prim1, self.prim2, self.prim3, self.prim4)
     }
+}
+
+pub trait TryFromJsValue: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error>;
 }

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -250,11 +250,3 @@ impl<T: WasmAbi> WasmRet<T> {
         T::join(self.prim1, self.prim2, self.prim3, self.prim4)
     }
 }
-
-pub trait TryFromJsValue: Sized {
-    /// The type returned in the event of a conversion error.
-    type Error;
-
-    /// Performs the conversion.
-    fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error>;
-}

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -2,7 +2,6 @@ use core::borrow::Borrow;
 use core::ops::{Deref, DerefMut};
 
 use crate::describe::*;
-use crate::JsValue;
 
 /// A trait for anything that can be converted into a type that can cross the
 /// wasm ABI directly, eg `u32` or `f64`.

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -251,6 +251,19 @@ impl<T: WasmAbi> WasmRet<T> {
     }
 }
 
+/// `TryFromJsValue` is a trait for converting a JavaScript value (`JsValue`)
+/// into a Rust type. It is particularly useful when dealing with JavaScript
+/// objects in WebAssembly, allowing for custom conversion logic that might
+/// be needed when interacting with JavaScript APIs or passing data between
+/// Rust and JavaScript.
+///
+/// This trait is intended as a solution to the limitations imposed by the
+/// automatic derivation of `TryFrom<JsValue>` in `wasm-bindgen`, which
+/// restricts the ability to implement custom conversions for ABI-bound structs.
+///
+/// Types implementing this trait must specify their conversion logic from
+/// `JsValue` to the Rust type, handling any potential errors that may occur
+/// during the conversion process.
 pub trait TryFromJsValue: Sized {
     /// The type returned in the event of a conversion error.
     type Error;

--- a/src/convert/traits.rs
+++ b/src/convert/traits.rs
@@ -251,18 +251,12 @@ impl<T: WasmAbi> WasmRet<T> {
     }
 }
 
-/// `TryFromJsValue` is a trait for converting a JavaScript value (`JsValue`)
-/// into a Rust type. It is particularly useful when dealing with JavaScript
-/// objects in WebAssembly, allowing for custom conversion logic that might
-/// be needed when interacting with JavaScript APIs or passing data between
-/// Rust and JavaScript.
-///
-/// This trait is intended as a solution to the limitations imposed by the
-/// automatic derivation of `TryFrom<JsValue>` in `wasm-bindgen`, which
-/// restricts the ability to implement custom conversions for ABI-bound structs.
+/// [`TryFromJsValue`] is a trait for converting a JavaScript value ([`JsValue`])
+/// into a Rust type. It is used by the [`wasm_bindgen`](wasm_bindgen_macro::wasm_bindgen)
+/// proc-macro to allow conversion to user types.
 ///
 /// Types implementing this trait must specify their conversion logic from
-/// `JsValue` to the Rust type, handling any potential errors that may occur
+/// [`JsValue`] to the Rust type, handling any potential errors that may occur
 /// during the conversion process.
 pub trait TryFromJsValue: Sized {
     /// The type returned in the event of a conversion error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -815,6 +815,17 @@ if_std! {
             }
         }
     }
+
+    impl crate::convert::TryFromJsValue for String {
+        type Error = JsValue;
+
+        fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error> {
+            match value.as_string() {
+                Some(s) => Ok(s),
+                None => Err(value),
+            }
+        }
+    }
 }
 
 impl From<bool> for JsValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -816,7 +816,7 @@ if_std! {
         }
     }
 
-    impl crate::convert::TryFromJsValue for String {
+    impl crate::TryFromJsValue for String {
         type Error = JsValue;
 
         fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error> {
@@ -1911,4 +1911,12 @@ impl From<JsError> for JsValue {
     fn from(error: JsError) -> Self {
         error.value
     }
+}
+
+pub trait TryFromJsValue: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error;
+
+    /// Performs the conversion.
+    fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use core::ops::{
 };
 use core::u32;
 
-use crate::convert::{FromWasmAbi, WasmRet, WasmSlice};
+use crate::convert::{FromWasmAbi, TryFromJsValue, WasmRet, WasmSlice};
 
 macro_rules! if_std {
     ($($i:item)*) => ($(
@@ -816,7 +816,7 @@ if_std! {
         }
     }
 
-    impl crate::TryFromJsValue for String {
+    impl TryFromJsValue for String {
         type Error = JsValue;
 
         fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error> {
@@ -1911,12 +1911,4 @@ impl From<JsError> for JsValue {
     fn from(error: JsError) -> Self {
         error.value
     }
-}
-
-pub trait TryFromJsValue: Sized {
-    /// The type returned in the event of a conversion error.
-    type Error;
-
-    /// Performs the conversion.
-    fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error>;
 }


### PR DESCRIPTION
This commit replaces the usage of the standard library's TryFrom trait with a custom TryFromJsValue trait added for handling the conversion from JavaScript values in WASM. This trait has been implemented for different types across multiple modules to ensure consistent error handling on failed conversions.

fixes #3685