### PR TITLE
Add `WASM_BINDGEN_DRIVER_TIMEOUT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Added WASM ABI support for `u128` and `i128`
   [#4222](https://github.com/rustwasm/wasm-bindgen/pull/4222)
 
+* The timeout to connect to the test driver in `wasm-bindgen-test-runner` can now be configured via `WASM_BINDGEN_DRIVER_TIMEOUT`. This is useful when testing on a slower machine, e.g. CI.
+  [#4266](https://github.com/rustwasm/wasm-bindgen/pull/4266)
+
 ### Changed
 
 * String enums now generate private TypeScript types but only if used.

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -55,7 +55,12 @@ pub struct LegacyNewSessionParameters {
 /// binary, controlling it, running tests, scraping output, displaying output,
 /// etc. It will return `Ok` if all tests finish successfully, and otherwise it
 /// will return an error if some tests failed.
-pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error> {
+pub fn run(
+    server: &SocketAddr,
+    shell: &Shell,
+    driver_timeout: u64,
+    test_timeout: u64,
+) -> Result<(), Error> {
     let driver = Driver::find()?;
     let mut drop_log: Box<dyn FnMut()> = Box::new(|| ());
     let driver_url = match driver.location() {
@@ -79,7 +84,7 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
             // Wait for the driver to come online and bind its port before we try to
             // connect to it.
             let start = Instant::now();
-            let max = Duration::new(5, 0);
+            let max = Duration::new(driver_timeout, 0);
             let mut bound = false;
             while start.elapsed() < max {
                 if TcpStream::connect(driver_addr).is_ok() {
@@ -160,7 +165,7 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
     //       information.
     shell.status("Waiting for test to finish...");
     let start = Instant::now();
-    let max = Duration::new(timeout, 0);
+    let max = Duration::new(test_timeout, 0);
     while start.elapsed() < max {
         if client.text(&id, &output)?.contains("test result: ") {
             break;

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -188,7 +188,7 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
+    let test_timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
         .map(|timeout| {
             timeout
                 .parse()
@@ -197,8 +197,16 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or(20);
 
     if debug {
-        println!("Set timeout to {} seconds...", timeout);
+        println!("Set timeout to {} seconds...", test_timeout);
     }
+
+    let driver_timeout = env::var("WASM_BINDGEN_DRIVER_TIMEOUT")
+        .map(|timeout| {
+            timeout
+                .parse()
+                .expect("Could not parse 'WASM_BINDGEN_DRIVER_TIMEOUT'")
+        })
+        .unwrap_or(5);
 
     // Make the generated bindings available for the tests to execute against.
     shell.status("Executing bindgen...");
@@ -281,7 +289,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             thread::spawn(|| srv.run());
-            headless::run(&addr, &shell, timeout)?;
+            headless::run(&addr, &shell, driver_timeout, test_timeout)?;
         }
     }
     Ok(())


### PR DESCRIPTION
This PR introduces the `WASM_BINDGEN_DRIVER_TIMEOUT` environment variable for `wasm-bindgen-test-runner`, which sets the timeout for connecting to the test driver.

Before this PR the timeout was fixed to 5 seconds, which failed often when testing Safari in GitHub Actions CI. My experience is that the MacOS ARM runners, nowadays the default, tend to stall quite a lot, which I believe was the reason why this triggered the timeout so often and made CIs fail consistently.