### PR TITLE
Enabled and auto generated `forget()` method for `UsbDevice`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Introduce environment variable `WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION` to disable origin isolation for `wasm-bindgen-test-runner`.
   [#3807](https://github.com/rustwasm/wasm-bindgen/pull/3807)
 
+* Add `forget()` method for `UsbDevice`
+  [#3821](https://github.com/rustwasm/wasm-bindgen/pull/3821)
+
 ### Changed
 
 * Stabilize `ClipboardEvent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Introduce environment variable `WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION` to disable origin isolation for `wasm-bindgen-test-runner`.
   [#3807](https://github.com/rustwasm/wasm-bindgen/pull/3807)
 
-* Add `forget()` method for `UsbDevice`
+* Add bindings for `USBDevice.forget()`.
   [#3821](https://github.com/rustwasm/wasm-bindgen/pull/3821)
 
 ### Changed

--- a/crates/web-sys/src/features/gen_UsbDevice.rs
+++ b/crates/web-sys/src/features/gen_UsbDevice.rs
@@ -306,6 +306,17 @@ extern "C" {
         data: &mut [u8],
     ) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
+    # [wasm_bindgen (method , structural , js_class = "USBDevice" , js_name = forget)]
+    #[doc = "The `forget()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/USBDevice/forget)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `UsbDevice`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn forget(this: &UsbDevice) -> ::js_sys::Promise;
+    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "USBDevice" , js_name = isochronousTransferIn)]
     #[doc = "The `isochronousTransferIn()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/unstable/WebUSB.webidl
+++ b/crates/web-sys/webidls/unstable/WebUSB.webidl
@@ -62,6 +62,7 @@ interface USBDevice {
   readonly attribute FrozenArray<USBConfiguration> configurations;
   readonly attribute boolean opened;
   Promise<undefined> open();
+  Promise<undefined> forget();
   Promise<undefined> close();
   Promise<undefined> selectConfiguration(octet configurationValue);
   Promise<undefined> claimInterface(octet interfaceNumber);


### PR DESCRIPTION
This will allow the user to forget a device which has been "trusted" or "remembered" by the browser.

As defined here: https://developer.mozilla.org/en-US/docs/Web/API/USBDevice/forget

Apologies for my earlier erroneous pull request.