### PR TITLE
Fix/improve stack pointer detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@
 * Allow ex/importing structs, functions and parameters named with raw identifiers.
   [#4025](https://github.com/rustwasm/wasm-bindgen/pull/4025)
 
+* Implement a more reliable way to detect the stack pointer.
+  [#4036](https://github.com/rustwasm/wasm-bindgen/pull/4036)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.92](https://github.com/rustwasm/wasm-bindgen/compare/0.2.91...0.2.92)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3963,13 +3963,13 @@ impl<'a> Context<'a> {
         if self.stack_pointer_shim_injected {
             return Ok(());
         }
-        let stack_pointer = match self.aux.shadow_stack_pointer {
+        let stack_pointer = match self.aux.stack_pointer {
             Some(s) => s,
             // In theory this shouldn't happen since malloc is included in
             // most wasm binaries (and may be gc'd out) and that almost
             // always pulls in a stack pointer. We can try to synthesize
             // something here later if necessary.
-            None => bail!("failed to find shadow stack pointer"),
+            None => bail!("failed to find stack pointer"),
         };
 
         use walrus::ir::*;

--- a/crates/cli-support/src/multivalue.rs
+++ b/crates/cli-support/src/multivalue.rs
@@ -18,21 +18,21 @@ pub fn run(module: &mut Module) -> Result<(), Error> {
         extract_xform(module, adapter, &mut to_xform, &mut slots);
     }
     if to_xform.is_empty() {
-        // Early exit to avoid failing if we don't have a memory or shadow stack
+        // Early exit to avoid failing if we don't have a memory or stack
         // pointer because this is a minimal module that doesn't use linear
         // memory.
         module.customs.add(*adapters);
         return Ok(());
     }
 
-    let shadow_stack_pointer = module
+    let stack_pointer = module
         .customs
         .get_typed::<WasmBindgenAux>()
         .expect("aux section should be present")
-        .shadow_stack_pointer
-        .ok_or_else(|| anyhow!("failed to find shadow stack pointer in wasm module"))?;
+        .stack_pointer
+        .ok_or_else(|| anyhow!("failed to find stack pointer in wasm module"))?;
     let memory = wasm_conventions::get_memory(module)?;
-    let wrappers = multi_value_xform::run(module, memory, shadow_stack_pointer, &to_xform)?;
+    let wrappers = multi_value_xform::run(module, memory, stack_pointer, &to_xform)?;
 
     for (slot, id) in slots.into_iter().zip(wrappers) {
         match slot {

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -90,8 +90,7 @@ pub fn process(
 
 impl<'a> Context<'a> {
     fn init(&mut self) -> Result<(), Error> {
-        self.aux.shadow_stack_pointer =
-            wasm_bindgen_wasm_conventions::get_shadow_stack_pointer(self.module);
+        self.aux.stack_pointer = wasm_bindgen_wasm_conventions::get_stack_pointer(self.module);
 
         // Make a map from string name to ids of all exports
         for export in self.module.exports.iter() {

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -57,7 +57,7 @@ pub struct WasmBindgenAux {
 
     /// Various intrinsics used for JS glue generation
     pub exn_store: Option<walrus::FunctionId>,
-    pub shadow_stack_pointer: Option<walrus::GlobalId>,
+    pub stack_pointer: Option<walrus::GlobalId>,
     pub thread_destroy: Option<walrus::FunctionId>,
 }
 
@@ -430,7 +430,7 @@ impl walrus::CustomSection for WasmBindgenAux {
         if let Some(id) = self.exn_store {
             roots.push_func(id);
         }
-        if let Some(id) = self.shadow_stack_pointer {
+        if let Some(id) = self.stack_pointer {
             roots.push_global(id);
         }
         if let Some(id) = self.thread_destroy {

--- a/crates/cli-support/src/wit/section.rs
+++ b/crates/cli-support/src/wit/section.rs
@@ -50,7 +50,7 @@ pub fn add(module: &mut Module) -> Result<(), Error> {
         externref_drop: _,
         externref_drop_slice: _,
         exn_store: _,
-        shadow_stack_pointer: _,
+        stack_pointer: _,
         function_table: _,
         thread_destroy: _,
     } = *aux;

--- a/crates/threads-xform/src/lib.rs
+++ b/crates/threads-xform/src/lib.rs
@@ -153,8 +153,8 @@ impl Config {
         assert!(self.thread_stack_size % PAGE_SIZE == 0);
 
         let stack = Stack {
-            pointer: wasm_conventions::get_shadow_stack_pointer(module)
-                .ok_or_else(|| anyhow!("failed to find shadow stack pointer"))?,
+            pointer: wasm_conventions::get_stack_pointer(module)
+                .ok_or_else(|| anyhow!("failed to find stack pointer"))?,
             temp: temp_stack as i32,
             temp_lock: thread_counter_addr + 4,
             alloc: stack_alloc,

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -16,3 +16,4 @@ walrus = "0.20.2"
 # Matching the version `walrus` depends on.
 wasmparser = "0.80"
 anyhow = "1.0"
+log = "0.4"


### PR DESCRIPTION
Stack pointer detection war currently done by finding *the one global* that is an `i32` and initialized to a non-zero.
This is unreliable, as encountered in #3995, in the worst case scenario this could lead to some pretty bad undefined behavior.
This PR tries to find the stack pointer by name first, `__stack_pointer`, before falling back to the old method.

Additionally, I renamed all instances of "shadow stack" to just "stack", as this was inaccurate and was previously meant to describe the fact that Wasm basically has two stacks: the user-managed stack inside the Wasm module and the other stack belonging to the Wasm engine.