### PR TITLE
Fix triggering `clippy::mem_forget` lint in exported structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
 * Fixed Rust values not getting GC'd if they were created via. a constructor.
   [#3940](https://github.com/rustwasm/wasm-bindgen/pull/3940)
 
+* Fix triggering `clippy::mem_forget` lint in exported structs.
+  [#3985](https://github.com/rustwasm/wasm-bindgen/pull/3985)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.92](https://github.com/rustwasm/wasm-bindgen/compare/0.2.91...0.2.92)

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -394,6 +394,7 @@ impl ToTokens for ast::Struct {
                         #wasm_bindgen::__rt::std::result::Result::Err(value)
                     } else {
                         // Don't run `JsValue`'s destructor, `unwrap_fn` already did that for us.
+                        #[allow(clippy::mem_forget)]
                         #wasm_bindgen::__rt::std::mem::forget(value);
                         unsafe {
                             #wasm_bindgen::__rt::std::result::Result::Ok(

--- a/tests/wasm/3944.rs
+++ b/tests/wasm/3944.rs
@@ -1,0 +1,6 @@
+#![deny(clippy::mem_forget)]
+
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+struct Foo2;

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -473,7 +473,7 @@ fn drop_during_call_ok() {
         assert_eq!(x, 3);
 
         // make sure `A` is bound to our closure environment.
-        drop(&a);
+        let _a = &a;
         unsafe {
             assert!(!HIT);
         }

--- a/tests/wasm/ignore.rs
+++ b/tests/wasm/ignore.rs
@@ -1,3 +1,5 @@
+use wasm_bindgen_test::wasm_bindgen_test;
+
 #[wasm_bindgen_test]
 #[ignore]
 fn should_panic() {

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -14,6 +14,8 @@ extern crate serde_derive;
 
 use wasm_bindgen::prelude::*;
 
+#[path = "3944.rs"]
+pub mod _3944;
 pub mod api;
 pub mod arg_names;
 pub mod async_vecs;
@@ -31,6 +33,7 @@ pub mod final_;
 pub mod futures;
 pub mod gc;
 pub mod getters_and_setters;
+pub mod ignore;
 pub mod import_class;
 pub mod imports;
 pub mod intrinsics;


### PR DESCRIPTION
I think its fine to explicitly allow certain lints.

Fixes #3944.