### PR TITLE
Annotate methods in WebCodecs that throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@
 * Use `table.fill` when appropriate.
   [#3446](https://github.com/rustwasm/wasm-bindgen/pull/3446)
 
+* Annotated methods in WebCodecs that throw.
+  [#3970](https://github.com/rustwasm/wasm-bindgen/pull/3970)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.

--- a/crates/web-sys/src/features/gen_AudioData.rs
+++ b/crates/web-sys/src/features/gen_AudioData.rs
@@ -97,7 +97,7 @@ extern "C" {
     pub fn new(init: &AudioDataInit) -> Result<AudioData, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "AudioDataCopyToOptions")]
-    # [wasm_bindgen (method , structural , js_class = "AudioData" , js_name = allocationSize)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioData" , js_name = allocationSize)]
     #[doc = "The `allocationSize()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioData/allocationSize)"]
@@ -106,9 +106,12 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn allocation_size(this: &AudioData, options: &AudioDataCopyToOptions) -> u32;
+    pub fn allocation_size(
+        this: &AudioData,
+        options: &AudioDataCopyToOptions,
+    ) -> Result<u32, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "AudioData" , js_name = clone)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioData" , js_name = clone)]
     #[doc = "The `clone()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioData/clone)"]
@@ -117,7 +120,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn clone(this: &AudioData) -> AudioData;
+    pub fn clone(this: &AudioData) -> Result<AudioData, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "AudioData" , js_name = close)]
     #[doc = "The `close()` method."]
@@ -131,7 +134,7 @@ extern "C" {
     pub fn close(this: &AudioData);
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "AudioDataCopyToOptions")]
-    # [wasm_bindgen (method , structural , js_class = "AudioData" , js_name = copyTo)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioData" , js_name = copyTo)]
     #[doc = "The `copyTo()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioData/copyTo)"]
@@ -144,10 +147,10 @@ extern "C" {
         this: &AudioData,
         destination: &::js_sys::Object,
         options: &AudioDataCopyToOptions,
-    );
+    ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "AudioDataCopyToOptions")]
-    # [wasm_bindgen (method , structural , js_class = "AudioData" , js_name = copyTo)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioData" , js_name = copyTo)]
     #[doc = "The `copyTo()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioData/copyTo)"]
@@ -160,5 +163,5 @@ extern "C" {
         this: &AudioData,
         destination: &mut [u8],
         options: &AudioDataCopyToOptions,
-    );
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_AudioDecoder.rs
+++ b/crates/web-sys/src/features/gen_AudioDecoder.rs
@@ -52,7 +52,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(init: &AudioDecoderInit) -> Result<AudioDecoder, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "AudioDecoder" , js_name = close)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioDecoder" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder/close)"]
@@ -61,10 +61,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn close(this: &AudioDecoder);
+    pub fn close(this: &AudioDecoder) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "AudioDecoderConfig")]
-    # [wasm_bindgen (method , structural , js_class = "AudioDecoder" , js_name = configure)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioDecoder" , js_name = configure)]
     #[doc = "The `configure()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder/configure)"]
@@ -73,10 +73,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn configure(this: &AudioDecoder, config: &AudioDecoderConfig);
+    pub fn configure(this: &AudioDecoder, config: &AudioDecoderConfig) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "EncodedAudioChunk")]
-    # [wasm_bindgen (method , structural , js_class = "AudioDecoder" , js_name = decode)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioDecoder" , js_name = decode)]
     #[doc = "The `decode()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder/decode)"]
@@ -85,7 +85,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn decode(this: &AudioDecoder, chunk: &EncodedAudioChunk);
+    pub fn decode(this: &AudioDecoder, chunk: &EncodedAudioChunk) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "AudioDecoder" , js_name = flush)]
     #[doc = "The `flush()` method."]
@@ -110,7 +110,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_config_supported(config: &AudioDecoderConfig) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "AudioDecoder" , js_name = reset)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioDecoder" , js_name = reset)]
     #[doc = "The `reset()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioDecoder/reset)"]
@@ -119,5 +119,5 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn reset(this: &AudioDecoder);
+    pub fn reset(this: &AudioDecoder) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_AudioEncoder.rs
+++ b/crates/web-sys/src/features/gen_AudioEncoder.rs
@@ -52,7 +52,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(init: &AudioEncoderInit) -> Result<AudioEncoder, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "AudioEncoder" , js_name = close)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioEncoder" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/close)"]
@@ -61,10 +61,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn close(this: &AudioEncoder);
+    pub fn close(this: &AudioEncoder) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "AudioEncoderConfig")]
-    # [wasm_bindgen (method , structural , js_class = "AudioEncoder" , js_name = configure)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioEncoder" , js_name = configure)]
     #[doc = "The `configure()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/configure)"]
@@ -73,10 +73,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn configure(this: &AudioEncoder, config: &AudioEncoderConfig);
+    pub fn configure(this: &AudioEncoder, config: &AudioEncoderConfig) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "AudioData")]
-    # [wasm_bindgen (method , structural , js_class = "AudioEncoder" , js_name = encode)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioEncoder" , js_name = encode)]
     #[doc = "The `encode()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/encode)"]
@@ -85,7 +85,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn encode(this: &AudioEncoder, data: &AudioData);
+    pub fn encode(this: &AudioEncoder, data: &AudioData) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "AudioEncoder" , js_name = flush)]
     #[doc = "The `flush()` method."]
@@ -110,7 +110,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_config_supported(config: &AudioEncoderConfig) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "AudioEncoder" , js_name = reset)]
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioEncoder" , js_name = reset)]
     #[doc = "The `reset()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioEncoder/reset)"]
@@ -119,5 +119,5 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn reset(this: &AudioEncoder);
+    pub fn reset(this: &AudioEncoder) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_EncodedAudioChunk.rs
+++ b/crates/web-sys/src/features/gen_EncodedAudioChunk.rs
@@ -74,7 +74,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(init: &EncodedAudioChunkInit) -> Result<EncodedAudioChunk, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "EncodedAudioChunk" , js_name = copyTo)]
+    # [wasm_bindgen (catch , method , structural , js_class = "EncodedAudioChunk" , js_name = copyTo)]
     #[doc = "The `copyTo()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/EncodedAudioChunk/copyTo)"]
@@ -83,9 +83,12 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_to_with_buffer_source(this: &EncodedAudioChunk, destination: &::js_sys::Object);
+    pub fn copy_to_with_buffer_source(
+        this: &EncodedAudioChunk,
+        destination: &::js_sys::Object,
+    ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "EncodedAudioChunk" , js_name = copyTo)]
+    # [wasm_bindgen (catch , method , structural , js_class = "EncodedAudioChunk" , js_name = copyTo)]
     #[doc = "The `copyTo()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/EncodedAudioChunk/copyTo)"]
@@ -94,5 +97,8 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_to_with_u8_array(this: &EncodedAudioChunk, destination: &mut [u8]);
+    pub fn copy_to_with_u8_array(
+        this: &EncodedAudioChunk,
+        destination: &mut [u8],
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_EncodedVideoChunk.rs
+++ b/crates/web-sys/src/features/gen_EncodedVideoChunk.rs
@@ -74,7 +74,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(init: &EncodedVideoChunkInit) -> Result<EncodedVideoChunk, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "EncodedVideoChunk" , js_name = copyTo)]
+    # [wasm_bindgen (catch , method , structural , js_class = "EncodedVideoChunk" , js_name = copyTo)]
     #[doc = "The `copyTo()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/EncodedVideoChunk/copyTo)"]
@@ -83,9 +83,12 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_to_with_buffer_source(this: &EncodedVideoChunk, destination: &::js_sys::Object);
+    pub fn copy_to_with_buffer_source(
+        this: &EncodedVideoChunk,
+        destination: &::js_sys::Object,
+    ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "EncodedVideoChunk" , js_name = copyTo)]
+    # [wasm_bindgen (catch , method , structural , js_class = "EncodedVideoChunk" , js_name = copyTo)]
     #[doc = "The `copyTo()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/EncodedVideoChunk/copyTo)"]
@@ -94,5 +97,8 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn copy_to_with_u8_array(this: &EncodedVideoChunk, destination: &mut [u8]);
+    pub fn copy_to_with_u8_array(
+        this: &EncodedVideoChunk,
+        destination: &mut [u8],
+    ) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_VideoDecoder.rs
+++ b/crates/web-sys/src/features/gen_VideoDecoder.rs
@@ -52,7 +52,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(init: &VideoDecoderInit) -> Result<VideoDecoder, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "VideoDecoder" , js_name = close)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoDecoder" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/close)"]
@@ -61,10 +61,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn close(this: &VideoDecoder);
+    pub fn close(this: &VideoDecoder) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoDecoderConfig")]
-    # [wasm_bindgen (method , structural , js_class = "VideoDecoder" , js_name = configure)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoDecoder" , js_name = configure)]
     #[doc = "The `configure()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/configure)"]
@@ -73,10 +73,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn configure(this: &VideoDecoder, config: &VideoDecoderConfig);
+    pub fn configure(this: &VideoDecoder, config: &VideoDecoderConfig) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "EncodedVideoChunk")]
-    # [wasm_bindgen (method , structural , js_class = "VideoDecoder" , js_name = decode)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoDecoder" , js_name = decode)]
     #[doc = "The `decode()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/decode)"]
@@ -85,7 +85,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn decode(this: &VideoDecoder, chunk: &EncodedVideoChunk);
+    pub fn decode(this: &VideoDecoder, chunk: &EncodedVideoChunk) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "VideoDecoder" , js_name = flush)]
     #[doc = "The `flush()` method."]
@@ -110,7 +110,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_config_supported(config: &VideoDecoderConfig) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "VideoDecoder" , js_name = reset)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoDecoder" , js_name = reset)]
     #[doc = "The `reset()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/reset)"]
@@ -119,5 +119,5 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn reset(this: &VideoDecoder);
+    pub fn reset(this: &VideoDecoder) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_VideoEncoder.rs
+++ b/crates/web-sys/src/features/gen_VideoEncoder.rs
@@ -52,7 +52,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn new(init: &VideoEncoderInit) -> Result<VideoEncoder, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "VideoEncoder" , js_name = close)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoEncoder" , js_name = close)]
     #[doc = "The `close()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/close)"]
@@ -61,10 +61,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn close(this: &VideoEncoder);
+    pub fn close(this: &VideoEncoder) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoEncoderConfig")]
-    # [wasm_bindgen (method , structural , js_class = "VideoEncoder" , js_name = configure)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoEncoder" , js_name = configure)]
     #[doc = "The `configure()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/configure)"]
@@ -73,10 +73,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn configure(this: &VideoEncoder, config: &VideoEncoderConfig);
+    pub fn configure(this: &VideoEncoder, config: &VideoEncoderConfig) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrame")]
-    # [wasm_bindgen (method , structural , js_class = "VideoEncoder" , js_name = encode)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoEncoder" , js_name = encode)]
     #[doc = "The `encode()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/encode)"]
@@ -85,10 +85,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn encode(this: &VideoEncoder, frame: &VideoFrame);
+    pub fn encode(this: &VideoEncoder, frame: &VideoFrame) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(all(feature = "VideoEncoderEncodeOptions", feature = "VideoFrame",))]
-    # [wasm_bindgen (method , structural , js_class = "VideoEncoder" , js_name = encode)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoEncoder" , js_name = encode)]
     #[doc = "The `encode()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/encode)"]
@@ -101,7 +101,7 @@ extern "C" {
         this: &VideoEncoder,
         frame: &VideoFrame,
         options: &VideoEncoderEncodeOptions,
-    );
+    ) -> Result<(), JsValue>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "VideoEncoder" , js_name = flush)]
     #[doc = "The `flush()` method."]
@@ -126,7 +126,7 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub fn is_config_supported(config: &VideoEncoderConfig) -> ::js_sys::Promise;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "VideoEncoder" , js_name = reset)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoEncoder" , js_name = reset)]
     #[doc = "The `reset()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoEncoder/reset)"]
@@ -135,5 +135,5 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn reset(this: &VideoEncoder);
+    pub fn reset(this: &VideoEncoder) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_VideoFrame.rs
+++ b/crates/web-sys/src/features/gen_VideoFrame.rs
@@ -349,7 +349,7 @@ extern "C" {
         init: &VideoFrameBufferInit,
     ) -> Result<VideoFrame, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "VideoFrame" , js_name = allocationSize)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoFrame" , js_name = allocationSize)]
     #[doc = "The `allocationSize()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/allocationSize)"]
@@ -358,10 +358,10 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn allocation_size(this: &VideoFrame) -> u32;
+    pub fn allocation_size(this: &VideoFrame) -> Result<u32, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "VideoFrameCopyToOptions")]
-    # [wasm_bindgen (method , structural , js_class = "VideoFrame" , js_name = allocationSize)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoFrame" , js_name = allocationSize)]
     #[doc = "The `allocationSize()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/allocationSize)"]
@@ -373,9 +373,9 @@ extern "C" {
     pub fn allocation_size_with_options(
         this: &VideoFrame,
         options: &VideoFrameCopyToOptions,
-    ) -> u32;
+    ) -> Result<u32, JsValue>;
     #[cfg(web_sys_unstable_apis)]
-    # [wasm_bindgen (method , structural , js_class = "VideoFrame" , js_name = clone)]
+    # [wasm_bindgen (catch , method , structural , js_class = "VideoFrame" , js_name = clone)]
     #[doc = "The `clone()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/clone)"]
@@ -384,7 +384,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn clone(this: &VideoFrame) -> VideoFrame;
+    pub fn clone(this: &VideoFrame) -> Result<VideoFrame, JsValue>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (method , structural , js_class = "VideoFrame" , js_name = close)]
     #[doc = "The `close()` method."]

--- a/crates/web-sys/webidls/unstable/WebCodecs.webidl
+++ b/crates/web-sys/webidls/unstable/WebCodecs.webidl
@@ -5,11 +5,11 @@ interface AudioDecoder {
   readonly attribute CodecState state;
   readonly attribute unsigned long decodeQueueSize;
 
-  undefined configure(AudioDecoderConfig config);
-  undefined decode(EncodedAudioChunk chunk);
+  [Throws] undefined configure(AudioDecoderConfig config);
+  [Throws] undefined decode(EncodedAudioChunk chunk);
   Promise<undefined> flush();
-  undefined reset();
-  undefined close();
+  [Throws] undefined reset();
+  [Throws] undefined close();
 
   static Promise<AudioDecoderSupport> isConfigSupported(AudioDecoderConfig config);
 };
@@ -28,11 +28,11 @@ interface VideoDecoder {
   readonly attribute CodecState state;
   readonly attribute unsigned long decodeQueueSize;
 
-  undefined configure(VideoDecoderConfig config);
-  undefined decode(EncodedVideoChunk chunk);
+  [Throws] undefined configure(VideoDecoderConfig config);
+  [Throws] undefined decode(EncodedVideoChunk chunk);
   Promise<undefined> flush();
-  undefined reset();
-  undefined close();
+  [Throws] undefined reset();
+  [Throws] undefined close();
 
   static Promise<VideoDecoderSupport> isConfigSupported(VideoDecoderConfig config);
 };
@@ -51,11 +51,11 @@ interface AudioEncoder {
   readonly attribute CodecState state;
   readonly attribute unsigned long encodeQueueSize;
 
-  undefined configure(AudioEncoderConfig config);
-  undefined encode(AudioData data);
+  [Throws] undefined configure(AudioEncoderConfig config);
+  [Throws] undefined encode(AudioData data);
   Promise<undefined> flush();
-  undefined reset();
-  undefined close();
+  [Throws] undefined reset();
+  [Throws] undefined close();
 
   static Promise<AudioEncoderSupport> isConfigSupported(AudioEncoderConfig config);
 };
@@ -80,11 +80,11 @@ interface VideoEncoder {
   readonly attribute CodecState state;
   readonly attribute unsigned long encodeQueueSize;
 
-  undefined configure(VideoEncoderConfig config);
-  undefined encode(VideoFrame frame, optional VideoEncoderEncodeOptions options = {});
+  [Throws] undefined configure(VideoEncoderConfig config);
+  [Throws] undefined encode(VideoFrame frame, optional VideoEncoderEncodeOptions options = {});
   Promise<undefined> flush();
-  undefined reset();
-  undefined close();
+  [Throws] undefined reset();
+  [Throws] undefined close();
 
   static Promise<VideoEncoderSupport> isConfigSupported(VideoEncoderConfig config);
 };
@@ -199,13 +199,13 @@ callback WebCodecsErrorCallback = undefined(DOMException error);
 
 [Exposed=(Window,DedicatedWorker)]
 interface EncodedAudioChunk {
-  constructor(EncodedAudioChunkInit init);
+  [Throws] constructor(EncodedAudioChunkInit init);
   readonly attribute EncodedAudioChunkType type;
   readonly attribute long long timestamp;          // microseconds
   readonly attribute unsigned long long? duration; // microseconds
   readonly attribute unsigned long byteLength;
 
-  undefined copyTo([AllowShared] BufferSource destination);
+  [Throws] undefined copyTo([AllowShared] BufferSource destination);
 };
 
 dictionary EncodedAudioChunkInit {
@@ -222,13 +222,13 @@ enum EncodedAudioChunkType {
 
 [Exposed=(Window,DedicatedWorker)]
 interface EncodedVideoChunk {
-  constructor(EncodedVideoChunkInit init);
+  [Throws] constructor(EncodedVideoChunkInit init);
   readonly attribute EncodedVideoChunkType type;
   readonly attribute long long timestamp;             // microseconds
   readonly attribute unsigned long long? duration;    // microseconds
   readonly attribute unsigned long byteLength;
 
-  undefined copyTo([AllowShared] BufferSource destination);
+  [Throws] undefined copyTo([AllowShared] BufferSource destination);
 };
 
 dictionary EncodedVideoChunkInit {
@@ -245,7 +245,7 @@ enum EncodedVideoChunkType {
 
 [Exposed=(Window,DedicatedWorker), Serializable, Transferable]
 interface AudioData {
-  constructor(AudioDataInit init);
+  [Throws] constructor(AudioDataInit init);
 
   readonly attribute AudioSampleFormat? format;
   readonly attribute float sampleRate;
@@ -254,9 +254,9 @@ interface AudioData {
   readonly attribute unsigned long long duration;  // microseconds
   readonly attribute long long timestamp;          // microseconds
 
-  unsigned long allocationSize(AudioDataCopyToOptions options);
-  undefined copyTo([AllowShared] BufferSource destination, AudioDataCopyToOptions options);
-  AudioData clone();
+  [Throws] unsigned long allocationSize(AudioDataCopyToOptions options);
+  [Throws] undefined copyTo([AllowShared] BufferSource destination, AudioDataCopyToOptions options);
+  [Throws] AudioData clone();
   undefined close();
 };
 
@@ -289,8 +289,8 @@ enum AudioSampleFormat {
 
 [Exposed=(Window,DedicatedWorker), Serializable, Transferable]
 interface VideoFrame {
-  constructor(CanvasImageSource image, optional VideoFrameInit init = {});
-  constructor([AllowShared] BufferSource data, VideoFrameBufferInit init);
+  [Throws] constructor(CanvasImageSource image, optional VideoFrameInit init = {});
+  [Throws] constructor([AllowShared] BufferSource data, VideoFrameBufferInit init);
 
   readonly attribute VideoPixelFormat? format;
   readonly attribute unsigned long codedWidth;
@@ -303,12 +303,12 @@ interface VideoFrame {
   readonly attribute long long? timestamp;          // microseconds
   readonly attribute VideoColorSpace colorSpace;
 
-  unsigned long allocationSize(
+  [Throws] unsigned long allocationSize(
       optional VideoFrameCopyToOptions options = {});
   Promise<sequence<PlaneLayout>> copyTo(
       [AllowShared] BufferSource destination,
       optional VideoFrameCopyToOptions options = {});
-  VideoFrame clone();
+  [Throws] VideoFrame clone();
   undefined close();
 };
 
@@ -418,7 +418,7 @@ enum VideoMatrixCoefficients {
 
 [Exposed=(Window,DedicatedWorker), SecureContext]
 interface ImageDecoder {
-  constructor(ImageDecoderInit init);
+  [Throws] constructor(ImageDecoderInit init);
 
   readonly attribute DOMString type;
   readonly attribute boolean complete;


### PR DESCRIPTION
I went through all methods in [`WebCodecs.webidl`](https://github.com/rustwasm/wasm-bindgen/blob/9b37613bbab0cd71f55dcc782d59dd00c1d4d200/crates/web-sys/webidls/unstable/WebCodecs.webidl) and annotated those that throw according to the [spec](https://www.w3.org/TR/webcodecs) with `[Throws]`.

This is not a breaking change since the [`WebCodecs.webidl`](https://github.com/rustwasm/wasm-bindgen/blob/9b37613bbab0cd71f55dcc782d59dd00c1d4d200/crates/web-sys/webidls/unstable/WebCodecs.webidl) file is located in the `unstable` directory.