### PR TITLE
Make sure deploy CI job runs last

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -534,8 +534,8 @@ jobs:
       - dist_macos_x86_64
       - dist_macos_aarch64
       - dist_windows
-      - build_examples
-      - build_nightly
+      - test_examples
+      - test_nightly
       - build_benchmarks
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Follow-up to #4058, where we forgot to adjust the deploy CI job to run last.