### PR TITLE
Add a crates/cli/tests/reference/enums.rs test

### DIFF
--- a/crates/cli/tests/reference/enums.d.ts
+++ b/crates/cli/tests/reference/enums.d.ts
@@ -1,0 +1,19 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+* @param {Color} color
+* @returns {Color}
+*/
+export function enum_echo(color: Color): Color;
+/**
+* @param {Color | undefined} [color]
+* @returns {Color | undefined}
+*/
+export function option_enum_echo(color?: Color): Color | undefined;
+/**
+*/
+export enum Color {
+  Green = 0,
+  Yellow = 1,
+  Red = 2,
+}

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -1,0 +1,54 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8Memory0 = null;
+
+function getUint8Memory0() {
+    if (cachedUint8Memory0 === null || cachedUint8Memory0.byteLength === 0) {
+        cachedUint8Memory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8Memory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8Memory0().subarray(ptr, ptr + len));
+}
+/**
+* @param {Color} color
+* @returns {Color}
+*/
+export function enum_echo(color) {
+    const ret = wasm.enum_echo(color);
+    return ret;
+}
+
+function isLikeNone(x) {
+    return x === undefined || x === null;
+}
+/**
+* @param {Color | undefined} [color]
+* @returns {Color | undefined}
+*/
+export function option_enum_echo(color) {
+    const ret = wasm.option_enum_echo(isLikeNone(color) ? 3 : color);
+    return ret === 3 ? undefined : ret;
+}
+
+/**
+*/
+export const Color = Object.freeze({ Green:0,"0":"Green",Yellow:1,"1":"Yellow",Red:2,"2":"Red", });
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+

--- a/crates/cli/tests/reference/enums.rs
+++ b/crates/cli/tests/reference/enums.rs
@@ -1,0 +1,19 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[derive(PartialEq, Debug)]
+pub enum Color {
+    Green,
+    Yellow,
+    Red,
+}
+
+#[wasm_bindgen]
+pub fn enum_echo(color: Color) -> Color {
+    color
+}
+
+#[wasm_bindgen]
+pub fn option_enum_echo(color: Option<Color>) -> Option<Color> {
+    color
+}

--- a/crates/cli/tests/reference/enums.wat
+++ b/crates/cli/tests/reference/enums.wat
@@ -1,0 +1,9 @@
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (func $enum_echo (;0;) (type 0) (param i32) (result i32))
+  (func $option_enum_echo (;1;) (type 0) (param i32) (result i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "enum_echo" (func $enum_echo))
+  (export "option_enum_echo" (func $option_enum_echo))
+)


### PR DESCRIPTION
This makes it easier to see the current enum implementation and will make it easier to review changes to it.

Generated by writing the `enum.rs` and running
```
BLESS=1 cargo test -p wasm-bindgen-cli
```