### PR TITLE
Add `.into()` to the generated code for async fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@
 * Deprecate builder-pattern type setters for WebIDL dictionary types and introduce non-mutable setters instead.
   [#3993](https://github.com/rustwasm/wasm-bindgen/pull/3993)
 
+* Allow imported async functions to return any type that can be converted from a `JsValue`.
+  [#3919](https://github.com/rustwasm/wasm-bindgen/pull/3919)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1335,9 +1335,9 @@ impl TryToTokens for ast::ImportFunction {
                         ).await
                     };
                     convert_ret = if self.catch {
-                        quote! { Ok(#future?.into()) }
+                        quote! { Ok(#wasm_bindgen::JsCast::unchecked_from_js(#future?)) }
                     } else {
-                        quote! { #future.expect("unexpected exception").into() }
+                        quote! { #wasm_bindgen::JsCast::unchecked_from_js(#future.expect("unexpected exception")) }
                     };
                 } else {
                     abi_ret = quote! {

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1335,9 +1335,9 @@ impl TryToTokens for ast::ImportFunction {
                         ).await
                     };
                     convert_ret = if self.catch {
-                        quote! { Ok(#future?) }
+                        quote! { Ok(#future?.into()) }
                     } else {
-                        quote! { #future.expect("unexpected exception") }
+                        quote! { #future.expect("unexpected exception").into() }
                     };
                 } else {
                     abi_ret = quote! {

--- a/tests/wasm/futures.rs
+++ b/tests/wasm/futures.rs
@@ -1,3 +1,4 @@
+use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
@@ -8,10 +9,16 @@ extern "C" {
     async fn call_exports() -> Result<JsValue, JsValue>;
 
     async fn call_promise() -> JsValue;
+    #[wasm_bindgen(js_name = call_promise)]
+    async fn call_promise_string() -> JsString;
     #[wasm_bindgen(catch)]
     async fn call_promise_ok() -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch, js_name = call_promise_ok)]
+    async fn call_promise_ok_string() -> Result<JsString, JsString>;
     #[wasm_bindgen(catch)]
     async fn call_promise_err() -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch, js_name = call_promise_err)]
+    async fn call_promise_err_string() -> Result<JsString, JsString>;
 
     #[wasm_bindgen]
     async fn call_promise_unit();
@@ -142,6 +149,11 @@ async fn test_promise() {
 }
 
 #[wasm_bindgen_test]
+async fn test_promise_string() {
+    assert_eq!(String::from(call_promise_string().await), "ok")
+}
+
+#[wasm_bindgen_test]
 async fn test_promise_ok() {
     assert_eq!(
         call_promise_ok().await.map(|j| j.as_string()),
@@ -150,10 +162,26 @@ async fn test_promise_ok() {
 }
 
 #[wasm_bindgen_test]
+async fn test_promise_ok_string() {
+    assert_eq!(
+        call_promise_ok_string().await.map(String::from),
+        Ok(String::from("ok"))
+    )
+}
+
+#[wasm_bindgen_test]
 async fn test_promise_err() {
     assert_eq!(
         call_promise_err().await.map_err(|j| j.as_string()),
         Err(Some(String::from("error")))
+    )
+}
+
+#[wasm_bindgen_test]
+async fn test_promise_err_string() {
+    assert_eq!(
+        call_promise_err_string().await.map_err(String::from),
+        Err(String::from("error"))
     )
 }
 


### PR DESCRIPTION
Without this I am getting an error for declarations like these:

```rust
    #[wasm_bindgen(method, getter)]
    pub async fn closed(this: &WebTransport) -> WebTransportCloseInfo;
```

```rust
    #[wasm_bindgen(method, getter, catch)]
    pub async fn closed(this: &WebTransport) -> Result<WebTransportCloseInfo, JsValue>;
```

I have tried to also create a test for this to catch regressions, but was unable to figure out where to put it.

<details><summary>Test</summary>
<p>

```rust
use wasm_bindgen::prelude::*;

#[wasm_bindgen]
extern "C" {
    #[wasm_bindgen]
    #[derive(Debug, Clone)]
    pub type WebTransportCloseInfo;
}

#[wasm_bindgen]
extern "C" {
    #[wasm_bindgen]
    #[derive(Debug, Clone)]
    pub type WebTransport;

    #[wasm_bindgen(method, getter, catch)]
    pub async fn closed(this: &WebTransport) -> Result<WebTransportCloseInfo, JsValue>;
}
```

</p>
</details> 