### PR TITLE
Update JamesIves/github-pages-deploy-action in GHA workflow to newest v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -500,7 +500,7 @@ jobs:
       with:
         name: gh-pages
         path: gh-pages.tar.gz
-    - uses: JamesIves/github-pages-deploy-action@v4.4.1
+    - uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages
         folder: gh-pages


### PR DESCRIPTION
Updates the [`JamesIves/github-pages-deploy-action`](https://github.com/JamesIves/github-pages-deploy-action) action used in the GitHub Actions workflow to its newest version to get rid of the related Node.js 16 deprecation warning.

Still using an older version of `JamesIves/github-pages-deploy-action` will generate some warning like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/7830205111

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/download-artifact@v3, actions/upload-artifact@v3, JamesIves/github-pages-deploy-action@v4.4.1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings for `JamesIves/github-pages-deploy-action`, because v4.5.0 uses Node.js 20.