### PR TITLE
Improved how references test handles paths

### DIFF
--- a/crates/cli/tests/reference.rs
+++ b/crates/cli/tests/reference.rs
@@ -42,7 +42,7 @@ fn main() -> Result<()> {
     let filter = env::args().nth(1);
 
     let mut tests = Vec::new();
-    let dir = env::current_dir()?.join("tests/reference");
+    let dir = repo_root().join("crates/cli/tests/reference");
     for entry in dir.read_dir()? {
         let path = entry?.path();
         if path.extension().and_then(|s| s.to_str()) != Some("rs") {
@@ -224,19 +224,15 @@ fn diff(a: &str, b: &str) -> Result<()> {
 }
 
 fn target_dir() -> PathBuf {
-    let mut dir = env::current_exe().unwrap();
-    dir.pop(); // current exe
-    if dir.ends_with("deps") {
-        dir.pop();
-    }
-    dir.pop(); // debug and/or release
-    dir
+    repo_root().join("target/tests/reference")
 }
 
 fn repo_root() -> PathBuf {
     let mut repo_root = env::current_dir().unwrap();
-    repo_root.pop(); // remove 'cli'
-    repo_root.pop(); // remove 'crates'
+    if repo_root.file_name() == Some("cli".as_ref()) {
+        repo_root.pop(); // remove 'cli'
+        repo_root.pop(); // remove 'crates'
+    }
     repo_root
 }
 


### PR DESCRIPTION
This is a PR for the improvements I made in #4216.

Changes:
1. All paths are now relative to the repo root instead of cwd. This means that the test will work no matter the cwd. I did this to make debuggers work with `references.rs` without any config. Debuggers in VSCode can be configured to use a different cwd, but that would require creating a `.vscode/launch.json`. Now the default debugger just works.
2. The compiler output is longer in `/target` but `/target/tests/reference`. The old target messed up incremental compilation for `references.rs` itself, which meant that running `references.rs` always meant compiler 50 or so deps before every run. On my old laptop, this means that running `references.rs` was 2 minutes of compiling and 30 sec of running tests, every time.