### PR TITLE
Deprecate `Bindgen::reference_types()`

### DIFF
--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -125,6 +125,7 @@ impl Bindgen {
         self
     }
 
+    #[deprecated = "automatically detected via `-Ctarget-feature=+reference-types`"]
     pub fn reference_types(&mut self, enable: bool) -> &mut Bindgen {
         self.externref = enable;
         self

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -129,6 +129,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .omit_default_module_path(args.flag_omit_default_module_path)
         .split_linked_modules(args.flag_split_linked_modules);
     if let Some(true) = args.flag_reference_types {
+        #[allow(deprecated)]
         b.reference_types(true);
     }
     if let Some(ref name) = args.flag_no_modules_global {


### PR DESCRIPTION
This PR deprecated `Bindgen::reference_types()`, as the corresponding CLI flag is now deprecated as well.

Follow-up to #4237.