### PR TITLE
Bump `base64` to v0.22

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.57"
 
 [dependencies]
 anyhow = "1.0"
-base64 = "0.21"
+base64 = "0.22"
 log = "0.4"
 rustc-demangle = "0.1.13"
 serde_json = "1.0"


### PR DESCRIPTION
Updates the `base64` crate from v0.21 to v0.22

See their [release notes](https://github.com/marshallpierce/rust-base64/blob/v0.22.1/RELEASE-NOTES.md#0220).