### PR TITLE
`wasm-bindgen-futures`: Use single-threaded implementation when multi-threading is impossible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Add bindings for `CanvasState.reset()`, affecting `CanvasRenderingContext2D` and `OffscreenCanvasRenderingContext2D`.
   [#3844](https://github.com/rustwasm/wasm-bindgen/pull/3844)
 
+### Fixed
+
+* Allow `wasm-bindgen-futures` to run correctly when using the atomics target feature in an environment that has no support for `Atomics.waitAsync()` and without cross-origin isolation.
+  [#3848](https://github.com/rustwasm/wasm-bindgen/pull/3848)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.91](https://github.com/rustwasm/wasm-bindgen/compare/0.2.90...0.2.91)

--- a/crates/futures/src/queue.rs
+++ b/crates/futures/src/queue.rs
@@ -19,7 +19,7 @@ struct QueueState {
     // The queue of Tasks which are to be run in order. In practice this is all the
     // synchronous work of futures, and each `Task` represents calling `poll` on
     // a future "at the right time".
-    tasks: RefCell<VecDeque<Rc<crate::task::Task>>>,
+    tasks: RefCell<VecDeque<Rc<dyn crate::task::Task>>>,
 
     // This flag indicates whether we've scheduled `run_all` to run in the future.
     // This is used to ensure that it's only scheduled once.
@@ -58,7 +58,7 @@ pub(crate) struct Queue {
 
 impl Queue {
     // Schedule a task to run on the next tick
-    pub(crate) fn schedule_task(&self, task: Rc<crate::task::Task>) {
+    pub(crate) fn schedule_task(&self, task: Rc<dyn crate::task::Task>) {
         self.state.tasks.borrow_mut().push_back(task);
         // Use queueMicrotask to execute as soon as possible. If it does not exist
         // fall back to the promise resolution
@@ -71,7 +71,7 @@ impl Queue {
         }
     }
     // Append a task to the currently running queue, or schedule it
-    pub(crate) fn push_task(&self, task: Rc<crate::task::Task>) {
+    pub(crate) fn push_task(&self, task: Rc<dyn crate::task::Task>) {
         // It would make sense to run this task on the same tick.  For now, we
         // make the simplifying choice of always scheduling tasks for a future tick.
         self.schedule_task(task)

--- a/crates/futures/src/task/multithread.rs
+++ b/crates/futures/src/task/multithread.rs
@@ -1,3 +1,4 @@
+use super::Task as _;
 use std::cell::RefCell;
 use std::future::Future;
 use std::mem::ManuallyDrop;
@@ -84,27 +85,8 @@ pub(crate) struct Task {
     inner: RefCell<Option<Inner>>,
 }
 
-impl Task {
-    pub(crate) fn spawn(future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
-        let atomic = AtomicWaker::new();
-        let waker = unsafe { Waker::from_raw(AtomicWaker::into_raw_waker(atomic.clone())) };
-        let this = Rc::new(Task {
-            atomic,
-            waker,
-            inner: RefCell::new(None),
-        });
-
-        let closure = {
-            let this = Rc::clone(&this);
-            Closure::new(move |_| this.run())
-        };
-        *this.inner.borrow_mut() = Some(Inner { future, closure });
-
-        // Queue up the Future's work to happen on the next microtask tick.
-        crate::queue::QUEUE.with(move |queue| queue.schedule_task(this));
-    }
-
-    pub(crate) fn run(&self) {
+impl super::Task for Task {
+    fn run(&self) {
         let mut borrow = self.inner.borrow_mut();
 
         // Same as `singlethread.rs`, handle spurious wakeups happening after we
@@ -159,6 +141,27 @@ impl Task {
             }
             break;
         }
+    }
+}
+
+impl Task {
+    pub(crate) fn spawn(future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
+        let atomic = AtomicWaker::new();
+        let waker = unsafe { Waker::from_raw(AtomicWaker::into_raw_waker(atomic.clone())) };
+        let this = Rc::new(Task {
+            atomic,
+            waker,
+            inner: RefCell::new(None),
+        });
+
+        let closure = {
+            let this = Rc::clone(&this);
+            Closure::new(move |_| this.run())
+        };
+        *this.inner.borrow_mut() = Some(Inner { future, closure });
+
+        // Queue up the Future's work to happen on the next microtask tick.
+        crate::queue::QUEUE.with(move |queue| queue.schedule_task(this));
     }
 }
 

--- a/crates/futures/src/task/singlethread.rs
+++ b/crates/futures/src/task/singlethread.rs
@@ -21,6 +21,38 @@ pub(crate) struct Task {
     is_queued: Cell<bool>,
 }
 
+impl super::Task for Task {
+    fn run(&self) {
+        let mut borrow = self.inner.borrow_mut();
+
+        // Wakeups can come in after a Future has finished and been destroyed,
+        // so handle this gracefully by just ignoring the request to run.
+        let inner = match borrow.as_mut() {
+            Some(inner) => inner,
+            None => return,
+        };
+
+        // Ensure that if poll calls `waker.wake()` we can get enqueued back on
+        // the run queue.
+        self.is_queued.set(false);
+
+        let poll = {
+            let mut cx = Context::from_waker(&inner.waker);
+            inner.future.as_mut().poll(&mut cx)
+        };
+
+        // If a future has finished (`Ready`) then clean up resources associated
+        // with the future ASAP. This ensures that we don't keep anything extra
+        // alive in-memory by accident. Our own struct, `Rc<Task>` won't
+        // actually go away until all wakers referencing us go away, which may
+        // take quite some time, so ensure that the heaviest of resources are
+        // released early.
+        if poll.is_ready() {
+            *borrow = None;
+        }
+    }
+}
+
 impl Task {
     pub(crate) fn spawn(future: Pin<Box<dyn Future<Output = ()> + 'static>>) {
         let this = Rc::new(Self {
@@ -96,35 +128,5 @@ impl Task {
             RawWakerVTable::new(raw_clone, raw_wake, raw_wake_by_ref, raw_drop);
 
         RawWaker::new(Rc::into_raw(this) as *const (), &VTABLE)
-    }
-
-    pub(crate) fn run(&self) {
-        let mut borrow = self.inner.borrow_mut();
-
-        // Wakeups can come in after a Future has finished and been destroyed,
-        // so handle this gracefully by just ignoring the request to run.
-        let inner = match borrow.as_mut() {
-            Some(inner) => inner,
-            None => return,
-        };
-
-        // Ensure that if poll calls `waker.wake()` we can get enqueued back on
-        // the run queue.
-        self.is_queued.set(false);
-
-        let poll = {
-            let mut cx = Context::from_waker(&inner.waker);
-            inner.future.as_mut().poll(&mut cx)
-        };
-
-        // If a future has finished (`Ready`) then clean up resources associated
-        // with the future ASAP. This ensures that we don't keep anything extra
-        // alive in-memory by accident. Our own struct, `Rc<Task>` won't
-        // actually go away until all wakers referencing us go away, which may
-        // take quite some time, so ensure that the heaviest of resources are
-        // released early.
-        if poll.is_ready() {
-            *borrow = None;
-        }
     }
 }


### PR DESCRIPTION
I encountered this when using the atomics target feature while running in a shared worker in Firefox, where cross-origin isolation is impossible and therefor sharing a `SharedArrayBuffer` with a dedicated worker is not available, which was the workaround used for Firefox not implementing `Atomics.waitAsync()`.

The solution is to use the single-threaded implementation of `wasm-bindgen-futures` when we detect that multi-threading is impossible.

Note: I somehow managed to accidentally push this commit onto the main branch ... which I promptly reverted and added a branch protection so this doesn't happen again.