### PR TITLE
Fix CI failures introduced by Rust 1.78 (except `clippy::empty_docs`)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,3 @@
-# TODO: we shouldn't check this in to git, need to figure out how to avoid doing
-# that.
 [target.wasm32-unknown-unknown]
 runner = 'cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner --'
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-bindgen-benchmark"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
+edition = "2018"
 rust-version = "1.57"
 
 [dependencies]

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2797,15 +2797,15 @@ impl<'a> Context<'a> {
             match &js.name {
                 JsImportName::Module { module, name } => {
                     let import = self.module.imports.get_mut(id);
-                    import.module = module.clone();
-                    import.name = name.clone();
+                    import.module.clone_from(module);
+                    import.name.clone_from(name);
                     return Ok(true);
                 }
                 JsImportName::LocalModule { module, name } => {
                     let module = self.config.local_module_name(module);
                     let import = self.module.imports.get_mut(id);
                     import.module = module;
-                    import.name = name.clone();
+                    import.name.clone_from(name);
                     return Ok(true);
                 }
                 JsImportName::InlineJs {
@@ -2818,7 +2818,7 @@ impl<'a> Context<'a> {
                         .inline_js_module_name(unique_crate_identifier, *snippet_idx_in_crate);
                     let import = self.module.imports.get_mut(id);
                     import.module = module;
-                    import.name = name.clone();
+                    import.name.clone_from(name);
                     return Ok(true);
                 }
 
@@ -4133,6 +4133,7 @@ impl ExportedClass {
         }
     }
 
+    #[allow(clippy::assigning_clones)] // Clippy's suggested fix doesn't work at MSRV.
     fn push_accessor_ts(
         &mut self,
         docs: &str,

--- a/crates/cli/tests/reference/add.wat
+++ b/crates/cli/tests/reference/add.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32 i32) (result i32)))
   (func $add_u32 (;0;) (type 0) (param i32 i32) (result i32))
   (func $add_i32 (;1;) (type 0) (param i32 i32) (result i32))

--- a/crates/cli/tests/reference/anyref-empty.wat
+++ b/crates/cli/tests/reference/anyref-empty.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func))
   (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;0;) (type 0)))
   (table (;0;) 128 externref)

--- a/crates/cli/tests/reference/anyref-import-catch.wat
+++ b/crates/cli/tests/reference/anyref-import-catch.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func))
   (type (;1;) (func (result i32)))
   (type (;2;) (func (param i32)))

--- a/crates/cli/tests/reference/anyref-nop.wat
+++ b/crates/cli/tests/reference/anyref-nop.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func))
   (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;0;) (type 0)))
   (func $foo (;1;) (type 0))

--- a/crates/cli/tests/reference/builder.wat
+++ b/crates/cli/tests/reference/builder.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (result i32)))
   (type (;1;) (func (param i32)))
   (func $classbuilder_builder (;0;) (type 0) (result i32))

--- a/crates/cli/tests/reference/constructor.wat
+++ b/crates/cli/tests/reference/constructor.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (result i32)))
   (type (;1;) (func (param i32)))
   (func $classconstructor_new (;0;) (type 0) (result i32))

--- a/crates/cli/tests/reference/empty.wat
+++ b/crates/cli/tests/reference/empty.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (memory (;0;) 16)
   (export "memory" (memory 0))
 )

--- a/crates/cli/tests/reference/enums.wat
+++ b/crates/cli/tests/reference/enums.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32) (result i32)))
   (func $enum_echo (;0;) (type 0) (param i32) (result i32))
   (func $option_enum_echo (;1;) (type 0) (param i32) (result i32))

--- a/crates/cli/tests/reference/import-catch.wat
+++ b/crates/cli/tests/reference/import-catch.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32)))
   (type (;1;) (func (param i32) (result i32)))
   (func $exported (;0;) (type 0) (param i32))

--- a/crates/cli/tests/reference/nop.wat
+++ b/crates/cli/tests/reference/nop.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func))
   (func $nop (;0;) (type 0))
   (memory (;0;) 17)

--- a/crates/cli/tests/reference/pointers.wat
+++ b/crates/cli/tests/reference/pointers.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32) (result i32)))
   (func $const_pointer (;0;) (type 0) (param i32) (result i32))
   (func $mut_pointer (;1;) (type 0) (param i32) (result i32))

--- a/crates/cli/tests/reference/result-string.wat
+++ b/crates/cli/tests/reference/result-string.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32)))
   (type (;1;) (func (param i32) (result i32)))
   (type (;2;) (func (param i32 i32 i32)))

--- a/crates/cli/tests/reference/skip-jsdoc.wat
+++ b/crates/cli/tests/reference/skip-jsdoc.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32) (result i32)))
   (func $docme (;0;) (type 0) (param i32) (result i32))
   (memory (;0;) 17)

--- a/crates/cli/tests/reference/string-arg.wat
+++ b/crates/cli/tests/reference/string-arg.wat
@@ -1,4 +1,4 @@
-(module
+(module $reference_test.wasm
   (type (;0;) (func (param i32 i32)))
   (type (;1;) (func (param i32 i32) (result i32)))
   (type (;2;) (func (param i32 i32 i32 i32) (result i32)))

--- a/tests/wasm/slice.rs
+++ b/tests/wasm/slice.rs
@@ -233,6 +233,7 @@ impl ReturnVecApplication {
         ReturnVecApplication { thing }
     }
 
+    #[allow(clippy::assigning_clones)] // false positive, should be fixed by https://github.com/rust-lang/rust-clippy/pull/12756
     pub fn tick(&mut self) {
         self.thing = self.thing.clone();
     }


### PR DESCRIPTION
There's already #3946 for fixing `clippy::empty_docs`, so I've left that to it.