### PR TITLE
Fix GC for references and hold parameter references over async await

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1293,7 +1293,7 @@ impl Invocation {
         match self {
             Invocation::Core { id, .. } => {
                 let name = cx.export_name_of(*id);
-                if asyncness {
+                if asyncness && args.len() > 0 {
                     let mut argscopy = args.to_vec();
                     argscopy[0] = String::from("that.__wbg_ptr");
                     let root_objects: Vec<&str> = argscopy

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1295,7 +1295,7 @@ impl Invocation {
         match self {
             Invocation::Core { id, .. } => {
                 let name = cx.export_name_of(*id);
-                if asyncness && args.len() > 0 && cx.config.weak_refs {
+                if asyncness && !args.is_empty() && cx.config.weak_refs {
                     let mut argscopy = args.to_vec();
                     argscopy[0] = String::from("that.__wbg_ptr");
                     let root_objects: Vec<&str> = argscopy

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1021,10 +1021,12 @@ fn instruction(
             match constructor {
                 Some(name) if name == class => {
                     js.prelude(&format!("this.__wbg_ptr = {} >>> 0;", val));
-                    js.prelude(&format!(
-                        "{}Finalization.register(this, this.__wbg_ptr, this);",
-                        class
-                    ));
+                    if js.cx.config.weak_refs {
+                        js.prelude(&format!(
+                            "{}Finalization.register(this, this.__wbg_ptr, this);",
+                            class
+                        ));
+                    }
                     js.push("this".into());
                 }
                 Some(_) | None => {
@@ -1293,7 +1295,7 @@ impl Invocation {
         match self {
             Invocation::Core { id, .. } => {
                 let name = cx.export_name_of(*id);
-                if asyncness && args.len() > 0 {
+                if asyncness && args.len() > 0 && cx.config.weak_refs {
                     let mut argscopy = args.to_vec();
                     argscopy[0] = String::from("that.__wbg_ptr");
                     let root_objects: Vec<&str> = argscopy

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1307,10 +1307,10 @@ impl Invocation {
                         r#"
                         (function () {{
                             return new Promise((resolve, reject) => {{
-                                that.__paramRefs = that._paramRefs || {{}};
-                                that.__paramRefs[that.__wbg_ptr>>>0] = [{}];
+                                that.__paramRefs = that.__paramRefs || {{}};
+                                that.__paramRefs[that.__wbg_ptr] = [{}];
                                 wasm.{}({}).then(resolve).catch(reject).finally(() => {{
-                                    delete that.__paramRefs[that.__wbg_ptr>>>0];
+                                    delete that.__paramRefs[that.__wbg_ptr];
                                 }});
                             }})}})()"#,
                         root_objects.join(","),


### PR DESCRIPTION
The PR ( https://github.com/rustwasm/wasm-bindgen/pull/3562 ) removed the wrapper generation which was also responsible for registering to the JS FinalizationRegistry to garbage collect to run the clean up code when a GC occurred.

This PR reenables the registration to allow reference types to properly garbage collect, however there was also an issue where objects was garbage collected (wasm-bindgen 0.2.87 and below) where an WASM object if passed as a parameter to an asynchronous method was garbage collected while it was awaited, 0.2.88/0.2.89 does not exhibit this problem as the garbage collection was broken (and thus leaks memory instead), this PR introduces a small runtime wrapper for asynchronous calls that makes sure the variables stay in scope during the function call.

The code generation is hard to follow so I'm not confident this is the preferred solution and are open to changes and pointers to improve the patch.