### PR TITLE
Add missing HtmlFormElement::request_submit method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Added
 
-* Add bindings for `HtmlFormElement::request_submit` and `HtmlFormElement::request_submit_with_submitter` methods
+* Add bindings for `HTMLFormElement.requestSubmit()`.
   [#3747](https://github.com/rustwasm/wasm-bindgen/pull/3747)
 
 * Add bindings for `RTCRtpSender.getCapabilities(DOMString)` method, `RTCRtpCapabilities`, `RTCRtpCodecCapability` and `RTCRtpHeaderExtensionCapability`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Added
 
+* Add bindings for `HtmlFormElement::request_submit` and `HtmlFormElement::request_submit_with_submitter` methods
+  [#3747](https://github.com/rustwasm/wasm-bindgen/pull/3747)
+
 * Add bindings for `RTCRtpSender.getCapabilities(DOMString)` method, `RTCRtpCapabilities`, `RTCRtpCodecCapability` and `RTCRtpHeaderExtensionCapability`.
   [#3737](https://github.com/rustwasm/wasm-bindgen/pull/3737)
 

--- a/crates/web-sys/src/features/gen_HtmlFormElement.rs
+++ b/crates/web-sys/src/features/gen_HtmlFormElement.rs
@@ -167,6 +167,23 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `HtmlFormElement`*"]
     pub fn report_validity(this: &HtmlFormElement) -> bool;
+    # [wasm_bindgen (catch , method , structural , js_class = "HTMLFormElement" , js_name = requestSubmit)]
+    #[doc = "The `requestSubmit()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlFormElement`*"]
+    pub fn request_submit(this: &HtmlFormElement) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "HTMLFormElement" , js_name = requestSubmit)]
+    #[doc = "The `requestSubmit()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlFormElement`*"]
+    pub fn request_submit_with_submitter(
+        this: &HtmlFormElement,
+        submitter: Option<&HtmlElement>,
+    ) -> Result<(), JsValue>;
     # [wasm_bindgen (method , structural , js_class = "HTMLFormElement" , js_name = reset)]
     #[doc = "The `reset()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/HTMLFormElement.webidl
+++ b/crates/web-sys/webidls/enabled/HTMLFormElement.webidl
@@ -43,6 +43,8 @@ interface HTMLFormElement : HTMLElement {
 
   [Throws]
   undefined submit();
+  [Throws]
+  undefined requestSubmit(optional HTMLElement? submitter = null);
   [CEReactions]
   undefined reset();
   boolean checkValidity();


### PR DESCRIPTION
Add the `HtmlFormElement::request_submit*` methods that were missing from the IDL file in `web-sys`

https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit
https://html.spec.whatwg.org/#htmlformelement