### PR TITLE
Fix `JsCast::instanceof()` not respecting JS namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@
 * Only emit `table.fill` instructions if the bulk-memory proposal is enabled.
   [#4237](https://github.com/rustwasm/wasm-bindgen/pull/4237)
 
+* Fixed calls to `JsCast::instanceof()` not respecting JavaScript namespaces.
+  [#4241](https://github.com/rustwasm/wasm-bindgen/pull/4241)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -708,7 +708,11 @@ impl ConvertToAst<(&ast::Program, BindgenAttrs)> for syn::ForeignItemType {
             .map_or_else(|| self.ident.to_string(), |s| s.to_string());
         let typescript_type = attrs.typescript_type().map(|s| s.0.to_string());
         let is_type_of = attrs.is_type_of().cloned();
-        let shim = format!("__wbg_instanceof_{}_{}", self.ident, ShortHash(&self.ident));
+        let shim = format!(
+            "__wbg_instanceof_{}_{}",
+            self.ident,
+            ShortHash((attrs.js_namespace().map(|(ns, _)| ns), &self.ident))
+        );
         let mut extends = Vec::new();
         let mut vendor_prefixes = Vec::new();
         let no_deref = attrs.no_deref().is_some();


### PR DESCRIPTION
This is a bit unfortunate, but I'm going to bet there are a couple more bugs like this.

Fixes #4220.
Cc @cdata.