### PR TITLE
Disable `multivalue` in tests

### DIFF
--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -138,10 +138,10 @@ fn runtest(test: &Path) -> Result<()> {
     exec(&mut bindgen)?;
 
     if !contents.contains("async") {
-        let js = fs::read_to_string(td.path().join("reference_test_bg.js"))?;
-        assert_same(&js, &test.with_extension("js"))?;
         let wat = sanitize_wasm(&td.path().join("reference_test_bg.wasm"))?;
         assert_same(&wat, &test.with_extension("wat"))?;
+        let js = fs::read_to_string(td.path().join("reference_test_bg.js"))?;
+        assert_same(&js, &test.with_extension("js"))?;
     }
     let d_ts = fs::read_to_string(td.path().join("reference_test.d.ts"))?;
     assert_same(&d_ts, &test.with_extension("d.ts"))?;


### PR DESCRIPTION
I couldn't really find a lot of docs on how to disable this, so I spend like an hour figuring this out.

I also slightly changed how `reference.rs` determines the repo root, test file dir, and target dir. I needed to do this, because debugging in VSCode sets the cwd to the workspace root by default, which messed up all paths. Now debugging this just works. 

I also changed the target dir for the references. This stops the cache of all crates from constantly being invalidated, which massively speeds up repeated runs of tests and rust analyzer for me.