### PR TITLE
Don't emit snippets without `--split-linked-modules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,9 @@
 * `#[track_caller]` is now always applied on `UnwrapThrowExt` methods when not targetting `wasm32-unknown-unknown`.
   [#4042](https://github.com/rustwasm/wasm-bindgen/pull/4042)
 
+* Fixed linked modules emitting snippet files when not using `--split-linked-modules`.
+  [#4066](https://github.com/rustwasm/wasm-bindgen/pull/4066)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.92](https://github.com/rustwasm/wasm-bindgen/compare/0.2.91...0.2.92)

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -368,13 +368,7 @@ impl Bindgen {
         // auxiliary section for all sorts of miscellaneous information and
         // features #[wasm_bindgen] supports that aren't covered by wasm
         // interface types.
-        wit::process(
-            &mut module,
-            programs,
-            self.externref,
-            thread_count,
-            self.emit_start,
-        )?;
+        wit::process(self, &mut module, programs, thread_count)?;
 
         // Now that we've got type information from the webidl processing pass,
         // touch up the output of rustc to insert externref shims where necessary.
@@ -599,14 +593,6 @@ impl Output {
 
     pub fn start(&self) -> Option<&String> {
         self.generated.start.as_ref()
-    }
-
-    pub fn snippets(&self) -> &HashMap<String, Vec<String>> {
-        &self.generated.snippets
-    }
-
-    pub fn local_modules(&self) -> &HashMap<String, String> {
-        &self.generated.local_modules
     }
 
     pub fn npm_dependencies(&self) -> &HashMap<String, (PathBuf, String)> {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -156,6 +156,7 @@ macro_rules! shared_api {
         struct LocalModule<'a> {
             identifier: &'a str,
             contents: &'a str,
+            linked_module: bool,
         }
         }
     }; // end of mac case

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "3501400214978266446";
+const APPROVED_SCHEMA_FILE_HASH: &str = "9336383503182818021";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
This PR stop `wasm-bindgen` from emitting snippet files without using `--split-linked-modules`, which in this case remain unused anyway.

Cc @RReverser.
Fixes #3330.