### PR TITLE
Stabilize Web Share API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Implement `From<NonNull<T>>` for `JsValue`.
   [#3877](https://github.com/rustwasm/wasm-bindgen/pull/3877)
 
+### Changed
+
+* Stabilize Web Share API.
+  [#3882](https://github.com/rustwasm/wasm-bindgen/pull/3882)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.

--- a/crates/web-sys/src/features/gen_Navigator.rs
+++ b/crates/web-sys/src/features/gen_Navigator.rs
@@ -331,18 +331,13 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Navigator`, `StorageManager`*"]
     pub fn storage(this: &Navigator) -> StorageManager;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "Navigator" , js_name = canShare)]
     #[doc = "The `canShare()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Navigator`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn can_share(this: &Navigator) -> bool;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ShareData")]
     # [wasm_bindgen (method , structural , js_class = "Navigator" , js_name = canShare)]
     #[doc = "The `canShare()` method."]
@@ -350,9 +345,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Navigator`, `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn can_share_with_data(this: &Navigator, data: &ShareData) -> bool;
     # [wasm_bindgen (catch , method , structural , js_class = "Navigator" , js_name = getGamepads)]
     #[doc = "The `getGamepads()` method."]
@@ -501,18 +493,13 @@ extern "C" {
         url: &str,
         data: Option<&ReadableStream>,
     ) -> Result<bool, JsValue>;
-    #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "Navigator" , js_name = share)]
     #[doc = "The `share()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Navigator`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn share(this: &Navigator) -> ::js_sys::Promise;
-    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ShareData")]
     # [wasm_bindgen (method , structural , js_class = "Navigator" , js_name = share)]
     #[doc = "The `share()` method."]
@@ -520,9 +507,6 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Navigator`, `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn share_with_data(this: &Navigator, data: &ShareData) -> ::js_sys::Promise;
     # [wasm_bindgen (method , structural , js_class = "Navigator" , js_name = vibrate)]
     #[doc = "The `vibrate()` method."]

--- a/crates/web-sys/src/features/gen_ShareData.rs
+++ b/crates/web-sys/src/features/gen_ShareData.rs
@@ -2,7 +2,6 @@
 #![allow(clippy::all)]
 use super::*;
 use wasm_bindgen::prelude::*;
-#[cfg(web_sys_unstable_apis)]
 #[wasm_bindgen]
 extern "C" {
     # [wasm_bindgen (extends = :: js_sys :: Object , js_name = ShareData)]
@@ -10,31 +9,20 @@ extern "C" {
     #[doc = "The `ShareData` dictionary."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type ShareData;
 }
-#[cfg(web_sys_unstable_apis)]
 impl ShareData {
     #[doc = "Construct a new `ShareData`."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new() -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `files` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn files(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("files"), &JsValue::from(val));
@@ -45,13 +33,9 @@ impl ShareData {
         let _ = r;
         self
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `text` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn text(&mut self, val: &str) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("text"), &JsValue::from(val));
@@ -62,13 +46,9 @@ impl ShareData {
         let _ = r;
         self
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `title` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn title(&mut self, val: &str) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("title"), &JsValue::from(val));
@@ -79,13 +59,9 @@ impl ShareData {
         let _ = r;
         self
     }
-    #[cfg(web_sys_unstable_apis)]
     #[doc = "Change the `url` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ShareData`*"]
-    #[doc = ""]
-    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
-    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn url(&mut self, val: &str) -> &mut Self {
         use wasm_bindgen::JsValue;
         let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("url"), &JsValue::from(val));
@@ -97,7 +73,6 @@ impl ShareData {
         self
     }
 }
-#[cfg(web_sys_unstable_apis)]
 impl Default for ShareData {
     fn default() -> Self {
         Self::new()

--- a/crates/web-sys/webidls/enabled/Share.webidl
+++ b/crates/web-sys/webidls/enabled/Share.webidl
@@ -1,14 +1,13 @@
 /* -*- Mode: IDL; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /*
  * API for sharing text, links and other content to an arbitrary destination of the user's choice.
- * W3C Working Draft, 22 November 2021
+ * W3C Recommendation, 30 May 2023
  * The origin of this IDL file is:
  * https://www.w3.org/TR/web-share
  */
 
 partial interface Navigator {
   [SecureContext] Promise<undefined> share(optional ShareData data = {});
-
   [SecureContext] boolean canShare(optional ShareData data = {});
 };
 


### PR DESCRIPTION
[Web Share API is a W3C Recommendation](https://www.w3.org/TR/web-share/) since 30 May 2023. The webidl file was already up to date, meaning changes are mainly cosmetic (doc strings/drop of `web_sys_unstable_apis` feature).

Fixes #2514.