### PR TITLE
Only generate Js values for string enums if used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Fixed methods with `self: &Self` consuming the object.
   [#4178](https://github.com/rustwasm/wasm-bindgen/pull/4178)
 
+* Fixed unused string enums generating JS values.
+  [#4193](https://github.com/rustwasm/wasm-bindgen/pull/4193)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -701,6 +701,7 @@ fn instruction(
 
         Instruction::WasmToStringEnum { name } => {
             let index = js.pop();
+            js.cx.expose_string_enum(name);
             js.push(wasm_to_string_enum(name, &index))
         }
 
@@ -709,11 +710,13 @@ fn instruction(
             // ["a","b","c"][index], the lookup will implicitly return map
             // the hole to undefined, because OOB indexes will return undefined.
             let index = js.pop();
+            js.cx.expose_string_enum(name);
             js.push(wasm_to_string_enum(name, &index))
         }
 
         Instruction::StringEnumToWasm { name, invalid } => {
             let enum_val = js.pop();
+            js.cx.expose_string_enum(name);
             js.push(string_enum_to_wasm(name, *invalid, &enum_val))
         }
 
@@ -723,6 +726,7 @@ fn instruction(
             hole,
         } => {
             let enum_val = js.pop();
+            js.cx.expose_string_enum(name);
             let enum_val_expr = string_enum_to_wasm(name, *invalid, &enum_val);
             js.cx.expose_is_like_none();
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -52,6 +52,13 @@ pub struct Context<'a> {
     /// function signatures, etc.
     typescript_refs: HashSet<TsReference>,
 
+    /// String enums that are used internally by the generated code.
+    ///
+    /// This tracks which string enums are used independently from whether their
+    /// type is used, because users may only use them in a way that doesn't
+    /// require the type or requires only the type.
+    used_string_enums: HashSet<String>,
+
     exported_classes: Option<BTreeMap<String, ExportedClass>>,
 
     /// A map of the name of npm dependencies we've loaded so far to the path
@@ -114,6 +121,7 @@ impl<'a> Context<'a> {
             defined_identifiers: Default::default(),
             wasm_import_definitions: Default::default(),
             typescript_refs: Default::default(),
+            used_string_enums: Default::default(),
             exported_classes: Some(Default::default()),
             config,
             threads_enabled: config.threads.is_enabled(module),
@@ -3852,13 +3860,20 @@ __wbg_set_wasm(wasm);"
             self.typescript.push_str(";\n");
         }
 
-        self.global(&format!(
-            "const __wbindgen_enum_{name} = [{values}];\n",
-            name = string_enum.name,
-            values = variants.join(", ")
-        ));
+        if self.used_string_enums.contains(&string_enum.name) {
+            // only generate the internal string enum array if it's actually used
+            self.global(&format!(
+                "const __wbindgen_enum_{name} = [{values}];\n",
+                name = string_enum.name,
+                values = variants.join(", ")
+            ));
+        }
 
         Ok(())
+    }
+
+    fn expose_string_enum(&mut self, string_enum_name: &str) {
+        self.used_string_enums.insert(string_enum_name.to_string());
     }
 
     fn generate_struct(&mut self, struct_: &AuxStruct) -> Result<(), Error> {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -52,7 +52,7 @@ pub struct Context<'a> {
     /// function signatures, etc.
     typescript_refs: HashSet<TsReference>,
 
-    /// String enums that are used internally by the generated code.
+    /// String enums that are used internally by the generated bindings.
     ///
     /// This tracks which string enums are used independently from whether their
     /// type is used, because users may only use them in a way that doesn't

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -83,10 +83,6 @@ export const ImplicitDiscriminant = Object.freeze({ A:0,"0":"A",B:1,"1":"B",C:42
 
 const __wbindgen_enum_ColorName = ["green", "yellow", "red"];
 
-const __wbindgen_enum_FooBar = ["foo", "bar"];
-
-const __wbindgen_enum_PrivateStringEnum = ["foo", "bar"];
-
 export function __wbindgen_throw(arg0, arg1) {
     throw new Error(getStringFromWasm0(arg0, arg1));
 };

--- a/crates/cli/tests/reference/web-sys.js
+++ b/crates/cli/tests/reference/web-sys.js
@@ -210,8 +210,6 @@ function handleError(f, args) {
 
 const __wbindgen_enum_MediaSourceEnum = ["camera", "screen", "application", "window", "browser", "microphone", "audioCapture", "other"];
 
-const __wbindgen_enum_MediaSourceReadyState = ["closed", "open", "ended"];
-
 export function __wbg_new_1cabf49927794f50() { return handleError(function (arg0, arg1) {
     const ret = new URL(getStringFromWasm0(arg0, arg1));
     return addHeapObject(ret);


### PR DESCRIPTION
This fixes the issue we talked about [here](https://github.com/rustwasm/wasm-bindgen/pull/4180#discussion_r1797780272). Basically, in #4147 I changed the bindings of string enums to use a variable storing an array (point 3). However, this array was always generated regardless of whether it was actually used or not.

This PR fixes the issue by marking which enums are used as the bindings are generated. Since we always generate the bindings of function that can use string enums before the variable of a string enum, this works out. I used the same `expose_*` pattern for the function that is commonly used for this type of task.