### PR TITLE
Fixed invalid type annotation for multivalue returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 * Fixed generated types when a static getter/setter has the same name as an instance getter/setter.
   [#4202](https://github.com/rustwasm/wasm-bindgen/pull/4202)
 
+* Fixed invalid TypeScript return types for multivalue signatures.
+  [#4210](https://github.com/rustwasm/wasm-bindgen/pull/4210)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -99,7 +99,7 @@ pub fn interface(module: &Module) -> Result<String, Error> {
             ret = match ty.results().len() {
                 0 => "void",
                 1 => "number",
-                _ => "any[]",
+                _ => "number[]",
             },
         ));
     }
@@ -147,7 +147,7 @@ pub fn typescript(module: &Module) -> Result<String, Error> {
             ret = match ty.results().len() {
                 0 => "void",
                 1 => "number",
-                _ => "any[]",
+                _ => "number[]",
             },
         ));
     }

--- a/crates/cli-support/src/wasm2es6js.rs
+++ b/crates/cli-support/src/wasm2es6js.rs
@@ -99,7 +99,7 @@ pub fn interface(module: &Module) -> Result<String, Error> {
             ret = match ty.results().len() {
                 0 => "void",
                 1 => "number",
-                _ => "Array",
+                _ => "any[]",
             },
         ));
     }
@@ -147,7 +147,7 @@ pub fn typescript(module: &Module) -> Result<String, Error> {
             ret = match ty.results().len() {
                 0 => "void",
                 1 => "number",
-                _ => "Array",
+                _ => "any[]",
             },
         ));
     }


### PR DESCRIPTION
fixes #4207

`Array` itself is not a valid type because it requires one generic parameter. I replaced it with `number[]`. I chose `number` as the element type, because that's what the surrounding code is using for everything.

Using `number` for everything is probably wrong, since WASM uses `bigint` for 64-bit ints AFAIK, but it shouldn't matter too much.