### PR TITLE
Add bindings for `MediaStreamTrack.getCapabilities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 * Added support for C-style enums with negative discriminants.
   [#4204](https://github.com/rustwasm/wasm-bindgen/pull/4204)
 
+* Added bindings for `MediaStreamTrack.getCapabilities`.
+  [#4236](https://github.com/rustwasm/wasm-bindgen/pull/4236)
+
 ### Changed
 
 * String enums now generate private TypeScript types but only if used.

--- a/crates/web-sys/src/features/gen_MediaStreamTrack.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamTrack.rs
@@ -129,6 +129,18 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `MediaStreamTrack`*"]
     pub fn clone(this: &MediaStreamTrack) -> MediaStreamTrack;
+    #[cfg(web_sys_unstable_apis)]
+    #[cfg(feature = "MediaTrackCapabilities")]
+    # [wasm_bindgen (method , structural , js_class = "MediaStreamTrack" , js_name = getCapabilities)]
+    #[doc = "The `getCapabilities()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/getCapabilities)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `MediaStreamTrack`, `MediaTrackCapabilities`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    pub fn get_capabilities(this: &MediaStreamTrack) -> MediaTrackCapabilities;
     #[cfg(feature = "MediaTrackConstraints")]
     # [wasm_bindgen (method , structural , js_class = "MediaStreamTrack" , js_name = getConstraints)]
     #[doc = "The `getConstraints()` method."]

--- a/crates/web-sys/src/features/gen_MediaTrackCapabilities.rs
+++ b/crates/web-sys/src/features/gen_MediaTrackCapabilities.rs
@@ -53,6 +53,24 @@ extern "C" {
     #[wasm_bindgen(method, setter = "autoGainControl")]
     pub fn set_auto_gain_control(this: &MediaTrackCapabilities, val: &::wasm_bindgen::JsValue);
     #[cfg(web_sys_unstable_apis)]
+    #[doc = "Get the `backgroundBlur` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `MediaTrackCapabilities`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, getter = "backgroundBlur")]
+    pub fn get_background_blur(this: &MediaTrackCapabilities) -> Option<::js_sys::Array>;
+    #[cfg(web_sys_unstable_apis)]
+    #[doc = "Change the `backgroundBlur` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `MediaTrackCapabilities`*"]
+    #[doc = ""]
+    #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
+    #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
+    #[wasm_bindgen(method, setter = "backgroundBlur")]
+    pub fn set_background_blur(this: &MediaTrackCapabilities, val: &::wasm_bindgen::JsValue);
+    #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "ULongRange")]
     #[doc = "Get the `channelCount` field of this object."]
     #[doc = ""]
@@ -325,6 +343,12 @@ impl MediaTrackCapabilities {
     #[deprecated = "Use `set_auto_gain_control()` instead."]
     pub fn auto_gain_control(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
         self.set_auto_gain_control(val);
+        self
+    }
+    #[cfg(web_sys_unstable_apis)]
+    #[deprecated = "Use `set_background_blur()` instead."]
+    pub fn background_blur(&mut self, val: &::wasm_bindgen::JsValue) -> &mut Self {
+        self.set_background_blur(val);
         self
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/webidls/unstable/MediaTrackCapabilities.webidl
+++ b/crates/web-sys/webidls/unstable/MediaTrackCapabilities.webidl
@@ -7,6 +7,10 @@
  * https://w3c.github.io/mediacapture-main/#dom-mediatrackcapabilities
  */
 
+partial interface MediaStreamTrack {
+  MediaTrackCapabilities getCapabilities ();
+};
+
 dictionary ULongRange {
   [Clamp] unsigned long max;
   [Clamp] unsigned long min;
@@ -33,4 +37,5 @@ dictionary MediaTrackCapabilities {
   ULongRange channelCount;
   DOMString deviceId;
   DOMString groupId;
+  sequence<boolean> backgroundBlur;
 };


### PR DESCRIPTION
Add bindings for [`MediaStreamTrack.getCapabilities`](https://www.w3.org/TR/mediacapture-streams/#dom-mediastreamtrack-getcapabilities) and stabilize [`MediaTrackCapabilities`](https://www.w3.org/TR/mediacapture-streams/#media-track-capabilities) (which it returns).