### PR TITLE
Update all crates to edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/wasm-bindgen"
 description = """
 Easy support for interacting between JS and Rust.
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [package.metadata.docs.rs]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-bindgen-benchmark"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 wasm-bindgen = { path = '../' }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen-backend"
 description = """
 Backend code generation of the wasm-bindgen tool
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [features]

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen-cli-support"
 description = """
 Shared support for the wasm-bindgen-cli package, an internal dependency
 """
-edition = '2018'
+edition = "2021"
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,7 +11,7 @@ description = """
 Command line interface of the `#[wasm_bindgen]` attribute and project. For more
 information see https://github.com/rustwasm/wasm-bindgen.
 """
-edition = '2018'
+edition = "2021"
 default-run = 'wasm-bindgen'
 rust-version = "1.76"
 

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -71,7 +71,10 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
             let mut cmd = Command::new(path);
             cmd.args(args).arg(format!("--port={}", driver_addr.port()));
             let mut child = BackgroundChild::spawn(path, &mut cmd, shell)?;
-            drop_log = Box::new(move || child.print_stdio_on_drop = false);
+            drop_log = Box::new(move || {
+                let _ = &child;
+                child.print_stdio_on_drop = false;
+            });
 
             // Wait for the driver to come online and bind its port before we try to
             // connect to it.

--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -62,7 +62,7 @@ fn runtest(test: &Path) -> Result<()> {
             name = \"reference-test\"
             authors = []
             version = \"1.0.0\"
-            edition = '2018'
+            edition = '2021'
 
             [dependencies]
             wasm-bindgen = {{ path = '{}' }}

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -79,7 +79,7 @@ impl Project {
                         name = \"{}\"
                         authors = []
                         version = \"1.0.0\"
-                        edition = '2018'
+                        edition = '2021'
 
                         [dependencies]
                         wasm-bindgen = {{ path = '{}' }}
@@ -207,7 +207,7 @@ fn bin_crate_works() {
                     name = \"bin_crate_works\"
                     authors = []
                     version = \"1.0.0\"
-                    edition = '2018'
+                    edition = '2021'
 
                     [dependencies]
                     wasm-bindgen = {{ path = '{}' }}
@@ -254,7 +254,7 @@ fn bin_crate_works_without_name_section() {
                     name = \"bin_crate_works_without_name_section\"
                     authors = []
                     version = \"1.0.0\"
-                    edition = '2018'
+                    edition = '2021'
 
                     [dependencies]
                     wasm-bindgen = {{ path = '{}' }}

--- a/crates/cli/tests/wasm-bindgen/npm.rs
+++ b/crates/cli/tests/wasm-bindgen/npm.rs
@@ -77,7 +77,7 @@ fn npm_conflict_rejected() {
                 name = "npm_conflict_rejected"
                 authors = []
                 version = "1.0.0"
-                edition = '2018'
+                edition = '2021'
 
                 [dependencies]
                 wasm-bindgen = {{ path = '{}' }}
@@ -124,7 +124,7 @@ fn npm_conflict_rejected() {
                 name = "bar"
                 authors = []
                 version = "1.0.0"
-                edition = '2018'
+                edition = '2021'
 
                 [dependencies]
                 wasm-bindgen = {{ path = '{}' }}

--- a/crates/example-tests/Cargo.toml
+++ b/crates/example-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"

--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen-externref-xform"
 description = """
 Internal externref transformations for wasm-bindgen
 """
-edition = '2018'
+edition = "2021"
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -8,7 +8,7 @@ name = "wasm-bindgen-futures"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures"
 readme = "./README.md"
 version = "0.4.42"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [package.metadata.docs.rs]

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -12,7 +12,7 @@ Bindings for all JS global objects and functions in all JS environments like
 Node.js and browsers, built on `#[wasm_bindgen]` using the `wasm-bindgen` crate.
 """
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [lib]

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen"
 description = """
 The part of the implementation of the `#[wasm_bindgen]` attribute that is not in the shared backend crate
 """
-edition = '2018'
+edition = "2021"
 rust-version = "1.57"
 
 [features]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen"
 description = """
 Definition of the `#[wasm_bindgen]` attribute, an internal dependency
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [lib]

--- a/crates/msrv/cli/Cargo.toml
+++ b/crates/msrv/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msrv-cli-test"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/crates/msrv/lib/Cargo.toml
+++ b/crates/msrv/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msrv-library-test"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen-multi-value-xform"
 description = """
 Internal multi-value transformations for wasm-bindgen
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Shared support between wasm-bindgen and wasm-bindgen cli, an internal
 dependency.
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 # Because only a single `wasm_bindgen` version can be used in a dependency

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The wasm-bindgen Developers"]
 description = "Internal testing macro for wasm-bindgen"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [lib]

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["The wasm-bindgen Developers"]
 description = "Internal testing crate for wasm-bindgen"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/wasm-bindgen"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [dependencies]

--- a/crates/test/sample/Cargo.toml
+++ b/crates/test/sample/Cargo.toml
@@ -2,7 +2,7 @@
 name = "sample"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 test = false

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen-threads-xform"
 description = """
 Support for threading-related transformations in wasm-bindgen
 """
-edition = "2018"
+edition = "2021"
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/typescript-tests/Cargo.toml
+++ b/crates/typescript-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "typescript-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 wasm-bindgen = { path = '../..' }

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/wasm-c
 homepage = "https://rustwasm.github.io/wasm-bindgen/"
 documentation = "https://docs.rs/wasm-bindgen-wasm-conventions"
 description = "Utilities for working with Wasm codegen conventions (usually established by LLVM/lld)"
-edition = "2018"
+edition = "2021"
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/wasm-bindgen-wasm-interpreter"
 description = """
 Micro-interpreter optimized for wasm-bindgen's use case
 """
-edition = '2018'
+edition = "2021"
 rust-version = "1.76"
 
 [dependencies]

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -10,7 +10,7 @@ description = """
 Bindings for all Web APIs, a procedurally generated crate from WebIDL
 """
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.57"
 
 [package.metadata.docs.rs]

--- a/crates/webidl-tests/Cargo.toml
+++ b/crates/webidl-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webidl-tests"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [lib]

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/wasm-bindgen"
 description = """
 Support for parsing WebIDL specific to wasm-bindgen
 """
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 env_logger = "0.11.5"

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -950,7 +950,7 @@ pub fn generate(from: &Path, to: &Path, options: Options) -> Result<String> {
         // run rustfmt on the generated file - really handy for debugging
         let result = Command::new("rustfmt")
             .arg("--edition")
-            .arg("2018")
+            .arg("2021")
             .args(paths)
             .status()
             .context("rustfmt failed")?;

--- a/examples/add/Cargo.toml
+++ b/examples/add/Cargo.toml
@@ -2,7 +2,7 @@
 name = "add"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/canvas/Cargo.toml
+++ b/examples/canvas/Cargo.toml
@@ -2,7 +2,7 @@
 name = "canvas"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/char/Cargo.toml
+++ b/examples/char/Cargo.toml
@@ -2,7 +2,7 @@
 name = "char"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/closures/Cargo.toml
+++ b/examples/closures/Cargo.toml
@@ -2,7 +2,7 @@
 name = "closures"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/console_log/Cargo.toml
+++ b/examples/console_log/Cargo.toml
@@ -2,7 +2,7 @@
 name = "console_log"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/deno/Cargo.toml
+++ b/examples/deno/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deno"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/dom/Cargo.toml
+++ b/examples/dom/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dom"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/duck-typed-interfaces/Cargo.toml
+++ b/examples/duck-typed-interfaces/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-duck-typed-interfaces"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/fetch/Cargo.toml
+++ b/examples/fetch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fetch"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -2,7 +2,7 @@
 name = "guide-supported-types-examples"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hello_world"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/import_js/crate/Cargo.toml
+++ b/examples/import_js/crate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "import_js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/julia_set/Cargo.toml
+++ b/examples/julia_set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "julia_set"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/paint/Cargo.toml
+++ b/examples/paint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-bindgen-paint"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/performance/Cargo.toml
+++ b/examples/performance/Cargo.toml
@@ -2,7 +2,7 @@
 name = "performance"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/raytrace-parallel/Cargo.toml
+++ b/examples/raytrace-parallel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "raytrace-parallel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/request-animation-frame/Cargo.toml
+++ b/examples/request-animation-frame/Cargo.toml
@@ -2,7 +2,7 @@
 name = "request-animation-frame"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/synchronous-instantiation/Cargo.toml
+++ b/examples/synchronous-instantiation/Cargo.toml
@@ -2,7 +2,7 @@
 name = "synchronous-instantiation"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "todomvc"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm-imports/Cargo.toml
+++ b/examples/wasm-in-wasm-imports/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-in-wasm-imports"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-wasm/Cargo.toml
+++ b/examples/wasm-in-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-in-wasm"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm-in-web-worker/Cargo.toml
+++ b/examples/wasm-in-web-worker/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-in-web-worker"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/wasm2js/Cargo.toml
+++ b/examples/wasm2js/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm2js"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/weather_report/Cargo.toml
+++ b/examples/weather_report/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.1"
 authors = ["Ayush <ayushmishra2005@gmail.com>"]
 categories = ["wasm"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webaudio/Cargo.toml
+++ b/examples/webaudio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webaudio"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webgl/Cargo.toml
+++ b/examples/webgl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webgl"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webrtc_datachannel/Cargo.toml
+++ b/examples/webrtc_datachannel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webrtc_datachannel"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/websockets/Cargo.toml
+++ b/examples/websockets/Cargo.toml
@@ -2,7 +2,7 @@
 name = "websockets"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/webxr/Cargo.toml
+++ b/examples/webxr/Cargo.toml
@@ -2,7 +2,7 @@
 name = "webxr"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler-no-modules/Cargo.toml
+++ b/examples/without-a-bundler-no-modules/Cargo.toml
@@ -2,7 +2,7 @@
 name = "without-a-bundler-no-modules"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/without-a-bundler/Cargo.toml
+++ b/examples/without-a-bundler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "without-a-bundler"
 version = "0.1.0"
 authors = ["The wasm-bindgen Developers"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib"]

--- a/tests/wasm/closures.rs
+++ b/tests/wasm/closures.rs
@@ -433,7 +433,7 @@ fn drop_drops() {
     }
     let a = A;
     let x: Closure<dyn Fn()> = Closure::new(move || {
-        let _ = a;
+        let _ = &a;
     });
     drop(x);
     unsafe {


### PR DESCRIPTION
This PR updates all crates to edition 2021.
Nothing notable except some closures using the wildcard pattern to capture variables and some disjoint captures as well.