### PR TITLE
Improved support for string enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Added `Debug` implementation to `JsError`.
   [#4136](https://github.com/rustwasm/wasm-bindgen/pull/4136)
 
+* Added support for `js_name` and `skip_typescript` attributes for string enums.
+  [#4147](https://github.com/rustwasm/wasm-bindgen/pull/4147)
+
 ### Changed
 
 * Implicitly enable reference type and multivalue transformations if the module already makes use of the corresponding target features.
@@ -75,6 +78,9 @@
 
 * Fixed error when importing very large JS files.
   [#4146](https://github.com/rustwasm/wasm-bindgen/pull/4146)
+
+* Fixed string enums not generating TypeScript types.
+  [#4147](https://github.com/rustwasm/wasm-bindgen/pull/4147)
 
 --------------------------------------------------------------------------------
 

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -337,12 +337,18 @@ pub struct StringEnum {
     pub vis: syn::Visibility,
     /// The Rust enum's identifiers
     pub name: Ident,
+    /// The name of this string enum in JS/TS code
+    pub js_name: String,
     /// The Rust identifiers for the variants
     pub variants: Vec<Ident>,
     /// The JS string values of the variants
     pub variant_values: Vec<String>,
+    /// The doc comments on this enum, if any
+    pub comments: Vec<String>,
     /// Attributes to apply to the Rust enum
     pub rust_attrs: Vec<syn::Attribute>,
+    /// Whether to generate a typescript definition for this enum
+    pub generate_typescript: bool,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
 }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1140,7 +1140,7 @@ impl ToTokens for ast::StringEnum {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let vis = &self.vis;
         let enum_name = &self.name;
-        let name_str = enum_name.to_string();
+        let name_str = self.js_name.to_string();
         let name_len = name_str.len() as u32;
         let name_chars = name_str.chars().map(u32::from);
         let variants = &self.variants;
@@ -1167,15 +1167,6 @@ impl ToTokens for ast::StringEnum {
         let variant_paths_ref = &variant_paths;
 
         let wasm_bindgen = &self.wasm_bindgen;
-
-        let describe_variants = self.variant_values.iter().map(|variant_value| {
-            let length = variant_value.len() as u32;
-            let chars = variant_value.chars().map(u32::from);
-            quote! {
-                inform(#length);
-                #(inform(#chars);)*
-            }
-        });
 
         (quote! {
             #(#attrs)*
@@ -1253,7 +1244,6 @@ impl ToTokens for ast::StringEnum {
                     inform(#name_len);
                     #(inform(#name_chars);)*
                     inform(#variant_count);
-                    #(#describe_variants)*
                 }
             }
 

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -359,8 +359,13 @@ fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner) -> Impor
     }
 }
 
-fn shared_import_enum<'a>(_i: &'a ast::StringEnum, _intern: &'a Interner) -> StringEnum {
-    StringEnum {}
+fn shared_import_enum<'a>(i: &'a ast::StringEnum, _intern: &'a Interner) -> StringEnum<'a> {
+    StringEnum {
+        name: &i.js_name,
+        generate_typescript: i.generate_typescript,
+        variant_values: i.variant_values.iter().map(|x| &**x).collect(),
+        comments: i.comments.iter().map(|s| &**s).collect(),
+    }
 }
 
 fn shared_struct<'a>(s: &'a ast::Struct, intern: &'a Interner) -> Struct<'a> {

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -362,6 +362,7 @@ fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner) -> Impor
 fn shared_import_enum<'a>(i: &'a ast::StringEnum, _intern: &'a Interner) -> StringEnum<'a> {
     StringEnum {
         name: &i.js_name,
+        public: !matches!(i.vis, syn::Visibility::Inherited),
         generate_typescript: i.generate_typescript,
         variant_values: i.variant_values.iter().map(|x| &**x).collect(),
         comments: i.comments.iter().map(|s| &**s).collect(),

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -362,7 +362,7 @@ fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner) -> Impor
 fn shared_import_enum<'a>(i: &'a ast::StringEnum, _intern: &'a Interner) -> StringEnum<'a> {
     StringEnum {
         name: &i.js_name,
-        public: !matches!(i.vis, syn::Visibility::Inherited),
+        public: matches!(i.vis, syn::Visibility::Public(_)),
         generate_typescript: i.generate_typescript,
         variant_values: i.variant_values.iter().map(|x| &**x).collect(),
         comments: i.comments.iter().map(|s| &**s).collect(),

--- a/crates/cli-support/src/descriptor.rs
+++ b/crates/cli-support/src/descriptor.rs
@@ -76,7 +76,6 @@ pub enum Descriptor {
         name: String,
         invalid: u32,
         hole: u32,
-        variant_values: Vec<String>,
     },
     RustStruct(String),
     Char,
@@ -171,12 +170,10 @@ impl Descriptor {
                 let variant_count = get(data);
                 let invalid = variant_count;
                 let hole = variant_count + 1;
-                let variant_values = (0..variant_count).map(|_| get_string(data)).collect();
                 Descriptor::StringEnum {
                     name,
                     invalid,
                     hole,
-                    variant_values,
                 }
             }
             RUST_STRUCT => {

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -576,20 +576,11 @@ fn instruction(
     log_error: &mut bool,
     constructor: &Option<String>,
 ) -> Result<(), Error> {
-    fn wasm_to_string_enum(variant_values: &[String], index: &str) -> String {
+    fn wasm_to_string_enum(name: &str, index: &str) -> String {
         // e.g. ["a","b","c"][someIndex]
-        let mut enum_val_expr = String::new();
-        enum_val_expr.push('[');
-        for variant in variant_values {
-            enum_val_expr.push_str(&format!("\"{variant}\","));
-        }
-        enum_val_expr.push(']');
-        enum_val_expr.push('[');
-        enum_val_expr.push_str(index);
-        enum_val_expr.push(']');
-        enum_val_expr
+        format!("_{name}_values[{index}]")
     }
-    fn string_enum_to_wasm(variant_values: &[String], invalid: u32, enum_val: &str) -> String {
+    fn string_enum_to_wasm(name: &str, invalid: u32, enum_val: &str) -> String {
         // e.g. (["a","b","c"].indexOf(someEnumVal) + 1 || 4) - 1
         //                                                 |
         //                                           invalid + 1
@@ -598,16 +589,10 @@ fn instruction(
         // and with +1 we get 0 which is falsey, so we can use || to
         // substitute invalid+1. Finally, we just do -1 to get the correct
         // values for everything.
-        let mut enum_val_expr = String::new();
-        enum_val_expr.push_str("([");
-        for variant in variant_values.iter() {
-            enum_val_expr.push_str(&format!("\"{variant}\","));
-        }
-        enum_val_expr.push_str(&format!(
-            "].indexOf({enum_val}) + 1 || {invalid}) - 1",
+        format!(
+            "(_{name}_values.indexOf({enum_val}) + 1 || {invalid}) - 1",
             invalid = invalid + 1
-        ));
-        enum_val_expr
+        )
     }
 
     match instr {
@@ -702,34 +687,31 @@ fn instruction(
             }
         }
 
-        Instruction::WasmToStringEnum { variant_values } => {
+        Instruction::WasmToStringEnum { name } => {
             let index = js.pop();
-            js.push(wasm_to_string_enum(variant_values, &index))
+            js.push(wasm_to_string_enum(name, &index))
         }
 
-        Instruction::OptionWasmToStringEnum { variant_values, .. } => {
+        Instruction::OptionWasmToStringEnum { name, .. } => {
             // Since hole is currently variant_count+1 and the lookup is
             // ["a","b","c"][index], the lookup will implicitly return map
             // the hole to undefined, because OOB indexes will return undefined.
             let index = js.pop();
-            js.push(wasm_to_string_enum(variant_values, &index))
+            js.push(wasm_to_string_enum(name, &index))
         }
 
-        Instruction::StringEnumToWasm {
-            variant_values,
-            invalid,
-        } => {
+        Instruction::StringEnumToWasm { name, invalid } => {
             let enum_val = js.pop();
-            js.push(string_enum_to_wasm(variant_values, *invalid, &enum_val))
+            js.push(string_enum_to_wasm(name, *invalid, &enum_val))
         }
 
         Instruction::OptionStringEnumToWasm {
-            variant_values,
+            name,
             invalid,
             hole,
         } => {
             let enum_val = js.pop();
-            let enum_val_expr = string_enum_to_wasm(variant_values, *invalid, &enum_val);
+            let enum_val_expr = string_enum_to_wasm(name, *invalid, &enum_val);
 
             // e.g. someEnumVal == undefined ? 4 : (string_enum_to_wasm(someEnumVal))
             //                  |

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -578,7 +578,7 @@ fn instruction(
 ) -> Result<(), Error> {
     fn wasm_to_string_enum(name: &str, index: &str) -> String {
         // e.g. ["a","b","c"][someIndex]
-        format!("_{name}_values[{index}]")
+        format!("__wbindgen_enum_{name}[{index}]")
     }
     fn string_enum_to_wasm(name: &str, invalid: u32, enum_val: &str) -> String {
         // e.g. (["a","b","c"].indexOf(someEnumVal) + 1 || 4) - 1
@@ -590,7 +590,7 @@ fn instruction(
         // substitute invalid+1. Finally, we just do -1 to get the correct
         // values for everything.
         format!(
-            "(_{name}_values.indexOf({enum_val}) + 1 || {invalid}) - 1",
+            "(__wbindgen_enum_{name}.indexOf({enum_val}) + 1 || {invalid}) - 1",
             invalid = invalid + 1
         )
     }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3839,7 +3839,7 @@ __wbg_set_wasm(wasm);"
         }
 
         self.global(&format!(
-            "const _{name}_values = [{values}];\n",
+            "const __wbindgen_enum_{name} = [{values}];\n",
             name = string_enum.name,
             values = variants.join(", ")
         ));

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3822,8 +3822,12 @@ __wbg_set_wasm(wasm);"
 
         if string_enum.generate_typescript {
             self.typescript.push_str(&docs);
-            self.typescript
-                .push_str(&format!("export type {} = ", string_enum.name));
+            if string_enum.public {
+                self.typescript.push_str("export ");
+            }
+            self.typescript.push_str("type ");
+            self.typescript.push_str(&string_enum.name);
+            self.typescript.push_str(" = ");
 
             if variants.is_empty() {
                 self.typescript.push_str("never");

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -108,11 +108,11 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::I32],
                 );
             },
-            Descriptor::StringEnum { name, variant_values, invalid, .. } => {
+            Descriptor::StringEnum { name, invalid, .. } => {
                 self.instruction(
                     &[AdapterType::StringEnum(name.clone())],
                     Instruction::StringEnumToWasm {
-                        variant_values: variant_values.clone(),
+                        name: name.clone(),
                         invalid: *invalid,
                     },
                     &[AdapterType::I32],
@@ -308,14 +308,13 @@ impl InstructionBuilder<'_, '_> {
             }
             Descriptor::StringEnum {
                 name,
-                variant_values,
                 invalid,
                 hole,
             } => {
                 self.instruction(
                     &[AdapterType::StringEnum(name.clone()).option()],
                     Instruction::OptionStringEnumToWasm {
-                        variant_values: variant_values.clone(),
+                        name: name.clone(),
                         invalid: *invalid,
                         hole: *hole,
                     },

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -573,7 +573,7 @@ impl<'a> Context<'a> {
             decode::ImportKind::Static(s) => self.import_static(&import, s),
             decode::ImportKind::String(s) => self.import_string(s),
             decode::ImportKind::Type(t) => self.import_type(&import, t),
-            decode::ImportKind::Enum(_) => Ok(()),
+            decode::ImportKind::Enum(e) => self.string_enum(e),
         }
     }
 
@@ -863,6 +863,32 @@ impl<'a> Context<'a> {
             .import_map
             .insert(id, AuxImport::Instanceof(import));
         Ok(())
+    }
+
+    fn string_enum(&mut self, string_enum: &decode::StringEnum<'_>) -> Result<(), Error> {
+        let aux = AuxStringEnum {
+            name: string_enum.name.to_string(),
+            comments: concatenate_comments(&string_enum.comments),
+            variant_values: string_enum
+                .variant_values
+                .iter()
+                .map(|v| v.to_string())
+                .collect(),
+            generate_typescript: string_enum.generate_typescript,
+        };
+        let mut result = Ok(());
+        self.aux
+            .string_enums
+            .entry(aux.name.clone())
+            .and_modify(|existing| {
+                result = Err(anyhow!(
+                    "duplicate string enums:\n{:?}\n{:?}",
+                    existing,
+                    aux
+                ));
+            })
+            .or_insert(aux);
+        result
     }
 
     fn enum_(&mut self, enum_: decode::Enum<'_>) -> Result<(), Error> {

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -868,6 +868,7 @@ impl<'a> Context<'a> {
     fn string_enum(&mut self, string_enum: &decode::StringEnum<'_>) -> Result<(), Error> {
         let aux = AuxStringEnum {
             name: string_enum.name.to_string(),
+            public: string_enum.public,
             comments: concatenate_comments(&string_enum.comments),
             variant_values: string_enum
                 .variant_values

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -42,6 +42,9 @@ pub struct WasmBindgenAux {
     /// Auxiliary information to go into JS/TypeScript bindings describing the
     /// exported enums from Rust.
     pub enums: HashMap<String, AuxEnum>,
+    /// Auxiliary information to go into JS/TypeScript bindings describing the
+    /// exported string enums from Rust.
+    pub string_enums: HashMap<String, AuxStringEnum>,
 
     /// Auxiliary information to go into JS/TypeScript bindings describing the
     /// exported structs from Rust and their fields they've got exported.
@@ -168,6 +171,18 @@ pub struct AuxEnum {
     /// A list of variants with their name, value and comments
     /// and whether typescript bindings should be generated for each variant
     pub variants: Vec<(String, u32, String)>,
+    /// Whether typescript bindings should be generated for this enum.
+    pub generate_typescript: bool,
+}
+
+#[derive(Debug)]
+pub struct AuxStringEnum {
+    /// The name of this enum
+    pub name: String,
+    /// The copied Rust comments to forward to JS
+    pub comments: String,
+    /// A list of variants values
+    pub variant_values: Vec<String>,
     /// Whether typescript bindings should be generated for this enum.
     pub generate_typescript: bool,
 }

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -179,6 +179,8 @@ pub struct AuxEnum {
 pub struct AuxStringEnum {
     /// The name of this enum
     pub name: String,
+    /// Whether this enum is public
+    pub public: bool,
     /// The copied Rust comments to forward to JS
     pub comments: String,
     /// A list of variants values

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -74,12 +74,7 @@ impl InstructionBuilder<'_, '_> {
                 self.output.push(AdapterType::F64);
             }
             Descriptor::Enum { name, .. } => self.outgoing_i32(AdapterType::Enum(name.clone())),
-            Descriptor::StringEnum {
-                name,
-                variant_values,
-                invalid: _,
-                hole: _,
-            } => self.outgoing_string_enum(name, variant_values),
+            Descriptor::StringEnum { name, .. } => self.outgoing_string_enum(name),
 
             Descriptor::Char => {
                 self.instruction(
@@ -293,16 +288,11 @@ impl InstructionBuilder<'_, '_> {
                     &[AdapterType::Enum(name.clone()).option()],
                 );
             }
-            Descriptor::StringEnum {
-                name,
-                invalid: _,
-                hole,
-                variant_values,
-            } => {
+            Descriptor::StringEnum { name, hole, .. } => {
                 self.instruction(
                     &[AdapterType::I32],
                     Instruction::OptionWasmToStringEnum {
-                        variant_values: variant_values.to_vec(),
+                        name: name.clone(),
                         hole: *hole,
                     },
                     &[AdapterType::StringEnum(String::from(name)).option()],
@@ -542,11 +532,11 @@ impl InstructionBuilder<'_, '_> {
         self.instruction(&[AdapterType::I32], instr, &[output]);
     }
 
-    fn outgoing_string_enum(&mut self, name: &str, variant_values: &[String]) {
+    fn outgoing_string_enum(&mut self, name: &str) {
         self.instruction(
             &[AdapterType::I32],
             Instruction::WasmToStringEnum {
-                variant_values: variant_values.to_vec(),
+                name: name.to_string(),
             },
             &[AdapterType::StringEnum(String::from(name))],
         );

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -143,22 +143,22 @@ pub enum Instruction {
 
     /// Pops a Wasm `i32` and pushes the enum variant as a string
     WasmToStringEnum {
-        variant_values: Vec<String>,
+        name: String,
     },
 
     OptionWasmToStringEnum {
-        variant_values: Vec<String>,
+        name: String,
         hole: u32,
     },
 
     /// pops a string and pushes the enum variant as an `i32`
     StringEnumToWasm {
-        variant_values: Vec<String>,
+        name: String,
         invalid: u32,
     },
 
     OptionStringEnumToWasm {
-        variant_values: Vec<String>,
+        name: String,
         invalid: u32,
         hole: u32,
     },

--- a/crates/cli/tests/reference/enums.d.ts
+++ b/crates/cli/tests/reference/enums.d.ts
@@ -20,8 +20,19 @@ export function get_name(color: Color): ColorName;
  * @returns {ColorName | undefined}
  */
 export function option_string_enum_echo(color?: ColorName): ColorName | undefined;
+/**
+ * A color.
+ */
 export enum Color {
   Green = 0,
   Yellow = 1,
   Red = 2,
 }
+/**
+ * The name of a color.
+ */
+export type ColorName = "green" | "yellow" | "red";
+/**
+ * An unused string enum.
+ */
+export type FooBar = "foo" | "bar";

--- a/crates/cli/tests/reference/enums.d.ts
+++ b/crates/cli/tests/reference/enums.d.ts
@@ -36,3 +36,4 @@ export type ColorName = "green" | "yellow" | "red";
  * An unused string enum.
  */
 export type FooBar = "foo" | "bar";
+type PrivateStringEnum = "foo" | "bar";

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -71,6 +71,8 @@ const _ColorName_values = ["green", "yellow", "red"];
 
 const _FooBar_values = ["foo", "bar"];
 
+const _PrivateStringEnum_values = ["foo", "bar"];
+
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
 };

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -50,7 +50,7 @@ export function option_enum_echo(color) {
  */
 export function get_name(color) {
     const ret = wasm.get_name(color);
-    return _ColorName_values[ret];
+    return __wbindgen_enum_ColorName[ret];
 }
 
 /**
@@ -58,8 +58,8 @@ export function get_name(color) {
  * @returns {ColorName | undefined}
  */
 export function option_string_enum_echo(color) {
-    const ret = wasm.option_string_enum_echo(color == undefined ? 4 : ((_ColorName_values.indexOf(color) + 1 || 4) - 1));
-    return _ColorName_values[ret];
+    const ret = wasm.option_string_enum_echo(color == undefined ? 4 : ((__wbindgen_enum_ColorName.indexOf(color) + 1 || 4) - 1));
+    return __wbindgen_enum_ColorName[ret];
 }
 
 /**
@@ -67,11 +67,11 @@ export function option_string_enum_echo(color) {
  */
 export const Color = Object.freeze({ Green:0,"0":"Green",Yellow:1,"1":"Yellow",Red:2,"2":"Red", });
 
-const _ColorName_values = ["green", "yellow", "red"];
+const __wbindgen_enum_ColorName = ["green", "yellow", "red"];
 
-const _FooBar_values = ["foo", "bar"];
+const __wbindgen_enum_FooBar = ["foo", "bar"];
 
-const _PrivateStringEnum_values = ["foo", "bar"];
+const __wbindgen_enum_PrivateStringEnum = ["foo", "bar"];
 
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -50,7 +50,7 @@ export function option_enum_echo(color) {
  */
 export function get_name(color) {
     const ret = wasm.get_name(color);
-    return ["green","yellow","red",][ret];
+    return _ColorName_values[ret];
 }
 
 /**
@@ -58,11 +58,18 @@ export function get_name(color) {
  * @returns {ColorName | undefined}
  */
 export function option_string_enum_echo(color) {
-    const ret = wasm.option_string_enum_echo(color == undefined ? 4 : ((["green","yellow","red",].indexOf(color) + 1 || 4) - 1));
-    return ["green","yellow","red",][ret];
+    const ret = wasm.option_string_enum_echo(color == undefined ? 4 : ((_ColorName_values.indexOf(color) + 1 || 4) - 1));
+    return _ColorName_values[ret];
 }
 
+/**
+ * A color.
+ */
 export const Color = Object.freeze({ Green:0,"0":"Green",Yellow:1,"1":"Yellow",Red:2,"2":"Red", });
+
+const _ColorName_values = ["green", "yellow", "red"];
+
+const _FooBar_values = ["foo", "bar"];
 
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));

--- a/crates/cli/tests/reference/enums.rs
+++ b/crates/cli/tests/reference/enums.rs
@@ -1,5 +1,6 @@
 use wasm_bindgen::prelude::*;
 
+/// A color.
 #[wasm_bindgen]
 #[derive(PartialEq, Debug)]
 pub enum Color {
@@ -18,6 +19,7 @@ pub fn option_enum_echo(color: Option<Color>) -> Option<Color> {
     color
 }
 
+/// The name of a color.
 #[wasm_bindgen]
 #[derive(PartialEq, Debug)]
 pub enum ColorName {
@@ -38,4 +40,12 @@ pub fn get_name(color: Color) -> ColorName {
 #[wasm_bindgen]
 pub fn option_string_enum_echo(color: Option<ColorName>) -> Option<ColorName> {
     color
+}
+
+/// An unused string enum.
+#[wasm_bindgen(js_name = "FooBar")]
+#[derive(PartialEq, Debug)]
+pub enum UnusedStringEnum {
+    Foo = "foo",
+    Bar = "bar",
 }

--- a/crates/cli/tests/reference/enums.rs
+++ b/crates/cli/tests/reference/enums.rs
@@ -49,3 +49,10 @@ pub enum UnusedStringEnum {
     Foo = "foo",
     Bar = "bar",
 }
+
+#[wasm_bindgen]
+#[derive(PartialEq, Debug)]
+enum PrivateStringEnum {
+    Foo = "foo",
+    Bar = "bar",
+}

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -6,26 +6,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-let cachedUint8ArrayMemory0 = null;
-
-function getUint8ArrayMemory0() {
-    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8ArrayMemory0;
-}
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
-}
-
 const heap = new Array(128).fill(undefined);
 
 heap.push(undefined, null, true, false);
@@ -44,6 +24,26 @@ function takeObject(idx) {
     const ret = getObject(idx);
     dropObject(idx);
     return ret;
+}
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 /**
  * @param {number} test
@@ -104,16 +104,16 @@ export class Test {
     }
 }
 
+export function __wbg_test2_39fe629b9aa739cf() {
+    const ret = test2();
+    return addHeapObject(ret);
+};
+
 export function __wbindgen_object_drop_ref(arg0) {
     takeObject(arg0);
 };
 
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
-};
-
-export function __wbg_test2_39fe629b9aa739cf() {
-    const ret = test2();
-    return addHeapObject(ret);
 };
 

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -6,26 +6,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const heap = new Array(128).fill(undefined);
-
-heap.push(undefined, null, true, false);
-
-function getObject(idx) { return heap[idx]; }
-
-let heap_next = heap.length;
-
-function dropObject(idx) {
-    if (idx < 132) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
-}
-
-function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
-}
-
 const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
@@ -44,6 +24,26 @@ function getUint8ArrayMemory0() {
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) { return heap[idx]; }
+
+let heap_next = heap.length;
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
 }
 /**
  * @param {number} test
@@ -109,11 +109,11 @@ export function __wbg_test2_39fe629b9aa739cf() {
     return addHeapObject(ret);
 };
 
-export function __wbindgen_object_drop_ref(arg0) {
-    takeObject(arg0);
-};
-
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
+};
+
+export function __wbindgen_object_drop_ref(arg0) {
+    takeObject(arg0);
 };
 

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1314,15 +1314,10 @@ fn string_enum(
     let mut variant_values = vec![];
 
     for v in enum_.variants.iter() {
-        match v.fields {
-            syn::Fields::Unit => (),
-            _ => bail_span!(v.fields, "only C-Style enums allowed with #[wasm_bindgen]"),
-        }
-
         let (_, expr) = match &v.discriminant {
             Some(pair) => pair,
             None => {
-                bail_span!(v, "all variants must have a value");
+                bail_span!(v, "all variants of a string enum must have a string value");
             }
         };
         match get_expr(expr) {
@@ -1368,6 +1363,16 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
         if self.variants.is_empty() {
             bail_span!(self, "cannot export empty enums to JS");
         }
+        for variant in self.variants.iter() {
+            match variant.fields {
+                syn::Fields::Unit => (),
+                _ => bail_span!(
+                    variant.fields,
+                    "enum variants with associated data are not supported with #[wasm_bindgen]"
+                ),
+            }
+        }
+
         let generate_typescript = opts.skip_typescript().is_none();
         let js_name = opts
             .js_name()
@@ -1377,15 +1382,21 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
 
         opts.check_used();
 
-        // Check if the first value is a string literal
-        if let Some((_, expr)) = &self.variants[0].discriminant {
-            if let syn::Expr::Lit(syn::ExprLit {
-                lit: syn::Lit::Str(_),
-                ..
-            }) = get_expr(expr)
-            {
-                return string_enum(self, program, js_name, generate_typescript, comments);
+        // Check if the enum is a string enum, by checking whether any variant has a string discriminant.
+        let is_string_enum = self.variants.iter().any(|v| {
+            if let Some((_, expr)) = &v.discriminant {
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(_),
+                    ..
+                }) = get_expr(expr)
+                {
+                    return true;
+                }
             }
+            false
+        });
+        if is_string_enum {
+            return string_enum(self, program, js_name, generate_typescript, comments);
         }
 
         let has_discriminant = self.variants[0].discriminant.is_some();
@@ -1400,11 +1411,6 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
             .iter()
             .enumerate()
             .map(|(i, v)| {
-                match v.fields {
-                    syn::Fields::Unit => (),
-                    _ => bail_span!(v.fields, "only C-Style enums allowed with #[wasm_bindgen]"),
-                }
-
                 // Require that everything either has a discriminant or doesn't.
                 // We don't really want to get in the business of emulating how
                 // rustc assigns values to enums.
@@ -1425,14 +1431,14 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
                             Err(_) => {
                                 bail_span!(
                                     int_lit,
-                                    "enums with #[wasm_bindgen] can only support \
+                                    "C-style enums with #[wasm_bindgen] can only support \
                                  numbers that can be represented as u32"
                                 );
                             }
                         },
                         expr => bail_span!(
                             expr,
-                            "enums with #[wasm_bindgen] may only have \
+                            "C-style enums with #[wasm_bindgen] may only have \
                              number literal values",
                         ),
                     },

--- a/crates/macro/ui-tests/invalid-enums.rs
+++ b/crates/macro/ui-tests/invalid-enums.rs
@@ -18,4 +18,23 @@ pub enum D {
     X = 4294967296,
 }
 
+#[wasm_bindgen]
+pub enum E {
+    A = 1,
+    B = "foo",
+}
+
+#[wasm_bindgen]
+pub enum F {
+    A = "foo",
+    B = 1,
+}
+
+#[wasm_bindgen]
+enum G {
+    A = "foo",
+    B = "bar",
+    C,
+}
+
 fn main() {}

--- a/crates/macro/ui-tests/invalid-enums.stderr
+++ b/crates/macro/ui-tests/invalid-enums.stderr
@@ -1,23 +1,41 @@
 error: cannot export empty enums to JS
- --> $DIR/invalid-enums.rs:4:1
+ --> ui-tests/invalid-enums.rs:4:1
   |
 4 | enum A {}
   | ^^^^^^^^^
 
-error: only C-Style enums allowed with #[wasm_bindgen]
- --> $DIR/invalid-enums.rs:8:6
+error: enum variants with associated data are not supported with #[wasm_bindgen]
+ --> ui-tests/invalid-enums.rs:8:6
   |
 8 |     D(u32),
   |      ^^^^^
 
-error: enums with #[wasm_bindgen] may only have number literal values
-  --> $DIR/invalid-enums.rs:13:9
+error: C-style enums with #[wasm_bindgen] may only have number literal values
+  --> ui-tests/invalid-enums.rs:13:9
    |
 13 |     X = 1 + 3,
    |         ^^^^^
 
-error: enums with #[wasm_bindgen] can only support numbers that can be represented as u32
-  --> $DIR/invalid-enums.rs:18:9
+error: C-style enums with #[wasm_bindgen] can only support numbers that can be represented as u32
+  --> ui-tests/invalid-enums.rs:18:9
    |
 18 |     X = 4294967296,
    |         ^^^^^^^^^^
+
+error: enums with #[wasm_bindgen] cannot mix string and non-string values
+  --> ui-tests/invalid-enums.rs:23:9
+   |
+23 |     A = 1,
+   |         ^
+
+error: enums with #[wasm_bindgen] cannot mix string and non-string values
+  --> ui-tests/invalid-enums.rs:30:9
+   |
+30 |     B = 1,
+   |         ^
+
+error: all variants of a string enum must have a string value
+  --> ui-tests/invalid-enums.rs:37:5
+   |
+37 |     C,
+   |     ^

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -106,6 +106,7 @@ macro_rules! shared_api {
 
         struct StringEnum<'a> {
             name: &'a str,
+            public: bool,
             variant_values: Vec<&'a str>,
             comments: Vec<&'a str>,
             generate_typescript: bool,

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -51,7 +51,7 @@ macro_rules! shared_api {
             Static(ImportStatic<'a>),
             String(ImportString<'a>),
             Type(ImportType<'a>),
-            Enum(StringEnum),
+            Enum(StringEnum<'a>),
         }
 
         struct ImportFunction<'a> {
@@ -104,7 +104,12 @@ macro_rules! shared_api {
             vendor_prefixes: Vec<&'a str>,
         }
 
-        struct StringEnum {}
+        struct StringEnum<'a> {
+            name: &'a str,
+            variant_values: Vec<&'a str>,
+            comments: Vec<&'a str>,
+            generate_typescript: bool,
+        }
 
         struct Export<'a> {
             class: Option<&'a str>,

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "9336383503182818021";
+const APPROVED_SCHEMA_FILE_HASH: &str = "17362973054744490747";
 
 #[test]
 fn schema_version() {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "17362973054744490747";
+const APPROVED_SCHEMA_FILE_HASH: &str = "9179028021460341559";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
Another string enum PR.

fixes #2153
fixes #3057

Changes:
1. Fixed #2153. Typescript types are now generated for string enums.
2. String enums now support the `skip_typescript` and `js_name` options, just like C-style enums.
3. Bindings now generate a non-exported array for the string enum variants and reference the array when converting to and from WASM.
4. Improved error messages. This together with 1. fixes #3057.

Everything (except `skip_typescript`) is tested in `crates/cli/tests/reference/enums.rs`.

### 1. Typescript types

String enums now generate TS types. Example:

```rs
/// The name of a color.
#[wasm_bindgen]
#[derive(PartialEq, Debug)]
pub enum ColorName {
    Green = "green",
    Yellow = "yellow",
    Red = "red",
}
```
```ts
/**
 * The name of a color.
 */
export type ColorName = "green" | "yellow" | "red";
```

I used a union type of string literal to represent the fact that there is no exported object on the JS side.

A [`const enum`](https://www.typescriptlang.org/docs/handbook/enums.html#const-enums) also would have been possible. In fact, this would have been the better option in a way, because it would allow users to use string enums just like regular enums, e.g. `ColorName.Green`. However, `const enum`s do not allow using string literals directly (e.g. `const _: ColorName = "green"` does not type check), and because `const enum`s are **not** supported by some bundlers.

### 2. `js_name` and `skip_typescript`

My goal was to make string enums and C-style enums are similar as possible, so I added support for these 2 attributes while I was at it. (In general, the code handling the implementation of string enums and C-style enums is now quite similar. Maybe it could be more unified in the future, but maybe that goes too far.)

`skip_typescript` is important to support, since users might have worked around the lack of string enum types with `typescript_custom_section` before (e.g. I did that in my project). While most of these custom type defs can be removed now, some users may wish to keep their types, and this option allows them to do so.

`js_name` is here for consistency and because it's useful.

### 3. Bindings

Instead of creating an array with all string enum variants for each conversion, I changed the bindings to create one global array. So instead of `["a", "b", "c"][index]` for each conversion, it now generates `_StringEnum_values[index]`.

I used `_{name}_values` as the name of the constant, because I wanted to avoid name collisions. I wasn't sure what the best way of doing this is, so I just made up a naming scheme that I feel is unlikely to be used by WASM bindgen users.

### 4. Improved error messages

As pointed out in #3057, the error messages for mixed string-and-C-style enums were not ideal. 

I fixed this by changing how string enums are detected. Now, when an enum contains one variant with a string discriminate, it's assumed to be a string enum. This makes it easier to give relevant error messages.

I also changed a few enum error messages that make it sound like *only* C-style enums are supported.