### PR TITLE
Implement `--skip` flag in test runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added support for running tests in shared and service workers with ``wasm_bindgen_test_configure!` `run_in_shared_worker` and `run_in_service_worker`.
   [#3804](https://github.com/rustwasm/wasm-bindgen/pull/3804)
 
+* Accept the `--skip` flag with `wasm-bindgen-test-runner`.
+  [#3803](https://github.com/rustwasm/wasm-bindgen/pull/3803)
+
 ### Changed
 
 * Stabilize `ClipboardEvent`.


### PR DESCRIPTION
This implements the [`--skip` flag](https://doc.rust-lang.org/1.75.0/rustc/tests/index.html#--skip-filter) for `wasm-bindgen-test-runner`. I tried to stay as close as possible to the behavior of `cargo test`, including the output.