### PR TITLE
wasm-bindgen-test-macro: fix wasm64 support

### DIFF
--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -123,7 +123,7 @@ pub fn wasm_bindgen_test(
 
     if let Some(path) = attributes.unsupported {
         tokens.extend(
-            quote! { #[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), #path)] },
+            quote! { #[cfg_attr(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")), #path)] },
         );
     }
 


### PR DESCRIPTION
Closes #4161