### PR TITLE
Hash full signature for imported functions

### DIFF
--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -52,7 +52,7 @@ export function exported() {
     }
 }
 
-export function __wbg_foo_fa0172cdeb670adb() { return handleError(function () {
+export function __wbg_foo_4e8309b1aa95a4ac() { return handleError(function () {
     foo();
 }, arguments) };
 

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -52,7 +52,7 @@ export function exported() {
     }
 }
 
-export function __wbg_foo_95fe1a04017077db() { return handleError(function () {
+export function __wbg_foo_fa0172cdeb670adb() { return handleError(function () {
     foo();
 }, arguments) };
 

--- a/crates/cli/tests/reference/import.js
+++ b/crates/cli/tests/reference/import.js
@@ -68,28 +68,28 @@ export function exported() {
     }
 }
 
-export function __wbg_add_0f820bc7ed50a898(arg0, arg1) {
+export function __wbg_add_7fbfb2c172506d12(arg0, arg1) {
     const ret = add(arg0, arg1);
     return ret;
 };
 
-export function __wbg_barfromfoo_fc0e2d223c6eed1f() {
+export function __wbg_barfromfoo_29614885590bfb6f() {
     bar_from_foo();
 };
 
-export function __wbg_catchme_6fd452194698de3b() { return handleError(function () {
+export function __wbg_catchme_f7d87ea824a61e87() { return handleError(function () {
     catch_me();
 }, arguments) };
 
-export function __wbg_nocatch_633680ea5fdb920d() {
+export function __wbg_nocatch_be850a8dddd9599d() {
     no_catch();
 };
 
-export function __wbg_reload_bd59a4b785b50f44() {
+export function __wbg_reload_84c12f152ad689f0() {
     window.location.reload();
 };
 
-export function __wbg_write_67852f31952d3412(arg0, arg1) {
+export function __wbg_write_c2ce0ce33a6087d5(arg0, arg1) {
     window.document.write(getStringFromWasm0(arg0, arg1));
 };
 

--- a/crates/cli/tests/reference/modules.d.ts
+++ b/crates/cli/tests/reference/modules.d.ts
@@ -1,0 +1,3 @@
+/* tslint:disable */
+/* eslint-disable */
+export function exported(): void;

--- a/crates/cli/tests/reference/modules.js
+++ b/crates/cli/tests/reference/modules.js
@@ -4,12 +4,6 @@ export function __wbg_set_wasm(val) {
 }
 
 
-const heap = new Array(128).fill(undefined);
-
-heap.push(undefined, null, true, false);
-
-function getObject(idx) { return heap[idx]; }
-
 const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
 let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
@@ -29,6 +23,12 @@ function getStringFromWasm0(ptr, len) {
     ptr = ptr >>> 0;
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) { return heap[idx]; }
 
 let heap_next = heap.length;
 
@@ -57,13 +57,13 @@ export function exported() {
     wasm.exported();
 }
 
-export function __wbg_parseFloat_a582c94ad6956cc9(arg0) {
-    const ret = parseFloat(getObject(arg0));
+export function __wbg_parseFloat_2be7f01c31025438(arg0, arg1) {
+    const ret = parseFloat(getStringFromWasm0(arg0, arg1));
     return ret;
 };
 
-export function __wbg_parseFloat_e7f07194fb2af388(arg0, arg1) {
-    const ret = parseFloat(getStringFromWasm0(arg0, arg1));
+export function __wbg_parseFloat_7bc8aecd47f33642(arg0) {
+    const ret = parseFloat(getObject(arg0));
     return ret;
 };
 

--- a/crates/cli/tests/reference/modules.js
+++ b/crates/cli/tests/reference/modules.js
@@ -8,24 +8,7 @@ const heap = new Array(128).fill(undefined);
 
 heap.push(undefined, null, true, false);
 
-let heap_next = heap.length;
-
-function addHeapObject(obj) {
-    if (heap_next === heap.length) heap.push(heap.length + 1);
-    const idx = heap_next;
-    heap_next = heap[idx];
-
-    heap[idx] = obj;
-    return idx;
-}
-
-function handleError(f, args) {
-    try {
-        return f.apply(this, args);
-    } catch (e) {
-        wasm.__wbindgen_exn_store(addHeapObject(e));
-    }
-}
+function getObject(idx) { return heap[idx]; }
 
 const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
 
@@ -47,7 +30,7 @@ function getStringFromWasm0(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-function getObject(idx) { return heap[idx]; }
+let heap_next = heap.length;
 
 function dropObject(idx) {
     if (idx < 132) return;
@@ -61,35 +44,35 @@ function takeObject(idx) {
     return ret;
 }
 
-export function exported() {
-    const ret = wasm.exported();
-    if (ret[1]) {
-        throw takeObject(ret[0]);
-    }
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1);
+    const idx = heap_next;
+    heap_next = heap[idx];
+
+    heap[idx] = obj;
+    return idx;
 }
 
-export function __wbg_add_0f820bc7ed50a898(arg0, arg1) {
-    const ret = add(arg0, arg1);
+export function exported() {
+    wasm.exported();
+}
+
+export function __wbg_parseFloat_a582c94ad6956cc9(arg0) {
+    const ret = parseFloat(getObject(arg0));
     return ret;
 };
 
-export function __wbg_barfromfoo_fc0e2d223c6eed1f() {
-    bar_from_foo();
+export function __wbg_parseFloat_e7f07194fb2af388(arg0, arg1) {
+    const ret = parseFloat(getStringFromWasm0(arg0, arg1));
+    return ret;
 };
 
-export function __wbg_catchme_6fd452194698de3b() { return handleError(function () {
-    catch_me();
-}, arguments) };
-
-export function __wbg_nocatch_633680ea5fdb920d() {
-    no_catch();
+export function __wbindgen_object_drop_ref(arg0) {
+    takeObject(arg0);
 };
 
-export function __wbg_reload_bd59a4b785b50f44() {
-    window.location.reload();
-};
-
-export function __wbg_write_67852f31952d3412(arg0, arg1) {
-    window.document.write(getStringFromWasm0(arg0, arg1));
+export function __wbindgen_string_new(arg0, arg1) {
+    const ret = getStringFromWasm0(arg0, arg1);
+    return addHeapObject(ret);
 };
 

--- a/crates/cli/tests/reference/modules.rs
+++ b/crates/cli/tests/reference/modules.rs
@@ -1,0 +1,27 @@
+use wasm_bindgen::prelude::*;
+
+mod a {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_name = parseFloat)]
+        pub fn parse_float(text: &JsValue) -> f64;
+    }
+}
+
+mod b {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_name = parseFloat)]
+        pub fn parse_float(text: &str) -> f64;
+    }
+}
+
+#[wasm_bindgen]
+pub fn exported() {
+    let _ = a::parse_float(&JsValue::from_str("3.14"));
+    let _ = b::parse_float("3.14");
+}

--- a/crates/cli/tests/reference/modules.rs
+++ b/crates/cli/tests/reference/modules.rs
@@ -20,8 +20,19 @@ mod b {
     }
 }
 
+mod a_again {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_name = parseFloat)]
+        pub fn parse_float(text: &JsValue) -> f64;
+    }
+}
+
 #[wasm_bindgen]
 pub fn exported() {
     let _ = a::parse_float(&JsValue::from_str("3.14"));
     let _ = b::parse_float("3.14");
+    let _ = a_again::parse_float(&JsValue::from_str("3.14"));
 }

--- a/crates/cli/tests/reference/modules.wat
+++ b/crates/cli/tests/reference/modules.wat
@@ -1,0 +1,9 @@
+(module $reference_test.wasm
+  (type (;0;) (func))
+  (func $exported (;0;) (type 0))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "exported" (func $exported))
+  (@custom "target_features" (after code) "\04+\0amultivalue+\0fmutable-globals+\0freference-types+\08sign-ext")
+)
+

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -104,7 +104,7 @@ export class Test {
     }
 }
 
-export function __wbg_test2_a7ee3654c08eebfe() {
+export function __wbg_test2_ae36e154b7589768() {
     const ret = test2();
     return addHeapObject(ret);
 };

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -104,7 +104,7 @@ export class Test {
     }
 }
 
-export function __wbg_test2_39fe629b9aa739cf() {
+export function __wbg_test2_a7ee3654c08eebfe() {
     const ret = test2();
     return addHeapObject(ret);
 };

--- a/crates/cli/tests/reference/targets-0.js
+++ b/crates/cli/tests/reference/targets-0.js
@@ -13,7 +13,7 @@ export function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 
-export function __wbg_random_5d40be260a2cfbac() {
+export function __wbg_random_32888cfc47f8ed4d() {
     const ret = Math.random();
     return ret;
 };

--- a/crates/cli/tests/reference/targets-0.js
+++ b/crates/cli/tests/reference/targets-0.js
@@ -13,7 +13,7 @@ export function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 
-export function __wbg_random_32888cfc47f8ed4d() {
+export function __wbg_random_8be0a899673d8681() {
     const ret = Math.random();
     return ret;
 };

--- a/crates/cli/tests/reference/targets-1.js
+++ b/crates/cli/tests/reference/targets-1.js
@@ -44,7 +44,7 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_random_32888cfc47f8ed4d = function() {
+    imports.wbg.__wbg_random_8be0a899673d8681 = function() {
         const ret = Math.random();
         return ret;
     };

--- a/crates/cli/tests/reference/targets-1.js
+++ b/crates/cli/tests/reference/targets-1.js
@@ -44,7 +44,7 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_random_5d40be260a2cfbac = function() {
+    imports.wbg.__wbg_random_32888cfc47f8ed4d = function() {
         const ret = Math.random();
         return ret;
     };

--- a/crates/cli/tests/reference/targets-2.js
+++ b/crates/cli/tests/reference/targets-2.js
@@ -50,7 +50,7 @@ let wasm_bindgen;
     function __wbg_get_imports() {
         const imports = {};
         imports.wbg = {};
-        imports.wbg.__wbg_random_32888cfc47f8ed4d = function() {
+        imports.wbg.__wbg_random_8be0a899673d8681 = function() {
             const ret = Math.random();
             return ret;
         };

--- a/crates/cli/tests/reference/targets-2.js
+++ b/crates/cli/tests/reference/targets-2.js
@@ -50,7 +50,7 @@ let wasm_bindgen;
     function __wbg_get_imports() {
         const imports = {};
         imports.wbg = {};
-        imports.wbg.__wbg_random_5d40be260a2cfbac = function() {
+        imports.wbg.__wbg_random_32888cfc47f8ed4d = function() {
             const ret = Math.random();
             return ret;
         };

--- a/crates/cli/tests/reference/targets-3.js
+++ b/crates/cli/tests/reference/targets-3.js
@@ -12,7 +12,7 @@ module.exports.add_that_might_fail = function(a, b) {
     return ret >>> 0;
 };
 
-module.exports.__wbg_random_32888cfc47f8ed4d = function() {
+module.exports.__wbg_random_8be0a899673d8681 = function() {
     const ret = Math.random();
     return ret;
 };

--- a/crates/cli/tests/reference/targets-3.js
+++ b/crates/cli/tests/reference/targets-3.js
@@ -12,7 +12,7 @@ module.exports.add_that_might_fail = function(a, b) {
     return ret >>> 0;
 };
 
-module.exports.__wbg_random_5d40be260a2cfbac = function() {
+module.exports.__wbg_random_32888cfc47f8ed4d = function() {
     const ret = Math.random();
     return ret;
 };

--- a/crates/cli/tests/reference/targets-4.js
+++ b/crates/cli/tests/reference/targets-4.js
@@ -10,7 +10,7 @@ export function add_that_might_fail(a, b) {
 
 const imports = {
     __wbindgen_placeholder__: {
-        __wbg_random_5d40be260a2cfbac: function() {
+        __wbg_random_32888cfc47f8ed4d: function() {
             const ret = Math.random();
             return ret;
         },

--- a/crates/cli/tests/reference/targets-4.js
+++ b/crates/cli/tests/reference/targets-4.js
@@ -10,7 +10,7 @@ export function add_that_might_fail(a, b) {
 
 const imports = {
     __wbindgen_placeholder__: {
-        __wbg_random_32888cfc47f8ed4d: function() {
+        __wbg_random_8be0a899673d8681: function() {
             const ret = Math.random();
             return ret;
         },

--- a/crates/cli/tests/reference/web-sys.js
+++ b/crates/cli/tests/reference/web-sys.js
@@ -210,7 +210,7 @@ export function get_media_source() {
 
 const __wbindgen_enum_MediaSourceEnum = ["camera", "screen", "application", "window", "browser", "microphone", "audioCapture", "other"];
 
-export function __wbg_new_afb0ba7f51a036ca() { return handleError(function (arg0, arg1) {
+export function __wbg_new_561a91ce53f10a66() { return handleError(function (arg0, arg1) {
     const ret = new URL(getStringFromWasm0(arg0, arg1));
     return addHeapObject(ret);
 }, arguments) };

--- a/crates/cli/tests/reference/web-sys.js
+++ b/crates/cli/tests/reference/web-sys.js
@@ -210,7 +210,7 @@ export function get_media_source() {
 
 const __wbindgen_enum_MediaSourceEnum = ["camera", "screen", "application", "window", "browser", "microphone", "audioCapture", "other"];
 
-export function __wbg_new_1cabf49927794f50() { return handleError(function (arg0, arg1) {
+export function __wbg_new_afb0ba7f51a036ca() { return handleError(function (arg0, arg1) {
     const ret = new URL(getStringFromWasm0(arg0, arg1));
     return addHeapObject(ret);
 }, arguments) };

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -21,6 +21,6 @@ strict-macro = []
 [dependencies]
 proc-macro2 = "1.0"
 quote = '1.0'
-syn = { version = '2.0', features = ['visit', 'visit-mut', 'full', 'extra-traits'] }
+syn = { version = '2.0', features = ['visit', 'visit-mut', 'full'] }
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.95" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -21,6 +21,6 @@ strict-macro = []
 [dependencies]
 proc-macro2 = "1.0"
 quote = '1.0'
-syn = { version = '2.0', features = ['visit', 'visit-mut', 'full'] }
+syn = { version = '2.0', features = ['visit', 'visit-mut', 'full', 'extra-traits'] }
 wasm-bindgen-backend = { path = "../backend", version = "=0.2.95" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -618,7 +618,7 @@ impl<'a> ConvertToAst<(&ast::Program, BindgenAttrs, &'a Option<ast::ImportModule
                 ast::ImportFunctionKind::Normal => (0, "n"),
                 ast::ImportFunctionKind::Method { ref class, .. } => (1, &class[..]),
             };
-            let data = (ns, &self.sig.ident, module);
+            let data = (ns, &self.sig, module);
             format!(
                 "__wbg_{}_{}",
                 wasm.name

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -618,7 +618,7 @@ impl<'a> ConvertToAst<(&ast::Program, BindgenAttrs, &'a Option<ast::ImportModule
                 ast::ImportFunctionKind::Normal => (0, "n"),
                 ast::ImportFunctionKind::Method { ref class, .. } => (1, &class[..]),
             };
-            let data = (ns, &self.sig, module);
+            let data = (ns, self.sig.to_token_stream().to_string(), module);
             format!(
                 "__wbg_{}_{}",
                 wasm.name


### PR DESCRIPTION
Fixes #4268 

The problem in #4268 was the short hash added to disambiguate imported functions only hashed the Rust identifier of the function. This is enough to ensure uniqueness within a single Rust module, but not across modules as in #4268. This resulted in 2 different wasm functions being exported under the same name.

I fixed this by hashing not just the function name, but the whole signature (name + inputs + outputs + some extra). This means that 2 function will only have the same hash if they have the same name, input, and outputs. If this happens, the functions also have the same ABI and exporting them both under the same name actually works.

(Note: I don't like that 2 functions with the same signature have the same hash, so if you want to, I can hash the source code position of the function as well to make collisions very unlikely.)

Consequently, the hashes of all imported functions are now different. A lot of tests were updated, but the main new test is called `modules.rs`. 

I also had to enable the `'extra-traits'` feature on `syn`. This feature enables implementing `Hash` for `syn::Signature` and other types.