### PR TITLE
Don't allow invalid Unicode scalar values in `char`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Make .wasm output deterministic when using `--reference-types`.
   [#3851](https://github.com/rustwasm/wasm-bindgen/pull/3851)
 
+* Don't allow invalid Unicode scalar values in `char`.
+  [#3866](https://github.com/rustwasm/wasm-bindgen/pull/3866)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.91](https://github.com/rustwasm/wasm-bindgen/compare/0.2.90...0.2.91)

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -502,6 +502,11 @@ impl<'a, 'b> JsBuilder<'a, 'b> {
         self.prelude(&format!("_assertNonNull({});", arg));
     }
 
+    fn assert_char(&mut self, arg: &str) {
+        self.cx.expose_assert_char();
+        self.prelude(&format!("_assertChar({});", arg));
+    }
+
     fn assert_optional_bigint(&mut self, arg: &str) {
         if !self.cx.config.debug {
             return;
@@ -739,7 +744,11 @@ fn instruction(
 
         Instruction::I32FromStringFirstChar => {
             let val = js.pop();
-            js.push(format!("{}.codePointAt(0)", val));
+            let i = js.tmp();
+            js.prelude(&format!("const char{i} = {val}.codePointAt(0);"));
+            let val = format!("char{i}");
+            js.assert_char(&val);
+            js.push(val);
         }
 
         Instruction::I32FromExternrefOwned => {
@@ -816,11 +825,18 @@ fn instruction(
 
         Instruction::I32FromOptionChar => {
             let val = js.pop();
+            let i = js.tmp();
             js.cx.expose_is_like_none();
-            js.push(format!(
-                "isLikeNone({0}) ? 0xFFFFFF : {0}.codePointAt(0)",
+            js.prelude(&format!(
+                "const char{i} = isLikeNone({0}) ? 0xFFFFFF : {0}.codePointAt(0);",
                 val
             ));
+            let val = format!("char{i}");
+            js.cx.expose_assert_char();
+            js.prelude(&format!(
+                "if ({val} !== 0xFFFFFF) {{ _assertChar({val}); }}"
+            ));
+            js.push(val);
         }
 
         Instruction::I32FromOptionEnum { hole } => {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2116,6 +2116,19 @@ impl<'a> Context<'a> {
         );
     }
 
+    fn expose_assert_char(&mut self) {
+        if !self.should_write_global("assert_char") {
+            return;
+        }
+        self.global(
+            "
+            function _assertChar(c) {
+                if (typeof(c) !== 'number' || c >= 0x110000 || (c >= 0xD800 && c < 0xE000)) throw new Error(`expected a number argument that is a valid Unicode scalar value, found ${c}`);
+            }
+            ",
+        );
+    }
+
     fn expose_make_mut_closure(&mut self) -> Result<(), Error> {
         if !self.should_write_global("make_mut_closure") {
             return Ok(());

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2123,7 +2123,7 @@ impl<'a> Context<'a> {
         self.global(
             "
             function _assertChar(c) {
-                if (typeof(c) !== 'number' || c >= 0x110000 || (c >= 0xD800 && c < 0xE000)) throw new Error(`expected a number argument that is a valid Unicode scalar value, found ${c}`);
+                if (typeof(c) === 'number' && (c >= 0x110000 || (c >= 0xD800 && c < 0xE000))) throw new Error(`expected a valid Unicode scalar value, found ${c}`);
             }
             ",
         );

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -188,6 +188,7 @@ impl FromWasmAbi for char {
 
     #[inline]
     unsafe fn from_abi(js: u32) -> char {
+        // SAFETY: Checked in bindings.
         char::from_u32_unchecked(js)
     }
 }

--- a/tests/wasm/char.js
+++ b/tests/wasm/char.js
@@ -2,6 +2,7 @@ const wasm = require('wasm-bindgen-test.js');
 const assert = require('assert');
 
 exports.js_identity = a => a;
+exports.js_option_identity = a => a;
 
 exports.js_works = () => {
     assert.strictEqual(wasm.letter(), 'a');
@@ -14,4 +15,7 @@ exports.js_works = () => {
     assert.strictEqual(wasm.rust_js_identity('㊻'), '㊻');
     wasm.rust_letter('a');
     wasm.rust_face('😀');
+
+    assert.throws(() => wasm.rust_js_identity('\uD83D'), /expected a number argument that is a valid Unicode scalar value, found 55357/);
+    assert.throws(() => wasm.rust_js_option_identity('\uD83D'), /expected a number argument that is a valid Unicode scalar value, found 55357/);
 };

--- a/tests/wasm/char.js
+++ b/tests/wasm/char.js
@@ -2,11 +2,11 @@ const wasm = require('wasm-bindgen-test.js');
 const assert = require('assert');
 
 exports.js_identity = a => a;
-exports.js_option_identity = a => a;
 
 exports.js_works = () => {
     assert.strictEqual(wasm.letter(), 'a');
     assert.strictEqual(wasm.face(), '😀');
+    assert.strictEqual(wasm.rust_identity(''), '\u0000');
     assert.strictEqual(wasm.rust_identity('Ղ'), 'Ղ');
     assert.strictEqual(wasm.rust_identity('ҝ'), 'ҝ');
     assert.strictEqual(wasm.rust_identity('Δ'), 'Δ');
@@ -16,6 +16,12 @@ exports.js_works = () => {
     wasm.rust_letter('a');
     wasm.rust_face('😀');
 
-    assert.throws(() => wasm.rust_js_identity('\uD83D'), /expected a number argument that is a valid Unicode scalar value, found 55357/);
-    assert.throws(() => wasm.rust_js_option_identity('\uD83D'), /expected a number argument that is a valid Unicode scalar value, found 55357/);
+    assert.strictEqual(wasm.rust_option_identity(undefined), undefined);
+    assert.strictEqual(wasm.rust_option_identity(null), undefined);
+    assert.strictEqual(wasm.rust_option_identity(''), '\u0000');
+    assert.strictEqual(wasm.rust_option_identity('\u0000'), '\u0000');
+
+    assert.throws(() => wasm.rust_identity(55357), /c.codePointAt is not a function/);
+    assert.throws(() => wasm.rust_identity('\uD83D'), /expected a valid Unicode scalar value, found 55357/);
+    assert.throws(() => wasm.rust_option_identity('\uD83D'), /expected a valid Unicode scalar value, found 55357/);
 };

--- a/tests/wasm/char.rs
+++ b/tests/wasm/char.rs
@@ -4,6 +4,7 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen(module = "tests/wasm/char.js")]
 extern "C" {
     fn js_identity(c: char) -> char;
+    fn js_option_identity(c: Option<char>) -> Option<char>;
     fn js_works();
 }
 
@@ -15,6 +16,11 @@ pub fn rust_identity(c: char) -> char {
 #[wasm_bindgen]
 pub fn rust_js_identity(c: char) -> char {
     js_identity(c)
+}
+
+#[wasm_bindgen]
+pub fn rust_js_option_identity(c: Option<char>) -> Option<char> {
+    js_option_identity(c)
 }
 
 #[wasm_bindgen]

--- a/tests/wasm/char.rs
+++ b/tests/wasm/char.rs
@@ -4,7 +4,6 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen(module = "tests/wasm/char.js")]
 extern "C" {
     fn js_identity(c: char) -> char;
-    fn js_option_identity(c: Option<char>) -> Option<char>;
     fn js_works();
 }
 
@@ -14,13 +13,13 @@ pub fn rust_identity(c: char) -> char {
 }
 
 #[wasm_bindgen]
-pub fn rust_js_identity(c: char) -> char {
-    js_identity(c)
+pub fn rust_option_identity(c: Option<char>) -> Option<char> {
+    c
 }
 
 #[wasm_bindgen]
-pub fn rust_js_option_identity(c: Option<char>) -> Option<char> {
-    js_option_identity(c)
+pub fn rust_js_identity(c: char) -> char {
+    js_identity(c)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
This adds runtime checks for passing `char` from JS, which prevents invalid Unicode scalar values.

Fixes #2269.