### PR TITLE
Fix link to Node.js module documentation

### DIFF
--- a/guide/src/reference/deployment.md
+++ b/guide/src/reference/deployment.md
@@ -22,6 +22,7 @@ The methods of deployment and integration here are primarily tied to the
 [`no-modules`]: #without-a-bundler
 [`nodejs`]: #nodejs
 [`deno`]: #deno
+[`experimental-nodejs-module`]: #nodejs-module
 
 ## Bundlers
 


### PR DESCRIPTION
Just a link to the header missing in the markdown file.
See https://rustwasm.github.io/docs/wasm-bindgen/reference/deployment.html.