### PR TITLE
Add alloc feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: cargo check --all
-    - run: cargo check --no-default-features
+    - run: cargo check --no-default-features --features alloc
 
   # Run `cargo clippy` over everything
   clippy:
@@ -67,7 +67,7 @@ jobs:
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-webidl -- -D warnings
     - run: cargo clippy --no-deps --all-features -p webidl-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p web-sys -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -- -D warnings
+    - run: cargo clippy --no-deps --no-default-features --features alloc --target wasm32-unknown-unknown -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown --tests -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-benchmark -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ features = ["serde-serialize"]
 test = false
 
 [features]
-default = ["spans", "std"]
+default = ["spans", "std", "alloc"]
 spans = ["wasm-bindgen-macro/spans"]
-std = []
+std = ["alloc"]
+alloc = []
 serde-serialize = ["serde", "serde_json", "std"]
 enable-interning = ["std"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
 
 extern crate alloc;
+#[cfg(not(feature = "alloc"))]
+compile_error!("`wasm-bindgen` requires the `alloc` feature to be enabled");
 
 use alloc::boxed::Box;
 use alloc::string::String;


### PR DESCRIPTION
Follow up to #4005. This keeps a path open to add a no-alloc implementation without breaking changes in the future, making `alloc` a required feature for now.

(This makes `default-features=false` without adding `std` or `alloc` break again like in the current release, but prevents sudden breakage from adding a new default feature in a future release.)

Note: I don't feel too strongly about this, and I'm not sure how useful wasm-bindgen can be without `alloc`, this is mostly a precautionary change.