### PR TITLE
Remove string enum type mentions from JS & TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@
 
 ### Changed
 
-* Sting enums are no longer generate TypeScript types.
+* String enums are no longer generate TypeScript types.
   [#4174](https://github.com/rustwasm/wasm-bindgen/pull/4174)
 
 ### Fixed
 
 * Fixed generated setters from WebIDL interface attributes binding to wrong JS method names.
   [#4170](https://github.com/rustwasm/wasm-bindgen/pull/4170)
+
+* Fix string enums showing up in JS documentation and TypeScript bindings without corresponding types.
+  [#4175](https://github.com/rustwasm/wasm-bindgen/pull/4175)
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1441,7 +1441,7 @@ fn adapter2ts(ty: &AdapterType, dst: &mut String) {
         AdapterType::NamedExternref(name) => dst.push_str(name),
         AdapterType::Struct(name) => dst.push_str(name),
         AdapterType::Enum(name) => dst.push_str(name),
-        AdapterType::StringEnum(name) => dst.push_str(name),
+        AdapterType::StringEnum => dst.push_str("any"),
         AdapterType::Function => dst.push_str("any"),
     }
 }

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -110,7 +110,7 @@ impl InstructionBuilder<'_, '_> {
             },
             Descriptor::StringEnum { name, invalid, .. } => {
                 self.instruction(
-                    &[AdapterType::StringEnum(name.clone())],
+                    &[AdapterType::StringEnum],
                     Instruction::StringEnumToWasm {
                         name: name.clone(),
                         invalid: *invalid,
@@ -312,7 +312,7 @@ impl InstructionBuilder<'_, '_> {
                 hole,
             } => {
                 self.instruction(
-                    &[AdapterType::StringEnum(name.clone()).option()],
+                    &[AdapterType::StringEnum.option()],
                     Instruction::OptionStringEnumToWasm {
                         name: name.clone(),
                         invalid: *invalid,

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -295,7 +295,7 @@ impl InstructionBuilder<'_, '_> {
                         name: name.clone(),
                         hole: *hole,
                     },
-                    &[AdapterType::StringEnum(String::from(name)).option()],
+                    &[AdapterType::StringEnum.option()],
                 );
             }
             Descriptor::RustStruct(name) => {
@@ -538,7 +538,7 @@ impl InstructionBuilder<'_, '_> {
             Instruction::WasmToStringEnum {
                 name: name.to_string(),
             },
-            &[AdapterType::StringEnum(String::from(name))],
+            &[AdapterType::StringEnum],
         );
     }
 

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -86,7 +86,7 @@ pub enum AdapterType {
     Option(Box<AdapterType>),
     Struct(String),
     Enum(String),
-    StringEnum(String),
+    StringEnum,
     NamedExternref(String),
     Function,
     NonNull,

--- a/crates/cli/tests/reference/enums.d.ts
+++ b/crates/cli/tests/reference/enums.d.ts
@@ -12,14 +12,14 @@ export function enum_echo(color: Color): Color;
 export function option_enum_echo(color?: Color): Color | undefined;
 /**
  * @param {Color} color
- * @returns {ColorName}
+ * @returns {any}
  */
-export function get_name(color: Color): ColorName;
+export function get_name(color: Color): any;
 /**
- * @param {ColorName | undefined} [color]
- * @returns {ColorName | undefined}
+ * @param {any | undefined} [color]
+ * @returns {any | undefined}
  */
-export function option_string_enum_echo(color?: ColorName): ColorName | undefined;
+export function option_string_enum_echo(color?: any): any | undefined;
 /**
  * A color.
  */

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -46,7 +46,7 @@ export function option_enum_echo(color) {
 
 /**
  * @param {Color} color
- * @returns {ColorName}
+ * @returns {any}
  */
 export function get_name(color) {
     const ret = wasm.get_name(color);
@@ -54,8 +54,8 @@ export function get_name(color) {
 }
 
 /**
- * @param {ColorName | undefined} [color]
- * @returns {ColorName | undefined}
+ * @param {any | undefined} [color]
+ * @returns {any | undefined}
  */
 export function option_string_enum_echo(color) {
     const ret = wasm.option_string_enum_echo(color == undefined ? 4 : ((__wbindgen_enum_ColorName.indexOf(color) + 1 || 4) - 1));


### PR DESCRIPTION
String enum types are showing up in JS documentation and TS signatures despite not being present.
This bug was introduced back in v0.2.93 with #3915.