### PR TITLE
Update env_logger to newer version

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,7 +21,7 @@ bin-dir = "wasm-bindgen-{ version }-{ target }/{ bin }{ binary-ext }"
 
 [dependencies]
 docopt = "1.0"
-env_logger = "0.8"
+env_logger = "0.11.5"
 anyhow = "1.0"
 log = "0.4"
 native-tls = { version = "0.2", default-features = false, optional = true }

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 rust-version = "1.57"
 
 [dependencies]
-env_logger = "0.8.1"
+env_logger = "0.11.5"
 anyhow = "1.0"
 heck = "0.3"
 log = "0.4.1"


### PR DESCRIPTION
The env_logger version  (0.8.1) currently used depends on the unmaintained atty crate which has known vulnerabilities: https://github.com/rust-cli/env_logger/pull/246

Updating to a newer version solves this issue. 