### PR TITLE
Stabilize ClipboardEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
+## Unreleased
+
+### Changed
+
+* Stabilize `ClipboardEvent`.
+  [#3791](https://github.com/rustwasm/wasm-bindgen/pull/3791)
+
 ## [0.2.90](https://github.com/rustwasm/wasm-bindgen/compare/0.2.89...0.2.90)
 
 Released 2024-01-06

--- a/crates/web-sys/src/features/gen_ClipboardEvent.rs
+++ b/crates/web-sys/src/features/gen_ClipboardEvent.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::all)]
 use super::*;
 use wasm_bindgen::prelude::*;
-#[cfg(web_sys_unstable_apis)]
 #[wasm_bindgen]
 extern "C" {
     # [wasm_bindgen (extends = Event , extends = :: js_sys :: Object , js_name = ClipboardEvent , typescript_type = "ClipboardEvent")]
@@ -12,11 +11,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEvent`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type ClipboardEvent;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "DataTransfer")]
     # [wasm_bindgen (structural , method , getter , js_class = "ClipboardEvent" , js_name = clipboardData)]
     #[doc = "Getter for the `clipboardData` field of this object."]
@@ -24,22 +19,14 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/clipboardData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEvent`, `DataTransfer`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clipboard_data(this: &ClipboardEvent) -> Option<DataTransfer>;
-    #[cfg(web_sys_unstable_apis)]
     #[wasm_bindgen(catch, constructor, js_class = "ClipboardEvent")]
     #[doc = "The `new ClipboardEvent(..)` constructor, creating a new instance of `ClipboardEvent`."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEvent`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(type_: &str) -> Result<ClipboardEvent, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ClipboardEventInit")]
     #[wasm_bindgen(catch, constructor, js_class = "ClipboardEvent")]
     #[doc = "The `new ClipboardEvent(..)` constructor, creating a new instance of `ClipboardEvent`."]
@@ -47,9 +34,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEvent`, `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new_with_event_init_dict(
         type_: &str,
         event_init_dict: &ClipboardEventInit,

--- a/crates/web-sys/src/features/gen_ClipboardEventInit.rs
+++ b/crates/web-sys/src/features/gen_ClipboardEventInit.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::all)]
 use super::*;
 use wasm_bindgen::prelude::*;
-#[cfg(web_sys_unstable_apis)]
 #[wasm_bindgen]
 extern "C" {
     # [wasm_bindgen (extends = :: js_sys :: Object , js_name = ClipboardEventInit)]
@@ -10,31 +9,20 @@ extern "C" {
     #[doc = "The `ClipboardEventInit` dictionary."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type ClipboardEventInit;
 }
-#[cfg(web_sys_unstable_apis)]
 impl ClipboardEventInit {
     #[doc = "Construct a new `ClipboardEventInit`."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `bubbles` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn bubbles(&mut self, val: bool) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(
@@ -49,13 +37,9 @@ impl ClipboardEventInit {
         let _ = r;
         self
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `cancelable` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn cancelable(&mut self, val: bool) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(
@@ -70,13 +54,9 @@ impl ClipboardEventInit {
         let _ = r;
         self
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `composed` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEventInit`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn composed(&mut self, val: bool) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(
@@ -91,14 +71,10 @@ impl ClipboardEventInit {
         let _ = r;
         self
     }
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "DataTransfer")]
     #[doc = "Change the `clipboardData` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardEventInit`, `DataTransfer`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn clipboard_data(&mut self, val: Option<&DataTransfer>) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(
@@ -114,7 +90,6 @@ impl ClipboardEventInit {
         self
     }
 }
-#[cfg(web_sys_unstable_apis)]
 impl Default for ClipboardEventInit {
     fn default() -> Self {
         Self::new()

--- a/crates/web-sys/webidls/enabled/ClipboardEvent.webidl
+++ b/crates/web-sys/webidls/enabled/ClipboardEvent.webidl
@@ -1,0 +1,18 @@
+/* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/*
+ * Clipboard API and events
+ * Editor’s Draft, 21 November 2023
+ *
+ * The origin of this IDL file is:
+ * https://w3c.github.io/clipboard-apis/#clipboard-event-interfaces
+ */
+
+dictionary ClipboardEventInit : EventInit {
+  DataTransfer? clipboardData = null;
+};
+
+[Exposed=Window]
+interface ClipboardEvent : Event {
+  constructor(DOMString type, optional ClipboardEventInit eventInitDict = {});
+  readonly attribute DataTransfer? clipboardData;
+};

--- a/crates/web-sys/webidls/unstable/Clipboard.webidl
+++ b/crates/web-sys/webidls/unstable/Clipboard.webidl
@@ -6,16 +6,6 @@
  * https://www.w3.org/TR/2021/WD-clipboard-apis-20210604/
  */
 
-dictionary ClipboardEventInit : EventInit {
-  DataTransfer? clipboardData = null;
-};
-
-[Exposed=Window]
-interface ClipboardEvent : Event {
-  constructor(DOMString type, optional ClipboardEventInit eventInitDict = {});
-  readonly attribute DataTransfer? clipboardData;
-};
-
 partial interface Navigator {
   [SecureContext, SameObject] readonly attribute Clipboard? clipboard;
 };


### PR DESCRIPTION
Unlike the rest of the Clipboard API (mostly around `read`), the `ClipboardEvent` has been supported by all browser since forever.