### PR TITLE
Add semicolon to "export { initSync }" in OutputMode::Web

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -487,7 +487,7 @@ impl<'a> Context<'a> {
             OutputMode::Web => {
                 self.imports_post.push_str("let wasm;\n");
                 init = self.gen_init(needs_manual_start, Some(&mut imports))?;
-                footer.push_str("export { initSync }\n");
+                footer.push_str("export { initSync };\n");
                 footer.push_str("export default __wbg_init;");
             }
         }


### PR DESCRIPTION
The rest of the generated js glue doesn't rely on implicit semicolons, but this line does. This causes some minifiers (one of which I happen to use) to output erroneous code.