### PR TITLE
Fix using `#[wasm_bindgen(js_name = default)]` with `#[wasm_bindgen(module = ...)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 * Fixed temporary folder detection by `wasm-bindgen-test-runner` on MacOS.
   [#3817](https://github.com/rustwasm/wasm-bindgen/pull/3817)
 
+* Fixed using `#[wasm_bindgen(js_name = default)]` with `#[wasm_bindgen(module = ...)]`.
+  [#3823](https://github.com/rustwasm/wasm-bindgen/pull/3823)
+
 ## [0.2.90](https://github.com/rustwasm/wasm-bindgen/compare/0.2.89...0.2.90)
 
 Released 2024-01-06

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -505,6 +505,7 @@ impl<'a> ConvertToAst<(&ast::Program, BindgenAttrs, &'a Option<ast::ImportModule
             false,
             None,
             false,
+            Some(&["default"]),
         )?
         .0;
         let catch = opts.catch().is_some();
@@ -793,14 +794,18 @@ impl ConvertToAst<BindgenAttrs> for syn::ItemFn {
             false,
             None,
             false,
+            None,
         )?;
         attrs.check_used();
         Ok(ret.0)
     }
 }
 
-pub(crate) fn is_js_keyword(keyword: &str) -> bool {
-    JS_KEYWORDS.contains(&keyword)
+pub(crate) fn is_js_keyword(keyword: &str, skip: Option<&[&str]>) -> bool {
+    JS_KEYWORDS
+        .iter()
+        .filter(|keyword| skip.filter(|skip| skip.contains(keyword)).is_none())
+        .any(|this| *this == keyword)
 }
 
 /// Construct a function (and gets the self type if appropriate) for our AST from a syn function.
@@ -814,6 +819,7 @@ fn function_from_decl(
     allow_self: bool,
     self_ty: Option<&Ident>,
     is_from_impl: bool,
+    skip_keywords: Option<&[&str]>,
 ) -> Result<(ast::Function, Option<ast::MethodSelf>), Diagnostic> {
     if sig.variadic.is_some() {
         bail_span!(sig.variadic, "can't #[wasm_bindgen] variadic functions");
@@ -852,7 +858,7 @@ fn function_from_decl(
     let replace_colliding_arg = |i: &mut syn::PatType| {
         if let syn::Pat::Ident(ref mut i) = *i.pat {
             let ident = i.ident.to_string();
-            if is_js_keyword(ident.as_str()) {
+            if is_js_keyword(ident.as_str(), skip_keywords) {
                 i.ident = Ident::new(format!("_{}", ident).as_str(), i.ident.span());
             }
         }
@@ -889,29 +895,33 @@ fn function_from_decl(
         syn::ReturnType::Type(_, ty) => Some(replace_self(*ty)),
     };
 
-    let (name, name_span, renamed_via_js_name) = if let Some((js_name, js_name_span)) =
-        opts.js_name()
-    {
-        let kind = operation_kind(opts);
-        let prefix = match kind {
-            OperationKind::Setter(_) => "set_",
-            _ => "",
-        };
-        let name = if prefix.is_empty() && opts.method().is_none() && is_js_keyword(js_name) {
-            format!("_{}", js_name)
+    let (name, name_span, renamed_via_js_name) =
+        if let Some((js_name, js_name_span)) = opts.js_name() {
+            let kind = operation_kind(opts);
+            let prefix = match kind {
+                OperationKind::Setter(_) => "set_",
+                _ => "",
+            };
+            let name = if prefix.is_empty()
+                && opts.method().is_none()
+                && is_js_keyword(js_name, skip_keywords)
+            {
+                format!("_{}", js_name)
+            } else {
+                format!("{}{}", prefix, js_name)
+            };
+            (name, js_name_span, true)
         } else {
-            format!("{}{}", prefix, js_name)
-        };
-        (name, js_name_span, true)
-    } else {
-        let name =
-            if !is_from_impl && opts.method().is_none() && is_js_keyword(&decl_name.to_string()) {
+            let name = if !is_from_impl
+                && opts.method().is_none()
+                && is_js_keyword(&decl_name.to_string(), skip_keywords)
+            {
                 format!("_{}", decl_name)
             } else {
                 decl_name.to_string()
             };
-        (name, decl_name.span(), false)
-    };
+            (name, decl_name.span(), false)
+        };
     Ok((
         ast::Function {
             arguments,
@@ -1188,6 +1198,7 @@ impl<'a> MacroParse<&ClassMarker> for &'a mut syn::ImplItemFn {
             true,
             Some(class),
             true,
+            None,
         )?;
         let method_kind = if opts.constructor().is_some() {
             ast::MethodKind::Constructor


### PR DESCRIPTION
This has already come up a couple of times, but after #2855 some things that worked before started failing. E.g. #3012 and #3208.

A better fix has been proposed in https://github.com/rustwasm/wasm-bindgen/pull/2855#discussion_r1191380905, but that would require more work, so this is a stopgap measure to fix #3012 only in the meantime.

Fixes https://github.com/rustwasm/wasm-bindgen/issues/3012.