### PR TITLE
Added missing space in doc comments

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -4297,7 +4297,12 @@ fn check_duplicated_getter_and_setter_names(
 
 fn format_doc_comments(comments: &str, js_doc_comments: Option<String>) -> String {
     let body: String = comments.lines().fold(String::new(), |mut output, c| {
-        let _ = writeln!(output, " *{}", c);
+        output.push_str(" *");
+        if !c.is_empty() && !c.starts_with(' ') {
+            output.push(' ');
+        }
+        output.push_str(c);
+        output.push('\n');
         output
     });
     let doc = if let Some(docs) = js_doc_comments {

--- a/crates/cli/tests/reference/web-sys.d.ts
+++ b/crates/cli/tests/reference/web-sys.d.ts
@@ -3,8 +3,8 @@
 export function get_url(): URL;
 export function get_media_source(): MediaSourceEnum;
 /**
- *The `MediaSourceEnum` enum.
+ * The `MediaSourceEnum` enum.
  *
- **This API requires the following crate features to be activated: `MediaSourceEnum`*
+ * *This API requires the following crate features to be activated: `MediaSourceEnum`*
  */
 type MediaSourceEnum = "camera" | "screen" | "application" | "window" | "browser" | "microphone" | "audioCapture" | "other";


### PR DESCRIPTION
This PR just fixes something super minor that bugged. When a Rust doc comment doesn't start with a space, the JSDoc comment won't either. None of the web-sys doc comments do, so web-sys string enums looked horrible.

This PR fixes this by inserting a space if the doc comment doesn't start with one. This means that properly-formatted Rust doc comments remain unchanged, but bad ones get "auto fixed".