### PR TITLE
fix missing typeof operator in __wbg_init() template in no-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 
-* Fix a missing typeof operator in the __wbg_init() template in no-modules mode
+* Fix JS shim default path detection for the no-modules target.
   [#3748](https://github.com/rustwasm/wasm-bindgen/pull/3748)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## [Unreleased](https://github.com/rustwasm/wasm-bindgen/compare/0.2.89...main)
 
+### Fixed
+
+* Fix a missing typeof operator in the __wbg_init() template in no-modules mode
+  [#3748](https://github.com/rustwasm/wasm-bindgen/pull/3748)
+
 ### Added
 
 * Add bindings for `RTCRtpSender.getCapabilities(DOMString)` method, `RTCRtpCapabilities`, `RTCRtpCodecCapability` and `RTCRtpHeaderExtensionCapability`.

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -717,7 +717,7 @@ impl<'a> Context<'a> {
                     stem = self.config.stem()?
                 ),
                 OutputMode::NoModules { .. } => "\
-                    if (typeof input === 'undefined' && script_src !== 'undefined') {
+                    if (typeof input === 'undefined' && typeof script_src !== 'undefined') {
                         input = script_src.replace(/\\.js$/, '_bg.wasm');
                     }"
                 .to_string(),

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -364,7 +364,7 @@ fn default_module_path_target_no_modules() {
     async function __wbg_init(input) {
         if (wasm !== undefined) return wasm;
 
-        if (typeof input === 'undefined' && script_src !== 'undefined') {
+        if (typeof input === 'undefined' && typeof script_src !== 'undefined') {
             input = script_src.replace(/\\.js$/, '_bg.wasm');
         }",
     ));


### PR DESCRIPTION
I noticed a TypeError originating in the generated javascript wrapper when using the `--no-modules` flag (I was messing around with web workers which can result in `script_src` actually being undefined). 

It appears the check is for `undefined` is against the value of `string_src`, rather than the type.