### PR TITLE
Implement `WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Accept the `--skip` flag with `wasm-bindgen-test-runner`.
   [#3803](https://github.com/rustwasm/wasm-bindgen/pull/3803)
 
+* Introduce environment variable `WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION` to disable origin isolation for `wasm-bindgen-test-runner`.
+  [#3807](https://github.com/rustwasm/wasm-bindgen/pull/3807)
+
 ### Changed
 
 * Stabilize `ClipboardEvent`.

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -250,6 +250,7 @@ fn main() -> anyhow::Result<()> {
                 &args,
                 &tests,
                 test_mode,
+                std::env::var("WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION").is_err(),
             )
             .context("failed to spawn server")?;
             let addr = srv.server_addr();


### PR DESCRIPTION
This is useful to test code that is also supposed to run correctly in environments that don't enable origin isolation.