### PR TITLE
Account for failure in publishing process

### DIFF
--- a/publish.rs
+++ b/publish.rs
@@ -216,6 +216,6 @@ fn publish(krate: &Crate) {
         .status()
         .expect("failed to run cargo");
     if !status.success() {
-        println!("FAIL: failed to publish `{}`: {}", krate.name, status);
+        panic!("FAIL: failed to publish `{}`: {}", krate.name, status);
     }
 }


### PR DESCRIPTION
We just had some funny failures in the CI during publishing: https://github.com/rustwasm/wasm-bindgen/actions/runs/8138814872/job/22240636231#step:13:1.

This PR changes the code to actually fail the process when we encounter any error during publishing.