### PR TITLE
Add methods for Typed Array and Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Implement `From<NonNull<T>>` for `JsValue`.
   [#3877](https://github.com/rustwasm/wasm-bindgen/pull/3877)
 
+* Add method `copy_within` for TypedArray, add methods `find_last`,`find_last_index` for Array.
+  [#3888](https://github.com/rustwasm/wasm-bindgen/pull/3888)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -392,6 +392,17 @@ extern "C" {
         predicate: &mut dyn FnMut(JsValue, u32, Array) -> bool,
     ) -> JsValue;
 
+    /// The `findLastIndex()` method of Array instances iterates the array in reverse order
+    /// and returns the index of the first element that satisfies the provided testing function.
+    /// If no elements satisfy the testing function, -1 is returned.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex)
+    #[wasm_bindgen(method, js_name = findLastIndex)]
+    pub fn find_last_index(
+        this: &Array,
+        predicate: &mut dyn FnMut(JsValue, u32, Array) -> bool,
+    ) -> i32;
+
     /// The `flat()` method creates a new array with all sub-array elements concatenated into it
     /// recursively up to the specified depth.
     ///

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -381,6 +381,17 @@ extern "C" {
     #[wasm_bindgen(method, js_name = findIndex)]
     pub fn find_index(this: &Array, predicate: &mut dyn FnMut(JsValue, u32, Array) -> bool) -> i32;
 
+    /// The `findLast()` method of Array instances iterates the array in reverse order
+    /// and returns the value of the first element that satisfies the provided testing function.
+    /// If no elements satisfy the testing function, undefined is returned.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast)
+    #[wasm_bindgen(method, js_name = findLast)]
+    pub fn find_last(
+        this: &Array,
+        predicate: &mut dyn FnMut(JsValue, u32, Array) -> bool,
+    ) -> JsValue;
+
     /// The `flat()` method creates a new array with all sub-array elements concatenated into it
     /// recursively up to the specified depth.
     ///

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -6174,6 +6174,13 @@ macro_rules! arrays {
             #[wasm_bindgen(method)]
             pub fn at(this: &$name, idx: i32) -> Option<$ty>;
 
+            /// The `copyWithin()` method shallow copies part of a typed array to another
+            /// location in the same typed array and returns it, without modifying its size.
+            ///
+            /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin)
+            #[wasm_bindgen(method, js_name = copyWithin)]
+            pub fn copy_within(this: &$name, target: i32, start: i32, end: i32) -> $name;
+
             /// Gets the value at `idx`, equivalent to the javascript `my_var = arr[idx]`.
             #[wasm_bindgen(method, structural, indexing_getter)]
             pub fn get_index(this: &$name, idx: u32) -> $ty;

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -464,6 +464,25 @@ fn find() {
 }
 
 #[wasm_bindgen_test]
+fn find_last() {
+    let even = js_array![2, 4, 6, 8];
+    assert_eq!(
+        even.find_last(&mut |x, _, _| x.as_f64().unwrap() % 2.0 == 0.0),
+        8
+    );
+    let odd = js_array![1, 3, 5, 7];
+    assert_eq!(
+        odd.find_last(&mut |x, _, _| x.as_f64().unwrap() % 2.0 == 0.0),
+        JsValue::undefined(),
+    );
+    let mixed = js_array![3, 5, 7, 10];
+    assert_eq!(
+        mixed.find_last(&mut |x, _, _| x.as_f64().unwrap() % 2.0 != 0.0),
+        7
+    );
+}
+
+#[wasm_bindgen_test]
 fn map() {
     let numbers = js_array![1, 4, 9];
     let sqrt = numbers.map(&mut |x, _, _| x.as_f64().unwrap().sqrt().into());

--- a/crates/js-sys/tests/wasm/Array.rs
+++ b/crates/js-sys/tests/wasm/Array.rs
@@ -531,6 +531,25 @@ fn find_index() {
 }
 
 #[wasm_bindgen_test]
+fn find_last_index() {
+    let even = js_array![2, 4, 6, 8];
+    assert_eq!(
+        even.find_last_index(&mut |e, _, _| e.as_f64().unwrap() % 2. == 0.),
+        3
+    );
+    let odd = js_array![1, 3, 5, 7];
+    assert_eq!(
+        odd.find_last_index(&mut |e, _, _| e.as_f64().unwrap() % 2. == 0.),
+        -1
+    );
+    let mixed = js_array![3, 5, 7, 10];
+    assert_eq!(
+        mixed.find_last_index(&mut |e, _, _| e.as_f64().unwrap() % 2. != 0.),
+        2
+    );
+}
+
+#[wasm_bindgen_test]
 fn to_locale_string() {
     let output = js_array![1, "a", Date::new(&"21 Dec 1997 14:12:00 UTC".into())]
         .to_locale_string(&"en".into(), &JsValue::undefined());

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -100,6 +100,24 @@ fn new_at() {
     each!(test_at);
 }
 
+macro_rules! test_copy_within {
+    ($arr:ident) => {{
+        let x: Vec<_> = vec![8, 5, 4, 3, 1, 2];
+        let array = $arr::from(x.into_iter().map(|v| v as _).collect::<Vec<_>>().as_slice());
+        array.copy_within(1, 4, 5);
+
+        assert_eq!(array.get_index(1) as f64, 1f64);
+
+        // if negatives were used
+        array.copy_within(-1, -3, -2);
+        assert_eq!(array.get_index(5) as f64, 3f64);
+    }};
+}
+#[wasm_bindgen_test]
+fn new_copy_within() {
+    each!(test_copy_within);
+}
+
 macro_rules! test_get_set {
     ($arr:ident) => {{
         let arr = $arr::new(&1.into());


### PR DESCRIPTION
1. add [find_last_index](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex) and [find_last](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast) for **Array**
2. add [copy_within](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin) for **Typed Array**

