### PR TITLE
Add `TextDecoder.decode` to `IMMUTABLE_SLICE_WHITELIST`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 * Removed `GamepadAxisMoveEvent`, `GamepadAxisMoveEventInit`, `GamepadButtonEvent`, `GamepadButtonEventInit` and `GamepadServiceTest`, which were seemingly never implemented by any JS environment.
   [#4134](https://github.com/rustwasm/wasm-bindgen/pull/4134)
 
+* Changed `TextDecoder.decode()` `input` parameter type from `&mut [u8]` to `&[u8]`.
+  [#4141](https://github.com/rustwasm/wasm-bindgen/pull/4141)
+
 ### Fixed
 
 * Fixed linked modules emitting snippet files when not using `--split-linked-modules`.

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -6,26 +6,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-let cachedUint8ArrayMemory0 = null;
-
-function getUint8ArrayMemory0() {
-    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8ArrayMemory0;
-}
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
-}
-
 const heap = new Array(128).fill(undefined);
 
 heap.push(undefined, null, true, false);
@@ -44,6 +24,26 @@ function takeObject(idx) {
     const ret = getObject(idx);
     dropObject(idx);
     return ret;
+}
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 /**
 * @param {number} test
@@ -110,11 +110,11 @@ export function __wbg_test2_39fe629b9aa739cf() {
     return addHeapObject(ret);
 };
 
-export function __wbindgen_throw(arg0, arg1) {
-    throw new Error(getStringFromWasm0(arg0, arg1));
-};
-
 export function __wbindgen_object_drop_ref(arg0) {
     takeObject(arg0);
+};
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
 };
 

--- a/crates/web-sys/src/features/gen_TextDecoder.rs
+++ b/crates/web-sys/src/features/gen_TextDecoder.rs
@@ -74,7 +74,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TextDecoder`*"]
-    pub fn decode_with_u8_array(this: &TextDecoder, input: &mut [u8]) -> Result<String, JsValue>;
+    pub fn decode_with_u8_array(this: &TextDecoder, input: &[u8]) -> Result<String, JsValue>;
     #[cfg(feature = "TextDecodeOptions")]
     # [wasm_bindgen (catch , method , structural , js_class = "TextDecoder" , js_name = decode)]
     #[doc = "The `decode()` method."]
@@ -96,7 +96,7 @@ extern "C" {
     #[doc = "*This API requires the following crate features to be activated: `TextDecodeOptions`, `TextDecoder`*"]
     pub fn decode_with_u8_array_and_options(
         this: &TextDecoder,
-        input: &mut [u8],
+        input: &[u8],
         options: &TextDecodeOptions,
     ) -> Result<String, JsValue>;
 }

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -102,6 +102,8 @@ pub(crate) static IMMUTABLE_SLICE_WHITELIST: Lazy<BTreeSet<&'static str>> = Lazy
         "sign",
         "unwrapKey",
         "verify",
+        // TextDecoder
+        "decode",
     ])
 });
 


### PR DESCRIPTION
According to [Encoding Standard](https://encoding.spec.whatwg.org/#dom-textdecoder-decode), the input buffer is not supposed to be modified by implementations, hence the input slice do not need to be mutable.