### PR TITLE
Implement `DerefMut` when using `#[wasm_bindgen(extend = ...)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Add bindings for `RTCRtpReceiver.getCapabilities(DOMString)` method.
   [#3941](https://github.com/rustwasm/wasm-bindgen/pull/3941)
 
+* Implement `DerefMut` when using `#[wasm_bindgen(extend = ...)]`.
+  [#3966](https://github.com/rustwasm/wasm-bindgen/pull/3966)
+
 ### Changed
 
 * Stabilize Web Share API.

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1046,6 +1046,14 @@ impl ToTokens for ast::ImportType {
                         &self.obj
                     }
                 }
+
+                #[automatically_derived]
+                impl core::ops::DerefMut for #rust_name {
+                    #[inline]
+                    fn deref_mut(&mut self) -> &mut #internal_obj {
+                        &mut self.obj
+                    }
+                }
             })
             .to_tokens(tokens);
         }

--- a/guide/src/reference/attributes/on-js-imports/no_deref.md
+++ b/guide/src/reference/attributes/on-js-imports/no_deref.md
@@ -1,7 +1,7 @@
 # `no_deref`
 
-The `no_deref` attribute can be used to say that no `Deref` impl should be
-generated for an imported type. If this attribute is not present, a `Deref` impl
+The `no_deref` attribute can be used to say that no `Deref/Mut` impl should be
+generated for an imported type. If this attribute is not present, a `Deref/Mut` impl
 will be generated with a `Target` of the type's first `extends` attribute, or
 `Target = JsValue` if there are no `extends` attributes.
 


### PR DESCRIPTION
I encountered this while trying to extend dictionary types, which use `&mut self` in their methods.

Additionally I briefly attempted to add `AsMut` as well, but it turned out this wouldn't work out quite as easy without adding a new `JsCast::unchecked_from_js_mut()` method, which would be a breaking change.