### PR TITLE
Introduce MSRV policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -438,6 +438,28 @@ jobs:
         name: doc_api
         path: docs.tar.gz
 
+  msrv-lib:
+    name: Check MSRV for libraries
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/msrv/lib
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update 1.57 && rustup default 1.57
+    - run: cargo build
+      
+  msrv-cli:
+    name: Check MSRV for CLI tools
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/msrv/cli
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update 1.76 && rustup default 1.76
+    - run: cargo build
+      
 
   deploy:
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn.lock
 .vscode
 webdriver.json
 benchmarks/pkg
+/crates/msrv/*/target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
 * Added support for WebIDL records. This added new methods to various APIs, notably `ClipboardItem()`, `GPUDeviceDescriptor.requiredLimits` and `Header()`.
   [#4030](https://github.com/rustwasm/wasm-bindgen/pull/4030)
 
+* Added an official MSRV policy. Library MSRV changes will be accompanied by a minor version bump. CLI tool MSRV can change with any version bump.
+  [#4038](https://github.com/rustwasm/wasm-bindgen/pull/4038)
+
 ### Changed
 
 * Stabilize Web Share API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ members = [
   "examples/synchronous-instantiation",
   "tests/no-std",
 ]
+exclude = ["crates/msrv"]
 resolver = "2"
 
 [patch.crates-io]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ You can find general documentation about using Rust and WebAssembly together
 - [web-sys](https://docs.rs/web-sys)
 - [wasm-bindgen-futures](https://docs.rs/wasm-bindgen-futures)
 
+## MSRV Policy
+
+Libraries that are released on [crates.io](https://crates.io) have a MSRV of v1.57. Changes to the MSRV will be accompanied by a minor version bump.
+
+CLI tools and their corresponding support libraries have a MSRV of v1.76. Changes to the MSRV will be accompanied by a patch version bump.
+
 ## License
 
 This project is licensed under either of

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -3,7 +3,6 @@ name = "wasm-bindgen-benchmark"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [dependencies]
 wasm-bindgen = { path = '../' }

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Shared support for the wasm-bindgen-cli package, an internal dependency
 """
 edition = '2018'
-rust-version = "1.57"
+rust-version = "1.76"
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2637,7 +2637,7 @@ impl<'a> Context<'a> {
                 assert!(!catch);
                 assert!(!log_error);
 
-                let ts_sig = export.generate_typescript.then(|| ts_sig.as_str());
+                let ts_sig = export.generate_typescript.then_some(ts_sig.as_str());
 
                 let js_docs = format_doc_comments(&export.comments, Some(js_doc));
                 let ts_docs = format_doc_comments(&export.comments, None);

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -13,7 +13,7 @@ information see https://github.com/rustwasm/wasm-bindgen.
 """
 edition = '2018'
 default-run = 'wasm-bindgen'
-rust-version = "1.57"
+rust-version = "1.76"
 
 [package.metadata.binstall]
 pkg-url = "https://github.com/rustwasm/wasm-bindgen/releases/download/{ version }/wasm-bindgen-{ version }-{ target }{ archive-suffix }"

--- a/crates/example-tests/Cargo.toml
+++ b/crates/example-tests/Cargo.toml
@@ -3,7 +3,6 @@ name = "example-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0.75"

--- a/crates/msrv/cli/Cargo.toml
+++ b/crates/msrv/cli/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "msrv-cli-test"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+wasm-bindgen-cli = { path = "../../cli" }

--- a/crates/msrv/lib/Cargo.toml
+++ b/crates/msrv/lib/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "msrv-library-test"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+js-sys = { path = "../../js-sys" }
+wasm-bindgen = { path = "../../../" }
+wasm-bindgen-futures = { path = "../../futures" }
+wasm-bindgen-test = { path = "../../test" }
+web-sys = { path = "../../web-sys" }
+
+bumpalo = "=3.12.0"
+log = "=0.4.18"
+scoped-tls = "=1.0.0"
+
+[patch.crates-io]
+wasm-bindgen = { path = "../../../" }

--- a/crates/test/src/rt/mod.rs
+++ b/crates/test/src/rt/mod.rs
@@ -216,7 +216,7 @@ impl Display for TestResult {
             TestResult::Ok => write!(f, "ok"),
             TestResult::Err(_) => write!(f, "FAIL"),
             TestResult::Ignored(None) => write!(f, "ignored"),
-            TestResult::Ignored(Some(reason)) => write!(f, "ignored, {reason}"),
+            TestResult::Ignored(Some(reason)) => write!(f, "ignored, {}", reason),
         }
     }
 }

--- a/crates/typescript-tests/Cargo.toml
+++ b/crates/typescript-tests/Cargo.toml
@@ -3,7 +3,6 @@ name = "typescript-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [dependencies]
 wasm-bindgen = { path = '../..' }

--- a/crates/webidl-tests/Cargo.toml
+++ b/crates/webidl-tests/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
 publish = false
-rust-version = "1.57"
 
 [lib]
 test = false

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -11,7 +11,6 @@ description = """
 Support for parsing WebIDL specific to wasm-bindgen
 """
 edition = "2018"
-rust-version = "1.57"
 
 [dependencies]
 env_logger = "0.11.5"

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -3,7 +3,6 @@ name = "add"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -3,7 +3,6 @@ name = "canvas"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -3,7 +3,6 @@ name = "char"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -3,7 +3,6 @@ name = "closures"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -3,7 +3,6 @@ name = "console_log"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/deno/Cargo.toml
+++ b/examples/deno/Cargo.toml
@@ -3,7 +3,6 @@ name = "deno"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -3,7 +3,6 @@ name = "dom"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -3,7 +3,6 @@ name = "rust-duck-typed-interfaces"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -3,7 +3,6 @@ name = "fetch"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -3,7 +3,6 @@ name = "guide-supported-types-examples"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -3,7 +3,6 @@ name = "hello_world"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -3,7 +3,6 @@ name = "julia_set"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -3,7 +3,6 @@ name = "wasm-bindgen-paint"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -3,7 +3,6 @@ name = "performance"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -3,7 +3,6 @@ name = "raytrace-parallel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/request-animation-frame/Cargo.toml
+++ b/examples/request-animation-frame/Cargo.toml
@@ -3,7 +3,6 @@ name = "request-animation-frame"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/synchronous-instantiation/Cargo.toml
+++ b/examples/synchronous-instantiation/Cargo.toml
@@ -3,7 +3,6 @@ name = "synchronous-instantiation"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -3,7 +3,6 @@ name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-audio-worklet/Cargo.toml
+++ b/examples/wasm-audio-worklet/Cargo.toml
@@ -2,7 +2,6 @@
 name = "wasm-audio-worklet"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm-imports/Cargo.toml
+++ b/examples/wasm-in-wasm-imports/Cargo.toml
@@ -3,7 +3,6 @@ name = "wasm-in-wasm-imports"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -3,7 +3,6 @@ name = "wasm-in-wasm"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-web-worker/Cargo.toml
+++ b/examples/wasm-in-web-worker/Cargo.toml
@@ -3,7 +3,6 @@ name = "wasm-in-web-worker"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -3,7 +3,6 @@ name = "wasm2js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/weather_report/Cargo.toml
+++ b/examples/weather_report/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Ayush <ayushmishra2005@gmail.com>"]
 categories = ["wasm"]
 readme = "README.md"
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -3,7 +3,6 @@ name = "webaudio"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -3,7 +3,6 @@ name = "webgl"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -3,7 +3,6 @@ name = "webrtc_datachannel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -3,7 +3,6 @@ name = "websockets"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webxr/Cargo.toml
+++ b/examples/webxr/Cargo.toml
@@ -3,7 +3,6 @@ name = "webxr"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler-no-modules/Cargo.toml
+++ b/examples/without-a-bundler-no-modules/Cargo.toml
@@ -3,7 +3,6 @@ name = "without-a-bundler-no-modules"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler/Cargo.toml
+++ b/examples/without-a-bundler/Cargo.toml
@@ -3,7 +3,6 @@ name = "without-a-bundler"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
 edition = "2018"
-rust-version = "1.57"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
This PR introduces a MSRV policy.

Library crates have an MSRV of v1.57 and changes to the MSRV are accompanied by a minor version bump.
The following crates are included in this policy:
- `wasm-bindgen`
- `js-sys`
- `web-sys`
- `wasm-bindgen-futures`
- `wasm-bindgen-test`
- `wasm-bindgen-macro`
- `wasm-bindgen-test-macro`
- `wasm-bindgen-macro-support`
- `wasm-bindgen-backend`
- `wasm-bindgen-shared`

CLI crates and their support libraries have an MSRV of v1.76, due to being dependent on the [`wasm-tools` ecosystem](https://github.com/bytecodealliance/wasm-tools). The MSRV is only guaranteed for a specific version, so it is only accompanied by a patch version bump.
The following crates are included in this policy:
- `wasm-bindgen-cli`
- `wasm-bindgen-cli-support`
- `wasm-bindgen-wasm-interpreter`
- `wasm-bindgen-threads-xform`
- `wasm-bindgen-multi-value-xform`
- `wasm-bindgen-externref-xform`
- `wasm-bindgen-wasm-conventions`

Fixes #3114.
Fixes #3918.