### PR TITLE
Add OptionIntoWasmAbi and OptionFromWasmAbi implementations for JsValue

### DIFF
--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -323,12 +323,26 @@ impl IntoWasmAbi for JsValue {
     }
 }
 
+impl OptionIntoWasmAbi for JsValue {
+    #[inline]
+    fn none() -> u32 {
+        JsValue::undefined().into_abi()
+    }
+}
+
 impl FromWasmAbi for JsValue {
     type Abi = u32;
 
     #[inline]
     unsafe fn from_abi(js: u32) -> JsValue {
         JsValue::_new(js)
+    }
+}
+
+impl OptionFromWasmAbi for JsValue {
+    #[inline]
+    fn is_none(js: &u32) -> bool {
+        *js == 0
     }
 }
 

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -50,6 +50,7 @@ pub mod optional_primitives;
 pub mod result;
 pub mod result_jserror;
 pub mod rethrow;
+pub mod return_result;
 pub mod simple;
 pub mod slice;
 pub mod string_vecs;

--- a/tests/wasm/return_result.js
+++ b/tests/wasm/return_result.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const wasm = require('wasm-bindgen-test');
+
+exports.call_exports = function () {
+  assert.strictEqual(undefined, wasm.nothing());
+  assert.strictEqual(3, wasm.return_3());
+  assert.strictEqual(4, wasm.return_4());
+  assert.strictEqual(42, wasm.return_option());
+  assert.strictEqual(42, wasm.return_option_some());
+  assert.strictEqual(undefined, wasm.return_option_none());
+};
+
+exports.return_value = function () {
+  return 'ok';
+};
+
+exports.return_some = function () {
+  return 'ok';
+};
+
+exports.return_none = function () {};

--- a/tests/wasm/return_result.rs
+++ b/tests/wasm/return_result.rs
@@ -1,0 +1,72 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[rustfmt::skip]
+#[wasm_bindgen(module = "tests/wasm/return_result.js")]
+extern "C" {
+    #[wasm_bindgen(catch)]
+    fn call_exports() -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(catch)]
+    fn return_value() -> Result<JsValue, JsValue>;
+    #[wasm_bindgen(catch)]
+    fn return_some() -> Result<Option<JsValue>, JsValue>;
+    #[wasm_bindgen(catch)]
+    fn return_none() -> Result<Option<JsValue>, JsValue>;
+}
+
+#[wasm_bindgen_test]
+fn smoke() {
+    call_exports().unwrap();
+}
+
+#[wasm_bindgen]
+pub fn nothing() -> Result<(), JsValue> {
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub fn return_3() -> Result<u32, JsValue> {
+    Ok(3)
+}
+
+#[wasm_bindgen]
+pub fn return_4() -> Result<JsValue, JsValue> {
+    Ok(4.into())
+}
+
+#[wasm_bindgen]
+pub fn return_option() -> Result<JsValue, JsValue> {
+    Ok(Some(42).into())
+}
+
+#[wasm_bindgen]
+pub fn return_option_some() -> Result<Option<JsValue>, JsValue> {
+    Ok(Some(42.into()))
+}
+
+#[wasm_bindgen]
+pub fn return_option_none() -> Result<Option<JsValue>, JsValue> {
+    Ok(None)
+}
+
+#[wasm_bindgen_test]
+fn test_return_value() {
+    assert_eq!(
+        return_value().unwrap().as_string(),
+        Some(String::from("ok"))
+    )
+}
+
+#[wasm_bindgen_test]
+fn test_return_some() {
+    assert_eq!(
+        return_some().unwrap().unwrap().as_string(),
+        Some(String::from("ok"))
+    )
+}
+
+#[wasm_bindgen_test]
+fn test_return_none() {
+    assert_eq!(return_none().unwrap().is_none(), true)
+}

--- a/tests/wasm/return_result.rs
+++ b/tests/wasm/return_result.rs
@@ -68,5 +68,5 @@ fn test_return_some() {
 
 #[wasm_bindgen_test]
 fn test_return_none() {
-    assert_eq!(return_none().unwrap().is_none(), true)
+    assert!(return_none().unwrap().is_none())
 }


### PR DESCRIPTION
OptionIntoWasmAbi: This will allow adding `#[wasm_bindgen]` to a function returning `Result<Option<JsValue>, ...>` which is useful for Rust code when it needs to return nothing and not want to create a `undefined` JsValue.

OptionFromWasmAbi: To be pair to `OptionIntoWasmAbi`, it allows transform a undefined or null in js to `None` if you define the return type of js method to `Result<Option<JsValue>, ...>`

P.S. I am not sure why the none check inside `OptionFromWasmAbi` is `*js == 0` instead of `*js == JSIDX_UNDEFINED`, and why it cannot distinguish undefined and null (both are 0). So the impl of `OptionFromWasmAbi` for JsValue could be wrong.
 

