### PR TITLE
Fix emitted package.json structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Fixed negative `BigInt` values being incorrectly formatted with two minus signs.
   [#4082](https://github.com/rustwasm/wasm-bindgen/pull/4082)
 
+* Fixed emitted `package.json` structure to correctly specify its dependencies
+  [#4091](https://github.com/rustwasm/wasm-bindgen/pull/4091)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.93](https://github.com/rustwasm/wasm-bindgen/compare/0.2.92...0.2.93)

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -18,6 +18,7 @@ anyhow = "1.0"
 base64 = "0.22"
 log = "0.4"
 rustc-demangle = "0.1.13"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.0"
 unicode-ident = "1.0.5"

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -641,12 +641,18 @@ impl Output {
         }
 
         if !gen.npm_dependencies.is_empty() {
-            let map = gen
-                .npm_dependencies
-                .iter()
-                .map(|(k, v)| (k, &v.1))
-                .collect::<BTreeMap<_, _>>();
-            let json = serde_json::to_string_pretty(&map)?;
+            #[derive(serde::Serialize)]
+            struct PackageJson<'a> {
+                dependencies: BTreeMap<&'a str, &'a str>,
+            }
+            let pj = PackageJson {
+                dependencies: gen
+                    .npm_dependencies
+                    .iter()
+                    .map(|(k, v)| (k.as_str(), v.1.as_str()))
+                    .collect(),
+            };
+            let json = serde_json::to_string_pretty(&pj)?;
             fs::write(out_dir.join("package.json"), json)?;
         }
 


### PR DESCRIPTION
Currently it emits incorrectly structured `package.json` like this:
```json
{
  "foo": "^0.21.1",
  "bar": "^0.21.4"
}
```

This PR fixes it to match [the spec](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#dependencies).
```json
{
  "dependencies": {
    "foo": "^0.21.1",
    "bar": "^0.21.4"
  }
}
```