### PR TITLE
Restrict to bumpalo v3.12.1

### DIFF
--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -17,7 +17,7 @@ spans = []
 extra-traits = ["syn/extra-traits"]
 
 [dependencies]
-bumpalo = "3.0.0"
+bumpalo = "~3.12.1"
 log = "0.4"
 once_cell = "1.12"
 proc-macro2 = "1.0"


### PR DESCRIPTION
This is the last version of bumpalo that compiles with wasm-bindgen's
stated MSRV of v1.57.
