### PR TITLE
Allow overriding headless test URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Add support for `Option<*const T>`, `Option<*mut T>` and `NonNull<T>`.
   [#3852](https://github.com/rustwasm/wasm-bindgen/pull/3852)
 
+* Allow overriding the URL used for headless tests by setting `WASM_BINDGEN_TEST_ADDRESS`.
+  [#3861](https://github.com/rustwasm/wasm-bindgen/pull/3861)
+
 ### Changed
 
 * Allow using `'static` lifetimes in functions marked with `#[wasm_bindgen]`. This does not allow references where they were not allowed before!

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -121,8 +121,8 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
 
     // Visit our local server to open up the page that runs tests, and then get
     // some handles to objects on the page which we'll be scraping output from.
-    let url = std::env::var("WASM_BINDGEN_TEST_ADDRESS")
-        .unwrap_or_else(|_| format!("http://{}", server));
+    let url =
+        std::env::var("WASM_BINDGEN_TEST_ADDRESS").unwrap_or_else(|_| format!("http://{}", server));
     shell.status(&format!("Visiting {}...", url));
     client.goto(&id, &url)?;
     shell.status("Loading page elements...");

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -121,7 +121,8 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
 
     // Visit our local server to open up the page that runs tests, and then get
     // some handles to objects on the page which we'll be scraping output from.
-    let url = format!("http://{}", server);
+    let url = std::env::var("WASM_BINDGEN_HEADLESS_TEST_URL")
+        .unwrap_or_else(|| format!("http://{}", server));
     shell.status(&format!("Visiting {}...", url));
     client.goto(&id, &url)?;
     shell.status("Loading page elements...");

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -121,7 +121,7 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
 
     // Visit our local server to open up the page that runs tests, and then get
     // some handles to objects on the page which we'll be scraping output from.
-    let url = std::env::var("WASM_BINDGEN_HEADLESS_TEST_URL")
+    let url = std::env::var("WASM_BINDGEN_TEST_ADDRESS")
         .unwrap_or_else(|_| format!("http://{}", server));
     shell.status(&format!("Visiting {}...", url));
     client.goto(&id, &url)?;

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -122,7 +122,7 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
     // Visit our local server to open up the page that runs tests, and then get
     // some handles to objects on the page which we'll be scraping output from.
     let url = std::env::var("WASM_BINDGEN_HEADLESS_TEST_URL")
-        .unwrap_or_else(|| format!("http://{}", server));
+        .unwrap_or_else(|_| format!("http://{}", server));
     shell.status(&format!("Visiting {}...", url));
     client.goto(&id, &url)?;
     shell.status("Loading page elements...");


### PR DESCRIPTION
I have wasm code that uses web-sys to make cross-origin requests with cookies. To test this interactively, I navigate to `http://localhost.mydomain.org:8000` (which I've set up to resolve to 127.0.0.1) instead of `http://localhost:8000`.

This PR would allow me to do the same for headless tests. I imagine it's also useful in combination with #3314.