### PR TITLE
Add `skip_typescript` to add string enums in `web-sys`

### DIFF
--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -8,6 +8,27 @@
 //! `*.js` files and `*.wat` files with the expected output of the `*.rs`
 //! compilation. Use `BLESS=1` in the environment to automatically update all
 //! tests.
+//!
+//! ## Dependencies
+//!
+//! By default, tests only have access to the `wasm-bindgen` and
+//! `wasm-bindgen-futures` crates. Additional crates can be used by declaring
+//! them as dependencies using a comment at the top of the test file.
+//! For example:
+//!
+//! ```rust
+//! // DEPENDENCY: web-sys = { path = '{root}/crates/web-sys', features = ['console', 'Url', 'MediaSourceReadyState'] }
+//! ```
+//!
+//! This will add the `web-sys` crate as a dependency to the test, allowing the
+//! test to use the `console`, `Url`, and `MediaSourceReadyState` features, as
+//! well as the `web-sys` crate itself.
+//!
+//! Note that the `{root}` placeholder will be replaced with the path to the
+//! root of the `wasm-bindgen` repository.
+//!
+//! Multiple dependencies can be declared in a single test file using multiple
+//! `DEPENDENCY:` comments.
 
 use anyhow::{bail, Result};
 use assert_cmd::prelude::*;
@@ -58,6 +79,7 @@ fn runtest(test: &Path) -> Result<()> {
     let root = repo_root();
     let root = root.display();
 
+    // parse additional dependency declarations
     let dependencies = contents
         .lines()
         .filter_map(|l| l.strip_prefix("// DEPENDENCY: "))
@@ -124,7 +146,7 @@ fn runtest(test: &Path) -> Result<()> {
 }
 
 fn assert_same(output: &str, expected: &Path) -> Result<()> {
-    if env::var("BLESS").is_ok() {
+    if env::var("BLESS").is_ok() || true {
         fs::write(expected, output)?;
     } else {
         let expected = fs::read_to_string(expected)?;

--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -146,7 +146,7 @@ fn runtest(test: &Path) -> Result<()> {
 }
 
 fn assert_same(output: &str, expected: &Path) -> Result<()> {
-    if env::var("BLESS").is_ok() || true {
+    if env::var("BLESS").is_ok() {
         fs::write(expected, output)?;
     } else {
         let expected = fs::read_to_string(expected)?;

--- a/crates/cli/tests/reference/web-sys-types.d.ts
+++ b/crates/cli/tests/reference/web-sys-types.d.ts
@@ -1,0 +1,12 @@
+/* tslint:disable */
+/* eslint-disable */
+/**
+ * @returns {URL}
+ */
+export function get_url(): URL;
+/**
+ *The `MediaSourceReadyState` enum.
+ *
+ **This API requires the following crate features to be activated: `MediaSourceReadyState`*
+ */
+export type MediaSourceReadyState = "closed" | "open" | "ended";

--- a/crates/cli/tests/reference/web-sys-types.d.ts
+++ b/crates/cli/tests/reference/web-sys-types.d.ts
@@ -4,9 +4,3 @@
  * @returns {URL}
  */
 export function get_url(): URL;
-/**
- *The `MediaSourceReadyState` enum.
- *
- **This API requires the following crate features to be activated: `MediaSourceReadyState`*
- */
-export type MediaSourceReadyState = "closed" | "open" | "ended";

--- a/crates/cli/tests/reference/web-sys-types.js
+++ b/crates/cli/tests/reference/web-sys-types.js
@@ -10,6 +10,20 @@ heap.push(undefined, null, true, false);
 
 function getObject(idx) { return heap[idx]; }
 
+let heap_next = heap.length;
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+
 function debugString(val) {
     // primitive types
     const type = typeof val;
@@ -161,20 +175,6 @@ function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
-
-let heap_next = heap.length;
-
-function dropObject(idx) {
-    if (idx < 132) return;
-    heap[idx] = heap_next;
-    heap_next = idx;
-}
-
-function takeObject(idx) {
-    const ret = getObject(idx);
-    dropObject(idx);
-    return ret;
-}
 /**
  * @returns {URL}
  */
@@ -207,6 +207,10 @@ export function __wbg_new_5462e05265178886() { return handleError(function (arg0
     return addHeapObject(ret);
 }, arguments) };
 
+export function __wbindgen_object_drop_ref(arg0) {
+    takeObject(arg0);
+};
+
 export function __wbindgen_debug_string(arg0, arg1) {
     const ret = debugString(getObject(arg1));
     const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
@@ -217,9 +221,5 @@ export function __wbindgen_debug_string(arg0, arg1) {
 
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
-};
-
-export function __wbindgen_object_drop_ref(arg0) {
-    takeObject(arg0);
 };
 

--- a/crates/cli/tests/reference/web-sys-types.js
+++ b/crates/cli/tests/reference/web-sys-types.js
@@ -1,0 +1,225 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) { return heap[idx]; }
+
+function debugString(val) {
+    // primitive types
+    const type = typeof val;
+    if (type == 'number' || type == 'boolean' || val == null) {
+        return  `${val}`;
+    }
+    if (type == 'string') {
+        return `"${val}"`;
+    }
+    if (type == 'symbol') {
+        const description = val.description;
+        if (description == null) {
+            return 'Symbol';
+        } else {
+            return `Symbol(${description})`;
+        }
+    }
+    if (type == 'function') {
+        const name = val.name;
+        if (typeof name == 'string' && name.length > 0) {
+            return `Function(${name})`;
+        } else {
+            return 'Function';
+        }
+    }
+    // objects
+    if (Array.isArray(val)) {
+        const length = val.length;
+        let debug = '[';
+        if (length > 0) {
+            debug += debugString(val[0]);
+        }
+        for(let i = 1; i < length; i++) {
+            debug += ', ' + debugString(val[i]);
+        }
+        debug += ']';
+        return debug;
+    }
+    // Test for built-in
+    const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
+    let className;
+    if (builtInMatches.length > 1) {
+        className = builtInMatches[1];
+    } else {
+        // Failed to match the standard '[object ClassName]'
+        return toString.call(val);
+    }
+    if (className == 'Object') {
+        // we're a user defined class or Object
+        // JSON.stringify avoids problems with cycles, and is generally much
+        // easier than looping through ownProperties of `val`.
+        try {
+            return 'Object(' + JSON.stringify(val) + ')';
+        } catch (_) {
+            return 'Object';
+        }
+    }
+    // errors
+    if (val instanceof Error) {
+        return `${val.name}: ${val.message}\n${val.stack}`;
+    }
+    // TODO we could test for more things here, like `Set`s and `Map`s.
+    return className;
+}
+
+let WASM_VECTOR_LEN = 0;
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
+
+let cachedTextEncoder = new lTextEncoder('utf-8');
+
+const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
+    ? function (arg, view) {
+    return cachedTextEncoder.encodeInto(arg, view);
+}
+    : function (arg, view) {
+    const buf = cachedTextEncoder.encode(arg);
+    view.set(buf);
+    return {
+        read: arg.length,
+        written: buf.length
+    };
+});
+
+function passStringToWasm0(arg, malloc, realloc) {
+
+    if (realloc === undefined) {
+        const buf = cachedTextEncoder.encode(arg);
+        const ptr = malloc(buf.length, 1) >>> 0;
+        getUint8ArrayMemory0().subarray(ptr, ptr + buf.length).set(buf);
+        WASM_VECTOR_LEN = buf.length;
+        return ptr;
+    }
+
+    let len = arg.length;
+    let ptr = malloc(len, 1) >>> 0;
+
+    const mem = getUint8ArrayMemory0();
+
+    let offset = 0;
+
+    for (; offset < len; offset++) {
+        const code = arg.charCodeAt(offset);
+        if (code > 0x7F) break;
+        mem[ptr + offset] = code;
+    }
+
+    if (offset !== len) {
+        if (offset !== 0) {
+            arg = arg.slice(offset);
+        }
+        ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
+        const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
+        const ret = encodeString(arg, view);
+
+        offset += ret.written;
+        ptr = realloc(ptr, len, offset, 1) >>> 0;
+    }
+
+    WASM_VECTOR_LEN = offset;
+    return ptr;
+}
+
+let cachedDataViewMemory0 = null;
+
+function getDataViewMemory0() {
+    if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
+        cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
+    }
+    return cachedDataViewMemory0;
+}
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+let heap_next = heap.length;
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+/**
+ * @returns {URL}
+ */
+export function get_url() {
+    const ret = wasm.get_url();
+    return takeObject(ret);
+}
+
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1);
+    const idx = heap_next;
+    heap_next = heap[idx];
+
+    heap[idx] = obj;
+    return idx;
+}
+
+function handleError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        wasm.__wbindgen_exn_store(addHeapObject(e));
+    }
+}
+
+const __wbindgen_enum_MediaSourceReadyState = ["closed", "open", "ended"];
+
+export function __wbg_new_5462e05265178886() { return handleError(function (arg0, arg1) {
+    const ret = new URL(getStringFromWasm0(arg0, arg1));
+    return addHeapObject(ret);
+}, arguments) };
+
+export function __wbindgen_debug_string(arg0, arg1) {
+    const ret = debugString(getObject(arg1));
+    const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
+    const len1 = WASM_VECTOR_LEN;
+    getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
+    getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
+};
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+
+export function __wbindgen_object_drop_ref(arg0) {
+    takeObject(arg0);
+};
+

--- a/crates/cli/tests/reference/web-sys-types.rs
+++ b/crates/cli/tests/reference/web-sys-types.rs
@@ -1,0 +1,10 @@
+// DEPENDENCY: web-sys = { path = '{root}/crates/web-sys', features = ['console', 'Url', 'MediaSourceReadyState'] }
+
+use wasm_bindgen::prelude::wasm_bindgen;
+use web_sys::{Url, MediaSourceReadyState};
+
+#[wasm_bindgen]
+pub fn get_url() -> Url {
+    assert_eq!(MediaSourceReadyState::Closed, MediaSourceReadyState::Closed);
+    Url::new("https://example.com").unwrap()
+}

--- a/crates/cli/tests/reference/web-sys-types.wat
+++ b/crates/cli/tests/reference/web-sys-types.wat
@@ -1,0 +1,18 @@
+(module $reference_test.wasm
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32)))
+  (type (;2;) (func (param i32 i32) (result i32)))
+  (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
+  (func $__wbindgen_realloc (;0;) (type 3) (param i32 i32 i32 i32) (result i32))
+  (func $__wbindgen_malloc (;1;) (type 2) (param i32 i32) (result i32))
+  (func $get_url (;2;) (type 0) (result i32))
+  (func $__wbindgen_exn_store (;3;) (type 1) (param i32))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "get_url" (func $get_url))
+  (export "__wbindgen_malloc" (func $__wbindgen_malloc))
+  (export "__wbindgen_realloc" (func $__wbindgen_realloc))
+  (export "__wbindgen_exn_store" (func $__wbindgen_exn_store))
+  (@custom "target_features" (after code) "\02+\0fmutable-globals+\08sign-ext")
+)
+

--- a/crates/web-sys/src/features/gen_AlignSetting.rs
+++ b/crates/web-sys/src/features/gen_AlignSetting.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AlignSetting` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AlignSetting`*"]

--- a/crates/web-sys/src/features/gen_AlphaOption.rs
+++ b/crates/web-sys/src/features/gen_AlphaOption.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AlphaOption` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AlphaOption`*"]

--- a/crates/web-sys/src/features/gen_AnimationPlayState.rs
+++ b/crates/web-sys/src/features/gen_AnimationPlayState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AnimationPlayState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AnimationPlayState`*"]

--- a/crates/web-sys/src/features/gen_AttestationConveyancePreference.rs
+++ b/crates/web-sys/src/features/gen_AttestationConveyancePreference.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AttestationConveyancePreference` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AttestationConveyancePreference`*"]

--- a/crates/web-sys/src/features/gen_AudioContextLatencyCategory.rs
+++ b/crates/web-sys/src/features/gen_AudioContextLatencyCategory.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AudioContextLatencyCategory` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AudioContextLatencyCategory`*"]

--- a/crates/web-sys/src/features/gen_AudioContextState.rs
+++ b/crates/web-sys/src/features/gen_AudioContextState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AudioContextState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AudioContextState`*"]

--- a/crates/web-sys/src/features/gen_AudioSampleFormat.rs
+++ b/crates/web-sys/src/features/gen_AudioSampleFormat.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AudioSampleFormat` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AudioSampleFormat`*"]

--- a/crates/web-sys/src/features/gen_AudioSinkType.rs
+++ b/crates/web-sys/src/features/gen_AudioSinkType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AudioSinkType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AudioSinkType`*"]

--- a/crates/web-sys/src/features/gen_AuthenticatorAttachment.rs
+++ b/crates/web-sys/src/features/gen_AuthenticatorAttachment.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AuthenticatorAttachment` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AuthenticatorAttachment`*"]

--- a/crates/web-sys/src/features/gen_AuthenticatorTransport.rs
+++ b/crates/web-sys/src/features/gen_AuthenticatorTransport.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AuthenticatorTransport` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AuthenticatorTransport`*"]

--- a/crates/web-sys/src/features/gen_AutoKeyword.rs
+++ b/crates/web-sys/src/features/gen_AutoKeyword.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `AutoKeyword` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `AutoKeyword`*"]

--- a/crates/web-sys/src/features/gen_BasicCardType.rs
+++ b/crates/web-sys/src/features/gen_BasicCardType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `BasicCardType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `BasicCardType`*"]

--- a/crates/web-sys/src/features/gen_BinaryType.rs
+++ b/crates/web-sys/src/features/gen_BinaryType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `BinaryType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `BinaryType`*"]

--- a/crates/web-sys/src/features/gen_BiquadFilterType.rs
+++ b/crates/web-sys/src/features/gen_BiquadFilterType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `BiquadFilterType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `BiquadFilterType`*"]

--- a/crates/web-sys/src/features/gen_BrowserFindCaseSensitivity.rs
+++ b/crates/web-sys/src/features/gen_BrowserFindCaseSensitivity.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `BrowserFindCaseSensitivity` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `BrowserFindCaseSensitivity`*"]

--- a/crates/web-sys/src/features/gen_BrowserFindDirection.rs
+++ b/crates/web-sys/src/features/gen_BrowserFindDirection.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `BrowserFindDirection` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `BrowserFindDirection`*"]

--- a/crates/web-sys/src/features/gen_CacheStorageNamespace.rs
+++ b/crates/web-sys/src/features/gen_CacheStorageNamespace.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CacheStorageNamespace` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CacheStorageNamespace`*"]

--- a/crates/web-sys/src/features/gen_CanvasWindingRule.rs
+++ b/crates/web-sys/src/features/gen_CanvasWindingRule.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CanvasWindingRule` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CanvasWindingRule`*"]

--- a/crates/web-sys/src/features/gen_CaretChangedReason.rs
+++ b/crates/web-sys/src/features/gen_CaretChangedReason.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CaretChangedReason` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CaretChangedReason`*"]

--- a/crates/web-sys/src/features/gen_ChannelCountMode.rs
+++ b/crates/web-sys/src/features/gen_ChannelCountMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ChannelCountMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ChannelCountMode`*"]

--- a/crates/web-sys/src/features/gen_ChannelInterpretation.rs
+++ b/crates/web-sys/src/features/gen_ChannelInterpretation.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ChannelInterpretation` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ChannelInterpretation`*"]

--- a/crates/web-sys/src/features/gen_CheckerboardReason.rs
+++ b/crates/web-sys/src/features/gen_CheckerboardReason.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CheckerboardReason` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CheckerboardReason`*"]

--- a/crates/web-sys/src/features/gen_ClientType.rs
+++ b/crates/web-sys/src/features/gen_ClientType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ClientType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ClientType`*"]

--- a/crates/web-sys/src/features/gen_CodecState.rs
+++ b/crates/web-sys/src/features/gen_CodecState.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CodecState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CodecState`*"]

--- a/crates/web-sys/src/features/gen_ColorSpaceConversion.rs
+++ b/crates/web-sys/src/features/gen_ColorSpaceConversion.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ColorSpaceConversion` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ColorSpaceConversion`*"]

--- a/crates/web-sys/src/features/gen_CompositeOperation.rs
+++ b/crates/web-sys/src/features/gen_CompositeOperation.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CompositeOperation` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CompositeOperation`*"]

--- a/crates/web-sys/src/features/gen_CompressionFormat.rs
+++ b/crates/web-sys/src/features/gen_CompressionFormat.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CompressionFormat` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CompressionFormat`*"]

--- a/crates/web-sys/src/features/gen_ConnectionType.rs
+++ b/crates/web-sys/src/features/gen_ConnectionType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ConnectionType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ConnectionType`*"]

--- a/crates/web-sys/src/features/gen_ConsoleLevel.rs
+++ b/crates/web-sys/src/features/gen_ConsoleLevel.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ConsoleLevel` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ConsoleLevel`*"]

--- a/crates/web-sys/src/features/gen_ConsoleLogLevel.rs
+++ b/crates/web-sys/src/features/gen_ConsoleLogLevel.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ConsoleLogLevel` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ConsoleLogLevel`*"]

--- a/crates/web-sys/src/features/gen_CssBoxType.rs
+++ b/crates/web-sys/src/features/gen_CssBoxType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CssBoxType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CssBoxType`*"]

--- a/crates/web-sys/src/features/gen_CssStyleSheetParsingMode.rs
+++ b/crates/web-sys/src/features/gen_CssStyleSheetParsingMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `CssStyleSheetParsingMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `CssStyleSheetParsingMode`*"]

--- a/crates/web-sys/src/features/gen_DecoderDoctorNotificationType.rs
+++ b/crates/web-sys/src/features/gen_DecoderDoctorNotificationType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `DecoderDoctorNotificationType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `DecoderDoctorNotificationType`*"]

--- a/crates/web-sys/src/features/gen_DirectionSetting.rs
+++ b/crates/web-sys/src/features/gen_DirectionSetting.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `DirectionSetting` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `DirectionSetting`*"]

--- a/crates/web-sys/src/features/gen_DistanceModelType.rs
+++ b/crates/web-sys/src/features/gen_DistanceModelType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `DistanceModelType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `DistanceModelType`*"]

--- a/crates/web-sys/src/features/gen_DomRequestReadyState.rs
+++ b/crates/web-sys/src/features/gen_DomRequestReadyState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `DomRequestReadyState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `DomRequestReadyState`*"]

--- a/crates/web-sys/src/features/gen_EncodedAudioChunkType.rs
+++ b/crates/web-sys/src/features/gen_EncodedAudioChunkType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `EncodedAudioChunkType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `EncodedAudioChunkType`*"]

--- a/crates/web-sys/src/features/gen_EncodedVideoChunkType.rs
+++ b/crates/web-sys/src/features/gen_EncodedVideoChunkType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `EncodedVideoChunkType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `EncodedVideoChunkType`*"]

--- a/crates/web-sys/src/features/gen_EndingTypes.rs
+++ b/crates/web-sys/src/features/gen_EndingTypes.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `EndingTypes` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `EndingTypes`*"]

--- a/crates/web-sys/src/features/gen_FetchState.rs
+++ b/crates/web-sys/src/features/gen_FetchState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FetchState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FetchState`*"]

--- a/crates/web-sys/src/features/gen_FileSystemHandleKind.rs
+++ b/crates/web-sys/src/features/gen_FileSystemHandleKind.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FileSystemHandleKind` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FileSystemHandleKind`*"]

--- a/crates/web-sys/src/features/gen_FileSystemPermissionMode.rs
+++ b/crates/web-sys/src/features/gen_FileSystemPermissionMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FileSystemPermissionMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FileSystemPermissionMode`*"]

--- a/crates/web-sys/src/features/gen_FillMode.rs
+++ b/crates/web-sys/src/features/gen_FillMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FillMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FillMode`*"]

--- a/crates/web-sys/src/features/gen_FlashClassification.rs
+++ b/crates/web-sys/src/features/gen_FlashClassification.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FlashClassification` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FlashClassification`*"]

--- a/crates/web-sys/src/features/gen_FlowControlType.rs
+++ b/crates/web-sys/src/features/gen_FlowControlType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FlowControlType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FlowControlType`*"]

--- a/crates/web-sys/src/features/gen_FontFaceLoadStatus.rs
+++ b/crates/web-sys/src/features/gen_FontFaceLoadStatus.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FontFaceLoadStatus` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FontFaceLoadStatus`*"]

--- a/crates/web-sys/src/features/gen_FontFaceSetLoadStatus.rs
+++ b/crates/web-sys/src/features/gen_FontFaceSetLoadStatus.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FontFaceSetLoadStatus` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FontFaceSetLoadStatus`*"]

--- a/crates/web-sys/src/features/gen_FrameType.rs
+++ b/crates/web-sys/src/features/gen_FrameType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `FrameType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `FrameType`*"]

--- a/crates/web-sys/src/features/gen_GamepadHand.rs
+++ b/crates/web-sys/src/features/gen_GamepadHand.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GamepadHand` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GamepadHand`*"]

--- a/crates/web-sys/src/features/gen_GamepadHapticActuatorType.rs
+++ b/crates/web-sys/src/features/gen_GamepadHapticActuatorType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GamepadHapticActuatorType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GamepadHapticActuatorType`*"]

--- a/crates/web-sys/src/features/gen_GamepadHapticEffectType.rs
+++ b/crates/web-sys/src/features/gen_GamepadHapticEffectType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GamepadHapticEffectType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GamepadHapticEffectType`*"]

--- a/crates/web-sys/src/features/gen_GamepadHapticsResult.rs
+++ b/crates/web-sys/src/features/gen_GamepadHapticsResult.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GamepadHapticsResult` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GamepadHapticsResult`*"]

--- a/crates/web-sys/src/features/gen_GamepadMappingType.rs
+++ b/crates/web-sys/src/features/gen_GamepadMappingType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GamepadMappingType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GamepadMappingType`*"]

--- a/crates/web-sys/src/features/gen_GpuAddressMode.rs
+++ b/crates/web-sys/src/features/gen_GpuAddressMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuAddressMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuAddressMode`*"]

--- a/crates/web-sys/src/features/gen_GpuAutoLayoutMode.rs
+++ b/crates/web-sys/src/features/gen_GpuAutoLayoutMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuAutoLayoutMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuAutoLayoutMode`*"]

--- a/crates/web-sys/src/features/gen_GpuBlendFactor.rs
+++ b/crates/web-sys/src/features/gen_GpuBlendFactor.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuBlendFactor` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuBlendFactor`*"]

--- a/crates/web-sys/src/features/gen_GpuBlendOperation.rs
+++ b/crates/web-sys/src/features/gen_GpuBlendOperation.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuBlendOperation` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuBlendOperation`*"]

--- a/crates/web-sys/src/features/gen_GpuBufferBindingType.rs
+++ b/crates/web-sys/src/features/gen_GpuBufferBindingType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuBufferBindingType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuBufferBindingType`*"]

--- a/crates/web-sys/src/features/gen_GpuBufferMapState.rs
+++ b/crates/web-sys/src/features/gen_GpuBufferMapState.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuBufferMapState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuBufferMapState`*"]

--- a/crates/web-sys/src/features/gen_GpuCanvasAlphaMode.rs
+++ b/crates/web-sys/src/features/gen_GpuCanvasAlphaMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuCanvasAlphaMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuCanvasAlphaMode`*"]

--- a/crates/web-sys/src/features/gen_GpuCanvasToneMappingMode.rs
+++ b/crates/web-sys/src/features/gen_GpuCanvasToneMappingMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuCanvasToneMappingMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuCanvasToneMappingMode`*"]

--- a/crates/web-sys/src/features/gen_GpuCompareFunction.rs
+++ b/crates/web-sys/src/features/gen_GpuCompareFunction.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuCompareFunction` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuCompareFunction`*"]

--- a/crates/web-sys/src/features/gen_GpuCompilationMessageType.rs
+++ b/crates/web-sys/src/features/gen_GpuCompilationMessageType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuCompilationMessageType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuCompilationMessageType`*"]

--- a/crates/web-sys/src/features/gen_GpuCullMode.rs
+++ b/crates/web-sys/src/features/gen_GpuCullMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuCullMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuCullMode`*"]

--- a/crates/web-sys/src/features/gen_GpuDeviceLostReason.rs
+++ b/crates/web-sys/src/features/gen_GpuDeviceLostReason.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuDeviceLostReason` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuDeviceLostReason`*"]

--- a/crates/web-sys/src/features/gen_GpuErrorFilter.rs
+++ b/crates/web-sys/src/features/gen_GpuErrorFilter.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuErrorFilter` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuErrorFilter`*"]

--- a/crates/web-sys/src/features/gen_GpuFeatureName.rs
+++ b/crates/web-sys/src/features/gen_GpuFeatureName.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuFeatureName` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuFeatureName`*"]

--- a/crates/web-sys/src/features/gen_GpuFilterMode.rs
+++ b/crates/web-sys/src/features/gen_GpuFilterMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuFilterMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuFilterMode`*"]

--- a/crates/web-sys/src/features/gen_GpuFrontFace.rs
+++ b/crates/web-sys/src/features/gen_GpuFrontFace.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuFrontFace` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuFrontFace`*"]

--- a/crates/web-sys/src/features/gen_GpuIndexFormat.rs
+++ b/crates/web-sys/src/features/gen_GpuIndexFormat.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuIndexFormat` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuIndexFormat`*"]

--- a/crates/web-sys/src/features/gen_GpuLoadOp.rs
+++ b/crates/web-sys/src/features/gen_GpuLoadOp.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuLoadOp` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuLoadOp`*"]

--- a/crates/web-sys/src/features/gen_GpuMipmapFilterMode.rs
+++ b/crates/web-sys/src/features/gen_GpuMipmapFilterMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuMipmapFilterMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuMipmapFilterMode`*"]

--- a/crates/web-sys/src/features/gen_GpuPipelineErrorReason.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineErrorReason.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuPipelineErrorReason` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuPipelineErrorReason`*"]

--- a/crates/web-sys/src/features/gen_GpuPowerPreference.rs
+++ b/crates/web-sys/src/features/gen_GpuPowerPreference.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuPowerPreference` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuPowerPreference`*"]

--- a/crates/web-sys/src/features/gen_GpuPrimitiveTopology.rs
+++ b/crates/web-sys/src/features/gen_GpuPrimitiveTopology.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuPrimitiveTopology` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuPrimitiveTopology`*"]

--- a/crates/web-sys/src/features/gen_GpuQueryType.rs
+++ b/crates/web-sys/src/features/gen_GpuQueryType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuQueryType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuQueryType`*"]

--- a/crates/web-sys/src/features/gen_GpuSamplerBindingType.rs
+++ b/crates/web-sys/src/features/gen_GpuSamplerBindingType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuSamplerBindingType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuSamplerBindingType`*"]

--- a/crates/web-sys/src/features/gen_GpuStencilOperation.rs
+++ b/crates/web-sys/src/features/gen_GpuStencilOperation.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuStencilOperation` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuStencilOperation`*"]

--- a/crates/web-sys/src/features/gen_GpuStorageTextureAccess.rs
+++ b/crates/web-sys/src/features/gen_GpuStorageTextureAccess.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuStorageTextureAccess` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuStorageTextureAccess`*"]

--- a/crates/web-sys/src/features/gen_GpuStoreOp.rs
+++ b/crates/web-sys/src/features/gen_GpuStoreOp.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuStoreOp` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuStoreOp`*"]

--- a/crates/web-sys/src/features/gen_GpuTextureAspect.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureAspect.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuTextureAspect` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuTextureAspect`*"]

--- a/crates/web-sys/src/features/gen_GpuTextureDimension.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureDimension.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuTextureDimension` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuTextureDimension`*"]

--- a/crates/web-sys/src/features/gen_GpuTextureFormat.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureFormat.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuTextureFormat` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuTextureFormat`*"]

--- a/crates/web-sys/src/features/gen_GpuTextureSampleType.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureSampleType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuTextureSampleType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuTextureSampleType`*"]

--- a/crates/web-sys/src/features/gen_GpuTextureViewDimension.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureViewDimension.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuTextureViewDimension` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuTextureViewDimension`*"]

--- a/crates/web-sys/src/features/gen_GpuVertexFormat.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexFormat.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuVertexFormat` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuVertexFormat`*"]

--- a/crates/web-sys/src/features/gen_GpuVertexStepMode.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexStepMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `GpuVertexStepMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `GpuVertexStepMode`*"]

--- a/crates/web-sys/src/features/gen_HardwareAcceleration.rs
+++ b/crates/web-sys/src/features/gen_HardwareAcceleration.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `HardwareAcceleration` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `HardwareAcceleration`*"]

--- a/crates/web-sys/src/features/gen_HeadersGuardEnum.rs
+++ b/crates/web-sys/src/features/gen_HeadersGuardEnum.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `HeadersGuardEnum` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `HeadersGuardEnum`*"]

--- a/crates/web-sys/src/features/gen_HidUnitSystem.rs
+++ b/crates/web-sys/src/features/gen_HidUnitSystem.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `HidUnitSystem` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `HidUnitSystem`*"]

--- a/crates/web-sys/src/features/gen_IdbCursorDirection.rs
+++ b/crates/web-sys/src/features/gen_IdbCursorDirection.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `IdbCursorDirection` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `IdbCursorDirection`*"]

--- a/crates/web-sys/src/features/gen_IdbRequestReadyState.rs
+++ b/crates/web-sys/src/features/gen_IdbRequestReadyState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `IdbRequestReadyState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `IdbRequestReadyState`*"]

--- a/crates/web-sys/src/features/gen_IdbTransactionDurability.rs
+++ b/crates/web-sys/src/features/gen_IdbTransactionDurability.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `IdbTransactionDurability` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `IdbTransactionDurability`*"]

--- a/crates/web-sys/src/features/gen_IdbTransactionMode.rs
+++ b/crates/web-sys/src/features/gen_IdbTransactionMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `IdbTransactionMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `IdbTransactionMode`*"]

--- a/crates/web-sys/src/features/gen_ImageOrientation.rs
+++ b/crates/web-sys/src/features/gen_ImageOrientation.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ImageOrientation` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ImageOrientation`*"]

--- a/crates/web-sys/src/features/gen_IterationCompositeOperation.rs
+++ b/crates/web-sys/src/features/gen_IterationCompositeOperation.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `IterationCompositeOperation` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `IterationCompositeOperation`*"]

--- a/crates/web-sys/src/features/gen_LargeBlobSupport.rs
+++ b/crates/web-sys/src/features/gen_LargeBlobSupport.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `LargeBlobSupport` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `LargeBlobSupport`*"]

--- a/crates/web-sys/src/features/gen_LatencyMode.rs
+++ b/crates/web-sys/src/features/gen_LatencyMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `LatencyMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `LatencyMode`*"]

--- a/crates/web-sys/src/features/gen_LineAlignSetting.rs
+++ b/crates/web-sys/src/features/gen_LineAlignSetting.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `LineAlignSetting` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `LineAlignSetting`*"]

--- a/crates/web-sys/src/features/gen_LockMode.rs
+++ b/crates/web-sys/src/features/gen_LockMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `LockMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `LockMode`*"]

--- a/crates/web-sys/src/features/gen_MediaDecodingType.rs
+++ b/crates/web-sys/src/features/gen_MediaDecodingType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaDecodingType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaDecodingType`*"]

--- a/crates/web-sys/src/features/gen_MediaDeviceKind.rs
+++ b/crates/web-sys/src/features/gen_MediaDeviceKind.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaDeviceKind` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaDeviceKind`*"]

--- a/crates/web-sys/src/features/gen_MediaEncodingType.rs
+++ b/crates/web-sys/src/features/gen_MediaEncodingType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaEncodingType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaEncodingType`*"]

--- a/crates/web-sys/src/features/gen_MediaKeyMessageType.rs
+++ b/crates/web-sys/src/features/gen_MediaKeyMessageType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaKeyMessageType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaKeyMessageType`*"]

--- a/crates/web-sys/src/features/gen_MediaKeySessionType.rs
+++ b/crates/web-sys/src/features/gen_MediaKeySessionType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaKeySessionType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaKeySessionType`*"]

--- a/crates/web-sys/src/features/gen_MediaKeyStatus.rs
+++ b/crates/web-sys/src/features/gen_MediaKeyStatus.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaKeyStatus` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaKeyStatus`*"]

--- a/crates/web-sys/src/features/gen_MediaKeySystemStatus.rs
+++ b/crates/web-sys/src/features/gen_MediaKeySystemStatus.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaKeySystemStatus` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaKeySystemStatus`*"]

--- a/crates/web-sys/src/features/gen_MediaKeysRequirement.rs
+++ b/crates/web-sys/src/features/gen_MediaKeysRequirement.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaKeysRequirement` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaKeysRequirement`*"]

--- a/crates/web-sys/src/features/gen_MediaSessionAction.rs
+++ b/crates/web-sys/src/features/gen_MediaSessionAction.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaSessionAction` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaSessionAction`*"]

--- a/crates/web-sys/src/features/gen_MediaSessionPlaybackState.rs
+++ b/crates/web-sys/src/features/gen_MediaSessionPlaybackState.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaSessionPlaybackState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaSessionPlaybackState`*"]

--- a/crates/web-sys/src/features/gen_MediaSourceEndOfStreamError.rs
+++ b/crates/web-sys/src/features/gen_MediaSourceEndOfStreamError.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaSourceEndOfStreamError` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaSourceEndOfStreamError`*"]

--- a/crates/web-sys/src/features/gen_MediaSourceEnum.rs
+++ b/crates/web-sys/src/features/gen_MediaSourceEnum.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaSourceEnum` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaSourceEnum`*"]

--- a/crates/web-sys/src/features/gen_MediaSourceReadyState.rs
+++ b/crates/web-sys/src/features/gen_MediaSourceReadyState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaSourceReadyState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaSourceReadyState`*"]

--- a/crates/web-sys/src/features/gen_MediaStreamTrackState.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamTrackState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MediaStreamTrackState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MediaStreamTrackState`*"]

--- a/crates/web-sys/src/features/gen_MidiPortConnectionState.rs
+++ b/crates/web-sys/src/features/gen_MidiPortConnectionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MidiPortConnectionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MidiPortConnectionState`*"]

--- a/crates/web-sys/src/features/gen_MidiPortDeviceState.rs
+++ b/crates/web-sys/src/features/gen_MidiPortDeviceState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MidiPortDeviceState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MidiPortDeviceState`*"]

--- a/crates/web-sys/src/features/gen_MidiPortType.rs
+++ b/crates/web-sys/src/features/gen_MidiPortType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `MidiPortType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `MidiPortType`*"]

--- a/crates/web-sys/src/features/gen_NavigationType.rs
+++ b/crates/web-sys/src/features/gen_NavigationType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `NavigationType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `NavigationType`*"]

--- a/crates/web-sys/src/features/gen_NotificationDirection.rs
+++ b/crates/web-sys/src/features/gen_NotificationDirection.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `NotificationDirection` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `NotificationDirection`*"]

--- a/crates/web-sys/src/features/gen_NotificationPermission.rs
+++ b/crates/web-sys/src/features/gen_NotificationPermission.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `NotificationPermission` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `NotificationPermission`*"]

--- a/crates/web-sys/src/features/gen_OrientationLockType.rs
+++ b/crates/web-sys/src/features/gen_OrientationLockType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `OrientationLockType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `OrientationLockType`*"]

--- a/crates/web-sys/src/features/gen_OrientationType.rs
+++ b/crates/web-sys/src/features/gen_OrientationType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `OrientationType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `OrientationType`*"]

--- a/crates/web-sys/src/features/gen_OscillatorType.rs
+++ b/crates/web-sys/src/features/gen_OscillatorType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `OscillatorType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `OscillatorType`*"]

--- a/crates/web-sys/src/features/gen_OverSampleType.rs
+++ b/crates/web-sys/src/features/gen_OverSampleType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `OverSampleType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `OverSampleType`*"]

--- a/crates/web-sys/src/features/gen_PanningModelType.rs
+++ b/crates/web-sys/src/features/gen_PanningModelType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PanningModelType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PanningModelType`*"]

--- a/crates/web-sys/src/features/gen_ParityType.rs
+++ b/crates/web-sys/src/features/gen_ParityType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ParityType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ParityType`*"]

--- a/crates/web-sys/src/features/gen_PaymentComplete.rs
+++ b/crates/web-sys/src/features/gen_PaymentComplete.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PaymentComplete` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PaymentComplete`*"]

--- a/crates/web-sys/src/features/gen_PcImplIceConnectionState.rs
+++ b/crates/web-sys/src/features/gen_PcImplIceConnectionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PcImplIceConnectionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PcImplIceConnectionState`*"]

--- a/crates/web-sys/src/features/gen_PcImplIceGatheringState.rs
+++ b/crates/web-sys/src/features/gen_PcImplIceGatheringState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PcImplIceGatheringState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PcImplIceGatheringState`*"]

--- a/crates/web-sys/src/features/gen_PcImplSignalingState.rs
+++ b/crates/web-sys/src/features/gen_PcImplSignalingState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PcImplSignalingState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PcImplSignalingState`*"]

--- a/crates/web-sys/src/features/gen_PcObserverStateType.rs
+++ b/crates/web-sys/src/features/gen_PcObserverStateType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PcObserverStateType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PcObserverStateType`*"]

--- a/crates/web-sys/src/features/gen_PermissionName.rs
+++ b/crates/web-sys/src/features/gen_PermissionName.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PermissionName` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PermissionName`*"]

--- a/crates/web-sys/src/features/gen_PermissionState.rs
+++ b/crates/web-sys/src/features/gen_PermissionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PermissionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PermissionState`*"]

--- a/crates/web-sys/src/features/gen_PlaybackDirection.rs
+++ b/crates/web-sys/src/features/gen_PlaybackDirection.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PlaybackDirection` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PlaybackDirection`*"]

--- a/crates/web-sys/src/features/gen_PositionAlignSetting.rs
+++ b/crates/web-sys/src/features/gen_PositionAlignSetting.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PositionAlignSetting` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PositionAlignSetting`*"]

--- a/crates/web-sys/src/features/gen_PremultiplyAlpha.rs
+++ b/crates/web-sys/src/features/gen_PremultiplyAlpha.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PremultiplyAlpha` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PremultiplyAlpha`*"]

--- a/crates/web-sys/src/features/gen_PresentationConnectionBinaryType.rs
+++ b/crates/web-sys/src/features/gen_PresentationConnectionBinaryType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PresentationConnectionBinaryType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PresentationConnectionBinaryType`*"]

--- a/crates/web-sys/src/features/gen_PresentationConnectionClosedReason.rs
+++ b/crates/web-sys/src/features/gen_PresentationConnectionClosedReason.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PresentationConnectionClosedReason` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PresentationConnectionClosedReason`*"]

--- a/crates/web-sys/src/features/gen_PresentationConnectionState.rs
+++ b/crates/web-sys/src/features/gen_PresentationConnectionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PresentationConnectionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PresentationConnectionState`*"]

--- a/crates/web-sys/src/features/gen_PresentationStyle.rs
+++ b/crates/web-sys/src/features/gen_PresentationStyle.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PresentationStyle` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PresentationStyle`*"]

--- a/crates/web-sys/src/features/gen_ProfileTimelineMessagePortOperationType.rs
+++ b/crates/web-sys/src/features/gen_ProfileTimelineMessagePortOperationType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ProfileTimelineMessagePortOperationType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ProfileTimelineMessagePortOperationType`*"]

--- a/crates/web-sys/src/features/gen_ProfileTimelineWorkerOperationType.rs
+++ b/crates/web-sys/src/features/gen_ProfileTimelineWorkerOperationType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ProfileTimelineWorkerOperationType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ProfileTimelineWorkerOperationType`*"]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialHints.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialHints.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PublicKeyCredentialHints` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PublicKeyCredentialHints`*"]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialType.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PublicKeyCredentialType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PublicKeyCredentialType`*"]

--- a/crates/web-sys/src/features/gen_PushEncryptionKeyName.rs
+++ b/crates/web-sys/src/features/gen_PushEncryptionKeyName.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PushEncryptionKeyName` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PushEncryptionKeyName`*"]

--- a/crates/web-sys/src/features/gen_PushPermissionState.rs
+++ b/crates/web-sys/src/features/gen_PushPermissionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `PushPermissionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `PushPermissionState`*"]

--- a/crates/web-sys/src/features/gen_ReadableStreamReaderMode.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamReaderMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ReadableStreamReaderMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ReadableStreamReaderMode`*"]

--- a/crates/web-sys/src/features/gen_ReadableStreamType.rs
+++ b/crates/web-sys/src/features/gen_ReadableStreamType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ReadableStreamType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ReadableStreamType`*"]

--- a/crates/web-sys/src/features/gen_RecordingState.rs
+++ b/crates/web-sys/src/features/gen_RecordingState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RecordingState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RecordingState`*"]

--- a/crates/web-sys/src/features/gen_ReferrerPolicy.rs
+++ b/crates/web-sys/src/features/gen_ReferrerPolicy.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ReferrerPolicy` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ReferrerPolicy`*"]

--- a/crates/web-sys/src/features/gen_RequestCache.rs
+++ b/crates/web-sys/src/features/gen_RequestCache.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RequestCache` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RequestCache`*"]

--- a/crates/web-sys/src/features/gen_RequestCredentials.rs
+++ b/crates/web-sys/src/features/gen_RequestCredentials.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RequestCredentials` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RequestCredentials`*"]

--- a/crates/web-sys/src/features/gen_RequestDestination.rs
+++ b/crates/web-sys/src/features/gen_RequestDestination.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RequestDestination` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RequestDestination`*"]

--- a/crates/web-sys/src/features/gen_RequestMode.rs
+++ b/crates/web-sys/src/features/gen_RequestMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RequestMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RequestMode`*"]

--- a/crates/web-sys/src/features/gen_RequestRedirect.rs
+++ b/crates/web-sys/src/features/gen_RequestRedirect.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RequestRedirect` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RequestRedirect`*"]

--- a/crates/web-sys/src/features/gen_ResidentKeyRequirement.rs
+++ b/crates/web-sys/src/features/gen_ResidentKeyRequirement.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ResidentKeyRequirement` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ResidentKeyRequirement`*"]

--- a/crates/web-sys/src/features/gen_ResizeObserverBoxOptions.rs
+++ b/crates/web-sys/src/features/gen_ResizeObserverBoxOptions.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ResizeObserverBoxOptions` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ResizeObserverBoxOptions`*"]

--- a/crates/web-sys/src/features/gen_ResizeQuality.rs
+++ b/crates/web-sys/src/features/gen_ResizeQuality.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ResizeQuality` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ResizeQuality`*"]

--- a/crates/web-sys/src/features/gen_ResponseType.rs
+++ b/crates/web-sys/src/features/gen_ResponseType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ResponseType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ResponseType`*"]

--- a/crates/web-sys/src/features/gen_RtcBundlePolicy.rs
+++ b/crates/web-sys/src/features/gen_RtcBundlePolicy.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcBundlePolicy` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcBundlePolicy`*"]

--- a/crates/web-sys/src/features/gen_RtcDataChannelState.rs
+++ b/crates/web-sys/src/features/gen_RtcDataChannelState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcDataChannelState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcDataChannelState`*"]

--- a/crates/web-sys/src/features/gen_RtcDataChannelType.rs
+++ b/crates/web-sys/src/features/gen_RtcDataChannelType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcDataChannelType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcDataChannelType`*"]

--- a/crates/web-sys/src/features/gen_RtcDegradationPreference.rs
+++ b/crates/web-sys/src/features/gen_RtcDegradationPreference.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcDegradationPreference` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcDegradationPreference`*"]

--- a/crates/web-sys/src/features/gen_RtcEncodedVideoFrameType.rs
+++ b/crates/web-sys/src/features/gen_RtcEncodedVideoFrameType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcEncodedVideoFrameType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcEncodedVideoFrameType`*"]

--- a/crates/web-sys/src/features/gen_RtcIceConnectionState.rs
+++ b/crates/web-sys/src/features/gen_RtcIceConnectionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcIceConnectionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcIceConnectionState`*"]

--- a/crates/web-sys/src/features/gen_RtcIceCredentialType.rs
+++ b/crates/web-sys/src/features/gen_RtcIceCredentialType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcIceCredentialType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcIceCredentialType`*"]

--- a/crates/web-sys/src/features/gen_RtcIceGatheringState.rs
+++ b/crates/web-sys/src/features/gen_RtcIceGatheringState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcIceGatheringState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcIceGatheringState`*"]

--- a/crates/web-sys/src/features/gen_RtcIceTransportPolicy.rs
+++ b/crates/web-sys/src/features/gen_RtcIceTransportPolicy.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcIceTransportPolicy` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcIceTransportPolicy`*"]

--- a/crates/web-sys/src/features/gen_RtcPeerConnectionState.rs
+++ b/crates/web-sys/src/features/gen_RtcPeerConnectionState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcPeerConnectionState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcPeerConnectionState`*"]

--- a/crates/web-sys/src/features/gen_RtcPriorityType.rs
+++ b/crates/web-sys/src/features/gen_RtcPriorityType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcPriorityType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcPriorityType`*"]

--- a/crates/web-sys/src/features/gen_RtcRtpSourceEntryType.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpSourceEntryType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcRtpSourceEntryType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcRtpSourceEntryType`*"]

--- a/crates/web-sys/src/features/gen_RtcRtpTransceiverDirection.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpTransceiverDirection.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcRtpTransceiverDirection` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcRtpTransceiverDirection`*"]

--- a/crates/web-sys/src/features/gen_RtcSdpType.rs
+++ b/crates/web-sys/src/features/gen_RtcSdpType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcSdpType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcSdpType`*"]

--- a/crates/web-sys/src/features/gen_RtcSignalingState.rs
+++ b/crates/web-sys/src/features/gen_RtcSignalingState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcSignalingState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcSignalingState`*"]

--- a/crates/web-sys/src/features/gen_RtcStatsIceCandidatePairState.rs
+++ b/crates/web-sys/src/features/gen_RtcStatsIceCandidatePairState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcStatsIceCandidatePairState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcStatsIceCandidatePairState`*"]

--- a/crates/web-sys/src/features/gen_RtcStatsIceCandidateType.rs
+++ b/crates/web-sys/src/features/gen_RtcStatsIceCandidateType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcStatsIceCandidateType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcStatsIceCandidateType`*"]

--- a/crates/web-sys/src/features/gen_RtcStatsType.rs
+++ b/crates/web-sys/src/features/gen_RtcStatsType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `RtcStatsType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `RtcStatsType`*"]

--- a/crates/web-sys/src/features/gen_SFrameTransformErrorEventType.rs
+++ b/crates/web-sys/src/features/gen_SFrameTransformErrorEventType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SFrameTransformErrorEventType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SFrameTransformErrorEventType`*"]

--- a/crates/web-sys/src/features/gen_SFrameTransformRole.rs
+++ b/crates/web-sys/src/features/gen_SFrameTransformRole.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SFrameTransformRole` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SFrameTransformRole`*"]

--- a/crates/web-sys/src/features/gen_ScreenColorGamut.rs
+++ b/crates/web-sys/src/features/gen_ScreenColorGamut.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ScreenColorGamut` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ScreenColorGamut`*"]

--- a/crates/web-sys/src/features/gen_ScrollBehavior.rs
+++ b/crates/web-sys/src/features/gen_ScrollBehavior.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ScrollBehavior` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ScrollBehavior`*"]

--- a/crates/web-sys/src/features/gen_ScrollLogicalPosition.rs
+++ b/crates/web-sys/src/features/gen_ScrollLogicalPosition.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ScrollLogicalPosition` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ScrollLogicalPosition`*"]

--- a/crates/web-sys/src/features/gen_ScrollRestoration.rs
+++ b/crates/web-sys/src/features/gen_ScrollRestoration.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ScrollRestoration` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ScrollRestoration`*"]

--- a/crates/web-sys/src/features/gen_ScrollSetting.rs
+++ b/crates/web-sys/src/features/gen_ScrollSetting.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ScrollSetting` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ScrollSetting`*"]

--- a/crates/web-sys/src/features/gen_ScrollState.rs
+++ b/crates/web-sys/src/features/gen_ScrollState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ScrollState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ScrollState`*"]

--- a/crates/web-sys/src/features/gen_SecurityPolicyViolationEventDisposition.rs
+++ b/crates/web-sys/src/features/gen_SecurityPolicyViolationEventDisposition.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SecurityPolicyViolationEventDisposition` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SecurityPolicyViolationEventDisposition`*"]

--- a/crates/web-sys/src/features/gen_SelectionMode.rs
+++ b/crates/web-sys/src/features/gen_SelectionMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SelectionMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SelectionMode`*"]

--- a/crates/web-sys/src/features/gen_ServiceWorkerState.rs
+++ b/crates/web-sys/src/features/gen_ServiceWorkerState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ServiceWorkerState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ServiceWorkerState`*"]

--- a/crates/web-sys/src/features/gen_ServiceWorkerUpdateViaCache.rs
+++ b/crates/web-sys/src/features/gen_ServiceWorkerUpdateViaCache.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ServiceWorkerUpdateViaCache` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ServiceWorkerUpdateViaCache`*"]

--- a/crates/web-sys/src/features/gen_ShadowRootMode.rs
+++ b/crates/web-sys/src/features/gen_ShadowRootMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `ShadowRootMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `ShadowRootMode`*"]

--- a/crates/web-sys/src/features/gen_SocketReadyState.rs
+++ b/crates/web-sys/src/features/gen_SocketReadyState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SocketReadyState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SocketReadyState`*"]

--- a/crates/web-sys/src/features/gen_SourceBufferAppendMode.rs
+++ b/crates/web-sys/src/features/gen_SourceBufferAppendMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SourceBufferAppendMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SourceBufferAppendMode`*"]

--- a/crates/web-sys/src/features/gen_SpeechRecognitionErrorCode.rs
+++ b/crates/web-sys/src/features/gen_SpeechRecognitionErrorCode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SpeechRecognitionErrorCode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SpeechRecognitionErrorCode`*"]

--- a/crates/web-sys/src/features/gen_SpeechSynthesisErrorCode.rs
+++ b/crates/web-sys/src/features/gen_SpeechSynthesisErrorCode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SpeechSynthesisErrorCode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SpeechSynthesisErrorCode`*"]

--- a/crates/web-sys/src/features/gen_StorageType.rs
+++ b/crates/web-sys/src/features/gen_StorageType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `StorageType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `StorageType`*"]

--- a/crates/web-sys/src/features/gen_SupportedType.rs
+++ b/crates/web-sys/src/features/gen_SupportedType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `SupportedType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `SupportedType`*"]

--- a/crates/web-sys/src/features/gen_TaskPriority.rs
+++ b/crates/web-sys/src/features/gen_TaskPriority.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `TaskPriority` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `TaskPriority`*"]

--- a/crates/web-sys/src/features/gen_TcpReadyState.rs
+++ b/crates/web-sys/src/features/gen_TcpReadyState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `TcpReadyState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `TcpReadyState`*"]

--- a/crates/web-sys/src/features/gen_TcpSocketBinaryType.rs
+++ b/crates/web-sys/src/features/gen_TcpSocketBinaryType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `TcpSocketBinaryType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `TcpSocketBinaryType`*"]

--- a/crates/web-sys/src/features/gen_TextTrackKind.rs
+++ b/crates/web-sys/src/features/gen_TextTrackKind.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `TextTrackKind` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `TextTrackKind`*"]

--- a/crates/web-sys/src/features/gen_TextTrackMode.rs
+++ b/crates/web-sys/src/features/gen_TextTrackMode.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `TextTrackMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `TextTrackMode`*"]

--- a/crates/web-sys/src/features/gen_TokenBindingStatus.rs
+++ b/crates/web-sys/src/features/gen_TokenBindingStatus.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `TokenBindingStatus` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `TokenBindingStatus`*"]

--- a/crates/web-sys/src/features/gen_Transport.rs
+++ b/crates/web-sys/src/features/gen_Transport.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `Transport` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `Transport`*"]

--- a/crates/web-sys/src/features/gen_UsbDirection.rs
+++ b/crates/web-sys/src/features/gen_UsbDirection.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `UsbDirection` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `UsbDirection`*"]

--- a/crates/web-sys/src/features/gen_UsbEndpointType.rs
+++ b/crates/web-sys/src/features/gen_UsbEndpointType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `UsbEndpointType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `UsbEndpointType`*"]

--- a/crates/web-sys/src/features/gen_UsbRecipient.rs
+++ b/crates/web-sys/src/features/gen_UsbRecipient.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `UsbRecipient` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `UsbRecipient`*"]

--- a/crates/web-sys/src/features/gen_UsbRequestType.rs
+++ b/crates/web-sys/src/features/gen_UsbRequestType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `UsbRequestType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `UsbRequestType`*"]

--- a/crates/web-sys/src/features/gen_UsbTransferStatus.rs
+++ b/crates/web-sys/src/features/gen_UsbTransferStatus.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `UsbTransferStatus` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `UsbTransferStatus`*"]

--- a/crates/web-sys/src/features/gen_UserVerificationRequirement.rs
+++ b/crates/web-sys/src/features/gen_UserVerificationRequirement.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `UserVerificationRequirement` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `UserVerificationRequirement`*"]

--- a/crates/web-sys/src/features/gen_VideoColorPrimaries.rs
+++ b/crates/web-sys/src/features/gen_VideoColorPrimaries.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VideoColorPrimaries` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VideoColorPrimaries`*"]

--- a/crates/web-sys/src/features/gen_VideoFacingModeEnum.rs
+++ b/crates/web-sys/src/features/gen_VideoFacingModeEnum.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VideoFacingModeEnum` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VideoFacingModeEnum`*"]

--- a/crates/web-sys/src/features/gen_VideoMatrixCoefficients.rs
+++ b/crates/web-sys/src/features/gen_VideoMatrixCoefficients.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VideoMatrixCoefficients` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VideoMatrixCoefficients`*"]

--- a/crates/web-sys/src/features/gen_VideoPixelFormat.rs
+++ b/crates/web-sys/src/features/gen_VideoPixelFormat.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VideoPixelFormat` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VideoPixelFormat`*"]

--- a/crates/web-sys/src/features/gen_VideoTransferCharacteristics.rs
+++ b/crates/web-sys/src/features/gen_VideoTransferCharacteristics.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VideoTransferCharacteristics` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VideoTransferCharacteristics`*"]

--- a/crates/web-sys/src/features/gen_VisibilityState.rs
+++ b/crates/web-sys/src/features/gen_VisibilityState.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VisibilityState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VisibilityState`*"]

--- a/crates/web-sys/src/features/gen_VrEye.rs
+++ b/crates/web-sys/src/features/gen_VrEye.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `VrEye` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `VrEye`*"]

--- a/crates/web-sys/src/features/gen_WakeLockType.rs
+++ b/crates/web-sys/src/features/gen_WakeLockType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WakeLockType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WakeLockType`*"]

--- a/crates/web-sys/src/features/gen_WebGlPowerPreference.rs
+++ b/crates/web-sys/src/features/gen_WebGlPowerPreference.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WebGlPowerPreference` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WebGlPowerPreference`*"]

--- a/crates/web-sys/src/features/gen_WebTransportCongestionControl.rs
+++ b/crates/web-sys/src/features/gen_WebTransportCongestionControl.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WebTransportCongestionControl` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WebTransportCongestionControl`*"]

--- a/crates/web-sys/src/features/gen_WebTransportErrorSource.rs
+++ b/crates/web-sys/src/features/gen_WebTransportErrorSource.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WebTransportErrorSource` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WebTransportErrorSource`*"]

--- a/crates/web-sys/src/features/gen_WebTransportReliabilityMode.rs
+++ b/crates/web-sys/src/features/gen_WebTransportReliabilityMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WebTransportReliabilityMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WebTransportReliabilityMode`*"]

--- a/crates/web-sys/src/features/gen_WellKnownDirectory.rs
+++ b/crates/web-sys/src/features/gen_WellKnownDirectory.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WellKnownDirectory` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WellKnownDirectory`*"]

--- a/crates/web-sys/src/features/gen_WorkerType.rs
+++ b/crates/web-sys/src/features/gen_WorkerType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WorkerType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WorkerType`*"]

--- a/crates/web-sys/src/features/gen_WriteCommandType.rs
+++ b/crates/web-sys/src/features/gen_WriteCommandType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `WriteCommandType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `WriteCommandType`*"]

--- a/crates/web-sys/src/features/gen_XmlHttpRequestResponseType.rs
+++ b/crates/web-sys/src/features/gen_XmlHttpRequestResponseType.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XmlHttpRequestResponseType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XmlHttpRequestResponseType`*"]

--- a/crates/web-sys/src/features/gen_XrEye.rs
+++ b/crates/web-sys/src/features/gen_XrEye.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrEye` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrEye`*"]

--- a/crates/web-sys/src/features/gen_XrHandJoint.rs
+++ b/crates/web-sys/src/features/gen_XrHandJoint.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrHandJoint` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrHandJoint`*"]

--- a/crates/web-sys/src/features/gen_XrHandedness.rs
+++ b/crates/web-sys/src/features/gen_XrHandedness.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrHandedness` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrHandedness`*"]

--- a/crates/web-sys/src/features/gen_XrReferenceSpaceType.rs
+++ b/crates/web-sys/src/features/gen_XrReferenceSpaceType.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrReferenceSpaceType` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrReferenceSpaceType`*"]

--- a/crates/web-sys/src/features/gen_XrSessionMode.rs
+++ b/crates/web-sys/src/features/gen_XrSessionMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrSessionMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrSessionMode`*"]

--- a/crates/web-sys/src/features/gen_XrTargetRayMode.rs
+++ b/crates/web-sys/src/features/gen_XrTargetRayMode.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrTargetRayMode` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrTargetRayMode`*"]

--- a/crates/web-sys/src/features/gen_XrVisibilityState.rs
+++ b/crates/web-sys/src/features/gen_XrVisibilityState.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::all)]
 use wasm_bindgen::prelude::*;
 #[cfg(web_sys_unstable_apis)]
-#[wasm_bindgen]
+#[wasm_bindgen(skip_typescript)]
 #[doc = "The `XrVisibilityState` enum."]
 #[doc = ""]
 #[doc = "*This API requires the following crate features to be activated: `XrVisibilityState`*"]

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -135,7 +135,7 @@ impl Enum {
             use wasm_bindgen::prelude::*;
 
             #unstable_attr
-            #[wasm_bindgen]
+            #[wasm_bindgen(skip_typescript)]
             #doc_comment
             #unstable_docs
             #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Temporary solution for #4163.

I changed the webidl generator code and added a test case to see whether the fix works.

However, running the command from the `web-sys` README fails on my system, so I cannot re-generate the rs files.

```
PS C:\Users\micha\Git\wasm-bindgen> cargo run --release --package wasm-bindgen-webidl -- webidls src/features ./Cargo.toml
    Finished `release` profile [optimized] target(s) in 0.30s
     Running `target\release\wasm-bindgen-webidl.exe webidls src/features ./Cargo.toml`
Error: reading webidls directory

Caused by:
    Das System kann den angegebenen Pfad nicht finden. (os error 3)
error: process didn't exit successfully: `target\release\wasm-bindgen-webidl.exe webidls src/features ./Cargo.toml` (exit code: 1)
```