### PR TITLE
Make it clearer which versions are affected by the constructor bug

### DIFF
--- a/guide/src/reference/attributes/on-rust-exports/constructor.md
+++ b/guide/src/reference/attributes/on-rust-exports/constructor.md
@@ -35,7 +35,7 @@ console.log(f.get_contents());
 
 ## Caveats
 
-Starting from v0.2.48 there is a bug in `wasm-bindgen` which breaks inheritance of exported Rust structs from JavaScript side (see [#3213](https://github.com/rustwasm/wasm-bindgen/issues/3213)). If you want to inherit from a Rust struct such as:
+In versions `>=v0.2.48, <0.2.88` of `wasm-bindgen`, there is a bug which breaks inheritance of exported Rust structs from JavaScript side (see [#3213](https://github.com/rustwasm/wasm-bindgen/issues/3213)). If you want to inherit from a Rust struct such as:
 
 ```rust
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
The form of the section informing users about an important bug was weird. It started with "versions `>=X` are affected", explained the bug and how it affects users, and then told users "actually, only versions `>=X, <Y` are affected" (literally: "This is no longer required as of v0.2.88"). This is bad form, because we are making users read through and understand a bug + workarounds only tell them at the very end that this isn't relevant to them.

This PR mentions the full affected version range at the start of the section.