### PR TITLE
Print location when using `expect_throw()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 
 * `UnwrapThrowExt for Result` now makes use of the required `Debug` bound to display the error as well.
   [#4035](https://github.com/rustwasm/wasm-bindgen/pull/4035)
+  [#4049](https://github.com/rustwasm/wasm-bindgen/pull/4049)
 
 * MSRV of CLI tools bumped to v1.76. This does not affect libraries like `wasm-bindgen`, `js-sys` and `web-sys`!
   [#4037](https://github.com/rustwasm/wasm-bindgen/pull/4037)


### PR DESCRIPTION
After going over it again I noticed that the `UnwrapThrow` implementation didn't really make sense. Because if you called `expect_throw()` you wouldn't get any location information.
So I just manually implemented both `unwrap_throw()` and `expect_throw()` for `Option` and `Result` and made it as close as possible to Std (apart from the location information).

I also noticed that the implementation I've fixed in #4035 wasn't exactly right, e.g. calling `Result::unwrap_throw()` would panic instead of throwing without `cfg(debug_assertions)`. Through the overhaul this was fixed as well.

In hindsight, I believe that adding a default implementation on `UnwrapThrow` was a mistake.

With this I will also close #2732, while leaving the discussion if the whole idea of `UnwrapThrow` is a good one or not to a different place and time.

Fixes #2732.
Follow-up to #4035 and #4042.