### PR TITLE
Add support for WebIDL records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@
 * Added bindings to the Device Memory API.
   [#4011](https://github.com/rustwasm/wasm-bindgen/pull/4011)
 
+* Added support for WebIDL records. This added new methods to various APIs, notably `ClipboardItem()`, `GPUDeviceDescriptor.requiredLimits` and `Header()`.
+  [#4030](https://github.com/rustwasm/wasm-bindgen/pull/4030)
+
 ### Changed
 
 * Stabilize Web Share API.

--- a/crates/web-sys/src/features/gen_AudioWorkletNodeOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioWorkletNodeOptions.rs
@@ -76,6 +76,16 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `AudioWorkletNodeOptions`*"]
     #[wasm_bindgen(method, setter = "outputChannelCount")]
     pub fn set_output_channel_count(this: &AudioWorkletNodeOptions, val: &::wasm_bindgen::JsValue);
+    #[doc = "Get the `parameterData` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AudioWorkletNodeOptions`*"]
+    #[wasm_bindgen(method, getter = "parameterData")]
+    pub fn get_parameter_data(this: &AudioWorkletNodeOptions) -> Option<::js_sys::Object>;
+    #[doc = "Change the `parameterData` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AudioWorkletNodeOptions`*"]
+    #[wasm_bindgen(method, setter = "parameterData")]
+    pub fn set_parameter_data(this: &AudioWorkletNodeOptions, val: &::js_sys::Object);
     #[doc = "Get the `processorOptions` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioWorkletNodeOptions`*"]
@@ -126,6 +136,11 @@ impl AudioWorkletNodeOptions {
     #[deprecated = "Use `set_output_channel_count()` instead."]
     pub fn output_channel_count(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
         self.set_output_channel_count(val);
+        self
+    }
+    #[deprecated = "Use `set_parameter_data()` instead."]
+    pub fn parameter_data(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_parameter_data(val);
         self
     }
     #[deprecated = "Use `set_processor_options()` instead."]

--- a/crates/web-sys/src/features/gen_AuthenticationExtensionsPrfInputs.rs
+++ b/crates/web-sys/src/features/gen_AuthenticationExtensionsPrfInputs.rs
@@ -39,6 +39,26 @@ extern "C" {
         this: &AuthenticationExtensionsPrfInputs,
         val: &AuthenticationExtensionsPrfValues,
     );
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `evalByCredential` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AuthenticationExtensionsPrfInputs`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "evalByCredential")]
+    pub fn get_eval_by_credential(
+        this: &AuthenticationExtensionsPrfInputs,
+    ) -> Option<::js_sys::Object>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `evalByCredential` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `AuthenticationExtensionsPrfInputs`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "evalByCredential")]
+    pub fn set_eval_by_credential(this: &AuthenticationExtensionsPrfInputs, val: &::js_sys::Object);
 }
 #[cfg(web_sys_unstable_apis)]
 impl AuthenticationExtensionsPrfInputs {
@@ -58,6 +78,12 @@ impl AuthenticationExtensionsPrfInputs {
     #[deprecated = "Use `set_eval()` instead."]
     pub fn eval(&mut self, val: &AuthenticationExtensionsPrfValues) -> &mut Self {
         self.set_eval(val);
+        self
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_eval_by_credential()` instead."]
+    pub fn eval_by_credential(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_eval_by_credential(val);
         self
     }
 }

--- a/crates/web-sys/src/features/gen_ClipboardItem.rs
+++ b/crates/web-sys/src/features/gen_ClipboardItem.rs
@@ -27,6 +27,46 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ClipboardItem`*"]
     pub fn types(this: &ClipboardItem) -> ::js_sys::Array;
+    #[wasm_bindgen(catch, constructor, js_class = "ClipboardItem")]
+    #[doc = "The `new ClipboardItem(..)` constructor, creating a new instance of `ClipboardItem`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ClipboardItem`*"]
+    pub fn new_with_record_from_str_to_str_promise(
+        items: &::js_sys::Object,
+    ) -> Result<ClipboardItem, JsValue>;
+    #[wasm_bindgen(catch, constructor, js_class = "ClipboardItem")]
+    #[doc = "The `new ClipboardItem(..)` constructor, creating a new instance of `ClipboardItem`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ClipboardItem`*"]
+    pub fn new_with_record_from_str_to_blob_promise(
+        items: &::js_sys::Object,
+    ) -> Result<ClipboardItem, JsValue>;
+    #[cfg(feature = "ClipboardItemOptions")]
+    #[wasm_bindgen(catch, constructor, js_class = "ClipboardItem")]
+    #[doc = "The `new ClipboardItem(..)` constructor, creating a new instance of `ClipboardItem`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ClipboardItem`, `ClipboardItemOptions`*"]
+    pub fn new_with_record_from_str_to_str_promise_and_options(
+        items: &::js_sys::Object,
+        options: &ClipboardItemOptions,
+    ) -> Result<ClipboardItem, JsValue>;
+    #[cfg(feature = "ClipboardItemOptions")]
+    #[wasm_bindgen(catch, constructor, js_class = "ClipboardItem")]
+    #[doc = "The `new ClipboardItem(..)` constructor, creating a new instance of `ClipboardItem`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ClipboardItem`, `ClipboardItemOptions`*"]
+    pub fn new_with_record_from_str_to_blob_promise_and_options(
+        items: &::js_sys::Object,
+        options: &ClipboardItemOptions,
+    ) -> Result<ClipboardItem, JsValue>;
     # [wasm_bindgen (method , structural , js_class = "ClipboardItem" , js_name = getType)]
     #[doc = "The `getType()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_DisplayNameResult.rs
+++ b/crates/web-sys/src/features/gen_DisplayNameResult.rs
@@ -30,6 +30,16 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `DisplayNameResult`*"]
     #[wasm_bindgen(method, setter = "style")]
     pub fn set_style(this: &DisplayNameResult, val: &str);
+    #[doc = "Get the `values` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DisplayNameResult`*"]
+    #[wasm_bindgen(method, getter = "values")]
+    pub fn get_values(this: &DisplayNameResult) -> Option<::js_sys::Object>;
+    #[doc = "Change the `values` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DisplayNameResult`*"]
+    #[wasm_bindgen(method, setter = "values")]
+    pub fn set_values(this: &DisplayNameResult, val: &::js_sys::Object);
 }
 impl DisplayNameResult {
     #[doc = "Construct a new `DisplayNameResult`."]
@@ -48,6 +58,11 @@ impl DisplayNameResult {
     #[deprecated = "Use `set_style()` instead."]
     pub fn style(&mut self, val: &str) -> &mut Self {
         self.set_style(val);
+        self
+    }
+    #[deprecated = "Use `set_values()` instead."]
+    pub fn values(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_values(val);
         self
     }
 }

--- a/crates/web-sys/src/features/gen_FilePickerAcceptType.rs
+++ b/crates/web-sys/src/features/gen_FilePickerAcceptType.rs
@@ -15,6 +15,24 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type FilePickerAcceptType;
     #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `accept` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `FilePickerAcceptType`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "accept")]
+    pub fn get_accept(this: &FilePickerAcceptType) -> Option<::js_sys::Object>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `accept` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `FilePickerAcceptType`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "accept")]
+    pub fn set_accept(this: &FilePickerAcceptType, val: &::js_sys::Object);
+    #[cfg(web_sys_unstable_apis)]
     #[doc = "Get the `description` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `FilePickerAcceptType`*"]
@@ -45,6 +63,12 @@ impl FilePickerAcceptType {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_accept()` instead."]
+    pub fn accept(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_accept(val);
+        self
     }
     #[cfg(web_sys_unstable_apis)]
     #[deprecated = "Use `set_description()` instead."]

--- a/crates/web-sys/src/features/gen_GpuDeviceDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuDeviceDescriptor.rs
@@ -70,6 +70,24 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     #[wasm_bindgen(method, setter = "requiredFeatures")]
     pub fn set_required_features(this: &GpuDeviceDescriptor, val: &::wasm_bindgen::JsValue);
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `requiredLimits` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuDeviceDescriptor`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "requiredLimits")]
+    pub fn get_required_limits(this: &GpuDeviceDescriptor) -> Option<::js_sys::Object>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `requiredLimits` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuDeviceDescriptor`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "requiredLimits")]
+    pub fn set_required_limits(this: &GpuDeviceDescriptor, val: &::js_sys::Object);
 }
 #[cfg(web_sys_unstable_apis)]
 impl GpuDeviceDescriptor {
@@ -101,6 +119,12 @@ impl GpuDeviceDescriptor {
     #[deprecated = "Use `set_required_features()` instead."]
     pub fn required_features(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
         self.set_required_features(val);
+        self
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_required_limits()` instead."]
+    pub fn required_limits(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_required_limits(val);
         self
     }
 }

--- a/crates/web-sys/src/features/gen_GpuFragmentState.rs
+++ b/crates/web-sys/src/features/gen_GpuFragmentState.rs
@@ -15,6 +15,24 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type GpuFragmentState;
     #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `constants` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuFragmentState`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "constants")]
+    pub fn get_constants(this: &GpuFragmentState) -> Option<::js_sys::Object>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `constants` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuFragmentState`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "constants")]
+    pub fn set_constants(this: &GpuFragmentState, val: &::js_sys::Object);
+    #[cfg(web_sys_unstable_apis)]
     #[doc = "Get the `entryPoint` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GpuFragmentState`*"]
@@ -86,6 +104,12 @@ impl GpuFragmentState {
         ret.module(module);
         ret.targets(targets);
         ret
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_constants()` instead."]
+    pub fn constants(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_constants(val);
+        self
     }
     #[cfg(web_sys_unstable_apis)]
     #[deprecated = "Use `set_entry_point()` instead."]

--- a/crates/web-sys/src/features/gen_GpuProgrammableStage.rs
+++ b/crates/web-sys/src/features/gen_GpuProgrammableStage.rs
@@ -15,6 +15,24 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type GpuProgrammableStage;
     #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `constants` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuProgrammableStage`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "constants")]
+    pub fn get_constants(this: &GpuProgrammableStage) -> Option<::js_sys::Object>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `constants` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuProgrammableStage`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "constants")]
+    pub fn set_constants(this: &GpuProgrammableStage, val: &::js_sys::Object);
+    #[cfg(web_sys_unstable_apis)]
     #[doc = "Get the `entryPoint` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GpuProgrammableStage`*"]
@@ -67,6 +85,12 @@ impl GpuProgrammableStage {
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.module(module);
         ret
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_constants()` instead."]
+    pub fn constants(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_constants(val);
+        self
     }
     #[cfg(web_sys_unstable_apis)]
     #[deprecated = "Use `set_entry_point()` instead."]

--- a/crates/web-sys/src/features/gen_GpuVertexState.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexState.rs
@@ -15,6 +15,24 @@ extern "C" {
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
     pub type GpuVertexState;
     #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `constants` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuVertexState`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "constants")]
+    pub fn get_constants(this: &GpuVertexState) -> Option<::js_sys::Object>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `constants` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `GpuVertexState`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "constants")]
+    pub fn set_constants(this: &GpuVertexState, val: &::js_sys::Object);
+    #[cfg(web_sys_unstable_apis)]
     #[doc = "Get the `entryPoint` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GpuVertexState`*"]
@@ -85,6 +103,12 @@ impl GpuVertexState {
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
         ret.module(module);
         ret
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_constants()` instead."]
+    pub fn constants(&mut self, val: &::js_sys::Object) -> &mut Self {
+        self.set_constants(val);
+        self
     }
     #[cfg(web_sys_unstable_apis)]
     #[deprecated = "Use `set_entry_point()` instead."]

--- a/crates/web-sys/src/features/gen_Headers.rs
+++ b/crates/web-sys/src/features/gen_Headers.rs
@@ -35,6 +35,13 @@ extern "C" {
     pub fn new_with_str_sequence_sequence(
         init: &::wasm_bindgen::JsValue,
     ) -> Result<Headers, JsValue>;
+    #[wasm_bindgen(catch, constructor, js_class = "Headers")]
+    #[doc = "The `new Headers(..)` constructor, creating a new instance of `Headers`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Headers/Headers)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Headers`*"]
+    pub fn new_with_record_from_str_to_str(init: &::js_sys::Object) -> Result<Headers, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "Headers" , js_name = append)]
     #[doc = "The `append()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_UrlSearchParams.rs
+++ b/crates/web-sys/src/features/gen_UrlSearchParams.rs
@@ -34,6 +34,15 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `UrlSearchParams`*"]
+    pub fn new_with_record_from_str_to_str(
+        init: &::js_sys::Object,
+    ) -> Result<UrlSearchParams, JsValue>;
+    #[wasm_bindgen(catch, constructor, js_class = "URLSearchParams")]
+    #[doc = "The `new UrlSearchParams(..)` constructor, creating a new instance of `UrlSearchParams`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `UrlSearchParams`*"]
     pub fn new_with_str(init: &str) -> Result<UrlSearchParams, JsValue>;
     # [wasm_bindgen (method , structural , js_class = "URLSearchParams" , js_name = append)]
     #[doc = "The `append()` method."]

--- a/crates/webidl/src/idl_type.rs
+++ b/crates/webidl/src/idl_type.rs
@@ -634,7 +634,7 @@ impl<'a> IdlType<'a> {
                 TypePosition::Return => Ok(js_sys("Array")),
             },
             IdlType::Promise(_idl_type) => Ok(js_sys("Promise")),
-            IdlType::Record(_idl_type_from, _idl_type_to) => Err(TypeError::CannotConvert),
+            IdlType::Record(_idl_type_from, _idl_type_to) => Ok(js_sys("Object")),
             IdlType::Union(idl_types) => {
                 // Note that most union types have already been expanded to
                 // their components via `flatten`. Unions in a return position


### PR DESCRIPTION
This PR adds support for WebIDL records by exposing it as a `js_sys::Object`.

While I do think that its unfortunate that we don't make use of the types already extracted from the WebIDL, this is already the case for many other types, e.g. `Promise`, `FrozenArray`, returned unions.
So I think instead of holding this up any longer, we can save any further improvements for future breaking changes.

Fixes #3587.