### PR TITLE
Revert TS string enum generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 * Added support for `Self` in complex type expressions in methods.
   [#4155](https://github.com/rustwasm/wasm-bindgen/pull/4155)
 
+### Changed
+
+* Sting enums are no longer generate TypeScript types.
+  [#4174](https://github.com/rustwasm/wasm-bindgen/pull/4174)
+
 ### Fixed
 
 * Fixed generated setters from WebIDL interface attributes binding to wrong JS method names.

--- a/crates/backend/src/ast.rs
+++ b/crates/backend/src/ast.rs
@@ -343,12 +343,8 @@ pub struct StringEnum {
     pub variants: Vec<Ident>,
     /// The JS string values of the variants
     pub variant_values: Vec<String>,
-    /// The doc comments on this enum, if any
-    pub comments: Vec<String>,
     /// Attributes to apply to the Rust enum
     pub rust_attrs: Vec<syn::Attribute>,
-    /// Whether to generate a typescript definition for this enum
-    pub generate_typescript: bool,
     /// Path to wasm_bindgen
     pub wasm_bindgen: Path,
 }

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1144,7 +1144,7 @@ impl ToTokens for ast::StringEnum {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let vis = &self.vis;
         let enum_name = &self.name;
-        let name_str = self.js_name.to_string();
+        let name_str = &self.js_name;
         let name_len = name_str.len() as u32;
         let name_chars = name_str.chars().map(u32::from);
         let variants = &self.variants;

--- a/crates/backend/src/encode.rs
+++ b/crates/backend/src/encode.rs
@@ -362,10 +362,7 @@ fn shared_import_type<'a>(i: &'a ast::ImportType, intern: &'a Interner) -> Impor
 fn shared_import_enum<'a>(i: &'a ast::StringEnum, _intern: &'a Interner) -> StringEnum<'a> {
     StringEnum {
         name: &i.js_name,
-        public: matches!(i.vis, syn::Visibility::Public(_)),
-        generate_typescript: i.generate_typescript,
         variant_values: i.variant_values.iter().map(|x| &**x).collect(),
-        comments: i.comments.iter().map(|s| &**s).collect(),
     }
 }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3816,31 +3816,11 @@ __wbg_set_wasm(wasm);"
     }
 
     fn generate_string_enum(&mut self, string_enum: &AuxStringEnum) -> Result<(), Error> {
-        let docs = format_doc_comments(&string_enum.comments, None);
-
         let variants: Vec<_> = string_enum
             .variant_values
             .iter()
             .map(|v| format!("\"{v}\""))
             .collect();
-
-        if string_enum.generate_typescript {
-            self.typescript.push_str(&docs);
-            if string_enum.public {
-                self.typescript.push_str("export ");
-            }
-            self.typescript.push_str("type ");
-            self.typescript.push_str(&string_enum.name);
-            self.typescript.push_str(" = ");
-
-            if variants.is_empty() {
-                self.typescript.push_str("never");
-            } else {
-                self.typescript.push_str(&variants.join(" | "));
-            }
-
-            self.typescript.push_str(";\n");
-        }
 
         self.global(&format!(
             "const __wbindgen_enum_{name} = [{values}];\n",

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -868,14 +868,11 @@ impl<'a> Context<'a> {
     fn string_enum(&mut self, string_enum: &decode::StringEnum<'_>) -> Result<(), Error> {
         let aux = AuxStringEnum {
             name: string_enum.name.to_string(),
-            public: string_enum.public,
-            comments: concatenate_comments(&string_enum.comments),
             variant_values: string_enum
                 .variant_values
                 .iter()
                 .map(|v| v.to_string())
                 .collect(),
-            generate_typescript: string_enum.generate_typescript,
         };
         let mut result = Ok(());
         self.aux

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -179,14 +179,8 @@ pub struct AuxEnum {
 pub struct AuxStringEnum {
     /// The name of this enum
     pub name: String,
-    /// Whether this enum is public
-    pub public: bool,
-    /// The copied Rust comments to forward to JS
-    pub comments: String,
     /// A list of variants values
     pub variant_values: Vec<String>,
-    /// Whether typescript bindings should be generated for this enum.
-    pub generate_typescript: bool,
 }
 
 #[derive(Debug)]

--- a/crates/cli/tests/reference/enums.d.ts
+++ b/crates/cli/tests/reference/enums.d.ts
@@ -43,12 +43,3 @@ export enum ImplicitDiscriminant {
   C = 42,
   D = 43,
 }
-/**
- * The name of a color.
- */
-export type ColorName = "green" | "yellow" | "red";
-/**
- * An unused string enum.
- */
-export type FooBar = "foo" | "bar";
-type PrivateStringEnum = "foo" | "bar";

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -83,10 +83,6 @@ export const ImplicitDiscriminant = Object.freeze({ A:0,"0":"A",B:1,"1":"B",C:42
 
 const __wbindgen_enum_ColorName = ["green", "yellow", "red"];
 
-const __wbindgen_enum_FooBar = ["foo", "bar"];
-
-const __wbindgen_enum_PrivateStringEnum = ["foo", "bar"];
-
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
 };

--- a/crates/cli/tests/reference/enums.rs
+++ b/crates/cli/tests/reference/enums.rs
@@ -45,19 +45,6 @@ pub fn option_string_enum_echo(color: Option<ColorName>) -> Option<ColorName> {
     color
 }
 
-/// An unused string enum.
-#[wasm_bindgen(js_name = "FooBar")]
-pub enum UnusedStringEnum {
-    Foo = "foo",
-    Bar = "bar",
-}
-
-#[wasm_bindgen]
-enum PrivateStringEnum {
-    Foo = "foo",
-    Bar = "bar",
-}
-
 #[wasm_bindgen]
 pub enum ImplicitDiscriminant {
     A,

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1321,8 +1321,6 @@ fn string_enum(
     enum_: syn::ItemEnum,
     program: &mut ast::Program,
     js_name: String,
-    generate_typescript: bool,
-    comments: Vec<String>,
 ) -> Result<(), Diagnostic> {
     let mut variants = vec![];
     let mut variant_values = vec![];
@@ -1358,9 +1356,7 @@ fn string_enum(
             js_name,
             variants,
             variant_values,
-            comments,
             rust_attrs: enum_.attrs,
-            generate_typescript,
             wasm_bindgen: program.wasm_bindgen.clone(),
         }),
     });
@@ -1410,7 +1406,7 @@ impl<'a> MacroParse<(&'a mut TokenStream, BindgenAttrs)> for syn::ItemEnum {
             false
         });
         if is_string_enum {
-            return string_enum(self, program, js_name, generate_typescript, comments);
+            return string_enum(self, program, js_name);
         }
 
         match self.vis {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -106,10 +106,7 @@ macro_rules! shared_api {
 
         struct StringEnum<'a> {
             name: &'a str,
-            public: bool,
             variant_values: Vec<&'a str>,
-            comments: Vec<&'a str>,
-            generate_typescript: bool,
         }
 
         struct Export<'a> {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "950257602071279980";
+const APPROVED_SCHEMA_FILE_HASH: &str = "2837603620805312754";
 
 #[test]
 fn schema_version() {


### PR DESCRIPTION
This reverts string enums generating TS types, as it could easily pollute the bindings by all the enums generated in `web-sys` or custom bindings in various libraries.

Cc @RunDevelopment.

Reverts parts of #4147.
Reopens #2153.
Fixes #4163.