### PR TITLE
Update Rust version for UI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -246,7 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - run: rustup update --no-self-update 1.69.0 && rustup default 1.69.0
+    - run: rustup update --no-self-update 1.76.0 && rustup default 1.76.0
     - run: cargo test -p wasm-bindgen-macro
     - run: cargo test -p wasm-bindgen-test-macro
 

--- a/crates/macro/ui-tests/async-errors.stderr
+++ b/crates/macro/ui-tests/async-errors.stderr
@@ -1,52 +1,48 @@
 error[E0277]: the trait bound `Result<(), ()>: IntoJsResult` is not satisfied
-  --> ui-tests/async-errors.rs:30:1
+  --> ui-tests/async-errors.rs:31:24
    |
-30 | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), ()>`
+31 | pub async fn bad1() -> Result<(), ()> { loop {} }
+   |                        ^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), ()>`
    |
    = help: the following other types implement trait `IntoJsResult`:
              Result<(), E>
              Result<T, E>
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<(), BadType>: IntoJsResult` is not satisfied
-  --> ui-tests/async-errors.rs:32:1
+  --> ui-tests/async-errors.rs:33:24
    |
-32 | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), BadType>`
+33 | pub async fn bad2() -> Result<(), BadType> { loop {} }
+   |                        ^^^^^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<(), BadType>`
    |
    = help: the following other types implement trait `IntoJsResult`:
              Result<(), E>
              Result<T, E>
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `wasm_bindgen::JsValue: From<BadType>` is not satisfied
-  --> ui-tests/async-errors.rs:34:1
+  --> ui-tests/async-errors.rs:35:24
    |
-34 | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `From<BadType>` is not implemented for `wasm_bindgen::JsValue`
+35 | pub async fn bad3() -> BadType { loop {} }
+   |                        ^^^^^^^ the trait `From<BadType>` is not implemented for `wasm_bindgen::JsValue`
    |
    = help: the following other types implement trait `From<T>`:
-             <wasm_bindgen::JsValue as From<&'a String>>
-             <wasm_bindgen::JsValue as From<&'a T>>
-             <wasm_bindgen::JsValue as From<&'a str>>
-             <wasm_bindgen::JsValue as From<*const T>>
-             <wasm_bindgen::JsValue as From<*mut T>>
-             <wasm_bindgen::JsValue as From<Array>>
-             <wasm_bindgen::JsValue as From<ArrayBuffer>>
-             <wasm_bindgen::JsValue as From<BigInt64Array>>
+             <wasm_bindgen::JsValue as From<bool>>
+             <wasm_bindgen::JsValue as From<isize>>
+             <wasm_bindgen::JsValue as From<i8>>
+             <wasm_bindgen::JsValue as From<i16>>
+             <wasm_bindgen::JsValue as From<i32>>
+             <wasm_bindgen::JsValue as From<i64>>
+             <wasm_bindgen::JsValue as From<i128>>
+             <wasm_bindgen::JsValue as From<usize>>
            and $N others
    = note: required for `BadType` to implement `Into<wasm_bindgen::JsValue>`
    = note: required for `BadType` to implement `IntoJsResult`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<BadType, wasm_bindgen::JsValue>: IntoJsResult` is not satisfied
-  --> ui-tests/async-errors.rs:36:1
+  --> ui-tests/async-errors.rs:37:24
    |
-36 | #[wasm_bindgen]
-   | ^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<BadType, wasm_bindgen::JsValue>`
+37 | pub async fn bad4() -> Result<BadType, JsValue> { loop {} }
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IntoJsResult` is not implemented for `Result<BadType, wasm_bindgen::JsValue>`
    |
    = help: the following other types implement trait `IntoJsResult`:
              Result<(), E>
              Result<T, E>
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -5,12 +5,12 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
   |            ^^^ the trait `FromWasmAbi` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
   |
   = help: the following other types implement trait `FromWasmAbi`:
-            *const T
-            *mut T
-            Box<[T]>
-            Clamped<T>
-            Option<T>
-            Option<f32>
-            Option<f64>
-            Option<i32>
+            bool
+            char
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
           and $N others

--- a/crates/macro/ui-tests/start-function.stderr
+++ b/crates/macro/ui-tests/start-function.stderr
@@ -11,37 +11,33 @@ error: the start function cannot have generics
    |        ^^^
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
-  --> ui-tests/start-function.rs:15:1
+  --> ui-tests/start-function.rs:16:14
    |
-15 | #[wasm_bindgen(start)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
+16 | fn foo5() -> Result<JsValue, ()> { Err(()) }
+   |              ^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
    |
    = help: the trait `wasm_bindgen::__rt::Start` is implemented for `Result<(), E>`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
-  --> ui-tests/start-function.rs:18:1
+  --> ui-tests/start-function.rs:19:14
    |
-18 | #[wasm_bindgen(start)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+19 | fn foo6() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
    |
    = help: the trait `wasm_bindgen::__rt::Start` is implemented for `Result<(), E>`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, ()>: wasm_bindgen::__rt::Start` is not satisfied
-  --> ui-tests/start-function.rs:27:1
+  --> ui-tests/start-function.rs:28:26
    |
-27 | #[wasm_bindgen(start)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
+28 | async fn foo_async3() -> Result<JsValue, ()> { Err(()) }
+   |                          ^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, ()>`
    |
    = help: the trait `wasm_bindgen::__rt::Start` is implemented for `Result<(), E>`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: wasm_bindgen::__rt::Start` is not satisfied
-  --> ui-tests/start-function.rs:30:1
+  --> ui-tests/start-function.rs:31:26
    |
-30 | #[wasm_bindgen(start)]
-   | ^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
+31 | async fn foo_async4() -> Result<JsValue, JsValue> { Ok(JsValue::from(1u32)) }
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `wasm_bindgen::__rt::Start` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
    |
    = help: the trait `wasm_bindgen::__rt::Start` is implemented for `Result<(), E>`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/struct-fields.stderr
+++ b/crates/macro/ui-tests/struct-fields.stderr
@@ -12,17 +12,13 @@ note: required by a bound in `__wbg_get_bar_a::assert_copy`
    = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: Clone` is not satisfied
-  --> ui-tests/struct-fields.rs:11:20
+  --> ui-tests/struct-fields.rs:12:12
    |
-11 |       #[wasm_bindgen(getter_with_clone)]
-   |                      ^----------------
-   |                      |
-   |  ____________________required by a bound introduced by this call
-   | |
-12 | |     pub b: Foo,
-   | |_________^ the trait `Clone` is not implemented for `Foo`
+12 |     pub b: Foo,
+   |            ^^^ the trait `Clone` is not implemented for `Foo`
    |
 help: consider annotating `Foo` with `#[derive(Clone)]`
    |
-3  | #[derive(Clone)]
+3  + #[derive(Clone)]
+4  | #[wasm_bindgen]
    |

--- a/crates/macro/ui-tests/traits-not-implemented.stderr
+++ b/crates/macro/ui-tests/traits-not-implemented.stderr
@@ -5,13 +5,13 @@ error[E0277]: the trait bound `A: IntoWasmAbi` is not satisfied
   | ^^^^^^^^^^^^^^^ the trait `IntoWasmAbi` is not implemented for `A`
   |
   = help: the following other types implement trait `IntoWasmAbi`:
-            &'a (dyn Fn() -> R + 'b)
-            &'a (dyn Fn(A) -> R + 'b)
-            &'a (dyn Fn(A, B) -> R + 'b)
-            &'a (dyn Fn(A, B, C) -> R + 'b)
-            &'a (dyn Fn(A, B, C, D) -> R + 'b)
-            &'a (dyn Fn(A, B, C, D, E) -> R + 'b)
-            &'a (dyn Fn(A, B, C, D, E, F) -> R + 'b)
-            &'a (dyn Fn(A, B, C, D, E, F, G) -> R + 'b)
+            bool
+            char
+            isize
+            i8
+            i16
+            i32
+            i64
+            usize
           and $N others
   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/wasm-bindgen.stderr
+++ b/crates/macro/ui-tests/wasm-bindgen.stderr
@@ -5,6 +5,12 @@ error[E0433]: failed to resolve: could not find `convert` in `test`
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ could not find `convert` in `test`
    |
    = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing one of these items
+   |
+3  + use crate::test::test::convert;
+   |
+3  + use wasm_bindgen::convert;
+   |
 
 error[E0425]: cannot find function `future_to_promise` in module `test`
   --> ui-tests/wasm-bindgen.rs:40:1
@@ -15,5 +21,5 @@ error[E0425]: cannot find function `future_to_promise` in module `test`
    = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing this function
    |
-3  | use wasm_bindgen_futures::future_to_promise;
+3  + use wasm_bindgen_futures::future_to_promise;
    |

--- a/crates/test-macro/ui-tests/crate.stderr
+++ b/crates/test-macro/ui-tests/crate.stderr
@@ -3,3 +3,8 @@ error[E0433]: failed to resolve: use of undeclared crate or module `foo`
    |
 17 | #[wasm_bindgen_test(crate = foo)]
    |                             ^^^ use of undeclared crate or module `foo`
+   |
+help: consider importing this module
+   |
+5  + use wasm_bindgen_test::__rt;
+   |


### PR DESCRIPTION
This is because the latest version of `bumpalo` we rely on requires Rust v1.73.0 now.