### PR TITLE
Update `AudioBufferSourceNode` to latest W3C draft

### DIFF
--- a/crates/web-sys/src/features/gen_AudioBufferSourceNode.rs
+++ b/crates/web-sys/src/features/gen_AudioBufferSourceNode.rs
@@ -86,20 +86,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
     pub fn set_loop_end(this: &AudioBufferSourceNode, value: f64);
-    # [wasm_bindgen (structural , method , getter , js_class = "AudioBufferSourceNode" , js_name = onended)]
-    #[doc = "Getter for the `onended` field of this object."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/onended)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn onended(this: &AudioBufferSourceNode) -> Option<::js_sys::Function>;
-    # [wasm_bindgen (structural , method , setter , js_class = "AudioBufferSourceNode" , js_name = onended)]
-    #[doc = "Setter for the `onended` field of this object."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/onended)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn set_onended(this: &AudioBufferSourceNode, value: Option<&::js_sys::Function>);
     #[cfg(feature = "BaseAudioContext")]
     #[wasm_bindgen(catch, constructor, js_class = "AudioBufferSourceNode")]
     #[doc = "The `new AudioBufferSourceNode(..)` constructor, creating a new instance of `AudioBufferSourceNode`."]
@@ -139,10 +125,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn start_with_when_and_grain_offset(
+    pub fn start_with_when_and_offset(
         this: &AudioBufferSourceNode,
         when: f64,
-        grain_offset: f64,
+        offset: f64,
     ) -> Result<(), JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = start)]
     #[doc = "The `start()` method."]
@@ -150,24 +136,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn start_with_when_and_grain_offset_and_grain_duration(
+    pub fn start_with_when_and_offset_and_duration(
         this: &AudioBufferSourceNode,
         when: f64,
-        grain_offset: f64,
-        grain_duration: f64,
+        offset: f64,
+        duration: f64,
     ) -> Result<(), JsValue>;
-    # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = stop)]
-    #[doc = "The `stop()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/stop)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn stop(this: &AudioBufferSourceNode) -> Result<(), JsValue>;
-    # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = stop)]
-    #[doc = "The `stop()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/stop)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn stop_with_when(this: &AudioBufferSourceNode, when: f64) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
@@ -10,34 +10,26 @@
  * liability, trademark and document use rules apply.
  */
 
-dictionary AudioBufferSourceOptions {
-             AudioBuffer? buffer;
-             float        detune = 0;
-             boolean      loop = false;
-             double       loopEnd = 0;
-             double       loopStart = 0;
-             float        playbackRate = 1;
-};
-
-[Pref="dom.webaudio.enabled",
- Constructor(BaseAudioContext context, optional AudioBufferSourceOptions options)]
+[Exposed=Window]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
-
+    constructor (BaseAudioContext context,
+                 optional AudioBufferSourceOptions options = {});
     attribute AudioBuffer? buffer;
-
     readonly attribute AudioParam playbackRate;
     readonly attribute AudioParam detune;
-
     attribute boolean loop;
     attribute double loopStart;
     attribute double loopEnd;
+    [Throws] undefined start (optional double when = 0,
+                     optional double offset,
+                     optional double duration);
+};
 
-    attribute EventHandler onended;
-
-    [Throws]
-    undefined start(optional double when = 0, optional double grainOffset = 0,
-               optional double grainDuration);
-
-    [Throws]
-    undefined stop (optional double when = 0);
+dictionary AudioBufferSourceOptions {
+    AudioBuffer? buffer;
+    float detune = 0;
+    boolean loop = false;
+    double loopEnd = 0;
+    double loopStart = 0;
+    float playbackRate = 1;
 };


### PR DESCRIPTION
With this PR, the `AudioBufferSourceNode` WebIDL file is updated to the latest version of the W3C draft at https://webaudio.github.io/web-audio-api/#AudioBufferSourceNode.

Namely, the `grain_` prefix from the `offset` and `duration` input parameters is removed.

The removed `attribute EventHandler onended;` can be accessed through the `AudioScheduledSourceNode` base class.