### PR TITLE
Improve the CI runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,8 +124,8 @@ jobs:
     - run: cargo test --target wasm32-unknown-unknown --features serde-serialize
     - run: cargo test --target wasm32-unknown-unknown --features enable-interning
 
-  test_wasm_bindgen_envs:
-    name: "Run wasm-bindgen crate tests with various environment variables"
+  test_wasm_bindgen_wasm:
+    name: "Run wasm-bindgen wasm test"
     runs-on: ubuntu-latest
     env:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
@@ -139,6 +139,19 @@ jobs:
     - run: cargo test --target wasm32-unknown-unknown --test wasm
       env:
         WASM_BINDGEN_NO_DEBUG: 1
+
+  test_wasm_bindgen_envs:
+    name: "Run wasm-bindgen crate tests with various environment variables"
+    runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
     - run: cargo test --target wasm32-unknown-unknown
       env:
         WASM_BINDGEN_EXTERNREF: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -548,6 +548,7 @@ jobs:
     permissions:
       contents: write #  to push changes in repo (jamesives/github-pages-deploy-action)
 
+    if: github.repository == 'rustwasm/wasm-bindgen'
     needs:
       - doc_api
       - doc_book

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     tags-ignore: [dev]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 defaults:
   run:
     shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,6 @@ jobs:
     - run: cargo clippy --no-deps --all-features -p example-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-externref-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p js-sys -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro-support -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-multi-value-xform -- -D warnings
@@ -67,11 +66,30 @@ jobs:
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-wasm-interpreter -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-webidl -- -D warnings
     - run: cargo clippy --no-deps --all-features -p webidl-tests -- -D warnings
+    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-benchmark -- -D warnings
+
+  # Run `cargo clippy` over web-sys and js-sys crates
+  clippy_web_sys:
+    name: Clippy (web-sys)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
+    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p js-sys -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p web-sys -- -D warnings
+
+  # Run `cargo clippy` over the project
+  clippy_project:
+    name: Clippy (project)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
     - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown --tests -- -D warnings
-    - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-benchmark -- -D warnings
     - run: for i in examples/*/; do cd "$i"; cargo +stable clippy --no-deps --all-features --target wasm32-unknown-unknown -- -D warnings || exit 1; cd ../..; done
 
   test_wasm_bindgen:
@@ -88,9 +106,36 @@ jobs:
         node-version: '20'
     - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --target wasm32-unknown-unknown
+    - run: cargo test --target wasm32-unknown-unknown -p wasm-bindgen-futures
+
+  test_wasm_bindgen_features:
+    name: "Run wasm-bindgen crate tests with different features"
+    runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --target wasm32-unknown-unknown --features serde-serialize
     - run: cargo test --target wasm32-unknown-unknown --features enable-interning
-    - run: cargo test --target wasm32-unknown-unknown -p wasm-bindgen-futures
+
+  test_wasm_bindgen_envs:
+    name: "Run wasm-bindgen crate tests with various environment variables"
+    runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
     - run: cargo test --target wasm32-unknown-unknown --test wasm
       env:
         WASM_BINDGEN_NO_DEBUG: 1
@@ -172,7 +217,31 @@ jobs:
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features Node
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features Element
     - run: cargo build --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --features Window
+
+  test_web_sys_all_features:
+    name: "Run web-sys crate tests with all features"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --all-features
+
+  test_web_sys_all_features_unstable:
+    name: "Run web-sys crate tests with all features and unstable APIs"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update stable && rustup default stable
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - uses: ./.github/actions/setup-geckodriver
     - run: cargo test --manifest-path crates/web-sys/Cargo.toml --target wasm32-unknown-unknown --all-features
       env:
         RUSTFLAGS: --cfg=web_sys_unstable_apis
@@ -449,7 +518,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update 1.57 && rustup default 1.57
     - run: cargo build
-      
+
   msrv-cli:
     name: Check MSRV for CLI tools
     runs-on: ubuntu-latest
@@ -460,7 +529,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: rustup update --no-self-update 1.76 && rustup default 1.76
     - run: cargo build
-      
+
 
   deploy:
     permissions:

--- a/_package.json
+++ b/_package.json
@@ -8,7 +8,6 @@
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.3.2",
     "mini-css-extract-plugin": "^2.7.6",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^3.11.2"

--- a/_package.json
+++ b/_package.json
@@ -5,11 +5,11 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "css-loader": "^6.8.1",
-    "html-webpack-plugin": "^5.3.2",
-    "mini-css-extract-plugin": "^2.7.6",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.0",
+    "mini-css-extract-plugin": "^2.9.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "5.0.4"
   }
 }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2835,7 +2835,7 @@ macro_rules! number_try_from {
             #[inline]
             fn try_from(x: $x) -> Result<Number, Self::Error> {
                 let x_f64 = x as f64;
-                if x_f64 >= Number::MIN_SAFE_INTEGER && x_f64 <= Number::MAX_SAFE_INTEGER {
+                if (Number::MIN_SAFE_INTEGER..=Number::MAX_SAFE_INTEGER).contains(&x_f64) {
                     Ok(Number::from(x_f64))
                 } else {
                     Err(TryFromIntError(()))

--- a/examples/add/package.json
+++ b/examples/add/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/add/package.json
+++ b/examples/add/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/add/webpack.config.js
+++ b/examples/add/webpack.config.js
@@ -14,12 +14,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/canvas/webpack.config.js
+++ b/examples/canvas/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/char/package.json
+++ b/examples/char/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/char/package.json
+++ b/examples/char/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/char/webpack.config.js
+++ b/examples/char/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/closures/package.json
+++ b/examples/closures/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/closures/package.json
+++ b/examples/closures/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/closures/webpack.config.js
+++ b/examples/closures/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/console_log/package.json
+++ b/examples/console_log/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/console_log/package.json
+++ b/examples/console_log/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/console_log/webpack.config.js
+++ b/examples/console_log/webpack.config.js
@@ -14,12 +14,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/dom/package.json
+++ b/examples/dom/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/dom/package.json
+++ b/examples/dom/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/dom/webpack.config.js
+++ b/examples/dom/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/duck-typed-interfaces/package.json
+++ b/examples/duck-typed-interfaces/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/duck-typed-interfaces/package.json
+++ b/examples/duck-typed-interfaces/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/duck-typed-interfaces/webpack.config.js
+++ b/examples/duck-typed-interfaces/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/fetch/webpack.config.js
+++ b/examples/fetch/webpack.config.js
@@ -14,12 +14,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/guide-supported-types-examples/package.json
+++ b/examples/guide-supported-types-examples/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/guide-supported-types-examples/package.json
+++ b/examples/guide-supported-types-examples/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/guide-supported-types-examples/webpack.config.js
+++ b/examples/guide-supported-types-examples/webpack.config.js
@@ -14,12 +14,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/hello_world/package.json
+++ b/examples/hello_world/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/hello_world/package.json
+++ b/examples/hello_world/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/hello_world/webpack.config.js
+++ b/examples/hello_world/webpack.config.js
@@ -14,12 +14,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/import_js/package.json
+++ b/examples/import_js/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/import_js/package.json
+++ b/examples/import_js/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/import_js/webpack.config.js
+++ b/examples/import_js/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, "crate")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/julia_set/package.json
+++ b/examples/julia_set/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/julia_set/package.json
+++ b/examples/julia_set/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/julia_set/webpack.config.js
+++ b/examples/julia_set/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/paint/package.json
+++ b/examples/paint/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/paint/package.json
+++ b/examples/paint/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/paint/webpack.config.js
+++ b/examples/paint/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/performance/package.json
+++ b/examples/performance/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/performance/package.json
+++ b/examples/performance/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/performance/webpack.config.js
+++ b/examples/performance/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/request-animation-frame/package.json
+++ b/examples/request-animation-frame/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^3.11.3"
   }
 }

--- a/examples/request-animation-frame/package.json
+++ b/examples/request-animation-frame/package.json
@@ -1,11 +1,10 @@
 {
   "scripts": {
     "build": "webpack",
-    "serve" : "webpack serve"
+    "serve": "webpack serve"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "text-encoding": "^0.7.0",
     "html-webpack-plugin": "^5.3.2",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",

--- a/examples/request-animation-frame/webpack.config.js
+++ b/examples/request-animation-frame/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -8,7 +8,6 @@
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.3.2",
     "mini-css-extract-plugin": "^2.7.6",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -5,11 +5,11 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "css-loader": "^6.8.1",
-    "html-webpack-plugin": "^5.3.2",
-    "mini-css-extract-plugin": "^2.7.6",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "css-loader": "^6.11.0",
+    "html-webpack-plugin": "^5.6.0",
+    "mini-css-extract-plugin": "^2.9.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/todomvc/webpack.config.js
+++ b/examples/todomvc/webpack.config.js
@@ -18,12 +18,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/wasm-in-wasm-imports/package.json
+++ b/examples/wasm-in-wasm-imports/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/wasm-in-wasm-imports/package.json
+++ b/examples/wasm-in-wasm-imports/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/wasm-in-wasm-imports/webpack.config.js
+++ b/examples/wasm-in-wasm-imports/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/wasm-in-wasm/package.json
+++ b/examples/wasm-in-wasm/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/wasm-in-wasm/package.json
+++ b/examples/wasm-in-wasm/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/wasm-in-wasm/webpack.config.js
+++ b/examples/wasm-in-wasm/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/weather_report/package.json
+++ b/examples/weather_report/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/weather_report/package.json
+++ b/examples/weather_report/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/weather_report/webpack.config.js
+++ b/examples/weather_report/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-            TextDecoder: ['text-encoding', 'TextDecoder'],
-            TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/webaudio/package.json
+++ b/examples/webaudio/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/webaudio/package.json
+++ b/examples/webaudio/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/webaudio/webpack.config.js
+++ b/examples/webaudio/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/webgl/package.json
+++ b/examples/webgl/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/webgl/package.json
+++ b/examples/webgl/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/webgl/webpack.config.js
+++ b/examples/webgl/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
       new WasmPackPlugin({
           crateDirectory: path.resolve(__dirname, ".")
       }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/webrtc_datachannel/package.json
+++ b/examples/webrtc_datachannel/package.json
@@ -5,9 +5,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/webrtc_datachannel/package.json
+++ b/examples/webrtc_datachannel/package.json
@@ -6,7 +6,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/webrtc_datachannel/webpack.config.js
+++ b/examples/webrtc_datachannel/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
         new WasmPackPlugin({
             crateDirectory: path.resolve(__dirname, ".")
         }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {

--- a/examples/webxr/package.json
+++ b/examples/webxr/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.3.2",
-    "text-encoding": "^0.7.0",
     "webpack": "^5.49.0",
     "webpack-cli": "^4.7.2",
     "webpack-dev-server": "^4.15.1"

--- a/examples/webxr/package.json
+++ b/examples/webxr/package.json
@@ -8,9 +8,9 @@
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
-    "html-webpack-plugin": "^5.3.2",
-    "webpack": "^5.49.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^4.15.1"
+    "html-webpack-plugin": "^5.6.0",
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4"
   }
 }

--- a/examples/webxr/webpack.config.js
+++ b/examples/webxr/webpack.config.js
@@ -16,12 +16,6 @@ module.exports = {
       new WasmPackPlugin({
           crateDirectory: path.resolve(__dirname, ".")
       }),
-        // Have this example work in Edge which doesn't ship `TextEncoder` or
-        // `TextDecoder` at this time.
-        new webpack.ProvidePlugin({
-          TextDecoder: ['text-encoding', 'TextDecoder'],
-          TextEncoder: ['text-encoding', 'TextEncoder']
-        })
     ],
     mode: 'development',
     experiments: {


### PR DESCRIPTION
Follow-up to #4051, see there for prior discussion.

This splits up the longest-running CI jobs into smaller jobs to improve the CI runtime.

The overall _usage_ didn't go down much, it's still around 100 minutes, but now it's spread out over more jobs.
(It's gotten a bit more stable slightly under the 100 minute mark with this PR, but not much.)

Additional changes are commented below.