### PR TITLE
Fix cargo wasm_bindgen = { path=../wasm-bindgen } local builds

### DIFF
--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -12,8 +12,3 @@ dependency.
 """
 edition = "2018"
 rust-version = "1.57"
-
-# Because only a single `wasm_bindgen` version can be used in a dependency
-# graph, pretend we link a native library so that `cargo` will provide better
-# error messages than the esoteric linker errors we would otherwise trigger.
-links = "wasm_bindgen"


### PR DESCRIPTION
Fixes https://github.com/rustwasm/wasm-bindgen/discussions/3764#discussioncomment-8022392

The cargo `links` change was introduced 5 years ago in commit https://github.com/rustwasm/wasm-bindgen/commit/7b6731fd3b4f766b10fa5126d1ca87e96bb3aa9e by @alexcrichton, so most probably there was (still is?) a very good justification about the error messages. OTOH, in my (comparatively very limited) experience with `wasm-bindgen`, this change is the difference between **`getrandom` errors** and **compiling successfully** in a local setting.

/cc @mmalenic