### PR TITLE
 Add a typescript test (not just a compile test) for enums

### DIFF
--- a/crates/typescript-tests/jest.config.cjs
+++ b/crates/typescript-tests/jest.config.cjs
@@ -8,7 +8,6 @@ module.exports = {
   // TODO: migrate all test files and remove this
   testPathIgnorePatterns: [
     ".*/src/custom_section.ts$",
-    ".*/src/enums.ts$",
     ".*/src/getters_setters.ts$",
     ".*/src/inspectable.ts$",
     ".*/src/memory.ts$",

--- a/crates/typescript-tests/jest.config.cjs
+++ b/crates/typescript-tests/jest.config.cjs
@@ -4,8 +4,22 @@ module.exports = {
   testEnvironment: 'node',
   extensionsToTreatAsEsm: [".ts"],
   verbose: true,
-  // TODO: match all test files
-  testMatch: ['**/src/simple_struct.ts', '**/src/typescript_type.ts'],
+  testMatch: ['**/src/*.ts'],
+  // TODO: migrate all test files and remove this
+  testPathIgnorePatterns: [
+    ".*/src/custom_section.ts$",
+    ".*/src/enums.ts$",
+    ".*/src/getters_setters.ts$",
+    ".*/src/inspectable.ts$",
+    ".*/src/memory.ts$",
+    ".*/src/omit_definition.ts$",
+    ".*/src/optional_fields.ts$",
+    ".*/src/opt_args_and_ret.ts$",
+    ".*/src/simple_async_fn.ts$",
+    ".*/src/simple_fn.ts$",
+    ".*/src/web_sys.ts$",
+    ".*/src/usize.ts$"
+  ],
   injectGlobals: false,
   globals: {
     'ts-jest':

--- a/crates/typescript-tests/src/enums.ts
+++ b/crates/typescript-tests/src/enums.ts
@@ -1,13 +1,28 @@
-import * as wbg from '../pkg/typescript_tests';
+import * as wbg from "../pkg/typescript_tests";
+import { expect, jest, test } from "@jest/globals";
 
-const a1: wbg.Foo = wbg.Foo.A;
-const a2: wbg.Foo.A = wbg.Foo.A;
-const a3: wbg.Foo.A = 1;
-const b1: wbg.Foo = wbg.Foo.B;
-const b2: wbg.Foo.B = wbg.Foo.B;
-const b3: wbg.Foo.B = 3;
+test("construction", () => {
+  const a1: wbg.Foo = wbg.Foo.A;
+  const a2: wbg.Foo.A = wbg.Foo.A;
+  expect(a1).toStrictEqual(a2);
+  const a3: wbg.Foo.A = 1;
+  expect(a1).toStrictEqual(a3);
 
-const fn_expects_enum: (_: wbg.Foo) => void = wbg.fn_expects_enum;
-const fn_returns_enum: () => wbg.Foo = wbg.fn_returns_enum;
-const fn_expects_option_enum: (_?: wbg.Foo) => void = wbg.fn_expects_option_enum;
-const fn_returns_option_enum: () => wbg.Foo | undefined = wbg.fn_returns_option_enum;
+  const b1: wbg.Foo = wbg.Foo.B;
+  const b2: wbg.Foo.B = wbg.Foo.B;
+  expect(b1).toStrictEqual(b2);
+  const b3: wbg.Foo.B = 3;
+  expect(b1).toStrictEqual(b3);
+  expect(() => { return a1 as wbg.Foo != b1 }).toBeTruthy();
+});
+
+test("function calls", () => {
+  const fn_expects_enum: (_: wbg.Foo) => void = wbg.fn_expects_enum;
+  const fn_returns_enum: () => wbg.Foo = wbg.fn_returns_enum;
+  const fn_expects_option_enum: (_?: wbg.Foo) => void = wbg.fn_expects_option_enum;
+  const fn_returns_option_enum: () => wbg.Foo | undefined = wbg.fn_returns_option_enum;
+
+  fn_expects_enum(wbg.Foo.B);
+  expect(fn_returns_enum()).toStrictEqual(wbg.Foo.A);
+  expect(fn_returns_option_enum()).toStrictEqual(wbg.Foo.A);
+});

--- a/crates/typescript-tests/src/enums.ts
+++ b/crates/typescript-tests/src/enums.ts
@@ -13,7 +13,7 @@ test("construction", () => {
   expect(b1).toStrictEqual(b2);
   const b3: wbg.Foo.B = 3;
   expect(b1).toStrictEqual(b3);
-  expect(() => { return a1 as wbg.Foo != b1 }).toBeTruthy();
+  expect(a1).not.toStrictEqual(b1);
 });
 
 test("function calls", () => {


### PR DESCRIPTION
Also changed from opt-in to opt-out for running TypeScript tests.

This will make sure that new tests are run by default.