### PR TITLE
Update actions/setup-node in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
@@ -120,7 +120,7 @@ jobs:
   #   - uses: actions/checkout@v3
   #   - run: rustup update --no-self-update stable && rustup default stable
   #   - run: rustup target add wasm32-unknown-unknown
-  #   - uses: actions/setup-node@v3
+  #   - uses: actions/setup-node@v4
   #     with:
   #       node-version: '20'
   #   - uses: ./.github/actions/setup-geckodriver
@@ -141,7 +141,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - run: cargo test
@@ -161,7 +161,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
@@ -190,7 +190,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
@@ -206,7 +206,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - run: cargo test -p wasm-bindgen-webidl
@@ -224,7 +224,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: '20'
     - run: cd crates/typescript-tests && ./run.sh


### PR DESCRIPTION
Updates the [`actions/setup-node`](https://github.com/actions/setup-node) action used in the GitHub Actions workflow to its newest major version.

Still using v3 of `actions/setup-node` will generate some warning like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/7804982319

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings for `actions/setup-node`, because v4 uses Node.js 20.