### PR TITLE
Handle empty coverage report

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -31,10 +31,13 @@ pub(crate) fn spawn(
     let cov_dump = r#"
         // Dump the coverage data collected during the tests
         const coverage = __wbgtest_cov_dump();
-        await fetch("/__wasm_bindgen/coverage", {
-            method: "POST",
-            body: coverage
-        });
+
+        if (coverage !== undefined) {
+            await fetch("/__wasm_bindgen/coverage", {
+                method: "POST",
+                body: coverage
+            });
+        }
     "#;
 
     let wbg_import_script = if test_mode.no_modules() {

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -6,26 +6,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const heap = new Array(128).fill(undefined);
-
-heap.push(undefined, null, true, false);
-
-function getObject(idx) { return heap[idx]; }
-
-let heap_next = heap.length;
-
-function dropObject(idx) {
-    if (idx < 132) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
-}
-
-function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
-}
-
 const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
@@ -44,6 +24,26 @@ function getUint8ArrayMemory0() {
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) { return heap[idx]; }
+
+let heap_next = heap.length;
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
 }
 /**
 * @param {number} test
@@ -110,11 +110,11 @@ export function __wbg_test2_39fe629b9aa739cf() {
     return addHeapObject(ret);
 };
 
-export function __wbindgen_object_drop_ref(arg0) {
-    takeObject(arg0);
-};
-
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
+};
+
+export function __wbindgen_object_drop_ref(arg0) {
+    takeObject(arg0);
 };
 

--- a/crates/test/src/coverage.rs
+++ b/crates/test/src/coverage.rs
@@ -2,7 +2,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 #[cfg(wasm_bindgen_unstable_test_coverage)]
 #[wasm_bindgen]
-pub fn __wbgtest_cov_dump() -> Vec<u8> {
+pub fn __wbgtest_cov_dump() -> Option<Vec<u8>> {
     let mut coverage = Vec::new();
     // SAFETY: this function is not thread-safe, but our whole test runner is running single-threaded.
     unsafe {
@@ -14,11 +14,11 @@ pub fn __wbgtest_cov_dump() -> Vec<u8> {
         RUSTFLAGS=\"-Cinstrument-coverage -Zno-profile-runtime --emit=llvm-ir\"",
         );
     }
-    coverage
+    Some(coverage)
 }
 
 #[cfg(not(wasm_bindgen_unstable_test_coverage))]
 #[wasm_bindgen]
-pub fn __wbgtest_cov_dump() -> Vec<u8> {
-    Vec::new()
+pub fn __wbgtest_cov_dump() -> Option<Vec<u8>> {
+    None
 }


### PR DESCRIPTION
Coverage reports are currently generated even if not enabled.
This PR fixes that.

Follow-up to #4060.