### PR TITLE
Fixed 2 minor bugs in JS glue code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 * Fixed `#[should_panic]` not working with `#[wasm_bindgen_test(unsupported = ...)]`.
   [#4196](https://github.com/rustwasm/wasm-bindgen/pull/4196)
 
-* Fixed a minor bug with regexes when printing debug information.
+* Fixed potential `null` error when using `JsValue::as_debug_string()`.
   [#4192](https://github.com/rustwasm/wasm-bindgen/pull/4192)
 
 --------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Fixed `#[should_panic]` not working with `#[wasm_bindgen_test(unsupported = ...)]`.
   [#4196](https://github.com/rustwasm/wasm-bindgen/pull/4196)
 
+* Fixed a minor bug with regexes when printing debug information.
+  [#4192](https://github.com/rustwasm/wasm-bindgen/pull/4192)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1958,7 +1958,6 @@ __wbg_set_wasm(wasm);"
                 if (!(instance instanceof klass)) {
                     throw new Error(`expected instance of ${klass.name}`);
                 }
-                return instance.ptr;
             }
             ",
         );
@@ -3997,7 +3996,7 @@ __wbg_set_wasm(wasm);"
                 // Test for built-in
                 const builtInMatches = /\\[object ([^\\]]+)\\]/.exec(toString.call(val));
                 let className;
-                if (builtInMatches.length > 1) {
+                if (builtInMatches && builtInMatches.length > 1) {
                     className = builtInMatches[1];
                 } else {
                     // Failed to match the standard '[object ClassName]'

--- a/crates/cli/tests/reference/web-sys.js
+++ b/crates/cli/tests/reference/web-sys.js
@@ -51,7 +51,7 @@ function debugString(val) {
     // Test for built-in
     const builtInMatches = /\[object ([^\]]+)\]/.exec(toString.call(val));
     let className;
-    if (builtInMatches.length > 1) {
+    if (builtInMatches && builtInMatches.length > 1) {
         className = builtInMatches[1];
     } else {
         // Failed to match the standard '[object ClassName]'


### PR DESCRIPTION
This separates the 2 bug fixes from #4189 into their own PR.

Changes:

1. `debugString` (this is the JS glue code version of `format!("{:?}", value)`) had a bug where it checked for a regex mismatch incorrectly. This would lead to dereferencing `null` at runtime, which throws a `TypeError`.
2. `_assertClass` returned `instance.ptr`. Here's the full code of the function:
    ```js
    function _assertClass(instance, klass) {
        if (!(instance instanceof klass)) {
            throw new Error(`expected instance of ${klass.name}`);
        }
        return instance.ptr;
    }
    ```
    Returning `instance.ptr` is weird for 2 reasons:
    - It's not used anywhere in the code. `_assertClass` is only used in one place and its return value is ignored. As @daxpedda [found out](https://github.com/rustwasm/wasm-bindgen/pull/4189#issuecomment-2408872554), the return value hasn't been used for 6 years now.
    - There is no `ptr` field. The `ptr` field was [renamed to `__wbg_ptr` one year ago](https://github.com/rustwasm/wasm-bindgen/pull/4189#issuecomment-2408715540) and this function wasn't updated.
    
    So I just removed the return statement and `instance.ptr`.
