### PR TITLE
Fix flaky tests

### DIFF
--- a/crates/example-tests/src/lib.rs
+++ b/crates/example-tests/src/lib.rs
@@ -354,14 +354,17 @@ pub async fn test_example(
             let conn = builder.serve_connection(TokioIo::new(stream), &service);
             tokio::pin!(conn);
 
-            tokio::select! {
+            let ret = tokio::select! {
                 res = conn.as_mut() => {
                     res.map_err(|e| anyhow::Error::msg(e.to_string()))
                 }
                 _ = rx => {
                     Ok(())
                 }
-            }
+            };
+
+            conn.graceful_shutdown();
+            ret
         },
         async {
             #[derive(Deserialize)]


### PR DESCRIPTION
I don't know much about `hyper` but searching for the "error shutting down connection" error message in its code led me to attempt the `graceful_shutdown` addition, and I haven't had an example run fail since.