### PR TITLE
Deprecate `--reference-types`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Reference type proposal transformations are not applied by default when detecting it in the Wasm module for the bundler target because currently `webpack` doesn't support it.
   [#4235](https://github.com/rustwasm/wasm-bindgen/pull/4235)
 
+* Deprecate `--reference-types` in favor of automatic target feature detection.
+  [#4237](https://github.com/rustwasm/wasm-bindgen/pull/4237)
+
 ### Fixed
 
 * Fixed methods with `self: &Self` consuming the object.
@@ -56,6 +59,9 @@
 
 * Fixed invalid TypeScript return types for multivalue signatures.
   [#4210](https://github.com/rustwasm/wasm-bindgen/pull/4210)
+
+* Only emit `table.fill` instructions if the bulk-memory proposal is enabled.
+  [#4237](https://github.com/rustwasm/wasm-bindgen/pull/4237)
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -40,7 +40,7 @@ Options:
     --web                        Deprecated, use `--target web`
     --no-modules                 Deprecated, use `--target no-modules`
     --weak-refs                  Deprecated, is runtime-detected
-    --reference-types            Enable usage of WebAssembly reference types
+    --reference-types            Deprecated, use `-Ctarget-feature=+reference-types`
     -V --version                 Print the version number of wasm-bindgen
 
 Additional documentation: https://rustwasm.github.io/wasm-bindgen/reference/cli.html

--- a/crates/externref-xform/tests/anyref-param.wat
+++ b/crates/externref-xform/tests/anyref-param.wat
@@ -25,8 +25,7 @@
     call $foo
     local.get 1
     ref.null extern
-    i32.const 1
-    table.fill 0
+    table.set 0
     local.get 1
     i32.const 1
     i32.add

--- a/crates/externref-xform/tests/mixed-export.wat
+++ b/crates/externref-xform/tests/mixed-export.wat
@@ -34,8 +34,7 @@
     call $a
     local.get 5
     ref.null extern
-    i32.const 1
-    table.fill 0
+    table.set 0
     local.get 5
     i32.const 1
     i32.add

--- a/guide/src/reference/cli.md
+++ b/guide/src/reference/cli.md
@@ -84,14 +84,6 @@ When generating bundler-compatible code (see the section on [deployment]) this
 indicates that the bundled code is always intended to go into a browser so a few
 checks for Node.js can be elided.
 
-### `--reference-types`
-
-Enables usage of the [WebAssembly References Types
-proposal](https://github.com/webassembly/reference-types) proposal, meaning that
-the WebAssembly binary will use `externref` when importing and exporting
-functions that work with `JsValue`. For more information see the [documentation
-about reference types](./reference-types.md).
-
 ### `--omit-default-module-path`
 
 Don't add WebAssembly fallback imports in generated JavaScript.

--- a/guide/src/reference/reference-types.md
+++ b/guide/src/reference/reference-types.md
@@ -42,7 +42,8 @@ export function takes_js_value(a) {
 
 We can see here how under the hood the JS is managing a table of JS values which
 are passed to the Wasm binary, so Wasm actually only works in indices. If we
-pass the `--reference-types` flag to the CLI, however, the generated JS looks like:
+compile with `-Ctarget-feature=+reference-types` (by default since Rust v1.82),
+however, the generated JS looks like:
 
 ```js
 export function takes_js_value(a) {


### PR DESCRIPTION
This deprecates `--reference-types` in favor of automatic target feature detection via `-Ctarget-feature=+reference-types`, which is the default since Rust v1.82.

This also avoids using the `table.fill` instruction without enabling the corresponding bulk-memory proposal.