### PR TITLE
Fix error when importing very large JS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@
 * Fixed `experimental-nodejs-module` target when used with `#[wasm_bindgen(start)]`.
   [#4093](https://github.com/rustwasm/wasm-bindgen/pull/4093)
 
+* Fixed error when importing very large JS files.
+  [#4146](https://github.com/rustwasm/wasm-bindgen/pull/4146)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.93](https://github.com/rustwasm/wasm-bindgen/compare/0.2.92...0.2.93)

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -133,11 +133,14 @@ impl TryToTokens for ast::Program {
             const _CHUNK_SLICES: [&[u8]; #chunk_len] = [
                 #(#encoded_chunks,)*
             ];
+            #[allow(long_running_const_eval)]
             const _CHUNK_LEN: usize = flat_len(_CHUNK_SLICES);
+            #[allow(long_running_const_eval)]
             const _CHUNKS: [u8; _CHUNK_LEN] = flat_byte_slices(_CHUNK_SLICES);
 
             const _LEN_BYTES: [u8; 4] = (_CHUNK_LEN as u32).to_le_bytes();
             const _ENCODED_BYTES_LEN: usize = _CHUNK_LEN + 4;
+            #[allow(long_running_const_eval)]
             const _ENCODED_BYTES: [u8; _ENCODED_BYTES_LEN] = flat_byte_slices([&_LEN_BYTES, &_CHUNKS]);
             &_ENCODED_BYTES
         });
@@ -174,6 +177,7 @@ impl TryToTokens for ast::Program {
                 const _LEN: usize = _PREFIX_JSON_BYTES_LEN + _ENCODED_BYTES_LEN;
 
                 #[link_section = "__wasm_bindgen_unstable"]
+                #[allow(long_running_const_eval)]
                 static _GENERATED: [u8; _LEN] = flat_byte_slices([_PREFIX_JSON_BYTES, _ENCODED_BYTES]);
             };
         })


### PR DESCRIPTION
[`long_running_const_eval`](https://doc.rust-lang.org/1.81.0/rustc/lints/listing/deny-by-default.html?highlight=long_running_const_eval#long-running-const-eval) is triggered when importing very large JS files via e.g. `#[wasm_bindgen(module = ...)]`.
This PR circumvents this error by just slapping `#[allow(long_running_const_eval)]` where appropriate.
Warnings are still emitted by the compiler, which I consider still a good idea, notifying the user why their compilation time has gone up.

Fixes #4115.