### PR TITLE
Specify `"type": "module"` when deploying to nodejs-module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
 * Fixed error when importing very large JS files.
   [#4146](https://github.com/rustwasm/wasm-bindgen/pull/4146)
 
+* Specify `"type": "module"` when deploying to nodejs-module
+  [#4092](https://github.com/rustwasm/wasm-bindgen/pull/4092)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.93](https://github.com/rustwasm/wasm-bindgen/compare/0.2.92...0.2.93)

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -661,12 +661,16 @@ impl Output {
                 .with_context(|| format!("failed to write `{}`", path.display()))?;
         }
 
-        if !gen.npm_dependencies.is_empty() {
+        let is_genmode_nodemodule = matches!(gen.mode, OutputMode::Node { module: true });
+        if !gen.npm_dependencies.is_empty() || is_genmode_nodemodule {
             #[derive(serde::Serialize)]
             struct PackageJson<'a> {
+                #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+                ty: Option<&'static str>,
                 dependencies: BTreeMap<&'a str, &'a str>,
             }
             let pj = PackageJson {
+                ty: is_genmode_nodemodule.then_some("module"),
                 dependencies: gen
                     .npm_dependencies
                     .iter()


### PR DESCRIPTION
~~WIP because this PR depends on #4091~~

When `--target experimental-nodejs-module` is specified, Either using `.mjs` extension or setting `"type": "module"` field on `package.json` is required to execute emitted javascript code using Node.js.

In this PR, I used `"type": "module"` approach because it makes lower impact on existing codebases since it doesn't change file name.