### PR TITLE
Allow using `'static` lifetimes in functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Changed
 
-* Allow using `'static` lifetimes in functions marked with `#[wasm_bindgen]`.
+* Allow using `'static` lifetimes in functions marked with `#[wasm_bindgen]`. This does not allow references where they were not allowed before!
   [#3856](https://github.com/rustwasm/wasm-bindgen/pull/3856)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 * Add support for `Option<*const T>`, `Option<*mut T>` and `NonNull<T>`.
   [#3852](https://github.com/rustwasm/wasm-bindgen/pull/3852)
 
+### Changed
+
+* Allow using `'static` lifetimes in functions marked with `#[wasm_bindgen]`.
+  [#3856](https://github.com/rustwasm/wasm-bindgen/pull/3856)
+
 ### Fixed
 
 * Make .wasm output deterministic when using `--reference-types`.

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1652,12 +1652,14 @@ fn assert_no_lifetimes(sig: &syn::Signature) -> Result<(), Diagnostic> {
     }
 
     impl<'ast> syn::visit::Visit<'ast> for Walk {
-        fn visit_lifetime(&mut self, i: &'ast syn::Lifetime) {
-            self.diagnostics.push(err_span!(
-                i,
-                "it is currently not sound to use lifetimes in function \
+        fn visit_lifetime(&mut self, lifetime: &'ast syn::Lifetime) {
+            if lifetime.ident != "static" {
+                self.diagnostics.push(err_span!(
+                    lifetime,
+                    "it is currently not sound to use lifetimes in function \
                  signatures"
-            ));
+                ));
+            }
         }
     }
     let mut walk = Walk {

--- a/crates/macro/ui-tests/invalid-imports-1.rs
+++ b/crates/macro/ui-tests/invalid-imports-1.rs
@@ -1,0 +1,41 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    type A;
+
+    #[wasm_bindgen(method)]
+    fn f1();
+    #[wasm_bindgen(method)]
+    fn f2(x: u32);
+    #[wasm_bindgen(method)]
+    fn f3(x: &&u32);
+    #[wasm_bindgen(method)]
+    fn f4(x: &foo::Bar);
+    #[wasm_bindgen(method)]
+    fn f4(x: &::Bar);
+    #[wasm_bindgen(method)]
+    fn f4(x: &Bar<T>);
+    #[wasm_bindgen(method)]
+    fn f4(x: &dyn Fn(T));
+
+    #[wasm_bindgen(constructor)]
+    fn f();
+    #[wasm_bindgen(constructor)]
+    fn f() -> ::Bar;
+    #[wasm_bindgen(constructor)]
+    fn f() -> &Bar;
+
+    #[wasm_bindgen(catch)]
+    fn f() -> u32;
+    #[wasm_bindgen(catch)]
+    fn f() -> &u32;
+    #[wasm_bindgen(catch)]
+    fn f() -> Result<>;
+    #[wasm_bindgen(catch)]
+    fn f() -> Result<'a>;
+    #[wasm_bindgen(catch)]
+    fn f() -> Result<&'static u32>;
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/invalid-imports-1.stderr
+++ b/crates/macro/ui-tests/invalid-imports-1.stderr
@@ -1,0 +1,65 @@
+error: imported methods must have at least one argument
+ --> ui-tests/invalid-imports-1.rs:8:5
+  |
+8 |     fn f1();
+  |     ^^^^^^^^
+
+error: first argument of method must be a shared reference
+  --> ui-tests/invalid-imports-1.rs:10:14
+   |
+10 |     fn f2(x: u32);
+   |              ^^^
+
+error: first argument of method must be a path
+  --> ui-tests/invalid-imports-1.rs:12:15
+   |
+12 |     fn f3(x: &&u32);
+   |               ^^^^
+
+error: paths with type parameters are not supported yet
+  --> ui-tests/invalid-imports-1.rs:18:15
+   |
+18 |     fn f4(x: &Bar<T>);
+   |               ^^^^^^
+
+error: first argument of method must be a path
+  --> ui-tests/invalid-imports-1.rs:20:15
+   |
+20 |     fn f4(x: &dyn Fn(T));
+   |               ^^^^^^^^^
+
+error: constructor returns must be bare types
+  --> ui-tests/invalid-imports-1.rs:23:5
+   |
+23 |     fn f();
+   |     ^^^^^^^
+
+error: return value of constructor must be a bare path
+  --> ui-tests/invalid-imports-1.rs:27:5
+   |
+27 |     fn f() -> &Bar;
+   |     ^^^^^^^^^^^^^^^
+
+error: must be Result<...>
+  --> ui-tests/invalid-imports-1.rs:30:15
+   |
+30 |     fn f() -> u32;
+   |               ^^^
+
+error: must be Result<...>
+  --> ui-tests/invalid-imports-1.rs:32:15
+   |
+32 |     fn f() -> &u32;
+   |               ^^^^
+
+error: must have at least one generic parameter
+  --> ui-tests/invalid-imports-1.rs:34:15
+   |
+34 |     fn f() -> Result<>;
+   |               ^^^^^^^^
+
+error: it is currently not sound to use lifetimes in function signatures
+  --> ui-tests/invalid-imports-1.rs:36:22
+   |
+36 |     fn f() -> Result<'a>;
+   |                      ^^

--- a/crates/macro/ui-tests/invalid-imports-2.rs
+++ b/crates/macro/ui-tests/invalid-imports-2.rs
@@ -1,0 +1,8 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    fn f() -> &'static u32;
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/invalid-imports-2.stderr
+++ b/crates/macro/ui-tests/invalid-imports-2.stderr
@@ -1,0 +1,5 @@
+error: cannot return references in #[wasm_bindgen] imports yet
+ --> ui-tests/invalid-imports-2.rs:5:15
+  |
+5 |     fn f() -> &'static u32;
+  |               ^^^^^^^^^^^^

--- a/crates/macro/ui-tests/invalid-imports.rs
+++ b/crates/macro/ui-tests/invalid-imports.rs
@@ -36,6 +36,8 @@ extern "C" {
     fn f() -> Result<>;
     #[wasm_bindgen(catch)]
     fn f() -> Result<'a>;
+    #[wasm_bindgen(catch)]
+    fn f() -> Result<&'static u32>;
 }
 
 fn main() {}

--- a/crates/macro/ui-tests/invalid-imports.stderr
+++ b/crates/macro/ui-tests/invalid-imports.stderr
@@ -1,9 +1,3 @@
-error: it is currently not sound to use lifetimes in function signatures
- --> ui-tests/invalid-imports.rs:7:16
-  |
-7 |     fn f() -> &'static u32;
-  |                ^^^^^^^
-
 error: imported methods must have at least one argument
   --> ui-tests/invalid-imports.rs:10:5
    |


### PR DESCRIPTION
Currently `#[wasm_bindgen]` disallows any kind of lifetime on functions.
This change allows it to accept `'static`.

Fixes #1187.