### PR TITLE
Fixes #3929 Allow exporting functions named "default".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ### Added
 
+* Allow exporting functions named `default`. Throw error in wasm-bindgen-cli if --target web and
+  an exported symbol is named `default`.
+  [#3930](https://github.com/rustwasm/wasm-bindgen/pull/3930)
+
 * Added support for arbitrary expressions when using `#[wasm_bindgen(typescript_custom_section)]`.
   [#3901](https://github.com/rustwasm/wasm-bindgen/pull/3901)
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -327,6 +327,13 @@ impl Bindgen {
                 .context("failed getting Wasm module")?,
         };
 
+        // Check that no exported symbol is called "default" if we target web.
+        if matches!(self.mode, OutputMode::Web)
+            && module.exports.iter().any(|export| export.name == "default")
+        {
+            bail!("exported symbol \"default\" not allowed for --target web")
+        }
+
         let thread_count = self
             .threads
             .run(&mut module)

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -799,7 +799,7 @@ impl ConvertToAst<BindgenAttrs> for syn::ItemFn {
             false,
             None,
             false,
-            None,
+            Some(&["default"]),
         )?;
         attrs.check_used();
         Ok(ret.0)


### PR DESCRIPTION
This PR fixes #3929.
This PR adds the keyword `default`to the argument `skip_keywords` for `fn function_from_decl` when exporting functions.