### PR TITLE
Deprecate `JsStatic` in favor of `#[wasm_bindgen(thread_local)]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 * Added an experimental Node.JS ES module target, in comparison the current `node` target uses CommonJS, with `--target experimental-nodejs-module` or when testing with `wasm_bindgen_test_configure!(run_in_node_experimental)`.
   [#4027](https://github.com/rustwasm/wasm-bindgen/pull/4027)
 
-* Added importing strings as `JsString` through `#[wasm_bindgen(static_string)] static STRING: JsString = "a string literal";`.
+* Added importing strings as `JsString` through `#[wasm_bindgen(thread_local, static_string)] static STRING: JsString = "a string literal";`.
   [#4055](https://github.com/rustwasm/wasm-bindgen/pull/4055)
 
 ### Changed
@@ -128,6 +128,12 @@
 
 * Filtered files in published crates, significantly reducing the package size and notably excluding any bash files.
   [#4046](https://github.com/rustwasm/wasm-bindgen/pull/4046)
+
+* Deprecated `JsStatic` in favor of `#[wasm_bindgen(thread_local)]`, which creates a `std::thread::LocalKey`. The syntax is otherwise the same.
+  [#4057](https://github.com/rustwasm/wasm-bindgen/pull/4057)
+
+* Removed `impl Deref for JsStatic` when compiling with `cfg(target_feature = "atomics")`, which was unsound.
+  [#4057](https://github.com/rustwasm/wasm-bindgen/pull/4057)
 
 ### Fixed
 

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -275,6 +275,8 @@ pub struct ImportStatic {
     pub js_name: String,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
+    /// [`true`] if using the new `thread_local` representation.
+    pub thread_local: bool,
 }
 
 /// The type of a static string being imported

--- a/crates/js-sys/tests/wasm/Object.rs
+++ b/crates/js-sys/tests/wasm/Object.rs
@@ -9,9 +9,9 @@ extern "C" {
     #[wasm_bindgen(method, setter, structural)]
     fn set_foo(this: &Foo42, val: JsValue);
 
-    #[wasm_bindgen(js_name = prototype, js_namespace = Object)]
+    #[wasm_bindgen(thread_local, js_name = prototype, js_namespace = Object)]
     static OBJECT_PROTOTYPE: JsValue;
-    #[wasm_bindgen(js_name = prototype, js_namespace = Array)]
+    #[wasm_bindgen(thread_local, js_name = prototype, js_namespace = Array)]
     static ARRAY_PROTOTYPE: JsValue;
 
     type DefinePropertyAttrs;
@@ -32,9 +32,9 @@ extern "C" {
     #[wasm_bindgen(constructor)]
     fn new() -> Foo;
 
-    #[wasm_bindgen(js_name = prototype, js_namespace = Foo)]
+    #[wasm_bindgen(thread_local, js_name = prototype, js_namespace = Foo)]
     static FOO_PROTOTYPE: Object;
-    #[wasm_bindgen(js_name = prototype, js_namespace = Bar)]
+    #[wasm_bindgen(thread_local, js_name = prototype, js_namespace = Bar)]
     static BAR_PROTOTYPE: Object;
 }
 
@@ -178,9 +178,9 @@ fn get_own_property_symbols() {
 #[wasm_bindgen_test]
 fn get_prototype_of() {
     let proto = JsValue::from(Object::get_prototype_of(&Object::new().into()));
-    assert_eq!(proto, *OBJECT_PROTOTYPE);
+    OBJECT_PROTOTYPE.with(|op| assert_eq!(proto, *op));
     let proto = JsValue::from(Object::get_prototype_of(&Array::new().into()));
-    assert_eq!(proto, *ARRAY_PROTOTYPE);
+    ARRAY_PROTOTYPE.with(|ap| assert_eq!(proto, *ap));
 }
 
 #[wasm_bindgen_test]
@@ -249,8 +249,8 @@ fn is_sealed() {
 #[wasm_bindgen_test]
 fn is_prototype_of() {
     let foo = JsValue::from(Foo::new());
-    assert!(FOO_PROTOTYPE.is_prototype_of(&foo));
-    assert!(!BAR_PROTOTYPE.is_prototype_of(&foo));
+    assert!(FOO_PROTOTYPE.with(|fp| fp.is_prototype_of(&foo)));
+    assert!(!BAR_PROTOTYPE.with(|bp| bp.is_prototype_of(&foo)));
 }
 
 #[wasm_bindgen_test]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -26,6 +26,7 @@ wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.92" }
 quote = "1.0"
 
 [dev-dependencies]
+js-sys = { path = "../js-sys" }
 trybuild = "1.0"
 wasm-bindgen = { path = "../.." }
 wasm-bindgen-futures = { path = "../futures" }

--- a/crates/macro/ui-tests/invalid-items.rs
+++ b/crates/macro/ui-tests/invalid-items.rs
@@ -10,15 +10,26 @@ pub const fn foo2() {}
 struct Foo<T>(T);
 
 #[wasm_bindgen]
+#[rustfmt::skip]
 extern "C" {
     static mut FOO: u32;
+
+    #[wasm_bindgen(static_string)]
+    static FOO2: JsString;
+
+    #[wasm_bindgen(thread_local, static_string)]
+    static FOO3: JsString;
+
+    static FOO4: JsString = "test";
+
+    #[wasm_bindgen(static_string)]
+    static FOO5: JsString = "test";
 
     pub fn foo3(x: i32, ...);
 }
 
 #[wasm_bindgen]
-extern "system" {
-}
+extern "system" {}
 
 #[wasm_bindgen]
 pub fn foo4<T>() {}

--- a/crates/macro/ui-tests/invalid-items.stderr
+++ b/crates/macro/ui-tests/invalid-items.stderr
@@ -17,43 +17,67 @@ error: structs with #[wasm_bindgen] cannot have lifetime or type parameters curr
    |           ^^^
 
 error: cannot import mutable globals yet
-  --> $DIR/invalid-items.rs:14:12
+  --> $DIR/invalid-items.rs:15:12
    |
-14 |     static mut FOO: u32;
+15 |     static mut FOO: u32;
    |            ^^^
 
-error: can't #[wasm_bindgen] variadic functions
-  --> $DIR/invalid-items.rs:16:25
+error: static strings require a string literal
+  --> $DIR/invalid-items.rs:17:20
    |
-16 |     pub fn foo3(x: i32, ...);
+17 |     #[wasm_bindgen(static_string)]
+   |                    ^^^^^^^^^^^^^
+
+error: static strings require a string literal
+  --> $DIR/invalid-items.rs:20:34
+   |
+20 |     #[wasm_bindgen(thread_local, static_string)]
+   |                                  ^^^^^^^^^^^^^
+
+error: static strings require `#[wasm_bindgen(static_string)]`
+  --> $DIR/invalid-items.rs:23:5
+   |
+23 |     static FOO4: JsString = "test";
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: static strings require `#[wasm_bindgen(thread_local)]`
+  --> $DIR/invalid-items.rs:26:5
+   |
+26 |     static FOO5: JsString = "test";
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: can't #[wasm_bindgen] variadic functions
+  --> $DIR/invalid-items.rs:28:25
+   |
+28 |     pub fn foo3(x: i32, ...);
    |                         ^^^
 
 error: only foreign mods with the `C` ABI are allowed
-  --> $DIR/invalid-items.rs:20:8
+  --> $DIR/invalid-items.rs:32:8
    |
-20 | extern "system" {
+32 | extern "system" {}
    |        ^^^^^^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:24:12
+  --> $DIR/invalid-items.rs:35:12
    |
-24 | pub fn foo4<T>() {}
+35 | pub fn foo4<T>() {}
    |            ^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:26:12
+  --> $DIR/invalid-items.rs:37:12
    |
-26 | pub fn foo5<'a>() {}
+37 | pub fn foo5<'a>() {}
    |            ^^^^
 
 error: can't #[wasm_bindgen] functions with lifetime or type parameters
-  --> $DIR/invalid-items.rs:28:12
+  --> $DIR/invalid-items.rs:39:12
    |
-28 | pub fn foo6<'a, T>() {}
+39 | pub fn foo6<'a, T>() {}
    |            ^^^^^^^
 
 error: #[wasm_bindgen] can only be applied to a function, struct, enum, impl, or extern block
-  --> $DIR/invalid-items.rs:31:1
+  --> $DIR/invalid-items.rs:42:1
    |
-31 | trait X {}
+42 | trait X {}
    | ^^^^^^^^^^

--- a/crates/macro/ui-tests/invalid-static-string.rs
+++ b/crates/macro/ui-tests/invalid-static-string.rs
@@ -1,0 +1,10 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+#[rustfmt::skip]
+extern "C" {
+    #[wasm_bindgen(thread_local, static_string)]
+    static FOO: JsValue = "test";
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/invalid-static-string.stderr
+++ b/crates/macro/ui-tests/invalid-static-string.stderr
@@ -1,0 +1,14 @@
+error[E0308]: mismatched types
+ --> $DIR/invalid-static-string.rs:3:1
+  |
+3 | #[wasm_bindgen]
+  | ^^^^^^^^^^^^^^^
+  | |
+  | expected `JsString`, found `JsValue`
+  | expected `JsString` because of return type
+  |
+  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: call `Into::into` on this expression to convert `wasm_bindgen::JsValue` into `JsString`
+  |
+3 | #[wasm_bindgen].into()
+  |                +++++++

--- a/crates/test/src/rt/browser.rs
+++ b/crates/test/src/rt/browser.rs
@@ -19,7 +19,8 @@ pub struct Browser {
 #[wasm_bindgen]
 extern "C" {
     type HTMLDocument;
-    static document: HTMLDocument;
+    #[wasm_bindgen(thread_local, js_name = document)]
+    static DOCUMENT: HTMLDocument;
     #[wasm_bindgen(method, structural)]
     fn getElementById(this: &HTMLDocument, id: &str) -> Element;
 
@@ -38,7 +39,7 @@ impl Browser {
     /// Creates a new instance of `Browser`, assuming that its APIs will work
     /// (requires `Node::new()` to have return `None` first).
     pub fn new() -> Browser {
-        let pre = document.getElementById("output");
+        let pre = DOCUMENT.with(|document| document.getElementById("output"));
         pre.set_text_content("");
         Browser { pre }
     }

--- a/crates/web-sys/tests/wasm/history.rs
+++ b/crates/web-sys/tests/wasm/history.rs
@@ -4,25 +4,27 @@ use web_sys::{History, ScrollRestoration};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_name = history, js_namespace = window)]
+    #[wasm_bindgen(thread_local, js_name = history, js_namespace = window)]
     static HISTORY: History;
 }
 
 #[wasm_bindgen_test]
 fn history() {
-    HISTORY
-        .set_scroll_restoration(ScrollRestoration::Manual)
-        .expect("failure to set scroll restoration");
-    assert_eq!(
-        HISTORY.scroll_restoration().unwrap(),
-        ScrollRestoration::Manual
-    );
+    HISTORY.with(|history| {
+        history
+            .set_scroll_restoration(ScrollRestoration::Manual)
+            .expect("failure to set scroll restoration");
+        assert_eq!(
+            history.scroll_restoration().unwrap(),
+            ScrollRestoration::Manual
+        );
 
-    HISTORY
-        .set_scroll_restoration(ScrollRestoration::Auto)
-        .expect("failure to set scroll restoration");
-    assert_eq!(
-        HISTORY.scroll_restoration().unwrap(),
-        ScrollRestoration::Auto
-    );
+        history
+            .set_scroll_restoration(ScrollRestoration::Auto)
+            .expect("failure to set scroll restoration");
+        assert_eq!(
+            history.scroll_restoration().unwrap(),
+            ScrollRestoration::Auto
+        );
+    });
 }

--- a/crates/web-sys/tests/wasm/performance.rs
+++ b/crates/web-sys/tests/wasm/performance.rs
@@ -4,12 +4,12 @@ use web_sys::Performance;
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_name = performance)]
+    #[wasm_bindgen(thread_local, js_name = performance)]
     static PERFORMANCE: Performance;
 }
 
 #[wasm_bindgen_test]
 fn to_json() {
-    let perf = JsValue::from(PERFORMANCE.to_json());
+    let perf = JsValue::from(PERFORMANCE.with(Performance::to_json));
     assert!(perf.is_object());
 }

--- a/examples/wasm-audio-worklet/src/dependent_module.rs
+++ b/examples/wasm-audio-worklet/src/dependent_module.rs
@@ -12,7 +12,7 @@ extern "C" {
     #[wasm_bindgen(method, getter)]
     fn url(this: &ImportMeta) -> JsString;
 
-    #[wasm_bindgen(js_namespace = import, js_name = meta)]
+    #[wasm_bindgen(thread_local, js_namespace = import, js_name = meta)]
     static IMPORT_META: ImportMeta;
 }
 
@@ -20,7 +20,7 @@ pub fn on_the_fly(code: &str) -> Result<String, JsValue> {
     // Generate the import of the bindgen ES module, assuming `--target web`.
     let header = format!(
         "import init, * as bindgen from '{}';\n\n",
-        IMPORT_META.url(),
+        IMPORT_META.with(ImportMeta::url),
     );
 
     let options = BlobPropertyBag::new();

--- a/guide/src/reference/attributes/on-js-imports/indexing-getter-setter-deleter.md
+++ b/guide/src/reference/attributes/on-js-imports/indexing-getter-setter-deleter.md
@@ -60,7 +60,8 @@ on methods:
 #[wasm_bindgen]
 extern "C" {
     type Foo;
-    static foo: Foo;
+    #[wasm_bindgen(thread_local)]
+    static FOO: Foo;
 
     #[wasm_bindgen(method, structural, indexing_getter)]
     fn get(this: &Foo, prop: &str) -> u32;
@@ -72,11 +73,13 @@ extern "C" {
     fn delete(this: &Foo, prop: &str);
 }
 
-assert_eq!(foo.get("ten"), 3);
+FOO.with(|foo| {
+    assert_eq!(foo.get("ten"), 3);
 
-foo.set("ten", 10);
-assert_eq!(foo.get("ten"), 10);
+    foo.set("ten", 10);
+    assert_eq!(foo.get("ten"), 10);
 
-foo.delete("ten");
-assert_eq!(foo.get("ten"), 3);
+    foo.delete("ten");
+    assert_eq!(foo.get("ten"), 3);
+});
 ```

--- a/guide/src/reference/static-js-objects.md
+++ b/guide/src/reference/static-js-objects.md
@@ -19,11 +19,12 @@ let COLORS = {
 ```rust
 #[wasm_bindgen]
 extern "C" {
+    #[wasm_bindgen(thread_local)]
     static COLORS;
 }
 
 fn get_colors() -> JsValue {
-    COLORS.clone()
+    COLORS.with(JsValue::clone)
 }
 ```
 
@@ -49,11 +50,11 @@ The binding for this module:
 #[wasm_bindgen(module = "/js/some-rollup.js")]
 extern "C" {
     // Likewise with the namespace--this refers to the object directly.
-    #[wasm_bindgen(js_name = namespace)]
+    #[wasm_bindgen(thread_local, js_name = namespace)]
     static NAMESPACE: JsValue;
 
     // Refer to SomeType's class
-    #[wasm_bindgen(js_name = SomeType)]
+    #[wasm_bindgen(thread_local, js_name = SomeType)]
     static SOME_TYPE: JsValue;
 
     // Other bindings for SomeType
@@ -70,7 +71,7 @@ Strings can be imported to avoid going through `TextDecoder/Encoder` when requir
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(static_string)]
+    #[wasm_bindgen(thread_local, static_string)]
     static STRING: JsString = "a string literal";
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1185,23 +1185,18 @@ impl Default for JsValue {
 /// This type implements `Deref` to the inner type so it's typically used as if
 /// it were `&T`.
 #[cfg(feature = "std")]
+#[deprecated = "use with `#[wasm_bindgen(thread_local)]` instead"]
 pub struct JsStatic<T: 'static> {
     #[doc(hidden)]
     pub __inner: &'static std::thread::LocalKey<T>,
 }
 
 #[cfg(feature = "std")]
+#[allow(deprecated)]
+#[cfg(not(target_feature = "atomics"))]
 impl<T: FromWasmAbi + 'static> Deref for JsStatic<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        // We know that our tls key is never overwritten after initialization,
-        // so it should be safe (on that axis at least) to hand out a reference
-        // that lives longer than the closure below.
-        //
-        // FIXME: this is not sound if we ever implement thread exit hooks on
-        // wasm, as the pointer will eventually be invalidated but you can get
-        // `&'static T` from this interface. We... probably need to deprecate
-        // and/or remove this interface nowadays.
         unsafe { self.__inner.with(|ptr| &*(ptr as *const T)) }
     }
 }

--- a/tests/headless/strings.rs
+++ b/tests/headless/strings.rs
@@ -15,7 +15,7 @@ fn string_roundtrip() {
 
     assert_eq!("\u{feff}bar", &identity("\u{feff}bar"));
 
-    assert_eq!(String::from(&*STRING), "foo")
+    assert_eq!(STRING.with(|s| String::from(s)), "foo");
 }
 
 #[wasm_bindgen]
@@ -23,6 +23,6 @@ fn string_roundtrip() {
 // See <https://github.com/rust-lang/rustfmt/issues/6267>.
 #[rustfmt::skip]
 extern "C" {
-    #[wasm_bindgen(static_string)]
+    #[wasm_bindgen(thread_local, static_string)]
     static STRING: JsString = "foo";
 }

--- a/tests/non_wasm.rs
+++ b/tests/non_wasm.rs
@@ -31,13 +31,14 @@ pub fn foo(x: bool) {
 #[wasm_bindgen]
 extern "C" {
     fn some_import();
+    #[wasm_bindgen(thread_local)]
     static A: JsValue;
 }
 
 #[wasm_bindgen]
 pub fn bar(_: &str) -> JsValue {
     some_import();
-    A.clone()
+    A.with(JsValue::clone)
 }
 
 #[wasm_bindgen]

--- a/tests/wasm/duplicates.rs
+++ b/tests/wasm/duplicates.rs
@@ -6,7 +6,8 @@ pub mod same_function_different_locations_a {
     #[wasm_bindgen(module = "tests/wasm/duplicates_a.js")]
     extern "C" {
         pub fn foo();
-        pub static bar: JsValue;
+        #[wasm_bindgen(thread_local, js_name = bar)]
+        pub static BAR: JsValue;
     }
 }
 
@@ -16,7 +17,8 @@ pub mod same_function_different_locations_b {
     #[wasm_bindgen(module = "tests/wasm/duplicates_a.js")]
     extern "C" {
         pub fn foo();
-        pub static bar: JsValue;
+        #[wasm_bindgen(thread_local, js_name = bar)]
+        pub static BAR: JsValue;
     }
 }
 
@@ -24,8 +26,8 @@ pub mod same_function_different_locations_b {
 fn same_function_different_locations() {
     same_function_different_locations_a::foo();
     same_function_different_locations_b::foo();
-    assert_eq!(*same_function_different_locations_a::bar, 3);
-    assert_eq!(*same_function_different_locations_a::bar, 3);
+    same_function_different_locations_a::BAR.with(|bar| assert_eq!(*bar, 3));
+    same_function_different_locations_a::BAR.with(|bar| assert_eq!(*bar, 3));
 }
 
 pub mod same_function_different_modules_a {
@@ -34,7 +36,8 @@ pub mod same_function_different_modules_a {
     #[wasm_bindgen(module = "tests/wasm/duplicates_b.js")]
     extern "C" {
         pub fn foo() -> bool;
-        pub static bar: JsValue;
+        #[wasm_bindgen(thread_local, js_name = bar)]
+        pub static BAR: JsValue;
     }
 }
 
@@ -44,7 +47,8 @@ pub mod same_function_different_modules_b {
     #[wasm_bindgen(module = "tests/wasm/duplicates_c.js")]
     extern "C" {
         pub fn foo() -> bool;
-        pub static bar: JsValue;
+        #[wasm_bindgen(thread_local, js_name = bar)]
+        pub static BAR: JsValue;
     }
 }
 
@@ -52,6 +56,6 @@ pub mod same_function_different_modules_b {
 fn same_function_different_modules() {
     assert!(same_function_different_modules_a::foo());
     assert!(!same_function_different_modules_b::foo());
-    assert_eq!(*same_function_different_modules_a::bar, 4);
-    assert_eq!(*same_function_different_modules_b::bar, 5);
+    same_function_different_modules_a::BAR.with(|bar| assert_eq!(*bar, 4));
+    same_function_different_modules_b::BAR.with(|bar| assert_eq!(*bar, 5));
 }

--- a/tests/wasm/imports.rs
+++ b/tests/wasm/imports.rs
@@ -23,6 +23,7 @@ extern "C" {
 
     fn assert_valid_error(val: JsValue);
 
+    #[wasm_bindgen(thread_local)]
     static IMPORT: JsValue;
 
     #[wasm_bindgen(js_name = return_three)]
@@ -35,7 +36,7 @@ extern "C" {
 
     #[allow(non_camel_case_types)]
     type bar;
-    #[wasm_bindgen(js_namespace = bar, js_name = foo)]
+    #[wasm_bindgen(thread_local, js_namespace = bar, js_name = foo)]
     static FOO: JsValue;
 
     fn take_custom_type(f: CustomType) -> CustomType;
@@ -46,7 +47,7 @@ extern "C" {
 
     #[wasm_bindgen(js_name = "baz$")]
     fn renamed_with_dollar_sign();
-    #[wasm_bindgen(js_name = "$foo")]
+    #[wasm_bindgen(thread_local, js_name = "$foo")]
     static RENAMED: JsValue;
 
     fn unused_import();
@@ -57,6 +58,7 @@ extern "C" {
     #[wasm_bindgen(static_method_of = StaticMethodCheck)]
     fn static_method_of_right_this();
 
+    #[wasm_bindgen(thread_local)]
     static STATIC_STRING: String;
 
     #[derive(Clone)]
@@ -170,7 +172,7 @@ fn free_imports() {
 
 #[wasm_bindgen_test]
 fn import_a_field() {
-    assert_eq!(IMPORT.as_f64(), Some(1.0));
+    assert_eq!(IMPORT.with(JsValue::as_f64), Some(1.0));
 }
 
 #[wasm_bindgen_test]
@@ -190,7 +192,7 @@ fn rust_keyword() {
 
 #[wasm_bindgen_test]
 fn rust_keyword2() {
-    assert_eq!(FOO.as_f64(), Some(3.0));
+    assert_eq!(FOO.with(JsValue::as_f64), Some(3.0));
 }
 
 #[wasm_bindgen_test]
@@ -222,7 +224,7 @@ fn rename_with_string() {
 
 #[wasm_bindgen_test]
 fn rename_static_with_string() {
-    assert_eq!(RENAMED.as_f64(), Some(1.0));
+    assert_eq!(RENAMED.with(JsValue::as_f64), Some(1.0));
 }
 
 #[wasm_bindgen_test]
@@ -285,7 +287,7 @@ fn undefined_function_is_ok() {
 
 #[wasm_bindgen_test]
 fn static_string_ok() {
-    assert_eq!(*STATIC_STRING, "x");
+    STATIC_STRING.with(|s| assert_eq!(*s, "x"));
 }
 
 #[wasm_bindgen_test]

--- a/tests/wasm/node.rs
+++ b/tests/wasm/node.rs
@@ -4,6 +4,7 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen(module = "tests/wasm/node.js")]
 extern "C" {
     fn test_works();
+    #[wasm_bindgen(thread_local)]
     static FOO: JsValue;
     fn hit();
 }
@@ -11,7 +12,7 @@ extern "C" {
 #[wasm_bindgen_test]
 fn works() {
     hit();
-    assert_eq!(FOO.as_f64(), Some(1.0));
+    assert_eq!(FOO.with(JsValue::as_f64), Some(1.0));
     test_works();
 }
 


### PR DESCRIPTION
This PR deprecated `JsStatic` in favor of `#[wasm_bindgen(thread_local)]`, which creates a `std::thread::LocalKey`. The syntax is otherwise the same.

```rust
#[wasm_bindgen]
extern "C" {
    #[wasm_bindgen(thread_local)]
    static FOO: JsValue;
}
```

`JsStatic` was pretty much a hack that exposed a thread local variable by transmuting the lifetime to `'static`, which does make sense on Web, but not with multi-threading, which was making this rather unsound.

Additionally, `impl Deref for JsStatic` is not present anymore when compiling with `cfg(target_feature = "atomics")` to remove the possibility of unsoundness entirely.