### PR TITLE
Update setup-geckodriver action to use Node.js 20

### DIFF
--- a/.github/actions/setup-geckodriver/action.yml
+++ b/.github/actions/setup-geckodriver/action.yml
@@ -2,5 +2,5 @@ name: 'Setup Geckodriver'
 description: 'Setup Geckodriver'
 
 runs:
-  using: node16
+  using: node20
   main: 'main.js'


### PR DESCRIPTION
Updates the action to setup Geckodriver used in the GitHub Actions workflow to run on Node.js 20 instead of Node.js 16.

Still using Node.js 16 for that action will generate some warnings like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/7804982319

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, ./.github/actions/setup-geckodriver. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The switch to Node.js 20 will get rid of this warning for the setup-geckodriver action.