### PR TITLE
Added type annotations for a few glue code functions

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1167,6 +1167,10 @@ __wbg_set_wasm(wasm);"
         // the linked list of heap slots that are free.
         self.global(&format!(
             "
+            /**
+             * @param {{number}} idx
+             * @returns {{void}}
+             */
             function dropObject(idx) {{
                 if (idx < {}) return;
                 heap[idx] = heap_next;
@@ -1307,10 +1311,14 @@ __wbg_set_wasm(wasm);"
         // a `SharedArrayBuffer` is in use.
         let shared = self.module.memories.get(memory).shared;
 
+        let js_doc =
+            "/** @type {(arg: string, view: Uint8Array) => TextEncoderEncodeIntoResult} */";
+
         match self.config.encode_into {
             EncodeInto::Always if !shared => {
                 self.global(&format!(
                     "
+                    {js_doc}
                     const encodeString = {};
                 ",
                     encode_into
@@ -1319,6 +1327,7 @@ __wbg_set_wasm(wasm);"
             EncodeInto::Test if !shared => {
                 self.global(&format!(
                     "
+                    {js_doc}
                     const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
                         ? {}
                         : {});
@@ -1329,6 +1338,7 @@ __wbg_set_wasm(wasm);"
             _ => {
                 self.global(&format!(
                     "
+                    {js_doc}
                     const encodeString = {};
                 ",
                     encode
@@ -1372,7 +1382,14 @@ __wbg_set_wasm(wasm);"
         );
 
         self.global(&format!(
-            "function {name}(arg, malloc, realloc) {{
+            "
+            /**
+             * @param {{string}} arg
+             * @param {{(size: number, align: number) => number}} malloc
+             * @param {{(ptr: number, oldSize: number, newSize: number, align: number) => number}} [realloc]
+             * @returns {{number}}
+             */
+            function {name}(arg, malloc, realloc) {{
                 {debug}
                 {ascii}
                 if (offset !== len) {{
@@ -1389,7 +1406,8 @@ __wbg_set_wasm(wasm);"
 
                 WASM_VECTOR_LEN = offset;
                 return ptr;
-            }}",
+            }}
+            ",
             name = ret,
             debug = debug,
             ascii = encode_as_ascii,
@@ -1451,6 +1469,11 @@ __wbg_set_wasm(wasm);"
                 let add = self.expose_add_to_externref_table(table, alloc)?;
                 self.global(&format!(
                     "
+                        /**
+                         * @param {{ArrayLike<unknown>}} array
+                         * @param {{(size: number, align: number) => number}} malloc
+                         * @returns {{number}}
+                         */
                         function {}(array, malloc) {{
                             const ptr = malloc(array.length * 4, 4) >>> 0;
                             const mem = {}();
@@ -1468,6 +1491,11 @@ __wbg_set_wasm(wasm);"
                 self.expose_add_heap_object();
                 self.global(&format!(
                     "
+                        /**
+                         * @param {{ArrayLike<unknown>}} array
+                         * @param {{(size: number, align: number) => number}} malloc
+                         * @returns {{number}}
+                         */
                         function {}(array, malloc) {{
                             const ptr = malloc(array.length * 4, 4) >>> 0;
                             const mem = {}();
@@ -1501,6 +1529,11 @@ __wbg_set_wasm(wasm);"
         self.expose_wasm_vector_len();
         self.global(&format!(
             "
+            /**
+             * @param {{ArrayLike<number>}} arg
+             * @param {{(size: number, align: number) => number}} malloc
+             * @returns {{number}}
+             */
             function {}(arg, malloc) {{
                 const ptr = malloc(arg.length * {size}, {size}) >>> 0;
                 {}().set(arg, ptr / {size});
@@ -1558,6 +1591,7 @@ __wbg_set_wasm(wasm);"
         args: &str,
         init: Option<&str>,
     ) -> Result<(), Error> {
+        let js_doc = format!("/** @type {{{s}}} */\n");
         match &self.config.mode {
             OutputMode::Node { .. } => {
                 let name = self.import_name(&JsImport {
@@ -1567,25 +1601,23 @@ __wbg_set_wasm(wasm);"
                     },
                     fields: Vec::new(),
                 })?;
-                self.global(&format!("let cached{} = new {}{};", s, name, args));
+                self.global(&format!("{js_doc}let cached{} = new {}{};", s, name, args));
             }
             OutputMode::Bundler {
                 browser_only: false,
             } => {
-                self.global(&format!(
-                    "
-                    const l{0} = typeof {0} === 'undefined' ? \
-                        (0, module.require)('util').{0} : {0};\
-                ",
-                    s
-                ));
-                self.global(&format!("let cached{0} = new l{0}{1};", s, args));
+                // this is a mix between the web and node version.
+                // we check if Text{En,De}coder is available (web) and if not, we require it (node).
+                let type_expr = format!(
+                    "typeof {s} === 'undefined' ? (0, module.require)('util').{s} : {s}"
+                );
+                self.global(&format!("{js_doc}let cached{s} = new ({type_expr}){args};"));
             }
             OutputMode::Deno
             | OutputMode::Web
             | OutputMode::NoModules { .. }
             | OutputMode::Bundler { browser_only: true } => {
-                self.global(&format!("const cached{0} = (typeof {0} !== 'undefined' ? new {0}{1} : {{ {2}: () => {{ throw Error('{0} not available') }} }} );", s, args, op))
+                self.global(&format!("{js_doc}const cached{0} = (typeof {0} !== 'undefined' ? new {0}{1} : {{ {2}: () => {{ throw Error('{0} not available') }} }} );", s, args, op))
             }
         };
 
@@ -1633,6 +1665,11 @@ __wbg_set_wasm(wasm);"
 
         self.global(&format!(
             "
+            /**
+             * @param {{number}} ptr
+             * @param {{number}} len
+             * @returns {{string}}
+             */
             function {}(ptr, len) {{
                 ptr = ptr >>> 0;
                 return cachedTextDecoder.decode({}().{}(ptr, ptr + len));
@@ -1804,6 +1841,10 @@ __wbg_set_wasm(wasm);"
         }
         self.global(&format!(
             "
+            /**
+             * @param {{number}} ptr
+             * @param {{number}} len
+             */
             function {name}(ptr, len) {{
                 ptr = ptr >>> 0;
                 return {mem}().subarray(ptr / {size}, ptr / {size} + len);
@@ -1892,10 +1933,10 @@ __wbg_set_wasm(wasm);"
             format!("{cache}.byteLength === 0", cache = cache)
         };
 
-        self.global(&format!("let {cache} = null;\n"));
-
         self.global(&format!(
             "
+            /** @type {{{kind} | null}} */
+            let {cache} = null;
             function {name}() {{
                 if ({cache} === null || {resized_check}) {{
                     {cache} = new {kind}(wasm.{mem}.buffer);
@@ -1940,11 +1981,14 @@ __wbg_set_wasm(wasm);"
         }
         self.global(
             "
+            /**
+             * @param {unknown} instance
+             * @param {Function} klass
+             */
             function _assertClass(instance, klass) {
                 if (!(instance instanceof klass)) {
                     throw new Error(`expected instance of ${klass.name}`);
                 }
-                return instance.ptr;
             }
             ",
         );
@@ -1987,6 +2031,10 @@ __wbg_set_wasm(wasm);"
         self.expose_drop_ref();
         self.global(
             "
+            /**
+             * @param {number} idx
+             * @returns {any}
+             */
             function takeObject(idx) {
                 const ret = getObject(idx);
                 dropObject(idx);
@@ -2018,6 +2066,10 @@ __wbg_set_wasm(wasm);"
         // one more slot and use that.
         self.global(&format!(
             "
+            /**
+             * @param {{unknown}} obj
+             * @returns {{number}}
+             */
             function addHeapObject(obj) {{
                 if (heap_next === heap.length) heap.push(heap.length + 1);
                 const idx = heap_next;
@@ -2177,6 +2229,10 @@ __wbg_set_wasm(wasm);"
         }
         self.global(
             "
+            /**
+             * @param {unknown} x
+             * @returns {x is undefined | null}
+             */
             function isLikeNone(x) {
                 return x === undefined || x === null;
             }
@@ -3911,7 +3967,11 @@ __wbg_set_wasm(wasm);"
 
         self.global(
             "
-           function debugString(val) {
+            /**
+             * @param {any} val
+             * @returns {string}
+             */
+            function debugString(val) {
                 // primitive types
                 const type = typeof val;
                 if (type == 'number' || type == 'boolean' || val == null) {
@@ -3952,7 +4012,7 @@ __wbg_set_wasm(wasm);"
                 // Test for built-in
                 const builtInMatches = /\\[object ([^\\]]+)\\]/.exec(toString.call(val));
                 let className;
-                if (builtInMatches.length > 1) {
+                if (builtInMatches && builtInMatches.length > 1) {
                     className = builtInMatches[1];
                 } else {
                     // Failed to match the standard '[object ClassName]'

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -4,14 +4,13 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
 
 cachedTextDecoder.decode();
 
+/** @type {Uint8Array | null} */
 let cachedUint8ArrayMemory0 = null;
-
 function getUint8ArrayMemory0() {
     if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
         cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
@@ -19,6 +18,11 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
@@ -39,8 +43,8 @@ function handleError(f, args) {
     }
 }
 
+/** @type {DataView | null} */
 let cachedDataViewMemory0 = null;
-
 function getDataViewMemory0() {
     if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
         cachedDataViewMemory0 = new DataView(wasm.memory.buffer);

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -4,14 +4,13 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
 
 cachedTextDecoder.decode();
 
+/** @type {Uint8Array | null} */
 let cachedUint8ArrayMemory0 = null;
-
 function getUint8ArrayMemory0() {
     if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
         cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
@@ -19,6 +18,11 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -4,14 +4,13 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
 
 cachedTextDecoder.decode();
 
+/** @type {Uint8Array | null} */
 let cachedUint8ArrayMemory0 = null;
-
 function getUint8ArrayMemory0() {
     if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
         cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
@@ -19,6 +18,11 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -4,14 +4,13 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
 
 cachedTextDecoder.decode();
 
+/** @type {Uint8Array | null} */
 let cachedUint8ArrayMemory0 = null;
-
 function getUint8ArrayMemory0() {
     if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
         cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
@@ -19,6 +18,11 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
@@ -32,6 +36,10 @@ export function enum_echo(color) {
     return ret;
 }
 
+/**
+ * @param {unknown} x
+ * @returns {x is undefined | null}
+ */
 function isLikeNone(x) {
     return x === undefined || x === null;
 }

--- a/crates/cli/tests/reference/import-catch.js
+++ b/crates/cli/tests/reference/import-catch.js
@@ -10,6 +10,10 @@ heap.push(undefined, null, true, false);
 
 let heap_next = heap.length;
 
+/**
+ * @param {unknown} obj
+ * @returns {number}
+ */
 function addHeapObject(obj) {
     if (heap_next === heap.length) heap.push(heap.length + 1);
     const idx = heap_next;
@@ -27,8 +31,8 @@ function handleError(f, args) {
     }
 }
 
+/** @type {DataView | null} */
 let cachedDataViewMemory0 = null;
-
 function getDataViewMemory0() {
     if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
         cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
@@ -38,12 +42,20 @@ function getDataViewMemory0() {
 
 function getObject(idx) { return heap[idx]; }
 
+/**
+ * @param {number} idx
+ * @returns {void}
+ */
 function dropObject(idx) {
     if (idx < 132) return;
     heap[idx] = heap_next;
     heap_next = idx;
 }
 
+/**
+ * @param {number} idx
+ * @returns {any}
+ */
 function takeObject(idx) {
     const ret = getObject(idx);
     dropObject(idx);

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -6,26 +6,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
-
-cachedTextDecoder.decode();
-
-let cachedUint8ArrayMemory0 = null;
-
-function getUint8ArrayMemory0() {
-    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
-        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
-    }
-    return cachedUint8ArrayMemory0;
-}
-
-function getStringFromWasm0(ptr, len) {
-    ptr = ptr >>> 0;
-    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
-}
-
 const heap = new Array(128).fill(undefined);
 
 heap.push(undefined, null, true, false);
@@ -34,16 +14,48 @@ function getObject(idx) { return heap[idx]; }
 
 let heap_next = heap.length;
 
+/**
+ * @param {number} idx
+ * @returns {void}
+ */
 function dropObject(idx) {
     if (idx < 132) return;
     heap[idx] = heap_next;
     heap_next = idx;
 }
 
+/**
+ * @param {number} idx
+ * @returns {any}
+ */
 function takeObject(idx) {
     const ret = getObject(idx);
     dropObject(idx);
     return ret;
+}
+
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+/** @type {Uint8Array | null} */
+let cachedUint8ArrayMemory0 = null;
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 /**
  * @param {number} test
@@ -54,6 +66,10 @@ export function test1(test) {
     return ret >>> 0;
 }
 
+/**
+ * @param {unknown} obj
+ * @returns {number}
+ */
 function addHeapObject(obj) {
     if (heap_next === heap.length) heap.push(heap.length + 1);
     const idx = heap_next;
@@ -109,11 +125,11 @@ export function __wbg_test2_39fe629b9aa739cf() {
     return addHeapObject(ret);
 };
 
-export function __wbindgen_throw(arg0, arg1) {
-    throw new Error(getStringFromWasm0(arg0, arg1));
-};
-
 export function __wbindgen_object_drop_ref(arg0) {
     takeObject(arg0);
+};
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
 };
 

--- a/crates/cli/tests/reference/result-string.js
+++ b/crates/cli/tests/reference/result-string.js
@@ -10,6 +10,10 @@ heap.push(undefined, null, true, false);
 
 let heap_next = heap.length;
 
+/**
+ * @param {unknown} obj
+ * @returns {number}
+ */
 function addHeapObject(obj) {
     if (heap_next === heap.length) heap.push(heap.length + 1);
     const idx = heap_next;
@@ -19,8 +23,8 @@ function addHeapObject(obj) {
     return idx;
 }
 
+/** @type {DataView | null} */
 let cachedDataViewMemory0 = null;
-
 function getDataViewMemory0() {
     if (cachedDataViewMemory0 === null || cachedDataViewMemory0.buffer.detached === true || (cachedDataViewMemory0.buffer.detached === undefined && cachedDataViewMemory0.buffer !== wasm.memory.buffer)) {
         cachedDataViewMemory0 = new DataView(wasm.memory.buffer);
@@ -30,26 +34,33 @@ function getDataViewMemory0() {
 
 function getObject(idx) { return heap[idx]; }
 
+/**
+ * @param {number} idx
+ * @returns {void}
+ */
 function dropObject(idx) {
     if (idx < 132) return;
     heap[idx] = heap_next;
     heap_next = idx;
 }
 
+/**
+ * @param {number} idx
+ * @returns {any}
+ */
 function takeObject(idx) {
     const ret = getObject(idx);
     dropObject(idx);
     return ret;
 }
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
 
 cachedTextDecoder.decode();
 
+/** @type {Uint8Array | null} */
 let cachedUint8ArrayMemory0 = null;
-
 function getUint8ArrayMemory0() {
     if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
         cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
@@ -57,6 +68,11 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -4,14 +4,13 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
-
-let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+/** @type {TextDecoder} */
+let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
 
 cachedTextDecoder.decode();
 
+/** @type {Uint8Array | null} */
 let cachedUint8ArrayMemory0 = null;
-
 function getUint8ArrayMemory0() {
     if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
         cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
@@ -19,6 +18,11 @@ function getUint8ArrayMemory0() {
     return cachedUint8ArrayMemory0;
 }
 
+/**
+ * @param {number} ptr
+ * @param {number} len
+ * @returns {string}
+ */
 function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
@@ -26,10 +30,10 @@ function getStringFromWasm0(ptr, len) {
 
 let WASM_VECTOR_LEN = 0;
 
-const lTextEncoder = typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder;
+/** @type {TextEncoder} */
+let cachedTextEncoder = new (typeof TextEncoder === 'undefined' ? (0, module.require)('util').TextEncoder : TextEncoder)('utf-8');
 
-let cachedTextEncoder = new lTextEncoder('utf-8');
-
+/** @type {(arg: string, view: Uint8Array) => TextEncoderEncodeIntoResult} */
 const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
     ? function (arg, view) {
     return cachedTextEncoder.encodeInto(arg, view);
@@ -43,6 +47,12 @@ const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
     };
 });
 
+/**
+ * @param {string} arg
+ * @param {(size: number, align: number) => number} malloc
+ * @param {(ptr: number, oldSize: number, newSize: number, align: number) => number} [realloc]
+ * @returns {number}
+ */
 function passStringToWasm0(arg, malloc, realloc) {
 
     if (realloc === undefined) {


### PR DESCRIPTION
I added type annotations to a few commonly-used JS glue code functions. This makes it a lot easier to understand the glue, because I have TS to help me out. 

Those type annotations also make it easier to verify the correctness of glue. And just to prove that: TS found 2 minor bugs in the JS glue code of our tests:


1. `debugString` (this is the JS glue code version of `format!("{:?}", value)`) had a bug where it checked for a regex mismatch incorrectly. This would lead to dereferencing `null` at runtime, which throws a `TypeError`.
2. `_assertClass` returned `instance.ptr`. Here's the full code of the function:
    ```js
    function _assertClass(instance, klass) {
        if (!(instance instanceof klass)) {
            throw new Error(`expected instance of ${klass.name}`);
        }
        return instance.ptr;
    }
    ```
    Returning `instance.ptr` is weird for 2 reasons:
    - It's not used anywhere in the code. `_assertClass` is only used in one place and its return value is ignored.
    - There is no `ptr` field. The author probably meant `__wbg_ptr` to get the internal pointer of a JS object.
    
    So I just removed the return statement and `instance.ptr`.

---

Aside from that, I did one additional change: I inline `lTextDecoder`:

```js
// before

const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;

let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });

// after

/** @type {TextDecoder} */
let cachedTextDecoder = new (typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder)('utf-8', { ignoreBOM: true, fatal: true });
```

This just made typing easier, but the expression something to get used to...