### PR TITLE
Implement coverage output

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -256,11 +256,10 @@ fn coverage_args(tmpdir: &Path) -> Option<PathBuf> {
     }
 
     // Profraw path is ignored if coverage isn't enabled
-    env::var_os("WASM_BINDGEN_TEST_COVERAGE")?;
-    log::warn!("Coverage support is still considered highly experimental!");
+    env::var_os("WASM_BINDGEN_UNSTABLE_TEST_COVERAGE")?;
     // TODO coverage link to wasm-bindgen book documenting correct usage
 
-    match env::var_os("WASM_BINDGEN_TEST_PROFRAW_OUT") {
+    match env::var_os("WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT") {
         Some(s) => {
             let mut buf = PathBuf::from(s);
             if buf.is_dir() {

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -264,7 +264,6 @@ fn coverage_args(tmpdir: &Path) -> Option<PathBuf> {
         .map(|s| s.to_str().unwrap().to_string())
         .unwrap_or_default();
 
-
     match env::var_os("WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT") {
         Some(s) => {
             let mut buf = PathBuf::from(s);

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -248,26 +248,32 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn coverage_args(tmpdir: &Path) -> Option<PathBuf> {
-    fn generated(tmpdir: &Path) -> String {
-        format!(
-            "{}.profraw",
+    fn generated(tmpdir: &Path, prefix: &str) -> String {
+        let res = format!(
+            "{prefix}{}.profraw",
             tmpdir.file_name().and_then(|s| s.to_str()).unwrap()
-        )
+        );
+        res
     }
 
     // Profraw path is ignored if coverage isn't enabled
     env::var_os("WASM_BINDGEN_UNSTABLE_TEST_COVERAGE")?;
     // TODO coverage link to wasm-bindgen book documenting correct usage
 
+    let prefix = env::var_os("WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_PREFIX")
+        .map(|s| s.to_str().unwrap().to_string())
+        .unwrap_or_default();
+
+
     match env::var_os("WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT") {
         Some(s) => {
             let mut buf = PathBuf::from(s);
             if buf.is_dir() {
-                buf.push(generated(tmpdir));
+                buf.push(generated(tmpdir, &prefix));
             }
             buf
         }
-        None => PathBuf::from(generated(tmpdir)),
+        None => PathBuf::from(generated(tmpdir, &prefix)),
     }
     .into()
 }

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -20,6 +20,8 @@ wasm-bindgen = { path = '../..', version = '0.2.90' }
 wasm-bindgen-futures = { path = '../futures', version = '0.4.40' }
 wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.40' }
 gg-alloc = { version = "1.0", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 minicov = { version = "0.3", optional = true }
 
 [lib]

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -8,6 +8,12 @@ repository = "https://github.com/rustwasm/wasm-bindgen"
 edition = "2018"
 rust-version = "1.57"
 
+[features]
+default = []
+experimental = ["coverage"]
+
+coverage = ["minicov"]
+
 [dependencies]
 console_error_panic_hook = '0.1'
 js-sys = { path = '../js-sys', version = '0.3.67' }
@@ -16,6 +22,7 @@ wasm-bindgen = { path = '../..', version = '0.2.90' }
 wasm-bindgen-futures = { path = '../futures', version = '0.4.40' }
 wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.40' }
 gg-alloc = { version = "1.0", optional = true }
+minicov = { version = "0.3", optional = true }
 
 [lib]
 test = false

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -10,9 +10,7 @@ rust-version = "1.57"
 
 [features]
 default = []
-experimental = ["coverage"]
-
-coverage = ["minicov"]
+unstable-coverage = ["minicov"]
 
 [dependencies]
 console_error_panic_hook = '0.1'

--- a/crates/test/src/coverage.rs
+++ b/crates/test/src/coverage.rs
@@ -1,0 +1,29 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[cfg(feature = "coverage")]
+#[wasm_bindgen]
+pub fn __wbgtest_cov_dump() -> Vec<u8> {
+    let mut coverage = Vec::new();
+    unsafe {
+        minicov::capture_coverage(&mut coverage).unwrap();
+    }
+    if coverage.is_empty() {
+        console_error!(
+            "Empty coverage data received. Make sure you compile the tests with
+        RUSTFLAGS=\"-Cinstrument-coverage -Zno-profile-runtime --emit=llvm-ir\"",
+        );
+    }
+    coverage
+}
+
+/// Called when setting WASM_BINDGEN_TEST_COVERAGE but coverage feature is disabled.
+/// Currently not being used because of issues in the interpreter regarding profiling
+/// information which cause an error before we get here.
+#[cfg(not(feature = "coverage"))]
+#[wasm_bindgen]
+pub fn __wbgtest_cov_dump() -> Vec<u8> {
+    console_error!(
+        "Coverage was supposed to be dumped, but the \"coverage\" feature is disabled in wasm-bindgen-test",
+    );
+    Vec::new()
+}

--- a/crates/test/src/coverage.rs
+++ b/crates/test/src/coverage.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::prelude::wasm_bindgen;
 
-#[cfg(feature = "coverage")]
+#[cfg(feature = "unstable-coverage")]
 #[wasm_bindgen]
 pub fn __wbgtest_cov_dump() -> Vec<u8> {
     let mut coverage = Vec::new();
@@ -16,10 +16,10 @@ pub fn __wbgtest_cov_dump() -> Vec<u8> {
     coverage
 }
 
-/// Called when setting WASM_BINDGEN_TEST_COVERAGE but coverage feature is disabled.
+/// Called when setting WASM_BINDGEN_UNSTABLE_TEST_COVERAGE but coverage feature is disabled.
 /// Currently not being used because of issues in the interpreter regarding profiling
 /// information which cause an error before we get here.
-#[cfg(not(feature = "coverage"))]
+#[cfg(not(feature = "unstable-coverage"))]
 #[wasm_bindgen]
 pub fn __wbgtest_cov_dump() -> Vec<u8> {
     console_error!(

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -21,6 +21,24 @@ macro_rules! console_log {
     )
 }
 
+/// Helper macro which acts like `println!` only routes to `console.warn`
+/// instead.
+#[macro_export]
+macro_rules! console_warn {
+    ($($arg:tt)*) => (
+        $crate::__rt::log_warn(&format_args!($($arg)*))
+    )
+}
+
+/// Helper macro which acts like `println!` only routes to `console.error`
+/// instead.
+#[macro_export]
+macro_rules! console_error {
+    ($($arg:tt)*) => (
+        $crate::__rt::log_error(&format_args!($($arg)*))
+    )
+}
+
 /// A macro used to configured how this test is executed by the
 /// `wasm-bindgen-test-runner` harness.
 ///
@@ -59,3 +77,5 @@ macro_rules! wasm_bindgen_test_configure {
 
 #[path = "rt/mod.rs"]
 pub mod __rt;
+
+mod coverage;

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -69,4 +69,8 @@ macro_rules! wasm_bindgen_test_configure {
 #[path = "rt/mod.rs"]
 pub mod __rt;
 
+// Make this only available to wasm32 so that we don't
+// import minicov on other archs.
+// That way you can use normal cargo test without minicov
+#[cfg(target_arch = "wasm32")]
 mod coverage;

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -21,15 +21,6 @@ macro_rules! console_log {
     )
 }
 
-/// Helper macro which acts like `println!` only routes to `console.warn`
-/// instead.
-#[macro_export]
-macro_rules! console_warn {
-    ($($arg:tt)*) => (
-        $crate::__rt::log_warn(&format_args!($($arg)*))
-    )
-}
-
 /// Helper macro which acts like `println!` only routes to `console.error`
 /// instead.
 #[macro_export]

--- a/crates/test/src/rt/mod.rs
+++ b/crates/test/src/rt/mod.rs
@@ -237,10 +237,6 @@ extern "C" {
     #[doc(hidden)]
     pub fn js_console_error(s: &str);
 
-    #[wasm_bindgen(js_namespace = console, js_name = warn)]
-    #[doc(hidden)]
-    pub fn js_console_warn(s: &str);
-
     // General-purpose conversion into a `String`.
     #[wasm_bindgen(js_name = String)]
     fn stringify(val: &JsValue) -> String;
@@ -249,11 +245,6 @@ extern "C" {
 /// Internal implementation detail of the `console_log!` macro.
 pub fn log(args: &fmt::Arguments) {
     js_console_log(&args.to_string());
-}
-
-/// Internal implementation detail of the `console_warn!` macro.
-pub fn log_warn(args: &fmt::Arguments) {
-    js_console_warn(&args.to_string());
 }
 
 /// Internal implementation detail of the `console_error!` macro.

--- a/crates/test/src/rt/mod.rs
+++ b/crates/test/src/rt/mod.rs
@@ -233,6 +233,14 @@ extern "C" {
     #[doc(hidden)]
     pub fn js_console_log(s: &str);
 
+    #[wasm_bindgen(js_namespace = console, js_name = error)]
+    #[doc(hidden)]
+    pub fn js_console_error(s: &str);
+
+    #[wasm_bindgen(js_namespace = console, js_name = warn)]
+    #[doc(hidden)]
+    pub fn js_console_warn(s: &str);
+
     // General-purpose conversion into a `String`.
     #[wasm_bindgen(js_name = String)]
     fn stringify(val: &JsValue) -> String;
@@ -241,6 +249,16 @@ extern "C" {
 /// Internal implementation detail of the `console_log!` macro.
 pub fn log(args: &fmt::Arguments) {
     js_console_log(&args.to_string());
+}
+
+/// Internal implementation detail of the `console_warn!` macro.
+pub fn log_warn(args: &fmt::Arguments) {
+    js_console_warn(&args.to_string());
+}
+
+/// Internal implementation detail of the `console_error!` macro.
+pub fn log_error(args: &fmt::Arguments) {
+    js_console_error(&args.to_string());
 }
 
 #[wasm_bindgen(js_class = WasmBindgenTestContext)]

--- a/crates/wasm-interpreter/src/lib.rs
+++ b/crates/wasm-interpreter/src/lib.rs
@@ -74,7 +74,7 @@ impl Interpreter {
     /// the `module` passed to `interpret` below.
     pub fn new(module: &Module) -> Result<Interpreter, anyhow::Error> {
         let mut ret = Interpreter::default();
-        ret.coverage = std::env::var_os("WASM_BINDGEN_TEST_COVERAGE").is_some();
+        ret.coverage = std::env::var_os("WASM_BINDGEN_UNSTABLE_TEST_COVERAGE").is_some();
 
         // The descriptor functions shouldn't really use all that much memory
         // (the LLVM call stack, now the wasm stack). To handle that let's give
@@ -227,7 +227,7 @@ impl Interpreter {
         log::debug!("arguments {:?}", args);
         let local = match &func.kind {
             walrus::FunctionKind::Local(l) => l,
-            _ => panic!("can only call locally defined functions. If you're compiling with profiling information you might want to set WASM_BINDGEN_TEST_COVERAGE (--coverage flag in wasm-pack)"),
+            _ => panic!("can only call locally defined functions. If you're compiling with profiling information you might want to set WASM_BINDGEN_UNSTABLE_TEST_COVERAGE (--coverage flag in wasm-pack)"),
         };
 
         let entry = local.entry_block();
@@ -273,7 +273,7 @@ impl Frame<'_> {
             Instr::Const(c) => match c.value {
                 Value::I32(n) => stack.push(n),
                 Value::I64(_) if coverage => stack.push(0),
-                _ => panic!("non-i32 constant. If you're compiling with profiling information you might want to set WASM_BINDGEN_TEST_COVERAGE (--coverage flag in wasm-pack)"),
+                _ => panic!("non-i32 constant. If you're compiling with profiling information you might want to set WASM_BINDGEN_UNSTABLE_TEST_COVERAGE (--coverage flag in wasm-pack)"),
             },
             Instr::LocalGet(e) => stack.push(self.locals.get(&e.local).cloned().unwrap_or(0)),
             Instr::LocalSet(e) => {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -110,6 +110,7 @@
   - [Writing Asynchronous Tests](./wasm-bindgen-test/asynchronous-tests.md)
   - [Testing in Headless Browsers](./wasm-bindgen-test/browsers.md)
   - [Continuous Integration](./wasm-bindgen-test/continuous-integration.md)
+  - [Coverage (Experimental)](./wasm-bindgen-test/coverage.md)
 
 - [Contributing to `wasm-bindgen`](./contributing/index.md)
   - [Testing](./contributing/testing.md)

--- a/guide/src/wasm-bindgen-test/coverage.md
+++ b/guide/src/wasm-bindgen-test/coverage.md
@@ -1,0 +1,45 @@
+# Generating Coverage Data
+
+You can ask the runner to generate coverage data from functions marked as `#[wasm_bindgen_test]` in the `.profraw` format.
+
+<div class="warning">
+  Coverage is still in an experimental state and may be unreliable and could experience
+  breaking changes at any time.
+</div>
+
+## Enabling the feature
+
+To enable this feature, you need to enable the `"unstable-coverage"` feature in your `wasm-bindgen-test` dependency.
+
+## Generating the data
+
+### `RUSTFLAGS` that need to be present
+
+Make sure you are using `RUSTFLAGS=-Cinstrument-coverage -Zno-profiler-runtime`.
+
+Due to the current limitation of `llvm-cov`, you can't get debug information out of a `.wasm`.
+Instead, [we can grab them from the LLVM IR][wasmcov], so consider adding `--emit=llvm-ir` as well.
+
+[wasmcov]: https://github.com/hknio/code-coverage-for-webassembly
+
+### Arguments to the test runner
+
+If you are using `wasm-pack` to run the tests, refer to the `wasm-pack` documentation.
+
+Otherwise, you can use the following environment variables when [executing the test runner][1] to control the coverage output:
+
+[1]: usage.html#appendix-using-wasm-bindgen-test-without-wasm-pack
+
+- `WASM_BINDGEN_UNSTABLE_TEST_COVERAGE` to generate a single `.profraw` in your current working directory.
+- `WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT` to control the file name of the profraw or the directory in which it is placed
+- `WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_PREFIX` to add a custom prefix to the profraw files. This can be useful if you're running the tests automatically in succession.
+
+### Example
+
+```sh
+RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir" wasm-pack test --coverage --profraw-out cov_data/
+# Generate the debug info on the host
+clang target/wasm32-unknown-unknown/debug/deps/{your-dot-wasm-without-extension}.ll -Wno-override-module -c -o wasm.o
+llvm-profdata merge --sparse cov_data/*.profraw -o cov_data/coverage.profdata
+llvm-cov --instr-profile=cov_data/coverage.profdata wasm.o --format=html --output-dir=coverage/ --sources .
+```


### PR DESCRIPTION
This follows up from https://github.com/rustwasm/wasm-bindgen/issues/3774.

Fixes https://github.com/rustwasm/wasm-bindgen/issues/2276.
Fixes https://github.com/rustwasm/wasm-bindgen/issues/3774.

# Overview

wasm-pack can set `WASM_BINDGEN_TEST_COVERAGE` to allow generating coverage data. `WASM_BINDGEN_TEST_PROFRAW_OUT` takes a path to specify where the generated .profraw file should be saved.

Test runners dump their coverage output after all tests have run. For browser tests, the data is sent to the server which can then dump the data into a profraw. For node/deno tests, the data is dumped directly to a file.

Merging the profraw files into a profdata and generating human-readable output (usually HTML) from the profdata is left to the user.

# Changes

## Interpreter changes

Generating profiling information causes i64s to be placed in the describe blocks that the interpreter parses. I tried adding `#[coverage(off)]` to these blocks to stop the profiling code from being generated but it didn't seem to be sufficient. I've kept comments about where I added these annotations in the diff here in case anyone has a suggestion of where else I could try adding them. All my attempts are in `codegen.rs`.

`#[coverage(off)]` isn't stabilized but I'm willing to open a stabilization PR if we are sure that it fixes our issues here. I'll be sure to document what I found more precisely in a separate issue to ensure the efforts aren't lost.

Until then, I added a coverage flag which allows skipping the instructions which are causing issues. If the flag isn't set, behavior is the same as before.

## Dumping the coverage

The coverage is dumped through the `__wbgtest_cov_dump()` command which requires enabling the `coverage` feature of `wasm-bindgen-test`.

## Test runner changes

### Browsers
The clients call `__wbgtest_cov_dump` and send the resulting data to the server. The server has an additional endpoint which writes coverage to a file.

### Node/Deno
The output is gathered and is dumped to a file directly.

## Usage

It's easiest to test if you also use [my fork of `wasm-pack`](https://github.com/aDogCalledSpot/wasm-pack/tree/coverage) (I'll follow-up with a PR there once we're happy with how everything works here).

Enable the coverage feature of the `wasm-bindgen-test` dependency.

```
# Build for use with minicov
RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir" wasm-pack test --chrome --headless --coverage --profraw-out wtest.profraw
# Generate a {file_name}.o which contains the mapping of wasm instructions
# to source code lines.
clang target/wasm32-unknown-unknown/debug/deps/{file_name}.ll -Wno-override-module -c -o {file_name}.o
# Merge all profraws into a profdata
llvm-profdata merge --sparse wtest.profraw -o coverage.profdata
# Build HTML output from the profdata
llvm-cov show --instr-profile=coverage.profdata {file_name}.o --format=html --output-dir=coverage/ --sources .
```

### Possible mistakes you can make:

So there are three things the user has to get right:

- `RUSTFLAGS` need to be set correctly when building in order to generate profiling information (profiling)
- `WASM_BINDGEN_TEST_COVERAGE` environment variable needs to be set (flag)
- `coverage` feature in `wasm_bindgen_test` needs to enabled (feature)

Here's the output of all the ways you can mix these up:

**No profiling, no feature, no flag**:
Fine, just as before

**No profiling, no feature, flag**:
Prints error saying that coverage was supposed to be dumped but feature disabled

**No profiling, feature, no flag**:
Fine, just as before. Note that you might have issues if you have a crate depending on `wasm-bindgen-test` that also has `minicov` as a dependency since you'll have multiple definitions of functions. This is why we have the feature.

**No profiling, feature, flag**:
Prints error saying that empty coverage data was received. Says what RUSTFLAGS to use (I wanted to have this as a warning but warnings don't seem to be forwarded to the command line in headless mode)

**Profiling, no feature, no flag**:
`wasm-bindgen-interpreter` will panic. Prints a hint. (*)

**Profiling, no feature, flag**:
`TypeError: The specifier "env" was a bare specifier`
(The JS interpreter can't find the calls to the profiling information)(**)

**Profiling, feature, no flag**:
`wasm-bindgen-interpreter` will panic (somewhere else for some reason). Prints a hint.(***)

**Profiling, feature, flag**:
You get coverage! 

(*) If we don't need the workaround in the interpreter, I'm pretty sure this would just take longer to compile but run fine

(**) A better message here would be great but I don't know how to detect this since the problem occurs at link time but it is only printed at runtime.

(**\*) If we don't need the workaround in the interpreter, this would probably also be fine.

# TODOs

- [x] Write an issue documenting the issues with `#[coverage(off)]` and link to it where appropriate
- [x] Write an entry to the book documenting this usage and the possible mistakes you can make and link to it where appropriate
