### PR TITLE
Reintroduce reading snippets and modules in `cli-support`

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -616,6 +616,14 @@ impl Output {
         self.generated.start.as_ref()
     }
 
+    pub fn snippets(&self) -> &HashMap<String, Vec<String>> {
+        &self.generated.snippets
+    }
+
+    pub fn local_modules(&self) -> &HashMap<String, String> {
+        &self.generated.local_modules
+    }
+
     pub fn npm_dependencies(&self) -> &HashMap<String, (PathBuf, String)> {
         &self.generated.npm_dependencies
     }


### PR DESCRIPTION
Previously removed in #4066.
As noted before: this is an internal API and therefore unstable.

Fixes #4159.