### PR TITLE
Enable transformations when detecting target features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 * Added bindings for the draft [WebRTC Encoded Transform](https://www.w3.org/TR/webrtc-encoded-transform) spec.
   [#4125](https://github.com/rustwasm/wasm-bindgen/pull/4125)
 
+### Changed
+
+* Implicitly enable reference type and multivalue transformations if the module already makes use of the corresponding target features.
+  [#4133](https://github.com/rustwasm/wasm-bindgen/pull/4133)
+
 ### Fixed
 
 * Fixed linked modules emitting snippet files when not using `--split-linked-modules`.

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -323,6 +323,17 @@ impl Bindgen {
                 .context("failed getting Wasm module")?,
         };
 
+        // Enable reference type transformations if the module is already using it.
+        if let Ok(true) = wasm_bindgen_wasm_conventions::target_feature(&module, "reference-types")
+        {
+            self.externref = true;
+        }
+
+        // Enable multivalue transformations if the module is already using it.
+        if let Ok(true) = wasm_bindgen_wasm_conventions::target_feature(&module, "multivalue") {
+            self.multi_value = true;
+        }
+
         // Check that no exported symbol is called "default" if we target web.
         if matches!(self.mode, OutputMode::Web)
             && module.exports.iter().any(|export| export.name == "default")


### PR DESCRIPTION
This is especially relevant for Rust v1.82, where the reference type and multivalue proposal will be enabled by default.