### PR TITLE
add cargo config alternative to set unstable rustflags

### DIFF
--- a/guide/src/web-sys/unstable-apis.md
+++ b/guide/src/web-sys/unstable-apis.md
@@ -37,5 +37,6 @@ to set its [rustflags](https://doc.rust-lang.org/cargo/reference/config.html#bui
 
 Within `./.cargo/config.toml`:
 ```toml
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run
+[build]
+rustflags = ["--cfg=web_sys_unstable_apis"]
 ```

--- a/guide/src/web-sys/unstable-apis.md
+++ b/guide/src/web-sys/unstable-apis.md
@@ -36,6 +36,6 @@ Alternatively, you can create a [cargo config file](https://doc.rust-lang.org/ca
 to set its [rustflags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags):
 
 Within `./.cargo/config.toml`:
-```bash
+```toml
 RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run
 ```

--- a/guide/src/web-sys/unstable-apis.md
+++ b/guide/src/web-sys/unstable-apis.md
@@ -23,9 +23,19 @@ APIs. Specifically, these APIs do not follow semver and may break whenever the
 WebIDL changes.
 
 Crates can opt-in to unstable APIs at compile-time by passing the `cfg` flag
-`web_sys_unstable_apis`. Typically the `RUSTFLAGS` environment variable is used
+`web_sys_unstable_apis`.
+
+Typically the `RUSTFLAGS` environment variable is used
 to do this. For example:
 
+```bash
+RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run
+```
+
+Alternatively, you can create a [cargo config file](https://doc.rust-lang.org/cargo/reference/config.html)
+to set its [rustflags](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags):
+
+Within `./.cargo/config.toml`:
 ```bash
 RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run
 ```


### PR DESCRIPTION
Working on https://github.com/mvlabat/bevy_egui/pull/270 ; I'd want to link to https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html ; but that page could have one more efficient and actionable advice:

use cargo config to set rustflags.