### PR TITLE
Add ability to set stack size for spawned threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 * Add WebIDL definitions relating to `Popover API`.
   [#3977](https://github.com/rustwasm/wasm-bindgen/pull/3977)
 
+* Added the `thread_stack_size` property to the object parameter of `default()` (`init()`) and `initSync()`, making it possible to set the stack size of spawned threads. `__wbindgen_thread_destroy()` now has a third optional parameter for the stack size, the default stack size is assumed when not passing it. When calling from the thread to be destroyed, by passing no parameters, the correct stack size is determined internally.
+  [#3995](https://github.com/rustwasm/wasm-bindgen/pull/3995)
+
 ### Changed
 
 * Stabilize Web Share API.
@@ -86,6 +89,12 @@
 * Deprecate `AudioBufferSourceNode.onended` and `AudioBufferSourceNode.stop()`.
   [#4020](https://github.com/rustwasm/wasm-bindgen/pull/4020)
 
+* Increase default stack size for spawned threads from 1 to 2 MB.
+  [#3995](https://github.com/rustwasm/wasm-bindgen/pull/3995)
+
+* Deprecated parameters to `default` (`init`) and `initSync` in favor of an object.
+  [#3995](https://github.com/rustwasm/wasm-bindgen/pull/3995)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.
@@ -117,6 +126,9 @@
  
 * Fixed Deno support.
   [#3990](https://github.com/rustwasm/wasm-bindgen/pull/3990)
+
+* Fix `__wbindgen_thread_destroy()` ignoring parameters.
+  [#3995](https://github.com/rustwasm/wasm-bindgen/pull/3995)
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -332,11 +332,17 @@ fn default_module_path_target_web() {
     let contents = fs::read_to_string(out_dir.join("default_module_path_target_web.js")).unwrap();
     assert!(contents.contains(
         "\
-async function __wbg_init(input) {
+async function __wbg_init(module_or_path) {
     if (wasm !== undefined) return wasm;
 
-    if (typeof input === 'undefined') {
-        input = new URL('default_module_path_target_web_bg.wasm', import.meta.url);
+
+    if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
+    ({module_or_path} = module_or_path)
+    else
+    console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+
+    if (typeof module_or_path === 'undefined') {
+        module_or_path = new URL('default_module_path_target_web_bg.wasm', import.meta.url);
     }",
     ));
 }
@@ -361,11 +367,17 @@ fn default_module_path_target_no_modules() {
     ));
     assert!(contents.contains(
         "\
-    async function __wbg_init(input) {
+    async function __wbg_init(module_or_path) {
         if (wasm !== undefined) return wasm;
 
-        if (typeof input === 'undefined' && typeof script_src !== 'undefined') {
-            input = script_src.replace(/\\.js$/, '_bg.wasm');
+
+        if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
+        ({module_or_path} = module_or_path)
+        else
+        console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+
+        if (typeof module_or_path === 'undefined' && typeof script_src !== 'undefined') {
+            module_or_path = script_src.replace(/\\.js$/, '_bg.wasm');
         }",
     ));
 }
@@ -384,8 +396,14 @@ fn omit_default_module_path_target_web() {
         fs::read_to_string(out_dir.join("omit_default_module_path_target_web.js")).unwrap();
     assert!(contents.contains(
         "\
-async function __wbg_init(input) {
+async function __wbg_init(module_or_path) {
     if (wasm !== undefined) return wasm;
+
+
+    if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
+    ({module_or_path} = module_or_path)
+    else
+    console.warn('using deprecated parameters for the initialization function; pass a single object instead')
 
 
     const imports = __wbg_get_imports();",
@@ -406,8 +424,14 @@ fn omit_default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("omit_default_module_path_target_no_modules.js")).unwrap();
     assert!(contents.contains(
         "\
-    async function __wbg_init(input) {
+    async function __wbg_init(module_or_path) {
         if (wasm !== undefined) return wasm;
+
+
+        if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
+        ({module_or_path} = module_or_path)
+        else
+        console.warn('using deprecated parameters for the initialization function; pass a single object instead')
 
 
         const imports = __wbg_get_imports();",

--- a/examples/synchronous-instantiation/worker.js
+++ b/examples/synchronous-instantiation/worker.js
@@ -7,7 +7,7 @@ self.onmessage = ({ data: bytes }) => {
    * via the default export. The synchronous method internally uses
    * `new WebAssembly.Module()` and `new WebAssembly.Instance()`.
    */
-  wasm.initSync(bytes);
+  wasm.initSync({ module: bytes });
 
   /**
    * Once initialized we can call our exported `greet()` functions.

--- a/examples/wasm-audio-worklet/src/worklet.js
+++ b/examples/wasm-audio-worklet/src/worklet.js
@@ -2,7 +2,7 @@ registerProcessor("WasmProcessor", class WasmProcessor extends AudioWorkletProce
     constructor(options) {
         super();
         let [module, memory, handle] = options.processorOptions;
-        bindgen.initSync(module, memory);
+        bindgen.initSync({ module, memory });
         this.processor = bindgen.WasmAudioProcessor.unpack(handle);
     }
     process(inputs, outputs) {

--- a/examples/websockets/index.js
+++ b/examples/websockets/index.js
@@ -1,5 +1,5 @@
 import init from './pkg/websockets.js';
 
 window.addEventListener('load', async () => {
-    await init('./pkg/websockets_bg.wasm');
+    await init({ module_or_path: './pkg/websockets_bg.wasm' });
 });


### PR DESCRIPTION
This does a couple of things:
- Changes the signature of `default()` and `initSync()` to take an object and moving all parameters into that object. The old signature still works, but is deprecated. This lets us add additional parameters without breaking changes.
- Increase the default stack size of spawned threads from 1 to 2 MB. This follows [Std's default for tier 1 targets](https://doc.rust-lang.org/1.79.0/std/thread/index.html#stack-size), but I'm unsure what to go by here.
- Add the property `thread_stack_size` to `default()` and `initSync()`, to let the user set the thread stack size.
- Modify `__wbindgen_thread_destroy()` to take an additional parameter specifying the thread stack size. This only comes into play when destroying other threads, when destroying the current thread, by passing no parameters, the correct thread stack size is determined internally.
- Fix `__wbindgen_thread_destroy()` ignoring parameters. Though I'm not exactly sure how not setting the correct locals to be parameters when building the function actually played out in reality.