### PR TITLE
Add importing strings as `JsString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
 * Added an experimental Node.JS ES module target, in comparison the current `node` target uses CommonJS, with `--target experimental-nodejs-module` or when testing with `wasm_bindgen_test_configure!(run_in_node_experimental)`.
   [#4027](https://github.com/rustwasm/wasm-bindgen/pull/4027)
 
+* Added importing strings as `JsString` through `#[wasm_bindgen(static_string)] static STRING: JsString = "a string literal";`.
+  [#4055](https://github.com/rustwasm/wasm-bindgen/pull/4055)
+
 ### Changed
 
 * Stabilize Web Share API.

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -29,6 +29,8 @@ pub struct Program {
     pub inline_js: Vec<String>,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
+    /// Path to js_sys
+    pub js_sys: Path,
     /// Path to wasm_bindgen_futures
     pub wasm_bindgen_futures: Path,
 }
@@ -44,6 +46,7 @@ impl Default for Program {
             typescript_custom_sections: Default::default(),
             inline_js: Default::default(),
             wasm_bindgen: syn::parse_quote! { wasm_bindgen },
+            js_sys: syn::parse_quote! { js_sys },
             wasm_bindgen_futures: syn::parse_quote! { wasm_bindgen_futures },
         }
     }
@@ -160,6 +163,8 @@ pub enum ImportKind {
     Function(ImportFunction),
     /// Importing a static value
     Static(ImportStatic),
+    /// Importing a static string
+    String(ImportString),
     /// Importing a type/class
     Type(ImportType),
     /// Importing a JS enum
@@ -270,6 +275,26 @@ pub struct ImportStatic {
     pub js_name: String,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
+}
+
+/// The type of a static string being imported
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq))]
+#[derive(Clone)]
+pub struct ImportString {
+    /// The visibility of this static string in Rust
+    pub vis: syn::Visibility,
+    /// The type specified by the user, which we only use to show an error if the wrong type is used.
+    pub ty: syn::Type,
+    /// The name of the shim function used to access this static
+    pub shim: Ident,
+    /// The name of this static on the Rust side
+    pub rust_name: Ident,
+    /// Path to wasm_bindgen
+    pub wasm_bindgen: Path,
+    /// Path to js_sys
+    pub js_sys: Path,
+    /// The string to export.
+    pub string: String,
 }
 
 /// The metadata for a type being imported
@@ -502,6 +527,7 @@ impl ImportKind {
         match *self {
             ImportKind::Function(_) => true,
             ImportKind::Static(_) => false,
+            ImportKind::String(_) => false,
             ImportKind::Type(_) => false,
             ImportKind::Enum(_) => false,
         }

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -297,6 +297,7 @@ fn shared_import_kind<'a>(
     Ok(match i {
         ast::ImportKind::Function(f) => ImportKind::Function(shared_import_function(f, intern)?),
         ast::ImportKind::Static(f) => ImportKind::Static(shared_import_static(f, intern)),
+        ast::ImportKind::String(f) => ImportKind::String(shared_import_string(f, intern)),
         ast::ImportKind::Type(f) => ImportKind::Type(shared_import_type(f, intern)),
         ast::ImportKind::Enum(f) => ImportKind::Enum(shared_import_enum(f, intern)),
     })
@@ -329,6 +330,13 @@ fn shared_import_static<'a>(i: &'a ast::ImportStatic, intern: &'a Interner) -> I
     ImportStatic {
         name: &i.js_name,
         shim: intern.intern(&i.shim),
+    }
+}
+
+fn shared_import_string<'a>(i: &'a ast::ImportString, intern: &'a Interner) -> ImportString<'a> {
+    ImportString {
+        shim: intern.intern(&i.shim),
+        string: &i.string,
     }
 }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3067,6 +3067,19 @@ impl<'a> Context<'a> {
                 self.import_name(js)
             }
 
+            AuxImport::String(string) => {
+                assert!(kind == AdapterJsImportKind::Normal);
+                assert!(!variadic);
+                assert_eq!(args.len(), 0);
+
+                let mut escaped = String::with_capacity(string.len());
+                string.chars().for_each(|c| match c {
+                    '`' | '\\' | '$' => escaped.extend(['\\', c]),
+                    _ => escaped.extend([c]),
+                });
+                Ok(format!("`{escaped}`"))
+            }
+
             AuxImport::Closure {
                 dtor,
                 mutable,

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -220,6 +220,9 @@ pub enum AuxImport {
     /// `JsImport`.
     Static(JsImport),
 
+    /// This import is expected to be a shim that returns an exported `JsString`.
+    String(String),
+
     /// This import is intended to manufacture a JS closure with the given
     /// signature and then return that back to Rust.
     Closure {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -49,6 +49,7 @@ macro_rules! shared_api {
         enum ImportKind<'a> {
             Function(ImportFunction<'a>),
             Static(ImportStatic<'a>),
+            String(ImportString<'a>),
             Type(ImportType<'a>),
             Enum(StringEnum),
         }
@@ -90,6 +91,11 @@ macro_rules! shared_api {
         struct ImportStatic<'a> {
             name: &'a str,
             shim: &'a str,
+        }
+
+        struct ImportString<'a> {
+            shim: &'a str,
+            string: &'a str,
         }
 
         struct ImportType<'a> {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "6362870592255096957";
+const APPROVED_SCHEMA_FILE_HASH: &str = "3501400214978266446";
 
 #[test]
 fn schema_version() {

--- a/guide/src/reference/static-js-objects.md
+++ b/guide/src/reference/static-js-objects.md
@@ -62,3 +62,15 @@ extern "C" {
     fn new() -> SomeType;
 }
 ```
+
+## Static strings
+
+Strings can be imported to avoid going through `TextDecoder/Encoder` when requiring just a `JsString`. This can be useful when dealing with environments where `TextDecoder/Encoder` is not available, like in audio worklets.
+
+```rust
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(static_string)]
+    static STRING: JsString = "a string literal";
+}
+```

--- a/tests/headless/strings.rs
+++ b/tests/headless/strings.rs
@@ -1,3 +1,4 @@
+use js_sys::JsString;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
 
@@ -13,4 +14,15 @@ fn string_roundtrip() {
     test_string_roundtrip(&Closure::wrap(Box::new(|s| s)));
 
     assert_eq!("\u{feff}bar", &identity("\u{feff}bar"));
+
+    assert_eq!(String::from(&*STRING), "foo")
+}
+
+#[wasm_bindgen]
+// Currently Rustfmt simply removes the value on this static.
+// See <https://github.com/rust-lang/rustfmt/issues/6267>.
+#[rustfmt::skip]
+extern "C" {
+    #[wasm_bindgen(static_string)]
+    static STRING: JsString = "foo";
 }


### PR DESCRIPTION
This PR adds the ability to import strings directly as `JsString`. This can be useful when trying to avoid `TextDecoder/Encoder`, e.g. when dealing with an audio worklet.

```rust
#[wasm_bindgen]
// Currently Rustfmt simply removes the value on this static.
// See <https://github.com/rust-lang/rustfmt/issues/6267>.
#[rustfmt::skip]
extern "C" {
    #[wasm_bindgen(static_string)]
    static STRING: JsString = "foo";
}
```

I added the `static_string` attribute item requirement because we might want to support other types in the future and we can't do type checking on the proc-macro level without knowing what the type should be. The alternative would be to do the type checking via `wasm-bindgen` by using descriptors, which isn't ideal for users.

Fixes #4031.