### PR TITLE
Introduce impl TryFrom for Number that succeeds iff the value is within the safe range

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2793,6 +2793,24 @@ macro_rules! number_from {
 }
 number_from!(i8 u8 i16 u16 i32 u32 f32 f64);
 
+macro_rules! number_try_from {
+    ($($x:ident)*) => ($(
+        impl TryFrom<$x> for Number {
+            type Error = $x;
+
+            #[inline]
+            fn try_from(x: $x) -> Result<Number, Self::Error> {
+                if x as f64 >= Number::MIN_SAFE_INTEGER && x as f64 <= Number::MAX_SAFE_INTEGER {
+                    Ok(Number::unchecked_from_js(JsValue::from(x as f64)))
+                } else {
+                    Err(x)
+                }
+            }
+        }
+    )*)
+}
+number_try_from!(i64 u64 i128 u128);
+
 // TODO: add this on the next major version, when blanket impl is removed
 /*
 impl convert::TryFrom<JsValue> for Number {

--- a/crates/js-sys/tests/wasm/Number.rs
+++ b/crates/js-sys/tests/wasm/Number.rs
@@ -1,4 +1,7 @@
-use std::f64::{INFINITY, NAN};
+use std::{
+    convert::TryFrom,
+    f64::{INFINITY, NAN},
+};
 
 use js_sys::*;
 use wasm_bindgen::prelude::*;
@@ -69,6 +72,21 @@ fn new() {
     let v = JsValue::from(n);
     assert!(v.is_object());
     assert_eq!(Number::from(v).value_of(), 42.);
+}
+
+#[wasm_bindgen_test]
+fn try_from() {
+    assert_eq!(Number::try_from(42u128).unwrap(), 42.);
+    assert_eq!(
+        Number::try_from(Number::MAX_SAFE_INTEGER as u64).unwrap(),
+        Number::MAX_SAFE_INTEGER
+    );
+    assert_eq!(
+        Number::try_from(Number::MIN_SAFE_INTEGER as i128).unwrap(),
+        Number::MIN_SAFE_INTEGER
+    );
+    assert!(Number::try_from(Number::MAX_SAFE_INTEGER as u128 + 1).is_err());
+    assert!(Number::try_from(Number::MIN_SAFE_INTEGER as i64 - 1).is_err());
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
As a counterpoint, raised by MaulingMonkey on discord: it could also make sense to round the number, so maybe TryFrom<u64> & co should not be implemented for Number?

OTOH, I personally think the added convenience is worth it, and by implementing TryFrom rather than From we make it explicit that the conversion is fallible, which should make it obvious that the behavior is "error out if the number is outside the safe range". Especially considering that `Number` in JavaScript is often used to describe integers in the safe range, probably much more often than it is actually used to describe floating point numbers.

A design question I had while writing this: should the `Error` type be just the passed-in value? It seems to be the way other `TryFrom` implementations in `js-sys` are currently done, so I went ahead with the same idea here.