### PR TITLE
Use `cfg(target_os = "unknown")`

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -159,7 +159,7 @@ impl TryToTokens for ast::Program {
         let prefix_json_bytes = syn::LitByteStr::new(&prefix_json_bytes, Span::call_site());
 
         (quote! {
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
             #[automatically_derived]
             const _: () = {
                 use #wasm_bindgen::__rt::{flat_len, flat_byte_slices};
@@ -268,12 +268,12 @@ impl ToTokens for ast::Struct {
                     let ptr = #wasm_bindgen::convert::IntoWasmAbi::into_abi(value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                     extern "C" {
                         fn #new_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                     unsafe fn #new_fn(_: u32) -> u32 {
                         panic!("cannot convert to JsValue outside of the wasm target")
                     }
@@ -285,7 +285,7 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
             #[automatically_derived]
             const _: () = {
                 #[no_mangle]
@@ -373,12 +373,12 @@ impl ToTokens for ast::Struct {
                     let idx = #wasm_bindgen::convert::IntoWasmAbi::into_abi(&value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                     extern "C" {
                         fn #unwrap_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                     unsafe fn #unwrap_fn(_: u32) -> u32 {
                         panic!("cannot convert from JsValue outside of the wasm target")
                     }
@@ -481,7 +481,7 @@ impl ToTokens for ast::StructField {
         (quote! {
             #[automatically_derived]
             const _: () = {
-                #[cfg_attr(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))), no_mangle)]
+                #[cfg_attr(all(target_arch = "wasm32", target_os = "unknown"), no_mangle)]
                 #[doc(hidden)]
                 pub unsafe extern "C" fn #getter(js: u32)
                     -> #wasm_bindgen::convert::WasmRet<<#ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi>
@@ -519,7 +519,7 @@ impl ToTokens for ast::StructField {
         let (args, names) = splat(wasm_bindgen, &Ident::new("val", rust_name.span()), &abi);
 
         (quote! {
-            #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
             #[automatically_derived]
             const _: () = {
                 #[no_mangle]
@@ -777,7 +777,7 @@ impl TryToTokens for ast::Export {
             const _: () = {
                 #(#attrs)*
                 #[cfg_attr(
-                    all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))),
+                    all(target_arch = "wasm32", target_os = "unknown"),
                     export_name = #export_name,
                 )]
                 pub unsafe extern "C" fn #generated_name(#(#args),*) -> #wasm_bindgen::convert::WasmRet<#projection::Abi> {
@@ -1036,11 +1036,11 @@ impl ToTokens for ast::ImportType {
                 impl JsCast for #rust_name {
                     fn instanceof(val: &JsValue) -> bool {
                         #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                        #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                         extern "C" {
                             fn #instanceof_shim(val: u32) -> u32;
                         }
-                        #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                         unsafe fn #instanceof_shim(_: u32) -> u32 {
                             panic!("cannot check instanceof on non-wasm targets");
                         }
@@ -1655,12 +1655,12 @@ impl ToTokens for ast::ImportStatic {
             #vis static #name: #wasm_bindgen::JsStatic<#ty> = {
                 fn init() -> #ty {
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                     extern "C" {
                         fn #shim_name() -> #abi_ret;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+                    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                     unsafe fn #shim_name() -> #abi_ret {
                         panic!("cannot access imported statics on non-wasm targets")
                     }
@@ -1725,7 +1725,7 @@ impl<'a, T: ToTokens> ToTokens for Descriptor<'a, T> {
         let attrs = &self.attrs;
         let wasm_bindgen = &self.wasm_bindgen;
         (quote! {
-            #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
             #[automatically_derived]
             const _: () = {
                 #(#attrs)*
@@ -1751,14 +1751,14 @@ fn extern_fn(
     abi_ret: TokenStream,
 ) -> TokenStream {
     quote! {
-        #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         #(#attrs)*
         #[link(wasm_import_module = "__wbindgen_placeholder__")]
         extern "C" {
             fn #import_name(#(#abi_arguments),*) -> #abi_ret;
         }
 
-        #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
         unsafe fn #import_name(#(#abi_arguments),*) -> #abi_ret {
             #(
                 drop(#abi_argument_names);

--- a/src/externref.rs
+++ b/src/externref.rs
@@ -106,7 +106,7 @@ fn internal_error(msg: &str) -> ! {
             std::process::abort();
         } else if #[cfg(all(
             target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
+            target_os = "unknown"
         ))] {
             core::arch::wasm32::unreachable();
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,14 +32,14 @@ macro_rules! if_std {
 
 macro_rules! externs {
     ($(#[$attr:meta])* extern "C" { $(fn $name:ident($($args:tt)*) -> $ret:ty;)* }) => (
-        #[cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))]
+        #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
         $(#[$attr])*
         extern "C" {
             $(fn $name($($args)*) -> $ret;)*
         }
 
         $(
-            #[cfg(not(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi")))))]
+            #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
             #[allow(unused_variables)]
             unsafe extern fn $name($($args)*) -> $ret {
                 panic!("function not implemented on non-wasm32 targets")
@@ -1340,20 +1340,14 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[cfg_attr(
         any(
             debug_assertions,
-            not(all(
-                target_arch = "wasm32",
-                not(any(target_os = "emscripten", target_os = "wasi"))
-            ))
+            not(all(target_arch = "wasm32", target_os = "unknown"))
         ),
         track_caller
     )]
     fn unwrap_throw(self) -> T {
         if cfg!(all(
             debug_assertions,
-            all(
-                target_arch = "wasm32",
-                not(any(target_os = "emscripten", target_os = "wasi"))
-            )
+            all(target_arch = "wasm32", target_os = "unknown")
         )) {
             let loc = core::panic::Location::caller();
             let msg = alloc::format!(
@@ -1374,10 +1368,7 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[cfg_attr(
         any(
             debug_assertions,
-            not(all(
-                target_arch = "wasm32",
-                not(any(target_os = "emscripten", target_os = "wasi"))
-            ))
+            not(all(target_arch = "wasm32", target_os = "unknown"))
         ),
         track_caller
     )]
@@ -1386,10 +1377,7 @@ pub trait UnwrapThrowExt<T>: Sized {
 
 impl<T> UnwrapThrowExt<T> for Option<T> {
     fn expect_throw(self, message: &str) -> T {
-        if cfg!(all(
-            target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
-        )) {
+        if cfg!(all(target_arch = "wasm32", target_os = "unknown")) {
             match self {
                 Some(val) => val,
                 None => throw_str(message),
@@ -1408,7 +1396,7 @@ where
         if cfg!(all(
             debug_assertions,
             target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
+            target_os = "unknown"
         )) {
             match self {
                 Ok(val) => val,
@@ -1431,10 +1419,7 @@ where
     }
 
     fn expect_throw(self, message: &str) -> T {
-        if cfg!(all(
-            target_arch = "wasm32",
-            not(any(target_os = "emscripten", target_os = "wasi"))
-        )) {
+        if cfg!(all(target_arch = "wasm32", target_os = "unknown")) {
             match self {
                 Ok(val) => val,
                 Err(_) => throw_str(message),
@@ -1792,7 +1777,7 @@ pub mod __rt {
                 std::process::abort();
             } else if #[cfg(all(
                 target_arch = "wasm32",
-                not(any(target_os = "emscripten", target_os = "wasi"))
+                target_os = "unknown"
             ))] {
                 core::arch::wasm32::unreachable();
             } else {


### PR DESCRIPTION
This PR changes any use of `cfg(not(any(target_os = "emscripten", target_os = "wasi")))` to simply `cfg(target_os = "unknown")`, which is much simpler.