### PR TITLE
Use `isLikeNone` to detect null/undefined for string enums

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -712,12 +712,11 @@ fn instruction(
         } => {
             let enum_val = js.pop();
             let enum_val_expr = string_enum_to_wasm(name, *invalid, &enum_val);
+            js.cx.expose_is_like_none();
 
-            // e.g. someEnumVal == undefined ? 4 : (string_enum_to_wasm(someEnumVal))
-            //                  |
-            //    double equals here in case it's null
+            // e.g. isLikeNone(someEnumVal) ? 4 : (string_enum_to_wasm(someEnumVal))
             js.push(format!(
-                "{enum_val} == undefined ? {hole} : ({enum_val_expr})"
+                "isLikeNone({enum_val}) ? {hole} : ({enum_val_expr})"
             ))
         }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2178,7 +2178,7 @@ __wbg_set_wasm(wasm);"
         self.global(
             "
             function isLikeNone(x) {
-                return x == null;
+                return x === undefined || x === null;
             }
         ",
         );

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2178,7 +2178,7 @@ __wbg_set_wasm(wasm);"
         self.global(
             "
             function isLikeNone(x) {
-                return x === undefined || x === null;
+                return x == null;
             }
         ",
         );

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -33,7 +33,7 @@ export function enum_echo(color) {
 }
 
 function isLikeNone(x) {
-    return x === undefined || x === null;
+    return x == null;
 }
 /**
  * @param {Color | undefined} [color]
@@ -58,7 +58,7 @@ export function get_name(color) {
  * @returns {any | undefined}
  */
 export function option_string_enum_echo(color) {
-    const ret = wasm.option_string_enum_echo(color == undefined ? 4 : ((__wbindgen_enum_ColorName.indexOf(color) + 1 || 4) - 1));
+    const ret = wasm.option_string_enum_echo(isLikeNone(color) ? 4 : ((__wbindgen_enum_ColorName.indexOf(color) + 1 || 4) - 1));
     return __wbindgen_enum_ColorName[ret];
 }
 

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -33,7 +33,7 @@ export function enum_echo(color) {
 }
 
 function isLikeNone(x) {
-    return x == null;
+    return x === undefined || x === null;
 }
 /**
  * @param {Color | undefined} [color]


### PR DESCRIPTION
This is a very minor thing I noticed. All conversions except the string enum one use `isLikeNone` to detect none-like JS values (`undefined` and `null`). So I change the JS string enum to WASM string enum conversion to use `isLikeNone` as well. All conversions new use `isLikeNone` to detect none-like values.
