### PR TITLE
Update actions/upload-artifact + actions/download-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,7 +274,7 @@ jobs:
         done
       env:
         RUSTFLAGS: --cfg=web_sys_unstable_apis
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: examples1
         path: exbuild
@@ -292,7 +292,7 @@ jobs:
             ./build.sh && mkdir -p ../../exbuild/$dir && cp -r ./* ../../exbuild/$dir
           ) || exit 1;
         done
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: examples2
         path: exbuild
@@ -304,11 +304,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: examples1
         path: exbuild
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: examples2
         path: exbuild
@@ -325,7 +325,7 @@ jobs:
     - run: rustup target add wasm32-unknown-unknown
     - run: cargo build --manifest-path benchmarks/Cargo.toml --release --target wasm32-unknown-unknown
     - run: cargo run -p wasm-bindgen-cli -- target/wasm32-unknown-unknown/release/wasm_bindgen_benchmark.wasm --out-dir benchmarks/pkg --target web
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: benchmarks
         path: benchmarks
@@ -342,7 +342,7 @@ jobs:
         strip -g target/x86_64-unknown-linux-musl/release/wasm-bindgen
         strip -g target/x86_64-unknown-linux-musl/release/wasm-bindgen-test-runner
         strip -g target/x86_64-unknown-linux-musl/release/wasm2es6js
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist_linux_x86_64_musl
         path: "target/x86_64-unknown-linux-musl/release/wasm*"
@@ -358,7 +358,7 @@ jobs:
         cargo build --manifest-path crates/cli/Cargo.toml --target aarch64-unknown-linux-gnu --features vendored-openssl --release
       env:
         CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist_linux_aarch64_gnu
         path: "target/aarch64-unknown-linux-gnu/release/wasm*"
@@ -371,7 +371,7 @@ jobs:
     - run: cargo build --manifest-path crates/cli/Cargo.toml --release
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.7
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist_macos_x86_64
         path: "target/release/wasm*"
@@ -386,7 +386,7 @@ jobs:
         cargo build --manifest-path crates/cli/Cargo.toml --target aarch64-apple-darwin --release
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.7
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist_macos_aarch64
         path: "target/aarch64-apple-darwin/release/wasm*"
@@ -399,7 +399,7 @@ jobs:
     - run: cargo build --manifest-path crates/cli/Cargo.toml --release
       env:
         RUSTFLAGS: -Ctarget-feature=+crt-static
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: dist_windows
         path: "target/release/wasm*"
@@ -412,7 +412,7 @@ jobs:
         curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.28/mdbook-v0.4.28-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
         echo $PWD >> $GITHUB_PATH
     - run: (cd guide && mdbook build)
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: doc_book
         path: guide/book/html
@@ -429,7 +429,7 @@ jobs:
         RUSTDOCFLAGS: --cfg=web_sys_unstable_apis
     - run: cargo doc --no-deps --manifest-path crates/futures/Cargo.toml
     - run: tar czvf docs.tar.gz target/doc
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: doc_api
         path: docs.tar.gz
@@ -455,7 +455,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         path: artifacts
     - run: find artifacts
@@ -484,7 +484,7 @@ jobs:
         mk x86_64-apple-darwin dist_macos_x86_64
         mk aarch64-apple-darwin dist_macos_aarch64
         mk x86_64-pc-windows-msvc dist_windows
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: gh-release
         path: gh-release
@@ -496,7 +496,7 @@ jobs:
         mv artifacts/examples2/* gh-pages/exbuild
         mv artifacts/benchmarks gh-pages/benchmarks
         tar czf gh-pages.tar.gz gh-pages
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: gh-pages
         path: gh-pages.tar.gz


### PR DESCRIPTION
Updates the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) and [`actions/download-artifact`](https://github.com/actions/download-artifact) actions used in the GitHub Actions workflow to their newest major version, v4.

Still using v3 of `actions/upload-artifact` and `actions/download-artifact` will generate some warning like in this run: https://github.com/rustwasm/wasm-bindgen/actions/runs/7830205111

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/download-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

The PR will get rid of those warnings for `actions/upload-artifact` and `actions/download-artifact`, because v4 uses Node.js 20 in both cases.