### PR TITLE
Add sccache to GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,17 @@ concurrency:
 permissions:
   contents: read #  to fetch code (actions/checkout)
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
 jobs:
   # Check Code style quickly by running `rustfmt` over all code
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
@@ -33,6 +39,8 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
@@ -43,6 +51,8 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
@@ -82,6 +92,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -108,6 +119,7 @@ jobs:
     - run: rustup default nightly-2024-07-06
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
+    - uses: mozilla-actions/sccache-action@v0.0.5
     # Note: we only run the browser tests here, because wasm-bindgen doesn't support threading in Node yet.
     - run: |
         RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
@@ -143,6 +155,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -163,6 +176,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -182,6 +196,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cd crates/web-sys && cargo run --release --package wasm-bindgen-webidl -- webidls src/features ./Cargo.toml
     - run: git diff --exit-code
 
@@ -192,6 +207,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -208,6 +224,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -226,6 +243,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
@@ -238,6 +256,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - uses: denoland/setup-deno@v1
       with:
         deno-version: v1.x
@@ -249,6 +268,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update 1.76.0 && rustup default 1.76.0
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo test -p wasm-bindgen-macro
     - run: cargo test -p wasm-bindgen-test-macro
 
@@ -258,6 +278,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     - run: |
         curl -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz -sSf > binaryen-version_112-x86_64-linux.tar.gz
@@ -288,6 +309,7 @@ jobs:
     - run: rustup default nightly-2024-07-06
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: |
         for dir in raytrace-parallel wasm-audio-worklet; do
           (cd examples/$dir &&
@@ -315,6 +337,7 @@ jobs:
         name: examples2
         path: exbuild
     - run: rustup update --no-self-update stable && rustup default stable
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo test -p example-tests
       env:
         EXBUILD: ${{ github.workspace }}/exbuild
@@ -325,6 +348,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add wasm32-unknown-unknown
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo build --manifest-path benchmarks/Cargo.toml --release --target wasm32-unknown-unknown
     - run: cargo run -p wasm-bindgen-cli -- target/wasm32-unknown-unknown/release/wasm_bindgen_benchmark.wasm --out-dir benchmarks/pkg --target web
     - uses: actions/upload-artifact@v4
@@ -338,6 +362,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add x86_64-unknown-linux-musl
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: sudo apt update -y && sudo apt install musl-tools -y
     - run: |
         cargo build --manifest-path crates/cli/Cargo.toml --target x86_64-unknown-linux-musl --features vendored-openssl --release
@@ -356,6 +381,7 @@ jobs:
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add aarch64-unknown-linux-gnu
     - run: sudo apt update -y && sudo apt install gcc-aarch64-linux-gnu -y
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: |
         cargo build --manifest-path crates/cli/Cargo.toml --target aarch64-unknown-linux-gnu --features vendored-openssl --release
       env:
@@ -370,6 +396,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo build --manifest-path crates/cli/Cargo.toml --release
       env:
         MACOSX_DEPLOYMENT_TARGET: 10.7
@@ -384,6 +411,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
     - run: rustup target add aarch64-apple-darwin
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: |
         cargo build --manifest-path crates/cli/Cargo.toml --target aarch64-apple-darwin --release
       env:
@@ -398,6 +426,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update stable && rustup default stable
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo build --manifest-path crates/cli/Cargo.toml --release
       env:
         RUSTFLAGS: -Ctarget-feature=+crt-static
@@ -421,6 +450,8 @@ jobs:
 
   doc_api:
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: ""
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update nightly && rustup default nightly
@@ -447,8 +478,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update 1.57 && rustup default 1.57
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo build
-      
+
   msrv-cli:
     name: Check MSRV for CLI tools
     runs-on: ubuntu-latest
@@ -458,8 +490,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update 1.76 && rustup default 1.76
+    - uses: mozilla-actions/sccache-action@v0.0.5
     - run: cargo build
-      
+
 
   deploy:
     permissions:


### PR DESCRIPTION
A lot of the jobs compile the same crates, both within the workflow and across PRs, so sccache might speed things up quite a bit.