### PR TITLE
wasm-bindgen-webidl: use `clap` instead of `structopt`

### DIFF
--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.0.0"
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "4.5", features = ["derive"] }
 env_logger = "0.11.5"
 heck = "0.5"
 lazy_static = "1.4.0"
@@ -15,7 +16,6 @@ once_cell = "1.12"
 proc-macro2 = "1.0"
 quote = '1.0'
 sourcefile = "0.2"
-structopt = "0.3.9"
 syn = { version = '2.0', features = ['extra-traits', 'full'] }
 wasm-bindgen-backend = { path = "../backend" }
 weedle = { git = "https://github.com/rustwasm/weedle.git" }

--- a/crates/webidl/src/main.rs
+++ b/crates/webidl/src/main.rs
@@ -1,33 +1,30 @@
 mod update_cargo_toml;
 
 use anyhow::Result;
+use clap::Parser;
 use std::path::PathBuf;
-use structopt::StructOpt;
 use update_cargo_toml::update_cargo_toml_features;
 
-#[derive(StructOpt, Debug)]
+#[derive(Parser, Debug)]
 #[structopt(
     name = "wasm-bindgen-webidl",
     about = "Converts WebIDL into wasm-bindgen compatible code."
 )]
 struct Opt {
-    #[structopt(parse(from_os_str))]
     input_dir: PathBuf,
 
-    #[structopt(parse(from_os_str))]
     output_dir: PathBuf,
 
-    #[structopt(long)]
+    #[clap(long)]
     no_features: bool,
 
-    #[structopt(parse(from_os_str))]
     cargo_toml_path: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
     env_logger::init();
 
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     let features = !opt.no_features;
 


### PR DESCRIPTION
structopt is unmaintained, it uses very old version of clap, which pulls some old dependencies