### PR TITLE
Fix triggering lints in testing facilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 * Fixed unused string enums generating JS values.
   [#4193](https://github.com/rustwasm/wasm-bindgen/pull/4193)
 
+* Fixed triggering lints in testing facilities.
+  [#4195](https://github.com/rustwasm/wasm-bindgen/pull/4195)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -111,13 +111,15 @@ pub fn wasm_bindgen_test(
     let wasm_bindgen_path = attributes.wasm_bindgen_path;
     tokens.extend(
         quote! {
-            #[no_mangle]
-            #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-            #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
-            pub extern "C" fn #name(cx: &#wasm_bindgen_path::__rt::Context) {
-                let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
-                #test_body
-            }
+            const _: () = {
+                #[no_mangle]
+                #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+                #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
+                pub extern "C" fn #name(cx: &#wasm_bindgen_path::__rt::Context) {
+                    let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
+                    #test_body
+                }
+            };
         },
     );
 

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -56,40 +56,52 @@ macro_rules! console_log {
 #[macro_export]
 macro_rules! wasm_bindgen_test_configure {
     (run_in_browser $($others:tt)*) => (
-        #[link_section = "__wasm_bindgen_test_unstable"]
-        #[cfg(target_arch = "wasm32")]
-        pub static __WBG_TEST_RUN_IN_BROWSER: [u8; 1] = [0x01];
-        $crate::wasm_bindgen_test_configure!($($others)*);
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_RUN_IN_BROWSER: [u8; 1] = [0x01];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
     );
     (run_in_worker $($others:tt)*) => (
-        #[link_section = "__wasm_bindgen_test_unstable"]
-        #[cfg(target_arch = "wasm32")]
-        pub static __WBG_TEST_RUN_IN_DEDICATED_WORKER: [u8; 1] = [0x02];
-        $crate::wasm_bindgen_test_configure!($($others)*);
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_RUN_IN_DEDICATED_WORKER: [u8; 1] = [0x02];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
     );
     (run_in_dedicated_worker $($others:tt)*) => (
-        #[link_section = "__wasm_bindgen_test_unstable"]
-        #[cfg(target_arch = "wasm32")]
-        pub static __WBG_TEST_RUN_IN_DEDICATED_WORKER: [u8; 1] = [0x02];
-        $crate::wasm_bindgen_test_configure!($($others)*);
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_RUN_IN_DEDICATED_WORKER: [u8; 1] = [0x02];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
     );
     (run_in_shared_worker $($others:tt)*) => (
-        #[link_section = "__wasm_bindgen_test_unstable"]
-        #[cfg(target_arch = "wasm32")]
-        pub static __WBG_TEST_RUN_IN_SHARED_WORKER: [u8; 1] = [0x03];
-        $crate::wasm_bindgen_test_configure!($($others)*);
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_RUN_IN_SHARED_WORKER: [u8; 1] = [0x03];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
     );
     (run_in_service_worker $($others:tt)*) => (
-        #[link_section = "__wasm_bindgen_test_unstable"]
-        #[cfg(target_arch = "wasm32")]
-        pub static __WBG_TEST_RUN_IN_SERVICE_WORKER: [u8; 1] = [0x04];
-        $crate::wasm_bindgen_test_configure!($($others)*);
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_RUN_IN_SERVICE_WORKER: [u8; 1] = [0x04];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
     );
     (run_in_node_experimental $($others:tt)*) => (
-        #[link_section = "__wasm_bindgen_test_unstable"]
-        #[cfg(target_arch = "wasm32")]
-        pub static __WBG_TEST_run_in_node_experimental: [u8; 1] = [0x05];
-        $crate::wasm_bindgen_test_configure!($($others)*);
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_run_in_node_experimental: [u8; 1] = [0x05];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
     );
     () => ()
 }


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/130025 Rustc now emits [`missing_docs`](https://doc.rust-lang.org/nightly/rustc/lints/listing/allowed-by-default.html?highlight=missing_docs#missing-docs) in tests.

We can avoid triggering lints by wrapping any relevant code in `const _: () = { ... };`.