### PR TITLE
Deprecate `--keep-debug` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 * Improved error messages for `self` arguments in invalid positions.
   [#4276](https://github.com/rustwasm/wasm-bindgen/pull/4276)
 
+* Deprecate `--keep-debug`. Debug information is now retained by default.
+  [#3876](https://github.com/rustwasm/wasm-bindgen/pull/3876)
+
 ### Fixed
 
 * Fixed methods with `self: &Self` consuming the object.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ resolver = "2"
 
 [patch.crates-io]
 js-sys = { path = 'crates/js-sys' }
+walrus = { git = "https://github.com/daxpedda/walrus", branch = "empty-dwarf" }
 wasm-bindgen = { path = '.' }
 wasm-bindgen-futures = { path = 'crates/futures' }
 web-sys = { path = 'crates/web-sys' }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -30,7 +30,6 @@ pub struct Bindgen {
     omit_imports: bool,
     demangle: bool,
     keep_lld_exports: bool,
-    keep_debug: bool,
     remove_name_section: bool,
     remove_producers_section: bool,
     omit_default_module_path: bool,
@@ -101,7 +100,6 @@ impl Bindgen {
             omit_imports: false,
             demangle: true,
             keep_lld_exports: false,
-            keep_debug: false,
             remove_name_section: false,
             remove_producers_section: false,
             emit_start: true,
@@ -252,11 +250,6 @@ impl Bindgen {
 
     pub fn keep_lld_exports(&mut self, keep_lld_exports: bool) -> &mut Bindgen {
         self.keep_lld_exports = keep_lld_exports;
-        self
-    }
-
-    pub fn keep_debug(&mut self, keep_debug: bool) -> &mut Bindgen {
-        self.keep_debug = keep_debug;
         self
     }
 
@@ -466,7 +459,7 @@ impl Bindgen {
             // include shared memory, so it fails that part of
             // validation!
             .strict_validate(false)
-            .generate_dwarf(self.keep_debug)
+            .generate_dwarf(true)
             .generate_name_section(!self.remove_name_section)
             .generate_producers_section(!self.remove_producers_section)
             .parse(bytes)

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -227,7 +227,6 @@ fn main() -> anyhow::Result<()> {
 
     b.debug(debug)
         .input_module(module, wasm)
-        .keep_debug(false)
         .emit_start(false)
         .generate(&tmpdir)
         .context("executing `wasm-bindgen` over the Wasm file")?;

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -28,7 +28,7 @@ Options:
     --debug                      Include otherwise-extraneous debug checks in output
     --no-demangle                Don't demangle Rust symbol names
     --keep-lld-exports           Keep exports synthesized by LLD
-    --keep-debug                 Keep debug sections in Wasm files
+    --keep-debug                 Deprecated, use Rustc to control debug information instead
     --remove-name-section        Remove the debugging `name` section of the file
     --remove-producers-section   Remove the telemetry `producers` section
     --omit-default-module-path   Don't add WebAssembly fallback imports in generated JavaScript
@@ -67,6 +67,7 @@ struct Args {
     flag_weak_refs: Option<bool>,
     flag_reference_types: Option<bool>,
     flag_keep_lld_exports: bool,
+    #[allow(dead_code)]
     flag_keep_debug: bool,
     flag_encode_into: Option<String>,
     flag_target: Option<String>,
@@ -121,7 +122,6 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .debug(args.flag_debug)
         .demangle(!args.flag_no_demangle)
         .keep_lld_exports(args.flag_keep_lld_exports)
-        .keep_debug(args.flag_keep_debug)
         .remove_name_section(args.flag_remove_name_section)
         .remove_producers_section(args.flag_remove_producers_section)
         .typescript(typescript)

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -73,11 +73,6 @@ When post-processing the `.wasm` binary, do not demangle Rust symbols in the
 When post-processing the `.wasm` binary, do not remove exports that are
 synthesized by Rust's linker, LLD.
 
-### `--keep-debug`
-
-When post-processing the `.wasm` binary, do not strip DWARF debug info custom
-sections.
-
 ### `--browser`
 
 When generating bundler-compatible code (see the section on [deployment]) this


### PR DESCRIPTION
Debug information is already controlled by Rustc/Cargo, but the reason this flag was introduced is to control debug information coming from the pre-compiled Std libraries, see https://github.com/rustwasm/wasm-bindgen/pull/466.

This can now be done by the user instead in Cargo with the [`strip`](https://doc.rust-lang.org/1.76.0/cargo/reference/profiles.html#strip) option, which is available since v1.59 (or directly with Rustc [`-C strip`](https://doc.rust-lang.org/1.76.0/rustc/codegen-options/index.html#strip) since v1.58).

Additionally, this will require no user action at all when v1.77 releases, which will strip Std's debug information automatically when no debug information is requested (e.g. the release profile), see https://github.com/rust-lang/cargo/pull/13257.

This should significantly improve the stacktraces with the downside of significantly increased Wasm file sizes in release mode for users who don't strip debug information or are using Cargo versions below v1.77.

We might want to hold off merging this until Rust v1.77 release, which would be 21th March, but considering how close this is (13 days) I think its alright.

See https://github.com/rustwasm/wasm-bindgen/pull/3483, which made this finally possible.
See https://github.com/rustwasm/wasm-bindgen/issues/3698 for tracking other debug information related improvements.

Blocked on https://github.com/rustwasm/walrus/pull/284 and a new Walrus release.