### PR TITLE
Update test coverage documentation to LLVM 19

### DIFF
--- a/guide/src/wasm-bindgen-test/coverage.md
+++ b/guide/src/wasm-bindgen-test/coverage.md
@@ -22,11 +22,7 @@ Currently it is particularly difficult to [deliver compile-line arguments to pro
 
 Make sure you are using `RUSTFLAGS=-Cinstrument-coverage -Zno-profiler-runtime`.
 
-Due to the current limitation of `llvm-cov`, we can't collect profiling symbols from the generated `.wasm` files. Instead, we can grab them from the LLVM IR with `--emit=llvm-ir` by using Clang. Additionally, the emitted LLVM IR files by Rust contain invalid code that can't be parsed by Clang, so they need to be adjusted.
-
-At the time of writing Rust Nightly uses LLVM v19, however [minicov] only supports LLVM v18. Usage of Clang or any LLVM tools must match the version used by [minicov].
-
-[minicov]: https://crates.io/crates/minicov
+Due to the current limitation of `llvm-cov`, we can't collect profiling symbols from the generated `.wasm` files. Instead, we can grab them from the LLVM IR with `--emit=llvm-ir` by using Clang. Usage of Clang or any LLVM tools must match the LLVM version used by Rust.
 
 ### Arguments to the test runner
 
@@ -58,11 +54,9 @@ CARGO_HOST_RUSTFLAGS=--cfg=wasm_bindgen_unstable_test_coverage \
 RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir --cfg=wasm_bindgen_unstable_test_coverage" \
 CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
 cargo +nightly test -Ztarget-applies-to-host -Zhost-config --tests
-# Adjust the LLVM IR and compile to object files:
+# Compile to object files:
 # - Extract a list of compiled artifacts from Cargo and filter them with `jq`.
 # - Figure out the path to the LLVM IR file corresponding to an artifact.
-# - Replace every function body with `unreachable`.
-# - Remove Rust-specific `range` annotations from function signatures.
 # - Compile to object file with Clang and store for later usage with `llvm-cov`.
 crate_name=name_of_the_tested_crate_in_snake_case
 objects=()
@@ -81,20 +75,14 @@ do
         file=$(dirname $file)/$(basename $file .wasm).ll
     fi
 
-    perl -i -p0e 's/(^define.*?$).*?^}/$1\nstart:\n  unreachable\n}/gms' $file
-    counter=1
-    while (( counter != 0 )); do
-        counter=$(perl -i -p0e '$c+= s/(^(define|declare)(,? [^\n ]+)*),? range\(.*?\)/$1/gm; END{print "$c"}' $file)
-    done
-
-  output = $(basename $file .ll).o
-  clang-18 $input -Wno-override-module -c -o $output
-  objects+=(-object $output)
+    output = $(basename $file .ll).o
+    clang-19 $file -Wno-override-module -c -o $output
+    objects+=(-object $output)
 done
 # Merge all generated raw profiling data.
-llvm-profdata-18 merge -sparse *.profraw -o coverage.profdata
+llvm-profdata-19 merge -sparse *.profraw -o coverage.profdata
 # Produce test coverage data in the HTML format and pass the object files we generated earlier.
-llvm-cov-18 show -show-instantiations=false -Xdemangler=rustfilt -output-dir coverage -format=html -instr-profile=coverage.profdata ${objects[@]} -sources src
+llvm-cov-19 show -show-instantiations=false -Xdemangler=rustfilt -output-dir coverage -format=html -instr-profile=coverage.profdata ${objects[@]} -sources src
 ```
 
 [rustc book]: https://doc.rust-lang.org/nightly/rustc/instrument-coverage.html


### PR DESCRIPTION
Now that `minicov` updated to LLVM v19, the discrepancy between Rust using LLVM v19 is resolved and the most hacky part isn't required anymore.