### PR TITLE
Update testing docs for `wasm-bindgen-macro`

### DIFF
--- a/crates/macro/README.md
+++ b/crates/macro/README.md
@@ -17,12 +17,10 @@ To add a test:
 * Create `ui-tests/my-awesome-test.rs`
 * Write an invalid `#[wasm_bindgen]` invocation, testing the error you're
   generating
-* Execute `cargo test -p ui-tests`, the test will fail
+* Execute `cargo test -p wasm-bindgen-macro --test ui`, the test will fail
 * From within the `ui-tests` folder, execute `./update-all-references.sh`. This
   should create a `my-awesome-test.stderr` file.
-* Inspect `my-awesome-test.stderr` to make sure it looks ok
-* Rerun `cargo test -p ui-tests` and your tests should pass!
 
-Testing here is a work in progress, see
-[#601](https://github.com/rustwasm/wasm-bindgen/issues/601) for more
-information.
+  OR if you are on Windows, set the `TRYBUILD=overwrite` environment variable (this is done as `$env:TRYBUILD="overwrite"` [in powershell](https://stackoverflow.com/a/1333717/7595472)) and run the command again.
+* Inspect `my-awesome-test.stderr` to make sure it looks ok
+* Rerun `cargo test -p wasm-bindgen-macro --test ui` and your tests should pass!


### PR DESCRIPTION
Changes:
1. The command in the docs was wrong. `cargo test -p ui-tests` doesn't work because there is `ui-tests` crate. The correct command is `cargo test -p wasm-bindgen-macro --test ui`.
2. The way for updating snaps was pretty much linux-only because it required running a bash script. I added a note explaining how you can do it on Windows with `TRYBUILD=overwrite`.
3. I removed the note linking to #601. That issue has long been closed and the note isn't relevant anymore.