### PR TITLE
Add `wasm_bindgen_test(unsupported = test)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 * Added support for `js_name` and `skip_typescript` attributes for string enums.
   [#4147](https://github.com/rustwasm/wasm-bindgen/pull/4147)
 
+* Added `unsupported` crate to `wasm_bindgen_test(unsupported = test)` as a way of running tests on non-Wasm targets as well.
+  [#4150](https://github.com/rustwasm/wasm-bindgen/pull/4150)
+
 ### Changed
 
 * Implicitly enable reference type and multivalue transformations if the module already makes use of the corresponding target features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,13 @@ serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.93" }
 
+[dev-dependencies]
+wasm-bindgen-test = { path = 'crates/test' }
+
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 js-sys = { path = 'crates/js-sys' }
 serde_derive = "1.0"
 wasm-bindgen-futures = { path = 'crates/futures' }
-wasm-bindgen-test = { path = 'crates/test' }
 wasm-bindgen-test-crate-a = { path = 'tests/crates/a' }
 wasm-bindgen-test-crate-b = { path = 'tests/crates/b' }
 

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -23,6 +23,7 @@ syn = { version = "2.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["macros"] }
 trybuild = "1.0"
 wasm-bindgen-test = { path = "../test" }
 

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -120,6 +120,10 @@ pub fn wasm_bindgen_test(
         },
     );
 
+    if let Some(path) = attributes.unsupported {
+        tokens.extend(quote! { #[#path] });
+    }
+
     tokens.extend(leading_tokens);
     tokens.push(ident.into());
     tokens.extend(body);
@@ -281,6 +285,7 @@ fn compile_error(span: Span, msg: &str) -> proc_macro::TokenStream {
 struct Attributes {
     r#async: bool,
     wasm_bindgen_path: syn::Path,
+    unsupported: Option<syn::Meta>,
 }
 
 impl Default for Attributes {
@@ -288,6 +293,7 @@ impl Default for Attributes {
         Self {
             r#async: false,
             wasm_bindgen_path: syn::parse_quote!(::wasm_bindgen_test),
+            unsupported: None,
         }
     }
 }
@@ -298,6 +304,8 @@ impl Attributes {
             self.r#async = true;
         } else if meta.path.is_ident("crate") {
             self.wasm_bindgen_path = meta.value()?.parse::<syn::Path>()?;
+        } else if meta.path.is_ident("unsupported") {
+            self.unsupported = Some(meta.value()?.parse::<syn::Meta>()?);
         } else {
             return Err(meta.error("unknown attribute"));
         }

--- a/crates/test-macro/ui-tests/crate.rs
+++ b/crates/test-macro/ui-tests/crate.rs
@@ -17,4 +17,7 @@ fn success_2() {}
 #[wasm_bindgen_test(crate = foo)]
 fn failure_1() {}
 
+#[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+fn success_3() {}
+
 fn main() {}

--- a/guide/src/wasm-bindgen-test/usage.md
+++ b/guide/src/wasm-bindgen-test/usage.md
@@ -27,6 +27,13 @@ fn pass() {
 fn fail() {
     assert_eq!(1, 2);
 }
+
+// On a target other then `wasm32-unknown-unknown`, the `#[test]` attribute
+// will be used instead, allowing this test to run on any target.
+#[wasm_bindgen_test(unsupported = test)]
+fn all_targets() {
+    assert_eq!(1, 2);
+}
 ```
 
 Writing tests is the same as normal Rust `#[test]`s, except we are using the

--- a/tests/non_wasm_test.rs
+++ b/tests/non_wasm_test.rs
@@ -1,0 +1,25 @@
+#![cfg(not(target_family = "wasm"))]
+
+use std::sync::{Arc, Condvar, Mutex};
+
+use once_cell::sync::Lazy;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+static TEST: Lazy<Arc<(Mutex<bool>, Condvar)>> =
+    Lazy::new(|| Arc::new((Mutex::new(false), Condvar::new())));
+
+#[wasm_bindgen_test(unsupported = test)]
+fn test_success() {
+    let mut success = TEST.0.lock().unwrap();
+    *success = true;
+    // We notify the condvar that the value has changed.
+    TEST.1.notify_one();
+}
+
+#[test]
+fn test() {
+    let mut success = TEST.0.lock().unwrap();
+    while !*success {
+        success = TEST.1.wait(success).unwrap();
+    }
+}


### PR DESCRIPTION
This allows tests to be run with user defined attributes on other targets then `wasm32-unknown-unknown`.
E.g. `#[wasm_bindgen_test(unsupported = tokio::test)]` would work as well for async functions.

Fixes #4139.