### PR TITLE
Improved indentation and enum formatting

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3910,12 +3910,9 @@ __wbg_set_wasm(wasm);"
             } else {
                 format_doc_comments(comments, None)
             };
-            if !variant_docs.is_empty() {
-                variants.push('\n');
-                variants.push_str(&variant_docs);
-            }
-            variants.push_str(&format!("{}:{},", name, value));
-            variants.push_str(&format!("\"{}\":\"{}\",", value, name));
+            variants.push_str(&variant_docs);
+            variants.push_str(&format!("{}: {}, ", name, value));
+            variants.push_str(&format!("\"{}\": \"{}\",\n", value, name));
             if enum_.generate_typescript {
                 self.typescript.push('\n');
                 if !variant_docs.is_empty() {
@@ -3945,7 +3942,7 @@ __wbg_set_wasm(wasm);"
 
         self.export(
             &enum_.name,
-            &format!("Object.freeze({{ {} }})", variants),
+            &format!("Object.freeze({{\n{}}})", variants),
             Some(&docs),
         )?;
 

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -502,8 +502,8 @@ fn reset_indentation(s: &str) -> String {
     for line in s.lines() {
         let line = line.trim();
 
+        // handle doc comments separately
         if is_doc_comment(line) {
-            // handle doc comments separately
             for _ in 0..indent {
                 dst.push_str("    ");
             }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -501,9 +501,22 @@ fn reset_indentation(s: &str) -> String {
 
     for line in s.lines() {
         let line = line.trim();
-        if line.starts_with('}') || (line.ends_with('}') && !is_doc_comment(line)) {
+
+        if is_doc_comment(line) {
+            // handle doc comments separately
+            for _ in 0..indent {
+                dst.push_str("    ");
+            }
+            dst.push(' ');
+            dst.push_str(line);
+            dst.push('\n');
+            continue;
+        }
+
+        if line.starts_with('}') {
             indent = indent.saturating_sub(1);
         }
+
         let extra = if line.starts_with(':') || line.starts_with('?') {
             1
         } else {
@@ -513,14 +526,11 @@ fn reset_indentation(s: &str) -> String {
             for _ in 0..indent + extra {
                 dst.push_str("    ");
             }
-            if is_doc_comment(line) {
-                dst.push(' ');
-            }
             dst.push_str(line);
         }
         dst.push('\n');
-        // Ignore { inside of comments and if it's an exported enum
-        if line.ends_with('{') && !is_doc_comment(line) && !line.ends_with("Object.freeze({") {
+
+        if line.ends_with('{') {
             indent += 1;
         }
     }

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -67,22 +67,28 @@ export function option_string_enum_echo(color) {
  * @enum {0 | 1 | 2}
  */
 export const Color = Object.freeze({
-/**
- * Green as a leaf.
- */
-Green:0,"0":"Green",
-/**
- * Yellow as the sun.
- */
-Yellow:1,"1":"Yellow",
-/**
- * Red as a rose.
- */
-Red:2,"2":"Red", });
+    /**
+     * Green as a leaf.
+     */
+    Green: 0, "0": "Green",
+    /**
+     * Yellow as the sun.
+     */
+    Yellow: 1, "1": "Yellow",
+    /**
+     * Red as a rose.
+     */
+    Red: 2, "2": "Red",
+});
 /**
  * @enum {0 | 1 | 42 | 43}
  */
-export const ImplicitDiscriminant = Object.freeze({ A:0,"0":"A",B:1,"1":"B",C:42,"42":"C",D:43,"43":"D", });
+export const ImplicitDiscriminant = Object.freeze({
+    A: 0, "0": "A",
+    B: 1, "1": "B",
+    C: 42, "42": "C",
+    D: 43, "43": "D",
+});
 
 const __wbindgen_enum_ColorName = ["green", "yellow", "red"];
 


### PR DESCRIPTION
Enums are now formatted with each variant on its own line. This makes enum definitions easier to read. It also allowed me to remove the hard-coded enum detection in `reset_indentation`, because it wasn't necessary anymore.

I also fixed a minor bug in `reset_indentation`. If a line started or ended with `}`, it decreased the indentation. This is the wrong condition, but it will lead to code after a braced(?) single-line statement (e.g. `if (cond) { doStuff() }`) to be indented incorrectly. This type of braced single-line statement is generated rarely, but it is used in a few places ([example](https://github.com/rustwasm/wasm-bindgen/blob/76776ef54cce17f1c7442b010e26d7eadaea3cd0/crates/cli-support/src/js/binding.rs#L924)). Rare or not, I believe `reset_indentation` should handle this case correctly.

