### PR TITLE
Support no-capture behavior in wasm-bindgen-test

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -145,10 +145,15 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
     shell.status("Waiting for test to finish...");
     let start = Instant::now();
     let max = Duration::new(timeout, 0);
+    let mut last_logs = String::new();
     while start.elapsed() < max {
         if client.text(&id, &output)?.contains("test result: ") {
             break;
         }
+        let all_logs = client.text(&id, &logs)?;
+        let new_logs = all_logs.strip_prefix(&last_logs).expect("console.log div reduced in size");
+        print!("{new_logs}");
+        last_logs = all_logs;
         thread::sleep(Duration::from_millis(100));
     }
     shell.clear();


### PR DESCRIPTION
Note: this is still a draft, I need to put that behind a config option. But before I complete it all, I wanted to get an idea what y'all think about this?

My context is, I want to fuzz a crate of mine that needs to run in a browser. I cannot fuzz for now, because fuzzers don't support wasm32. So I want to at least have a very long-running proptest that generates random data.

But then in order to be able to know what's happening, I now need to have a view of what the test actually displays, so that I can distinguish between "running fine" and "deadlocked/panicked".

So before I turn it into a proper configuration option, WDYT about this change?