### PR TITLE
Fixed incorrect deprecation warning when using default module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
+## Unreleased
+
+### Fixed
+
+* Fixed linked modules emitting snippet files when not using `--split-linked-modules`.
+  [#4066](https://github.com/rustwasm/wasm-bindgen/pull/4066)
+
+* Fixed incorrect deprecation warning when passing no parameter into `default()` (`init()`) or `initSync()`.
+  [#4074](https://github.com/rustwasm/wasm-bindgen/pull/4074)
+
+--------------------------------------------------------------------------------
+
 ## [0.2.93](https://github.com/rustwasm/wasm-bindgen/compare/0.2.92...0.2.93)
 
 Released 2024-08-13

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -870,10 +870,13 @@ impl<'a> Context<'a> {
                     if (wasm !== undefined) return wasm;
 
                     {init_stack_size}
-                    if (typeof module !== 'undefined' && Object.getPrototypeOf(module) === Object.prototype)
-                        ({{module{init_memory_arg}{init_stack_size_arg}}} = module)
-                    else
-                        console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+                    if (typeof module !== 'undefined') {{
+                        if (Object.getPrototypeOf(module) === Object.prototype) {{
+                            ({{module{init_memory_arg}{init_stack_size_arg}}} = module)
+                        }} else {{
+                            console.warn('using deprecated parameters for `initSync()`; pass a single object instead')
+                        }}
+                    }}
 
                     const imports = __wbg_get_imports();
 
@@ -892,10 +895,13 @@ impl<'a> Context<'a> {
                     if (wasm !== undefined) return wasm;
 
                     {init_stack_size}
-                    if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
-                        ({{module_or_path{init_memory_arg}{init_stack_size_arg}}} = module_or_path)
-                    else
-                        console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+                    if (typeof module_or_path !== 'undefined') {{
+                        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {{
+                            ({{module_or_path{init_memory_arg}{init_stack_size_arg}}} = module_or_path)
+                        }} else {{
+                            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+                        }}
+                    }}
 
                     {default_module_path}
                     const imports = __wbg_get_imports();

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -336,10 +336,13 @@ async function __wbg_init(module_or_path) {
     if (wasm !== undefined) return wasm;
 
 
-    if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
-    ({module_or_path} = module_or_path)
-    else
-    console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+    if (typeof module_or_path !== 'undefined') {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
 
     if (typeof module_or_path === 'undefined') {
         module_or_path = new URL('default_module_path_target_web_bg.wasm', import.meta.url);
@@ -371,10 +374,13 @@ fn default_module_path_target_no_modules() {
         if (wasm !== undefined) return wasm;
 
 
-        if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
-        ({module_or_path} = module_or_path)
-        else
-        console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        if (typeof module_or_path !== 'undefined') {
+            if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+                ({module_or_path} = module_or_path)
+            } else {
+                console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+            }
+        }
 
         if (typeof module_or_path === 'undefined' && typeof script_src !== 'undefined') {
             module_or_path = script_src.replace(/\\.js$/, '_bg.wasm');
@@ -400,10 +406,13 @@ async function __wbg_init(module_or_path) {
     if (wasm !== undefined) return wasm;
 
 
-    if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
-    ({module_or_path} = module_or_path)
-    else
-    console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+    if (typeof module_or_path !== 'undefined') {
+        if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+            ({module_or_path} = module_or_path)
+        } else {
+            console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        }
+    }
 
 
     const imports = __wbg_get_imports();",
@@ -428,10 +437,13 @@ fn omit_default_module_path_target_no_modules() {
         if (wasm !== undefined) return wasm;
 
 
-        if (typeof module_or_path !== 'undefined' && Object.getPrototypeOf(module_or_path) === Object.prototype)
-        ({module_or_path} = module_or_path)
-        else
-        console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+        if (typeof module_or_path !== 'undefined') {
+            if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
+                ({module_or_path} = module_or_path)
+            } else {
+                console.warn('using deprecated parameters for the initialization function; pass a single object instead')
+            }
+        }
 
 
         const imports = __wbg_get_imports();",


### PR DESCRIPTION
In #3995 we deprecated the old parameters passed into `default()` (`init()`) and `initSync()`in favor of an object containing the data we need.
If the old parameters were passed we emitted a warning, which we unfortunately also emit when **no parameters are passed**, which is definitely not deprecated.
`wasm-bindgen` should continue to handle figuring out the default module path on its own.

Thank you @fvirdia for reporting.
Follow-up to #3995.