### PR TITLE
readme: also link the guide built from the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
   </p>
 
   <h3>
-    <a href="https://rustwasm.github.io/docs/wasm-bindgen/">Guide</a>
+    <a href="https://rustwasm.github.io/docs/wasm-bindgen/">Guide (release)</a>
+    <span> | </span>
+    <a href="https://rustwasm.github.io/wasm-bindgen/">Guide (main branch)</a>
     <span> | </span>
     <a href="https://docs.rs/wasm-bindgen">API Docs</a>
     <span> | </span>

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@
   </p>
 
   <h3>
-    <a href="https://rustwasm.github.io/docs/wasm-bindgen/">Guide (release)</a>
-    <span> | </span>
     <a href="https://rustwasm.github.io/wasm-bindgen/">Guide (main branch)</a>
     <span> | </span>
     <a href="https://docs.rs/wasm-bindgen">API Docs</a>


### PR DESCRIPTION
I was confused by the two copies of the Guide on the website, and I hope this will prevent similar confusion for others.  I haven't actually tracked down how these are deployed, so please correct me if I have misunderstood the versions.  The changes from [this commit touching the Guide](https://github.com/rustwasm/wasm-bindgen/commit/fb518d3b190ca8885dbac5e149ce1bbef3d8a92b) are present [here](https://rustwasm.github.io/wasm-bindgen/reference/passing-rust-closures-to-js.html) but not [here](https://rustwasm.github.io/docs/wasm-bindgen/reference/passing-rust-closures-to-js.html).

The [pre-release version of the wasm-pack book](https://rustwasm.github.io/wasm-pack/book/) also has a banner at the top linking to the release version.  LMK if you want similar for this Guide, I will try to figure out how.