### PR TITLE
Add sorted_iter_mut for NonstandardWitSection.adapters for determinism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Add bindings for `CanvasState.reset()`, affecting `CanvasRenderingContext2D` and `OffscreenCanvasRenderingContext2D`.
   [#3844](https://github.com/rustwasm/wasm-bindgen/pull/3844)
 
+### Fixed
+
+* Make .wasm output deterministic when using `--reference-types`.
+  [#3851](https://github.com/rustwasm/wasm-bindgen/pull/3851)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.91](https://github.com/rustwasm/wasm-bindgen/compare/0.2.90...0.2.91)

--- a/crates/cli-support/src/externref.rs
+++ b/crates/cli-support/src/externref.rs
@@ -25,7 +25,7 @@ pub fn process(module: &mut Module) -> Result<()> {
 
     // Transform all exported functions in the module, using the bindings listed
     // for each exported function.
-    for (id, adapter) in section.adapters.iter_mut() {
+    for (id, adapter) in crate::sorted_iter_mut(&mut section.adapters) {
         let instructions = match &mut adapter.kind {
             AdapterKind::Local { instructions } => instructions,
             AdapterKind::Import { .. } => continue,
@@ -77,7 +77,7 @@ pub fn process(module: &mut Module) -> Result<()> {
     // Additionally we may need to update some adapter instructions other than
     // those found for the externref pass. These are some general "fringe support"
     // things necessary to get absolutely everything working.
-    for (_, adapter) in section.adapters.iter_mut() {
+    for (_, adapter) in crate::sorted_iter_mut(&mut section.adapters) {
         let instrs = match &mut adapter.kind {
             AdapterKind::Local { instructions } => instructions,
             AdapterKind::Import { .. } => continue,

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -785,3 +785,13 @@ where
     pairs.sort_by_key(|(k, _)| *k);
     pairs.into_iter()
 }
+
+/// Like `sorted_iter`, but produces mutable references to the values
+fn sorted_iter_mut<K, V>(map: &mut HashMap<K, V>) -> impl Iterator<Item = (&K, &mut V)>
+where
+    K: Ord,
+{
+    let mut pairs = map.iter_mut().collect::<Vec<_>>();
+    pairs.sort_by_key(|(k, _)| *k);
+    pairs.into_iter()
+}

--- a/crates/cli-support/src/multivalue.rs
+++ b/crates/cli-support/src/multivalue.rs
@@ -14,7 +14,7 @@ pub fn run(module: &mut Module) -> Result<(), Error> {
     let mut to_xform = Vec::new();
     let mut slots = Vec::new();
 
-    for (_, adapter) in adapters.adapters.iter_mut() {
+    for (_, adapter) in crate::sorted_iter_mut(&mut adapters.adapters) {
         extract_xform(module, adapter, &mut to_xform, &mut slots);
     }
     if to_xform.is_empty() {


### PR DESCRIPTION
In the `externref` code, we call `export_xform` while iterating over `adapters` with `iter_mut`. Calling `export_xform` can result in shims, with the id depending on the order in which we iterate over the exports.

This makes the .wasm output deterministic when using `--reference-types`