### PR TITLE
Fix `__wbg_set_wasm` call order on nodejs-module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 * Fixed multiline doc comment alignment and remove empty ones entirely.
   [#4135](https://github.com/rustwasm/wasm-bindgen/pull/4135)
 
-* Fix `__wbg_set_wasm` call order on nodejs-module
+* Fixed `experimental-nodejs-module` target when used with `#[wasm_bindgen(start)]`.
   [#4093](https://github.com/rustwasm/wasm-bindgen/pull/4093)
 
 --------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@
 * Fixed multiline doc comment alignment and remove empty ones entirely.
   [#4135](https://github.com/rustwasm/wasm-bindgen/pull/4135)
 
+* Fix `__wbg_set_wasm` call order on nodejs-module
+  [#4093](https://github.com/rustwasm/wasm-bindgen/pull/4093)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.93](https://github.com/rustwasm/wasm-bindgen/compare/0.2.92...0.2.93)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -483,6 +483,25 @@ impl<'a> Context<'a> {
                         module_name
                     ))));
                 }
+
+                match self.config.mode {
+                    OutputMode::Bundler { .. } => {
+                        start.get_or_insert_with(String::new).push_str(&format!(
+                            "\
+import {{ __wbg_set_wasm }} from \"./{module_name}_bg.js\";
+__wbg_set_wasm(wasm);"
+                        ));
+                    }
+
+                    OutputMode::Node { module: true } => {
+                        start.get_or_insert_with(String::new).push_str(&format!(
+                            "imports[\"./{module_name}_bg.js\"].__wbg_set_wasm(wasm);"
+                        ));
+                    }
+
+                    _ => {}
+                }
+
                 if needs_manual_start {
                     start
                         .get_or_insert_with(String::new)

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -701,10 +701,8 @@ impl Output {
                 write(
                     &js_path,
                     format!(
-                        "
-import {{ __wbg_set_wasm }} from \"./{js_name}\";
+                        "\
 {start}
-__wbg_set_wasm(wasm);
 export * from \"./{js_name}\";",
                     ),
                 )?;
@@ -712,10 +710,8 @@ export * from \"./{js_name}\";",
                 write(
                     &js_path,
                     format!(
-                        "
+                        "\
 import * as wasm from \"./{wasm_name}.wasm\";
-import {{ __wbg_set_wasm }} from \"./{js_name}\";
-__wbg_set_wasm(wasm);
 export * from \"./{js_name}\";
 {start}"
                     ),


### PR DESCRIPTION
When targeting `experimental-nodejs-module` and using `#[wasm_bindgen(start)]` attribute, current `wasm-bindgen` generates `wasm.__wbindgen_start();` statement *before* `__wbg_set_wasm` call:
```js
import { __wbg_set_wasm } from "./ej_bg.js";

let imports = {};
import * as import0 from './ej_bg.js';
imports['./ej_bg.js'] = import0;

// ... reducted... 

const wasm = wasmInstance.exports;
export const __wasm = wasm;


wasm.__wbindgen_start();

__wbg_set_wasm(wasm);
export * from "./ej_bg.js";
```

which causes runtime exception like below.

```
❯ node a/nm/ej.js
file:///tmp/ktmp/ej/a/nm/ej_bg.js:17
        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
                                                      ^

TypeError: Cannot read properties of undefined (reading 'memory')
    at getUint8ArrayMemory0 (file:///tmp/ktmp/ej/a/nm/ej_bg.js:17:55)
    at getStringFromWasm0 (file:///tmp/ktmp/ej/a/nm/ej_bg.js:24:37)
    at __wbindgen_string_new (file:///tmp/ktmp/ej/a/nm/ej_bg.js:62:17)
    at ej.wasm.wasm_bindgen::JsValue::from_str::h94d293071ebb3387 (wasm://wasm/ej.wasm-00039026:wasm-function[87]:0x7bf7)
```

This PR fixes this issue.