### PR TITLE
Introduce Array::from_slice for easy array building

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -748,6 +748,18 @@ impl Array {
 
         output
     }
+
+    /// Converts a slice to a JS array
+    pub fn from_slice<'a, T>(slice: &'a [T]) -> Array
+    where
+        JsValue: From<&'a T>,
+    {
+        let res = Array::new_with_length(u32::try_from(slice.len()).unwrap());
+        for (i, v) in slice.iter().enumerate() {
+            res.set(i as u32, JsValue::from(v));
+        }
+        res
+    }
 }
 
 impl std::iter::IntoIterator for Array {

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -99,6 +99,14 @@ fn to_vec() {
 }
 
 #[wasm_bindgen_test]
+fn from_slice() {
+    assert_eq!(
+        Array::from_slice(&["a", "b", "c"]).to_vec(),
+        vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")],
+    );
+}
+
+#[wasm_bindgen_test]
 fn iter() {
     let array = vec![JsValue::from("a"), JsValue::from("b"), JsValue::from("c")]
         .into_iter()

--- a/crates/macro/ui-tests/async-errors.stderr
+++ b/crates/macro/ui-tests/async-errors.stderr
@@ -27,6 +27,7 @@ error[E0277]: the trait bound `wasm_bindgen::JsValue: From<BadType>` is not sati
    | ^^^^^^^^^^^^^^^ the trait `From<BadType>` is not implemented for `wasm_bindgen::JsValue`
    |
    = help: the following other types implement trait `From<T>`:
+             <wasm_bindgen::JsValue as From<&'a &'b str>>
              <wasm_bindgen::JsValue as From<&'a String>>
              <wasm_bindgen::JsValue as From<&'a T>>
              <wasm_bindgen::JsValue as From<&'a str>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,6 +776,13 @@ impl<'a> From<&'a str> for JsValue {
     }
 }
 
+impl<'a, 'b> From<&'a &'b str> for JsValue {
+    #[inline]
+    fn from(s: &'a &'b str) -> JsValue {
+        JsValue::from_str(*s)
+    }
+}
+
 impl<T> From<*mut T> for JsValue {
     #[inline]
     fn from(s: *mut T) -> JsValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ impl<'a> From<&'a str> for JsValue {
 impl<'a, 'b> From<&'a &'b str> for JsValue {
     #[inline]
     fn from(s: &'a &'b str) -> JsValue {
-        JsValue::from_str(*s)
+        JsValue::from_str(s)
     }
 }
 


### PR DESCRIPTION
Hey! I've been looking for a way to easily build `Array`s, and eventually gave up. So I'm submitting this PR, that I think would be useful to easily build `Array`s of simple types at least :)

One thing that made me sad is, I apparently was unable to find a way to make slice-of-str typecheck without adding an `impl From<&&str> for JsValue`. I'd have loved to make it `impl<T> From<&T> for JsValue where JsValue: From<T>`, but 1. I'm not even sure whether that'd be allowed by orphan rules, and 2. I'm pretty sure it'd break backward-compatibility anyway.

Maybe I missed the one trait I should use, that'd support any of the ways to specify a JsValue? I can already say that `AsRef<JsValue>` is not it, because `["foo"].into_iter().collect::<Array>()` does not typecheck; and thus `JsCast` must not be it either.

For some context, I'm needing a way to easily build arrays for the users of [my IndexedDB bindings crate](https://crates.io/crates/indexed-db), as I just noticed that doing it inside the crate itself prevents some potential use cases (aka multi-entry indices).

What do you think about this? :)