### PR TITLE
Fix Rust edition 2024 compatibility

### DIFF
--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1894,9 +1894,9 @@ fn respan(input: TokenStream, span: &dyn ToTokens) -> TokenStream {
 
     for (i, token) in spans.into_iter().enumerate() {
         if i == 0 {
-            first_span = token.span();
+            first_span = Span::call_site().located_at(token.span());
         }
-        last_span = token.span();
+        last_span = Span::call_site().located_at(token.span());
     }
 
     let mut new_tokens = Vec::new();

--- a/crates/macro/ui-tests/missing-catch.stderr
+++ b/crates/macro/ui-tests/missing-catch.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>: FromWasmAbi` is not satisfied
  --> ui-tests/missing-catch.rs:6:9
   |
+3 | #[wasm_bindgen]
+  | --------------- in this procedural macro expansion
+...
 6 |     pub fn foo() -> Result<JsValue, JsValue>;
   |            ^^^ the trait `FromWasmAbi` is not implemented for `Result<wasm_bindgen::JsValue, wasm_bindgen::JsValue>`
   |
@@ -14,3 +17,4 @@ error[E0277]: the trait bound `Result<wasm_bindgen::JsValue, wasm_bindgen::JsVal
             i64
             usize
           and $N others
+  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/pub-not-copy.stderr
+++ b/crates/macro/ui-tests/pub-not-copy.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `String: std::marker::Copy` is not satisfied
  --> $DIR/pub-not-copy.rs:5:16
   |
+3 | #[wasm_bindgen]
+  | --------------- in this procedural macro expansion
+4 | pub struct A {
 5 |     pub field: String,
   |                ^^^^^^ the trait `std::marker::Copy` is not implemented for `String`
   |

--- a/crates/macro/ui-tests/struct-fields.stderr
+++ b/crates/macro/ui-tests/struct-fields.stderr
@@ -1,6 +1,9 @@
 error[E0277]: the trait bound `Foo: std::marker::Copy` is not satisfied
   --> ui-tests/struct-fields.rs:10:12
    |
+8  | #[wasm_bindgen]
+   | --------------- in this procedural macro expansion
+9  | struct Bar {
 10 |     pub a: Foo,
    |            ^^^ the trait `std::marker::Copy` is not implemented for `Foo`
    |

--- a/crates/macro/ui-tests/unknown-type-in-import.stderr
+++ b/crates/macro/ui-tests/unknown-type-in-import.stderr
@@ -8,3 +8,9 @@ help: you might be missing a type parameter
   |
 6 |     pub fn foo<A>(a: A);
   |               +++
+
+error[E0412]: cannot find type `A` in this scope
+ --> ui-tests/unknown-type-in-import.rs:6:19
+  |
+6 |     pub fn foo(a: A);
+  |                   ^ not found in this scope


### PR DESCRIPTION
This adds `unsafe` to all `extern "C" { ... }` generated blocks to account for edition 2024 requirements.

See https://github.com/rust-lang/rust/issues/132425 for more information why this is a problem considering macro edition hygiene should account for this in the first place.

Fixes #4218.