### PR TITLE
Added note for which versions of `wasm-bindgen` support i128

### DIFF
--- a/guide/src/reference/types/numbers.md
+++ b/guide/src/reference/types/numbers.md
@@ -11,6 +11,8 @@
 
 > **Note**: Wasm is currently a 32-bit architecture, so `isize` and `usize` are 32-bit integers and "fit" into a JavaScript `Number`.
 
+> **Note**: `u128` and `i128` require `wasm-bindgen` version 0.2.96 or later.
+
 ## Converting from JavaScript to Rust
 
 `wasm-bindgen` will automatically handle the conversion of JavaScript numbers to Rust numeric types. The conversion rules are as follows:


### PR DESCRIPTION
I forgot to add this to the docs in #4222. Since numbers are pretty fundamental, I think we should be clear that i128 is only supported in newer versions of WBG.