### PR TITLE
Allow typescript_type on struct fields.

### DIFF
--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -392,6 +392,8 @@ pub struct StructField {
     pub comments: Vec<String>,
     /// Whether to generate a typescript definition for this field
     pub generate_typescript: bool,
+    /// Whether to override the typescript type for this field
+    pub typescript_type: Option<String>,
     /// Whether to generate jsdoc documentation for this field
     pub generate_jsdoc: bool,
     /// The span of the `#[wasm_bindgen(getter_with_clone)]` attribute applied

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -364,6 +364,7 @@ fn shared_struct_field<'a>(s: &'a ast::StructField, _intern: &'a Interner) -> St
         comments: s.comments.iter().map(|s| &**s).collect(),
         generate_typescript: s.generate_typescript,
         generate_jsdoc: s.generate_jsdoc,
+        typescript_override: s.typescript_type.as_deref(),
     }
 }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2660,7 +2660,6 @@ impl<'a> Context<'a> {
                             AuxExportedMethodKind::Setter => {
                                 prefix += "set ";
                                 if export.generate_typescript {
-
                                     let ts_ret_ty = &ts_arg_tys[0];
 
                                     let ts_ret_ty = match &export.type_override {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2634,13 +2634,20 @@ impl<'a> Context<'a> {
                                 prefix += "get ";
                                 // For getters and setters, we generate a separate TypeScript definition.
                                 if export.generate_typescript {
+                                    // This is only set to `None` when generating a constructor.
+                                    let ts_ret_ty = ts_ret_ty
+                                        .as_deref()
+                                        .expect("missing return type for getter");
+
+                                    let ts_ret_ty = match &export.type_override {
+                                        Some(override_ty) => override_ty.clone(),
+                                        None => ts_ret_ty.to_owned(),
+                                    };
+
                                     exported.push_accessor_ts(
                                         &ts_docs,
                                         name,
-                                        // This is only set to `None` when generating a constructor.
-                                        ts_ret_ty
-                                            .as_deref()
-                                            .expect("missing return type for getter"),
+                                        &ts_ret_ty,
                                         false,
                                         receiver.is_static(),
                                     );
@@ -2653,10 +2660,18 @@ impl<'a> Context<'a> {
                             AuxExportedMethodKind::Setter => {
                                 prefix += "set ";
                                 if export.generate_typescript {
+
+                                    let ts_ret_ty = &ts_arg_tys[0];
+
+                                    let ts_ret_ty = match &export.type_override {
+                                        Some(override_ty) => override_ty.clone(),
+                                        None => ts_ret_ty.to_owned(),
+                                    };
+
                                     let is_optional = exported.push_accessor_ts(
                                         &ts_docs,
                                         name,
-                                        &ts_arg_tys[0],
+                                        &ts_ret_ty,
                                         true,
                                         receiver.is_static(),
                                     );

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -524,6 +524,7 @@ impl<'a> Context<'a> {
             AuxExport {
                 debug_name: wasm_name,
                 comments: concatenate_comments(&export.comments),
+                type_override: None,
                 arg_names: Some(export.function.arg_names),
                 asyncness: export.function.asyncness,
                 kind,
@@ -881,6 +882,8 @@ impl<'a> Context<'a> {
                 inner_ret: Some(descriptor.clone()),
             };
             let getter_id = self.export_adapter(getter_id, getter_descriptor)?;
+            let type_override = field.typescript_override.map(|s| s.to_string());
+
             self.aux.export_map.insert(
                 getter_id,
                 AuxExport {
@@ -888,6 +891,7 @@ impl<'a> Context<'a> {
                     arg_names: None,
                     asyncness: false,
                     comments: concatenate_comments(&field.comments),
+                    type_override: type_override.clone(),
                     kind: AuxExportKind::Method {
                         class: struct_.name.to_string(),
                         name: field.name.to_string(),
@@ -920,6 +924,7 @@ impl<'a> Context<'a> {
                     arg_names: None,
                     asyncness: false,
                     comments: concatenate_comments(&field.comments),
+                    type_override,
                     kind: AuxExportKind::Method {
                         class: struct_.name.to_string(),
                         name: field.name.to_string(),

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -70,6 +70,8 @@ pub struct AuxExport {
     pub debug_name: String,
     /// Comments parsed in Rust and forwarded here to show up in JS bindings.
     pub comments: String,
+    /// Used to replace the TypeScript type of a return value or struct field.
+    pub type_override: Option<String>,
     /// Argument names in Rust forwarded here to configure the names that show
     /// up in TypeScript bindings.
     pub arg_names: Option<Vec<String>>,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -444,6 +444,7 @@ impl<'a> ConvertToAst<(&ast::Program, BindgenAttrs)> for &'a mut syn::ItemStruct
             let comments = extract_doc_comments(&field.attrs);
             let getter = shared::struct_field_get(&js_name, &js_field_name);
             let setter = shared::struct_field_set(&js_name, &js_field_name);
+            let typescript_type = attrs.typescript_type().map(|s| s.0.to_string());
 
             fields.push(ast::StructField {
                 rust_name: member,
@@ -458,6 +459,7 @@ impl<'a> ConvertToAst<(&ast::Program, BindgenAttrs)> for &'a mut syn::ItemStruct
                 generate_jsdoc: attrs.skip_jsdoc().is_none(),
                 getter_with_clone: attrs.getter_with_clone().or(getter_with_clone).copied(),
                 wasm_bindgen: program.wasm_bindgen.clone(),
+                typescript_type,
             });
             attrs.check_used();
         }

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -145,6 +145,7 @@ macro_rules! shared_api {
             comments: Vec<&'a str>,
             generate_typescript: bool,
             generate_jsdoc: bool,
+            typescript_override: Option<&'a str>,
         }
 
         struct LocalModule<'a> {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -6,7 +6,7 @@ mod schema_hash_approval;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.92";
+pub const SCHEMA_VERSION: &str = "0.2.93";
 
 #[macro_export]
 macro_rules! shared_api {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "10197913343580353876";
+const APPROVED_SCHEMA_FILE_HASH: &str = "18435069958697426509";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
This enhances the ability of users to modify generated TypeScript buildings.  Specifically, this allows replacement of a struct field with a custom TypeScript type using the existing `typescript_type` attribute.

For more context, see issue #3953.