### PR TITLE
Properly indent the doc comments of enum variants

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3794,7 +3794,11 @@ __wbg_set_wasm(wasm);"
             if enum_.generate_typescript {
                 self.typescript.push('\n');
                 if !variant_docs.is_empty() {
-                    self.typescript.push_str(&variant_docs);
+                    for line in variant_docs.lines() {
+                        self.typescript.push_str("  ");
+                        self.typescript.push_str(line);
+                        self.typescript.push('\n');
+                    }
                 }
                 self.typescript.push_str(&format!("  {name} = {value},"));
             }

--- a/crates/cli/tests/reference/enums.d.ts
+++ b/crates/cli/tests/reference/enums.d.ts
@@ -24,8 +24,17 @@ export function option_string_enum_echo(color?: ColorName): ColorName | undefine
  * A color.
  */
 export enum Color {
+  /**
+   * Green as a leaf.
+   */
   Green = 0,
+  /**
+   * Yellow as the sun.
+   */
   Yellow = 1,
+  /**
+   * Red as a rose.
+   */
   Red = 2,
 }
 /**

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -65,7 +65,19 @@ export function option_string_enum_echo(color) {
 /**
  * A color.
  */
-export const Color = Object.freeze({ Green:0,"0":"Green",Yellow:1,"1":"Yellow",Red:2,"2":"Red", });
+export const Color = Object.freeze({
+/**
+ * Green as a leaf.
+ */
+Green:0,"0":"Green",
+/**
+ * Yellow as the sun.
+ */
+Yellow:1,"1":"Yellow",
+/**
+ * Red as a rose.
+ */
+Red:2,"2":"Red", });
 
 const __wbindgen_enum_ColorName = ["green", "yellow", "red"];
 

--- a/crates/cli/tests/reference/enums.rs
+++ b/crates/cli/tests/reference/enums.rs
@@ -4,8 +4,11 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 #[derive(PartialEq, Debug)]
 pub enum Color {
+    /// Green as a leaf.
     Green,
+    /// Yellow as the sun.
     Yellow,
+    /// Red as a rose.
     Red,
 }
 


### PR DESCRIPTION
Very small PR. The doc comments of enum variants weren't indented properly in `.d.ts` files. This PR fixes that.

The enum objects in `.js` aren't formatted sensibly with comments anyway, so I just left it as is.