### PR TITLE
Guide: added and async fn call example with f64

### DIFF
--- a/guide/src/reference/js-promises-and-rust-futures.md
+++ b/guide/src/reference/js-promises-and-rust-futures.md
@@ -32,8 +32,12 @@ must be `JsValue` or no return at all:
 ```rust
 #[wasm_bindgen]
 extern "C" {
-    async fn async_func_1() -> JsValue;
+    async fn async_func_1_ret_number() -> JsValue;
     async fn async_func_2();
+}
+
+async fn get_from_js() -> f64 {
+    async_func_1_ret_number().await.as_f64().unwrap_or(0.0)
 }
 ```
 


### PR DESCRIPTION
Added a small example (3 lines) to illustrate an async function call.

In the hind sight, the guide [explains that part pretty well](https://rustwasm.github.io/wasm-bindgen/reference/js-promises-and-rust-futures.html), but there was a bit of confusion in my head and it didn't "click" until I experimented with the async for a bit.

Having an example should help others comprehend the meaning of the paragraph just above it.

I admit that I may be adding more confusion without explaining that `async_func_1_ret_number()` returns a number, e.g. `200`.
Happy to expand, but I tried to keep the change to a minimum.

Feel free to reject :)