### PR TITLE
use immutable buffers in SubtleCrypto methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Stabilize `ClipboardEvent`.
   [#3791](https://github.com/rustwasm/wasm-bindgen/pull/3791)
 
+* Use immutable buffers in `SubtleCrypto` methods.
+  [#3797](https://github.com/rustwasm/wasm-bindgen/pull/3797)
+
 ## [0.2.90](https://github.com/rustwasm/wasm-bindgen/compare/0.2.89...0.2.90)
 
 Released 2024-01-06

--- a/crates/web-sys/src/features/gen_SubtleCrypto.rs
+++ b/crates/web-sys/src/features/gen_SubtleCrypto.rs
@@ -49,7 +49,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &::js_sys::Object,
         key: &CryptoKey,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = decrypt)]
@@ -62,7 +62,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &str,
         key: &CryptoKey,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = deriveBits)]
@@ -181,7 +181,7 @@ extern "C" {
     pub fn digest_with_object_and_u8_array(
         this: &SubtleCrypto,
         algorithm: &::js_sys::Object,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = digest)]
     #[doc = "The `digest()` method."]
@@ -192,7 +192,7 @@ extern "C" {
     pub fn digest_with_str_and_u8_array(
         this: &SubtleCrypto,
         algorithm: &str,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = encrypt)]
@@ -231,7 +231,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &::js_sys::Object,
         key: &CryptoKey,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = encrypt)]
@@ -244,7 +244,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &str,
         key: &CryptoKey,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = exportKey)]
@@ -347,7 +347,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &::js_sys::Object,
         key: &CryptoKey,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = sign)]
@@ -360,7 +360,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &str,
         key: &CryptoKey,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = unwrapKey)]
@@ -389,7 +389,7 @@ extern "C" {
     pub fn unwrap_key_with_u8_array_and_object_and_object(
         this: &SubtleCrypto,
         format: &str,
-        wrapped_key: &mut [u8],
+        wrapped_key: &[u8],
         unwrapping_key: &CryptoKey,
         unwrap_algorithm: &::js_sys::Object,
         unwrapped_key_algorithm: &::js_sys::Object,
@@ -423,7 +423,7 @@ extern "C" {
     pub fn unwrap_key_with_u8_array_and_str_and_object(
         this: &SubtleCrypto,
         format: &str,
-        wrapped_key: &mut [u8],
+        wrapped_key: &[u8],
         unwrapping_key: &CryptoKey,
         unwrap_algorithm: &str,
         unwrapped_key_algorithm: &::js_sys::Object,
@@ -457,7 +457,7 @@ extern "C" {
     pub fn unwrap_key_with_u8_array_and_object_and_str(
         this: &SubtleCrypto,
         format: &str,
-        wrapped_key: &mut [u8],
+        wrapped_key: &[u8],
         unwrapping_key: &CryptoKey,
         unwrap_algorithm: &::js_sys::Object,
         unwrapped_key_algorithm: &str,
@@ -491,7 +491,7 @@ extern "C" {
     pub fn unwrap_key_with_u8_array_and_str_and_str(
         this: &SubtleCrypto,
         format: &str,
-        wrapped_key: &mut [u8],
+        wrapped_key: &[u8],
         unwrapping_key: &CryptoKey,
         unwrap_algorithm: &str,
         unwrapped_key_algorithm: &str,
@@ -537,7 +537,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &::js_sys::Object,
         key: &CryptoKey,
-        signature: &mut [u8],
+        signature: &[u8],
         data: &::js_sys::Object,
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
@@ -551,7 +551,7 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &str,
         key: &CryptoKey,
-        signature: &mut [u8],
+        signature: &[u8],
         data: &::js_sys::Object,
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
@@ -566,7 +566,7 @@ extern "C" {
         algorithm: &::js_sys::Object,
         key: &CryptoKey,
         signature: &::js_sys::Object,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = verify)]
@@ -580,7 +580,7 @@ extern "C" {
         algorithm: &str,
         key: &CryptoKey,
         signature: &::js_sys::Object,
-        data: &mut [u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = verify)]
@@ -593,8 +593,8 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &::js_sys::Object,
         key: &CryptoKey,
-        signature: &mut [u8],
-        data: &mut [u8],
+        signature: &[u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = verify)]
@@ -607,8 +607,8 @@ extern "C" {
         this: &SubtleCrypto,
         algorithm: &str,
         key: &CryptoKey,
-        signature: &mut [u8],
-        data: &mut [u8],
+        signature: &[u8],
+        data: &[u8],
     ) -> Result<::js_sys::Promise, JsValue>;
     #[cfg(feature = "CryptoKey")]
     # [wasm_bindgen (catch , method , structural , js_class = "SubtleCrypto" , js_name = wrapKey)]

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -94,6 +94,13 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "FontFace", // TODO: Add another type's functions here. Leave a comment header with the type name
         // FileSystemSyncAccessHandle and FileSystemWritableFileStream
         "write",
+        // SubtleCrypto
+        "encrypt",
+        "decrypt",
+        "digest",
+        "sign",
+        "unwrapKey",
+        "verify",
     ])
 });
 


### PR DESCRIPTION
This change makes all the methods in `SubtleCrypto` use `&[u8]` parameters instead of `&mut [u8]`.

Here are the affected parameters:

- `decrypt(data)`: the [WebCrypto API states](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-encrypt):
  > Let data be the result of getting a copy of the bytes held by the data parameter passed to the decrypt method.
- `digest(data)`: the [WebCrypto API states](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-digest): 
  > Let data be the result of getting a copy of the bytes held by the data parameter passed to the digest method.
- `encrypt(data)`: the [WebCrypto API states](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-encrypt):
  > Let data be the result of getting a copy of the bytes held by the data parameter passed to the encrypt method.
- `sign(data)`: the [WebCrypto API states](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-sign):
  > Let data be the result of getting a copy of the bytes held by the data parameter passed to the sign method.
- `unwrapKey(wrapped_key)`: the [WebCrypto API states](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-unwrapKey):
  > Let wrappedKey be the result of getting a copy of the bytes held by the wrappedKey parameter passed to the unwrapKey method.
- `verify(signature, data)`: the [WebCrypto API states](https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-verify):
  > Let signature be the result of getting a copy of the bytes held by the signature parameter passed to the verify method.
  > Let data be the result of getting a copy of the bytes held by the data parameter passed to the verify method.

I take the API documentation language "getting a copy of the bytes" to mean that the original buffer is left unmodified.

I can't find any evidence that these buffers would be modified. I'm not sure how strong an argument that is.

Fixes #3795.