### PR TITLE
 Added "type found" msg to expose_assert_* fns #3766

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1147,7 +1147,7 @@ impl<'a> Context<'a> {
         self.global(
             "
             function _assertNum(n) {
-                if (typeof(n) !== 'number') throw new Error('expected a number argument');
+                if (typeof(n) !== 'number') throw new Error(`expected a number argument, found ${typeof(n)}`);
             }
             ",
         );
@@ -1160,7 +1160,7 @@ impl<'a> Context<'a> {
         self.global(
             "
             function _assertBigInt(n) {
-                if (typeof(n) !== 'bigint') throw new Error('expected a bigint argument');
+                if (typeof(n) !== 'bigint') throw new Error(`expected a bigint argument, found ${typeof(n)}`);
             }
             ",
         );
@@ -1174,7 +1174,7 @@ impl<'a> Context<'a> {
             "
             function _assertBoolean(n) {
                 if (typeof(n) !== 'boolean') {
-                    throw new Error('expected a boolean argument');
+                    throw new Error(`expected a boolean argument, found ${typeof(n)}`);
                 }
             }
             ",
@@ -1193,7 +1193,7 @@ impl<'a> Context<'a> {
 
         let debug = if self.config.debug {
             "
-                if (typeof(arg) !== 'string') throw new Error('expected a string argument');
+                if (typeof(arg) !== 'string') throw new Error(`expected a string argument, found ${typeof(arg)}`);
             "
         } else {
             ""

--- a/tests/wasm/simple.js
+++ b/tests/wasm/simple.js
@@ -28,6 +28,11 @@ exports.test_wrong_types = function() {
     return;
   assert.throws(() => wasm.simple_int('a'), /expected a number argument/);
   assert.throws(() => wasm.simple_str(3), /expected a string argument/);
+  assert.throws(() => wasm.simple_bool('a'), /expected a boolean argument/);
+
+  assert.doesNotThrow(() => wasm.simple_int(1));
+  assert.doesNotThrow(() => wasm.simple_str('a'));
+  assert.doesNotThrow(() => wasm.simple_bool(true));
 };
 
 exports.test_other_exports_still_available = function() {

--- a/tests/wasm/simple.rs
+++ b/tests/wasm/simple.rs
@@ -102,6 +102,9 @@ fn wrong_types() {
 pub fn simple_int(_a: u32) {}
 
 #[wasm_bindgen]
+pub fn simple_bool(_a: bool) {}
+
+#[wasm_bindgen]
 pub fn simple_str(_a: &str) {}
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
This PR prints out the type of the argument encountered when the type assertion fails as discussed in #3766

- old msg: `expected a number argument`
- mew msg: `expected a number argument, found string`

#### The core change
* added `, found ${typeof(n)}` to int, str and bool assertions

#### Related changes

Simple tests did not have anything for boolean type assertion, so I added one because this PR changes the bool assertion and needs a test.  
Was it included elsewhere and mine is a duplicate?

Only negative assertions were tested. E.g. passing a string to a number arg.  
I added positive tests as well. E.g. passing a number to a number arg.  
Maybe there was a reason why they were omitted?