### PR TITLE
Fixed nighly build of `wasm-bindgen-futures`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup default nightly-2023-05-08
+    - run: rustup default nightly-2024-02-06
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
     # Note: we only run the browser tests here, because wasm-bindgen doesn't support threading in Node yet.
@@ -283,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup default nightly-2023-05-08
+    - run: rustup default nightly-2024-02-06
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
     - run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
 * Fixed using `#[wasm_bindgen(js_name = default)]` with `#[wasm_bindgen(module = ...)]`.
   [#3823](https://github.com/rustwasm/wasm-bindgen/pull/3823)
 
+* Fixed nighly build of `wasm-bindgen-futures`.
+  [#3827](https://github.com/rustwasm/wasm-bindgen/pull/3827)
+
 ## [0.2.90](https://github.com/rustwasm/wasm-bindgen/compare/0.2.89...0.2.90)
 
 Released 2024-01-06

--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -30,7 +30,7 @@
 //! systems and make sure that Rust/JavaScript can work together with
 //! asynchronous and I/O work.
 
-#![cfg_attr(target_feature = "atomics", feature(stdsimd))]
+#![cfg_attr(target_feature = "atomics", feature(stdarch_wasm_atomic_wait))]
 #![deny(missing_docs)]
 
 use js_sys::Promise;


### PR DESCRIPTION
The nightly features `stdsimd` was recently just split into multiple features.
Specifically we now need the `stdarch_wasm_atomic_wait` feature for the atomics target.

See https://github.com/rust-lang/rust/pull/117372.