### PR TITLE
Fix `wasm_bindgen_test(unsupported = test)`

### DIFF
--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -23,7 +23,7 @@ syn = { version = "2.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trybuild = "1.0"
 wasm-bindgen-test = { path = "../test" }
 

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -112,6 +112,7 @@ pub fn wasm_bindgen_test(
     tokens.extend(
         quote! {
             #[no_mangle]
+            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
             #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
             pub extern "C" fn #name(cx: &#wasm_bindgen_path::__rt::Context) {
                 let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
@@ -121,7 +122,9 @@ pub fn wasm_bindgen_test(
     );
 
     if let Some(path) = attributes.unsupported {
-        tokens.extend(quote! { #[#path] });
+        tokens.extend(
+            quote! { #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), #path)] },
+        );
     }
 
     tokens.extend(leading_tokens);

--- a/crates/test-macro/ui-tests/crate.rs
+++ b/crates/test-macro/ui-tests/crate.rs
@@ -14,10 +14,7 @@ fn success_1() {}
 #[wasm_bindgen_test(crate = crate::wasm::test)]
 fn success_2() {}
 
-#[wasm_bindgen_test(crate = foo)]
+#[wasm_bindgen_test(crate(foo))]
 fn failure_1() {}
-
-#[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
-fn success_3() {}
 
 fn main() {}

--- a/crates/test-macro/ui-tests/crate.stderr
+++ b/crates/test-macro/ui-tests/crate.stderr
@@ -1,10 +1,5 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
-  --> ui-tests/crate.rs:17:29
+error: expected `=`
+  --> ui-tests/crate.rs:17:26
    |
-17 | #[wasm_bindgen_test(crate = foo)]
-   |                             ^^^ use of undeclared crate or module `foo`
-   |
-help: consider importing this module
-   |
-5  + use wasm_bindgen_test::__rt;
-   |
+17 | #[wasm_bindgen_test(crate(foo))]
+   |                          ^

--- a/crates/test-macro/ui-tests/unsupported.rs
+++ b/crates/test-macro/ui-tests/unsupported.rs
@@ -1,0 +1,17 @@
+#![no_implicit_prelude]
+
+extern crate wasm_bindgen_test_macro;
+extern crate tokio;
+//
+use wasm_bindgen_test_macro::wasm_bindgen_test;
+
+#[wasm_bindgen_test(unsupported = tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn success() {}
+
+#[wasm_bindgen_test(unsupported)]
+fn failure_1() {}
+
+#[wasm_bindgen_test(unsupported(test))]
+fn failure_2() {}
+
+fn main() {}

--- a/crates/test-macro/ui-tests/unsupported.stderr
+++ b/crates/test-macro/ui-tests/unsupported.stderr
@@ -1,0 +1,13 @@
+error: expected `=`
+  --> ui-tests/unsupported.rs:11:1
+   |
+11 | #[wasm_bindgen_test(unsupported)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `wasm_bindgen_test` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected `=`
+  --> ui-tests/unsupported.rs:14:32
+   |
+14 | #[wasm_bindgen_test(unsupported(test))]
+   |                                ^


### PR DESCRIPTION
The CI in the last PR #4150 didn't actually run, it was queued and the GitHub UI instead showed success.