### PR TITLE
Use object URLs for inlined linked modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,9 @@
 * Updated the WebGPU WebIDL to the current draft as of 2024-08-05.
   [#4062](https://github.com/rustwasm/wasm-bindgen/pull/4062)
 
+* Use object URLs for linked modules without `--split-linked-modules`.
+  [#4067](https://github.com/rustwasm/wasm-bindgen/pull/4067)
+
 ### Fixed
 
 * Copy port from headless test server when using `WASM_BINDGEN_TEST_ADDRESS`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ xxx_debug_only_print_generated_code = [
 ]
 
 [dependencies]
+once_cell = "1.12"
 wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.92" }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -190,16 +190,18 @@ impl TryToTokens for ast::LinkToModule {
         let link_function_name = self.0.link_function_name(0);
         let name = Ident::new(&link_function_name, Span::call_site());
         let wasm_bindgen = &self.0.wasm_bindgen;
-        let abi_ret = quote! { #wasm_bindgen::convert::WasmRet<<std::string::String as #wasm_bindgen::convert::FromWasmAbi>::Abi> };
+        let abi_ret = quote! { #wasm_bindgen::convert::WasmRet<<#wasm_bindgen::__rt::alloc::string::String as #wasm_bindgen::convert::FromWasmAbi>::Abi> };
         let extern_fn = extern_fn(&name, &[], &[], &[], abi_ret);
         (quote! {
             {
                 #program
                 #extern_fn
 
-                unsafe {
-                    <std::string::String as #wasm_bindgen::convert::FromWasmAbi>::from_abi(#name().join())
-                }
+                static __VAL: #wasm_bindgen::__rt::Lazy<String> = #wasm_bindgen::__rt::Lazy::new(|| unsafe {
+                    <#wasm_bindgen::__rt::alloc::string::String as #wasm_bindgen::convert::FromWasmAbi>::from_abi(#name().join())
+                });
+
+                #wasm_bindgen::__rt::alloc::string::String::clone(&__VAL)
             }
         })
         .to_tokens(tokens);

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3262,9 +3262,11 @@ impl<'a> Context<'a> {
                         '`' | '\\' | '$' => escaped.extend(['\\', c]),
                         _ => escaped.extend([c]),
                     });
-                    Ok(format!(
-                        "\"data:application/javascript,\" + encodeURIComponent(`{escaped}`)"
-                    ))
+                    prelude.push_str(&format!("const val = `{escaped}`;\n"));
+                    Ok("typeof URL.createObjectURL === 'undefined' ? \
+                        \"data:application/javascript,\" + encodeURIComponent(val) : \
+                        URL.createObjectURL(new Blob([val], { type: \"text/javascript\" }))"
+                        .to_owned())
                 } else {
                     Err(anyhow!("wasm-bindgen needs to be invoked with `--split-linked-modules`, because \"{}\" cannot be embedded.\n\
                         See https://rustwasm.github.io/wasm-bindgen/reference/cli.html#--split-linked-modules for details.", path))

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -6,26 +6,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-let cachedUint8ArrayMemory0 = null;
-
-function getUint8ArrayMemory0() {
-    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8ArrayMemory0;
-}
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
-}
-
 const heap = new Array(128).fill(undefined);
 
 heap.push(undefined, null, true, false);
@@ -44,6 +24,26 @@ function takeObject(idx) {
     const ret = getObject(idx);
     dropObject(idx);
     return ret;
+}
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 /**
 * @param {number} test
@@ -110,11 +110,11 @@ export function __wbg_test2_39fe629b9aa739cf() {
     return addHeapObject(ret);
 };
 
-export function __wbindgen_throw(arg0, arg1) {
-    throw new Error(getStringFromWasm0(arg0, arg1));
-};
-
 export function __wbindgen_object_drop_ref(arg0) {
     takeObject(arg0);
+};
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1518,6 +1518,7 @@ pub mod __rt {
     use alloc::alloc::{alloc, dealloc, realloc, Layout};
     use alloc::boxed::Box;
     use alloc::rc::Rc;
+    pub use once_cell::sync::Lazy;
 
     #[macro_export]
     #[doc(hidden)]


### PR DESCRIPTION
Currently `link_to!()` without `--split-linked-modules` would build a encoded URL and return it as a `String` when accessed.
This makes `link_to!()` quite pointless in this case as its not much better then using `include_str!()` in Rust.

This PR changes this case to use [object URLs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static) instead. The resulting URL is also cached on the Rust side with the help of `once_cell` (which was a dependency already), so we don't keep creating new object URLs over and over, which would be a memory leak.

A fallback is built-in for service-workers, where the API isn't present.

So this change is a trade-off, the URL is now permanently stored in Wasm memory once called, but the URL is always guaranteed to be quite short, except in the case of service workers. In contrast, when not using `--split-linked-modules`, the whole file was transferred into Wasm memory.

Follow-up to #3069.