### PR TITLE
Prepare v0.2.95 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
-## Unreleased
+## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)
+
+Released 2024-10-10
 
 ### Added
 
@@ -26,7 +28,7 @@
 
 --------------------------------------------------------------------------------
 
-## [0.2.94](https://github.com/rustwasm/wasm-bindgen/compare/0.2.93...0.2.94)
+## [0.2.94](https://github.com/rustwasm/wasm-bindgen/compare/0.2.93...0.2.94) (YANKED)
 
 Released 2024-10-09
 
@@ -492,7 +494,7 @@ Released 2023-11-27.
 
 --------------------------------------------------------------------------------
 
-## [0.2.88](https://github.com/rustwasm/wasm-bindgen/compare/0.2.87...0.2.88)
+## [0.2.88](https://github.com/rustwasm/wasm-bindgen/compare/0.2.87...0.2.88) (YANKED)
 
 Released 2023-11-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "wasm-bindgen"
 readme = "README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 rust-version = "1.57"
-version = "0.2.94"
+version = "0.2.95"
 
 [package.metadata.docs.rs]
 features = ["serde-serialize"]
@@ -45,7 +45,7 @@ cfg-if = "1.0.0"
 once_cell = "1.12"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.94" }
+wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.95" }
 
 [dev-dependencies]
 wasm-bindgen-test = { path = 'crates/test' }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-backend"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend"
 rust-version = "1.57"
-version = "0.2.94"
+version = "0.2.95"
 
 [features]
 extra-traits = ["syn/extra-traits"]
@@ -24,4 +24,4 @@ once_cell = "1.12"
 proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '2.0', features = ['full'] }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.94" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-cli-support"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli-support"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [dependencies]
 anyhow = "1.0"
@@ -23,9 +23,9 @@ serde_json = "1.0"
 tempfile = "3.0"
 unicode-ident = "1.0.5"
 walrus = "0.22"
-wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.94' }
-wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.94' }
-wasm-bindgen-shared = { path = "../shared", version = '=0.2.94' }
-wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.94' }
-wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.94' }
-wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.94' }
+wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.95' }
+wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.95' }
+wasm-bindgen-shared = { path = "../shared", version = '=0.2.95' }
+wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.95' }
+wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.95' }
+wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.95' }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-cli"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [package.metadata.binstall]
 bin-dir = "wasm-bindgen-{ version }-{ target }/{ bin }{ binary-ext }"
@@ -32,8 +32,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 ureq = { version = "2.7", default-features = false, features = ["brotli", "gzip"] }
 walrus = { version = "0.22", features = ['parallel'] }
-wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.94" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.94" }
+wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.95" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-externref-xform"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/externref-xform"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [dependencies]
 anyhow = "1.0"
 walrus = "0.22"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.94" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.95" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -10,7 +10,7 @@ name = "wasm-bindgen-futures"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures"
 rust-version = "1.57"
-version = "0.4.44"
+version = "0.4.45"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -19,8 +19,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 cfg-if = "1.0.0"
 futures-core = { version = '0.3.8', default-features = false, optional = true }
-js-sys = { path = "../js-sys", version = '0.3.71' }
-wasm-bindgen = { path = "../..", version = '0.2.94' }
+js-sys = { path = "../js-sys", version = '0.3.72' }
+wasm-bindgen = { path = "../..", version = '0.2.95' }
 
 [features]
 futures-core-03-stream = ['futures-core']

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -14,14 +14,14 @@ name = "js-sys"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys"
 rust-version = "1.57"
-version = "0.3.71"
+version = "0.3.72"
 
 [lib]
 doctest = false
 test = false
 
 [dependencies]
-wasm-bindgen = { path = "../..", version = "0.2.94" }
+wasm-bindgen = { path = "../..", version = "0.2.95" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-futures = { path = '../futures' }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-macro-support"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support"
 rust-version = "1.57"
-version = "0.2.94"
+version = "0.2.95"
 
 [features]
 extra-traits = ["syn/extra-traits"]
@@ -22,5 +22,5 @@ strict-macro = []
 proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '2.0', features = ['visit', 'visit-mut', 'full'] }
-wasm-bindgen-backend = { path = "../backend", version = "=0.2.94" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.94" }
+wasm-bindgen-backend = { path = "../backend", version = "=0.2.95" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-macro"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro"
 rust-version = "1.57"
-version = "0.2.94"
+version = "0.2.95"
 
 [lib]
 proc-macro = true
@@ -23,7 +23,7 @@ xxx_debug_only_print_generated_code = []
 
 [dependencies]
 quote = "1.0"
-wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.94" }
+wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.95" }
 
 [dev-dependencies]
 js-sys = { path = "../js-sys" }

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-multi-value-xform"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/multi-value-xform"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [dependencies]
 anyhow = "1.0"
 walrus = "0.22"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.94" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.95" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-shared"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared"
 rust-version = "1.57"
-version = "0.2.94"
+version = "0.2.95"
 
 # Because only a single `wasm_bindgen` version can be used in a dependency
 # graph, pretend we link a native library so that `cargo` will provide better

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -6,7 +6,7 @@ mod schema_hash_approval;
 // This gets changed whenever our schema changes.
 // At this time versions of wasm-bindgen and wasm-bindgen-cli are required to have the exact same
 // SCHEMA_VERSION in order to work together.
-pub const SCHEMA_VERSION: &str = "0.2.94";
+pub const SCHEMA_VERSION: &str = "0.2.95";
 
 #[macro_export]
 macro_rules! shared_api {

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "2837603620805312754";
+const APPROVED_SCHEMA_FILE_HASH: &str = "89356342330161978";
 
 #[test]
 fn schema_version() {

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test-macro"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 rust-version = "1.57"
-version = "0.3.44"
+version = "0.3.45"
 
 [lib]
 proc-macro = true

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -7,16 +7,16 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 rust-version = "1.57"
-version = "0.3.44"
+version = "0.3.45"
 
 [dependencies]
 console_error_panic_hook = '0.1'
 gg-alloc = { version = "1.0", optional = true }
-js-sys = { path = '../js-sys', version = '0.3.71' }
+js-sys = { path = '../js-sys', version = '0.3.72' }
 scoped-tls = "1.0"
-wasm-bindgen = { path = '../..', version = '0.2.94' }
-wasm-bindgen-futures = { path = '../futures', version = '0.4.44' }
-wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.44' }
+wasm-bindgen = { path = '../..', version = '0.2.95' }
+wasm-bindgen-futures = { path = '../futures', version = '0.4.45' }
+wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.45' }
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]
 minicov = "0.3"

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-threads-xform"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/threads-xform"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [dependencies]
 anyhow = "1.0"
 walrus = "0.22"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.94" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.95" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-wasm-conventions"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/wasm-conventions"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [dependencies]
 leb128 = "0.2"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -11,13 +11,13 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-wasm-interpreter"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/main/crates/wasm-interpreter"
 rust-version = "1.76"
-version = "0.2.94"
+version = "0.2.95"
 
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
 walrus = "0.22"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.94" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.95" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -12,7 +12,7 @@ name = "web-sys"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys"
 rust-version = "1.57"
-version = "0.3.71"
+version = "0.3.72"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -23,8 +23,8 @@ doctest = false
 test = false
 
 [dependencies]
-js-sys = { path = '../js-sys', version = '0.3.71' }
-wasm-bindgen = { path = "../..", version = "0.2.94" }
+js-sys = { path = '../js-sys', version = '0.3.72' }
+wasm-bindgen = { path = "../..", version = "0.2.95" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 futures = "0.3"


### PR DESCRIPTION
This is motivated by:
- Wrong `web-sys` bindings: #4169.
- Removal of unstable functions in `wasm-bindgen-support`: #4159.
- Undesirable pollution of TS bindings: #4174