### PR TITLE
Revise `#[track_caller]` condition on `UnwrapThrowExt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,9 @@
 * Implement a more reliable way to detect the stack pointer.
   [#4036](https://github.com/rustwasm/wasm-bindgen/pull/4036)
 
+* `#[track_caller]` is now always applied on `UnwrapThrowExt` methods when not targetting `wasm32-unknown-unknown`.
+  [#4042](https://github.com/rustwasm/wasm-bindgen/pull/4042)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.92](https://github.com/rustwasm/wasm-bindgen/compare/0.2.91...0.2.92)


### PR DESCRIPTION
The conditions for `#[track_caller]` on `UnwrapThrowExt` were exclusively using the `cfg(debug_assertions)` condition, which made them not apply when using them on native targets.
This PR adds a check for `wasm32-unknown-unknown`.

Fixes missing `cfg(debug_assertions)` condition in `impl UnwrapThrowExt for Result`, which was missed in #4035.
Remove wrong `cfg(feature = "std")` condition on `UnwrapThrowExt::unwrap_throw()`s default implementation, which was missed in #4005.

Thanks @Liamolucko!