### PR TITLE
Feat: Add `vibrate` field to `NotificationOptions` in web-sys crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@
 * Added an official MSRV policy. Library MSRV changes will be accompanied by a minor version bump. CLI tool MSRV can change with any version bump.
   [#4038](https://github.com/rustwasm/wasm-bindgen/pull/4038)
 
+* Added bindings to `NavigatorOptions.vibrate`.
+  [#4041](https://github.com/rustwasm/wasm-bindgen/pull/4041)
+
 ### Changed
 
 * Stabilize Web Share API.

--- a/crates/web-sys/src/features/gen_Navigator.rs
+++ b/crates/web-sys/src/features/gen_Navigator.rs
@@ -533,7 +533,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vibrate)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Navigator`*"]
-    pub fn vibrate_with_duration(this: &Navigator, duration: u32) -> bool;
+    pub fn vibrate_with_duration(this: &Navigator, pattern: u32) -> bool;
     # [wasm_bindgen (method , structural , js_class = "Navigator" , js_name = vibrate)]
     #[doc = "The `vibrate()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_NotificationOptions.rs
+++ b/crates/web-sys/src/features/gen_NotificationOptions.rs
@@ -142,6 +142,16 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `NotificationOptions`*"]
     #[wasm_bindgen(method, setter = "timestamp")]
     pub fn set_timestamp(this: &NotificationOptions, val: f64);
+    #[doc = "Get the `vibrate` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `NotificationOptions`*"]
+    #[wasm_bindgen(method, getter = "vibrate")]
+    pub fn get_vibrate(this: &NotificationOptions) -> Option<::js_sys::Array>;
+    #[doc = "Change the `vibrate` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `NotificationOptions`*"]
+    #[wasm_bindgen(method, setter = "vibrate")]
+    pub fn set_vibrate(this: &NotificationOptions, val: f64);
 }
 impl NotificationOptions {
     #[doc = "Construct a new `NotificationOptions`."]

--- a/crates/web-sys/src/features/gen_NotificationOptions.rs
+++ b/crates/web-sys/src/features/gen_NotificationOptions.rs
@@ -146,12 +146,12 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `NotificationOptions`*"]
     #[wasm_bindgen(method, getter = "vibrate")]
-    pub fn get_vibrate(this: &NotificationOptions) -> Option<::js_sys::Array>;
+    pub fn get_vibrate(this: &NotificationOptions) -> ::wasm_bindgen::JsValue;
     #[doc = "Change the `vibrate` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `NotificationOptions`*"]
     #[wasm_bindgen(method, setter = "vibrate")]
-    pub fn set_vibrate(this: &NotificationOptions, val: f64);
+    pub fn set_vibrate(this: &NotificationOptions, val: &::wasm_bindgen::JsValue);
 }
 impl NotificationOptions {
     #[doc = "Construct a new `NotificationOptions`."]
@@ -226,6 +226,11 @@ impl NotificationOptions {
     #[deprecated = "Use `set_timestamp()` instead."]
     pub fn timestamp(&mut self, val: f64) -> &mut Self {
         self.set_timestamp(val);
+        self
+    }
+    #[deprecated = "Use `set_vibrate()` instead."]
+    pub fn vibrate(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
+        self.set_vibrate(val);
         self
     }
 }

--- a/crates/web-sys/webidls/enabled/Navigator.webidl
+++ b/crates/web-sys/webidls/enabled/Navigator.webidl
@@ -134,14 +134,6 @@ partial interface Navigator {
   Promise<BatteryManager> getBattery();
 };
 
-// http://www.w3.org/TR/vibration/#vibration-interface
-partial interface Navigator {
-    // We don't support sequences in unions yet
-    //boolean vibrate ((unsigned long or sequence<unsigned long>) pattern);
-    boolean vibrate(unsigned long duration);
-    boolean vibrate(sequence<unsigned long> pattern);
-};
-
 // http://www.w3.org/TR/pointerevents/#extensions-to-the-navigator-interface
 partial interface Navigator {
     [Pref="dom.w3c_pointer_events.enabled"]

--- a/crates/web-sys/webidls/enabled/Notification.webidl
+++ b/crates/web-sys/webidls/enabled/Notification.webidl
@@ -41,7 +41,7 @@ dictionary NotificationOptions {
   USVString image;
   USVString icon;
   USVString badge;
-  sequence<unsigned long> vibrate = [];
+  VibratePattern vibrate = [];
   unsigned long long timestamp;
   boolean renotify = false;
   boolean? silent = null;

--- a/crates/web-sys/webidls/enabled/Notification.webidl
+++ b/crates/web-sys/webidls/enabled/Notification.webidl
@@ -41,6 +41,7 @@ dictionary NotificationOptions {
   USVString image;
   USVString icon;
   USVString badge;
+  sequence<unsigned long> vibrate = [];
   unsigned long long timestamp;
   boolean renotify = false;
   boolean? silent = null;

--- a/crates/web-sys/webidls/enabled/Vibration.webidl
+++ b/crates/web-sys/webidls/enabled/Vibration.webidl
@@ -1,0 +1,7 @@
+// https://www.w3.org/TR/vibration/#vibration-interface
+
+typedef (unsigned long or sequence<unsigned long>) VibratePattern;
+
+partial interface Navigator {
+    boolean vibrate(VibratePattern pattern);
+};

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -230,6 +230,13 @@ pub(crate) static FIXED_INTERFACES: Lazy<
                 ),
             ]),
         ),
+        (
+            "Navigator",
+            BTreeMap::from_iter([
+                ("vibrate_with_u32", "vibrate_with_duration"),
+                ("vibrate_with_u32_sequence", "vibrate_with_pattern"),
+            ]),
+        ),
     ])
 });
 


### PR DESCRIPTION
- Updated `Notification.webidl` to include the `vibrate` field in the `NotificationOptions` dictionary.
- Added getter `get_vibrate` to retrieve the `vibrate` field of `NotificationOptions`.
- Added setter `set_vibrate` to change the `vibrate` field of `NotificationOptions`.