### PR TITLE
[web-sys] Add `RTCRtpTransceiverDirection.stopped` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Unreleased
 
+### Added
+
+* Add bindings to `RTCRtpTransceiverDirection.stopped`.
+  [#4102](https://github.com/rustwasm/wasm-bindgen/pull/4102)
+
 ### Fixed
 
 * Fixed linked modules emitting snippet files when not using `--split-linked-modules`.

--- a/crates/web-sys/src/features/gen_RtcRtpTransceiverDirection.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpTransceiverDirection.rs
@@ -11,4 +11,5 @@ pub enum RtcRtpTransceiverDirection {
     Sendonly = "sendonly",
     Recvonly = "recvonly",
     Inactive = "inactive",
+    Stopped = "stopped",
 }

--- a/crates/web-sys/webidls/enabled/RTCRtpTransceiver.webidl
+++ b/crates/web-sys/webidls/enabled/RTCRtpTransceiver.webidl
@@ -11,7 +11,8 @@ enum RTCRtpTransceiverDirection {
     "sendrecv",
     "sendonly",
     "recvonly",
-    "inactive"
+    "inactive",
+    "stopped"
 };
 
 dictionary RTCRtpTransceiverInit {


### PR DESCRIPTION
Add [`stopped`](https://www.w3.org/TR/webrtc/#dom-rtcrtptransceiverdirection-stopped) variant to `RTCRtpTransceiverDirection` enum.