### PR TITLE
Update `AudioBufferSourceNode` WebIDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@
 * Update Web Authentication API to level 3.
   [#4000](https://github.com/rustwasm/wasm-bindgen/pull/4000)
 
+* Deprecate `AudioBufferSourceNode.onended` and `AudioBufferSourceNode.stop()`.
+  [#4020](https://github.com/rustwasm/wasm-bindgen/pull/4020)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.

--- a/crates/web-sys/src/features/gen_AudioBufferSourceNode.rs
+++ b/crates/web-sys/src/features/gen_AudioBufferSourceNode.rs
@@ -86,20 +86,6 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
     pub fn set_loop_end(this: &AudioBufferSourceNode, value: f64);
-    # [wasm_bindgen (structural , method , getter , js_class = "AudioBufferSourceNode" , js_name = onended)]
-    #[doc = "Getter for the `onended` field of this object."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/onended)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn onended(this: &AudioBufferSourceNode) -> Option<::js_sys::Function>;
-    # [wasm_bindgen (structural , method , setter , js_class = "AudioBufferSourceNode" , js_name = onended)]
-    #[doc = "Setter for the `onended` field of this object."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/onended)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn set_onended(this: &AudioBufferSourceNode, value: Option<&::js_sys::Function>);
     #[cfg(feature = "BaseAudioContext")]
     #[wasm_bindgen(catch, constructor, js_class = "AudioBufferSourceNode")]
     #[doc = "The `new AudioBufferSourceNode(..)` constructor, creating a new instance of `AudioBufferSourceNode`."]
@@ -139,10 +125,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn start_with_when_and_grain_offset(
+    pub fn start_with_when_and_offset(
         this: &AudioBufferSourceNode,
         when: f64,
-        grain_offset: f64,
+        offset: f64,
     ) -> Result<(), JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = start)]
     #[doc = "The `start()` method."]
@@ -150,24 +136,10 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn start_with_when_and_grain_offset_and_grain_duration(
+    pub fn start_with_when_and_offset_and_duration(
         this: &AudioBufferSourceNode,
         when: f64,
-        grain_offset: f64,
-        grain_duration: f64,
+        offset: f64,
+        duration: f64,
     ) -> Result<(), JsValue>;
-    # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = stop)]
-    #[doc = "The `stop()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/stop)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn stop(this: &AudioBufferSourceNode) -> Result<(), JsValue>;
-    # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = stop)]
-    #[doc = "The `stop()` method."]
-    #[doc = ""]
-    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/stop)"]
-    #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn stop_with_when(this: &AudioBufferSourceNode, when: f64) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/src/features/gen_AudioBufferSourceNode.rs
+++ b/crates/web-sys/src/features/gen_AudioBufferSourceNode.rs
@@ -86,6 +86,22 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
     pub fn set_loop_end(this: &AudioBufferSourceNode, value: f64);
+    # [wasm_bindgen (structural , method , getter , js_class = "AudioBufferSourceNode" , js_name = onended)]
+    #[doc = "Getter for the `onended` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/onended)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
+    #[deprecated]
+    pub fn onended(this: &AudioBufferSourceNode) -> Option<::js_sys::Function>;
+    # [wasm_bindgen (structural , method , setter , js_class = "AudioBufferSourceNode" , js_name = onended)]
+    #[doc = "Setter for the `onended` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/onended)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
+    #[deprecated]
+    pub fn set_onended(this: &AudioBufferSourceNode, value: Option<&::js_sys::Function>);
     #[cfg(feature = "BaseAudioContext")]
     #[wasm_bindgen(catch, constructor, js_class = "AudioBufferSourceNode")]
     #[doc = "The `new AudioBufferSourceNode(..)` constructor, creating a new instance of `AudioBufferSourceNode`."]
@@ -125,7 +141,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn start_with_when_and_offset(
+    pub fn start_with_when_and_grain_offset(
         this: &AudioBufferSourceNode,
         when: f64,
         offset: f64,
@@ -136,10 +152,26 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/start)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
-    pub fn start_with_when_and_offset_and_duration(
+    pub fn start_with_when_and_grain_offset_and_grain_duration(
         this: &AudioBufferSourceNode,
         when: f64,
         offset: f64,
         duration: f64,
     ) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = stop)]
+    #[doc = "The `stop()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/stop)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
+    #[deprecated]
+    pub fn stop(this: &AudioBufferSourceNode) -> Result<(), JsValue>;
+    # [wasm_bindgen (catch , method , structural , js_class = "AudioBufferSourceNode" , js_name = stop)]
+    #[doc = "The `stop()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBufferSourceNode/stop)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AudioBufferSourceNode`*"]
+    #[deprecated]
+    pub fn stop_with_when(this: &AudioBufferSourceNode, when: f64) -> Result<(), JsValue>;
 }

--- a/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
@@ -20,9 +20,11 @@ interface AudioBufferSourceNode : AudioScheduledSourceNode {
     attribute boolean loop;
     attribute double loopStart;
     attribute double loopEnd;
+    [RustDeprecated] attribute EventHandler onended;
     [Throws] undefined start (optional double when = 0,
                      optional double offset,
                      optional double duration);
+    [Throws, RustDeprecated] undefined stop (optional double when = 0);
 };
 
 dictionary AudioBufferSourceOptions {

--- a/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
+++ b/crates/web-sys/webidls/enabled/AudioBufferSourceNode.webidl
@@ -10,34 +10,26 @@
  * liability, trademark and document use rules apply.
  */
 
-dictionary AudioBufferSourceOptions {
-             AudioBuffer? buffer;
-             float        detune = 0;
-             boolean      loop = false;
-             double       loopEnd = 0;
-             double       loopStart = 0;
-             float        playbackRate = 1;
-};
-
-[Pref="dom.webaudio.enabled",
- Constructor(BaseAudioContext context, optional AudioBufferSourceOptions options)]
+[Exposed=Window]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
-
+    constructor (BaseAudioContext context,
+                 optional AudioBufferSourceOptions options = {});
     attribute AudioBuffer? buffer;
-
     readonly attribute AudioParam playbackRate;
     readonly attribute AudioParam detune;
-
     attribute boolean loop;
     attribute double loopStart;
     attribute double loopEnd;
+    [Throws] undefined start (optional double when = 0,
+                     optional double offset,
+                     optional double duration);
+};
 
-    attribute EventHandler onended;
-
-    [Throws]
-    undefined start(optional double when = 0, optional double grainOffset = 0,
-               optional double grainDuration);
-
-    [Throws]
-    undefined stop (optional double when = 0);
+dictionary AudioBufferSourceOptions {
+    AudioBuffer? buffer;
+    float detune = 0;
+    boolean loop = false;
+    double loopEnd = 0;
+    double loopStart = 0;
+    float playbackRate = 1;
 };

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -152,6 +152,19 @@ pub(crate) static FIXED_INTERFACES: Lazy<
             "ReadableStreamByobReader",
             BTreeMap::from_iter([("read", "read_with_array_buffer_view")]),
         ),
+        (
+            "AudioBufferSourceNode",
+            BTreeMap::from_iter([
+                (
+                    "start_with_when_and_offset",
+                    "start_with_when_and_grain_offset",
+                ),
+                (
+                    "start_with_when_and_offset_and_duration",
+                    "start_with_when_and_grain_offset_and_grain_duration",
+                ),
+            ]),
+        ),
     ])
 });
 

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -225,6 +225,7 @@ pub enum InterfaceAttributeKind {
 
 pub struct InterfaceAttribute {
     pub js_name: String,
+    pub deprecated: Option<Option<String>>,
     pub ty: Type,
     pub is_static: bool,
     pub structural: bool,
@@ -243,6 +244,7 @@ impl InterfaceAttribute {
     ) -> TokenStream {
         let InterfaceAttribute {
             js_name,
+            deprecated,
             ty,
             is_static,
             structural,
@@ -319,6 +321,10 @@ impl InterfaceAttribute {
         };
 
         let catch = if *catch { Some(quote!(catch,)) } else { None };
+        let deprecated = deprecated.as_ref().map(|msg| match msg {
+            Some(msg) => quote!( #[deprecated(note = #msg)] ),
+            None => quote!( #[deprecated] ),
+        });
 
         let doc_comment = comment(
             format!(
@@ -343,6 +349,7 @@ impl InterfaceAttribute {
             )]
             #doc_comment
             #unstable_docs
+            #deprecated
             #def
         }
     }
@@ -360,6 +367,7 @@ pub enum InterfaceMethodKind {
 pub struct InterfaceMethod {
     pub name: Ident,
     pub js_name: String,
+    pub deprecated: Option<Option<String>>,
     pub arguments: Vec<(Ident, Type)>,
     pub ret_ty: Option<Type>,
     pub kind: InterfaceMethodKind,
@@ -381,6 +389,7 @@ impl InterfaceMethod {
         let InterfaceMethod {
             name,
             js_name,
+            deprecated,
             arguments,
             ret_ty,
             kind,
@@ -463,6 +472,11 @@ impl InterfaceMethod {
 
         let doc_comment = comment(doc_comment, &required_doc_string(options, &features));
 
+        let deprecated = deprecated.as_ref().map(|msg| match msg {
+            Some(msg) => quote!( #[deprecated(note = #msg)] ),
+            None => quote!( #[deprecated] ),
+        });
+
         let ret = ret_ty.as_ref().map(|ret| quote!( #ret ));
 
         let ret = if *catch {
@@ -509,6 +523,7 @@ impl InterfaceMethod {
             )]
             #doc_comment
             #unstable_docs
+            #deprecated
             pub fn #name(#this #(#arguments),*) #ret;
         }
     }

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -696,6 +696,7 @@ impl<'src> FirstPassRecord<'src> {
         let structural = is_structural(attrs.as_ref(), container_attrs);
 
         let catch = throws(attrs);
+        let deprecated: Option<Option<String>> = get_rust_deprecated(attrs);
 
         let ty = type_
             .type_
@@ -712,6 +713,7 @@ impl<'src> FirstPassRecord<'src> {
                 catch: catch || getter_throws(parent_js_name, &js_name, attrs),
                 ty,
                 js_name: js_name.clone(),
+                deprecated: deprecated.clone(),
                 kind,
                 unstable,
             });
@@ -733,6 +735,7 @@ impl<'src> FirstPassRecord<'src> {
                     catch: catch || setter_throws(parent_js_name, &js_name, attrs),
                     ty,
                     js_name,
+                    deprecated,
                     kind,
                     unstable,
                 });

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -410,6 +410,7 @@ impl<'src> FirstPassRecord<'src> {
             let structural =
                 force_structural || is_structural(signature.orig.attrs.as_ref(), container_attrs);
             let catch = force_throws || throws(signature.orig.attrs);
+            let deprecated = get_rust_deprecated(signature.orig.attrs);
             let ret_ty = if id == &OperationId::IndexingGetter {
                 // All indexing getters should return optional values (or
                 // otherwise be marked with catch).
@@ -476,6 +477,7 @@ impl<'src> FirstPassRecord<'src> {
                     ret.push(InterfaceMethod {
                         name: rust_ident(&rust_name),
                         js_name: name.to_string(),
+                        deprecated: deprecated.clone(),
                         arguments,
                         ret_ty,
                         kind: kind.clone(),
@@ -507,6 +509,7 @@ impl<'src> FirstPassRecord<'src> {
                         ret.push(InterfaceMethod {
                             name: rust_ident(&format!("{}_{}", rust_name, i)),
                             js_name: name.to_string(),
+                            deprecated: deprecated.clone(),
                             arguments,
                             kind: kind.clone(),
                             ret_ty,


### PR DESCRIPTION
Deprecate `AudioBufferSourceNode.onended` and `AudioBufferSourceNode.stop()`.
This required coaxing the generator a little.

Replaces #3978.
Cc @pablosichert.