### PR TITLE
Remove span in generated field getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Add bindings for `UserActivation`.
   [#3719](https://github.com/rustwasm/wasm-bindgen/pull/3719)
 
+### Fixed
+
+* Fixed a compiler error when using `#[wasm_bindgen]` inside `macro_rules!`.
+  [#3725](https://github.com/rustwasm/wasm-bindgen/pull/3725)
+
 ### Removed
 
 * Removed Gecko-only `InstallTriggerData` and Gecko-internal `FlexLineGrowthState`, `GridDeclaration`, `GridTrackState`,

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -389,7 +389,14 @@ impl ToTokens for ast::StructField {
         };
         let maybe_assert_copy = respan(maybe_assert_copy, ty);
 
-        let mut val = quote! { (*js).borrow().#rust_name };
+        // Split this out so that it isn't affected by `quote_spanned!`.
+        //
+        // If we don't do this, it might end up being unable to reference `js`
+        // properly because it doesn't have the same span.
+        //
+        // See https://github.com/rustwasm/wasm-bindgen/pull/3725.
+        let js_token = quote! { js };
+        let mut val = quote_spanned!(self.rust_name.span()=> (*#js_token).borrow().#rust_name);
         if let Some(span) = self.getter_with_clone {
             val = quote_spanned!(span=> <#ty as Clone>::clone(&#val) );
         }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -389,7 +389,7 @@ impl ToTokens for ast::StructField {
         };
         let maybe_assert_copy = respan(maybe_assert_copy, ty);
 
-        let mut val = quote_spanned!(self.rust_name.span()=> (*js).borrow().#rust_name);
+        let mut val = quote! { (*js).borrow().#rust_name };
         if let Some(span) = self.getter_with_clone {
             val = quote_spanned!(span=> <#ty as Clone>::clone(&#val) );
         }

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -241,3 +241,10 @@ exports.js_test_inspectable_classes_can_override_generated_methods = () => {
     assert.strictEqual(overridden_inspectable.toString(), 'string was overwritten');
     overridden_inspectable.free();
 };
+
+exports.js_test_class_defined_in_macro = () => {
+    const macroClass = new wasm.InsideMacro();
+    assert.strictEqual(macroClass.a, 3);
+    macroClass.a = 5;
+    assert.strictEqual(macroClass.a, 5);
+};

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -34,6 +34,7 @@ extern "C" {
     fn js_test_option_classes();
     fn js_test_inspectable_classes();
     fn js_test_inspectable_classes_can_override_generated_methods();
+    fn js_test_class_defined_in_macro();
 }
 
 #[wasm_bindgen_test]
@@ -607,4 +608,28 @@ impl OverriddenInspectable {
     pub fn js_to_string(&self) -> String {
         String::from("string was overwritten")
     }
+}
+
+macro_rules! make_struct {
+    ($field:ident) => {
+        #[wasm_bindgen]
+        pub struct InsideMacro {
+            pub $field: u32,
+        }
+    };
+}
+
+make_struct!(a);
+
+#[wasm_bindgen]
+impl InsideMacro {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self { a: 3 }
+    }
+}
+
+#[wasm_bindgen_test]
+fn class_defined_in_macro() {
+    js_test_class_defined_in_macro();
 }


### PR DESCRIPTION
Fixes #3707

Previously, `(*js).borrow().#rust_name` was being given the span of `rust_name`, which seems like a fairly harmless thing to do at first glance. However, it turns out that the span of a token also affects its hygiene - turns out proc macros have hygiene too, not just declarative macros!

This caused a problem because the declaration of `js` had a span of `Span::call_site()`, but it was being accessed with `rust_name`'s span, which might be a different context where `js` doesn't exist.

Usually this is fine because `Span::call_site()` is in the same context as the struct definition: normal code. However, when you put `#[wasm_bindgen]` inside a `macro_rules!`, `Span::call_site()` is now in the context of that `macro_rules!`, while `rust_name`'s span is still in normal code which can't access variables from inside `macro_rules!`.

~~To fix that I've just removed the span from `(*js).borrow().#rust_name`, making it `Span::call_site()`. I don't think this should have any effect on diagnostics anyway, since I don't see how that code could ever cause a compile error.~~ Turns out it was used, so I just got rid of the span on `js` instead of the whole thing.