### PR TITLE
Add test for imported getters and setters

### DIFF
--- a/crates/cli/tests/reference/import-getter-setter.d.ts
+++ b/crates/cli/tests/reference/import-getter-setter.d.ts
@@ -1,0 +1,3 @@
+/* tslint:disable */
+/* eslint-disable */
+export function exported(): void;

--- a/crates/cli/tests/reference/import-getter-setter.js
+++ b/crates/cli/tests/reference/import-getter-setter.js
@@ -1,0 +1,102 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const heap = new Array(128).fill(undefined);
+
+heap.push(undefined, null, true, false);
+
+function getObject(idx) { return heap[idx]; }
+
+let heap_next = heap.length;
+
+function addHeapObject(obj) {
+    if (heap_next === heap.length) heap.push(heap.length + 1);
+    const idx = heap_next;
+    heap_next = heap[idx];
+
+    heap[idx] = obj;
+    return idx;
+}
+
+function dropObject(idx) {
+    if (idx < 132) return;
+    heap[idx] = heap_next;
+    heap_next = idx;
+}
+
+function takeObject(idx) {
+    const ret = getObject(idx);
+    dropObject(idx);
+    return ret;
+}
+
+export function exported() {
+    wasm.exported();
+}
+
+export function __wbg_another_edf1002f8e41a5da(arg0) {
+    const ret = getObject(arg0).prop2;
+    return ret;
+};
+
+export function __wbg_b_f17802a22332a667(arg0) {
+    const ret = getObject(arg0).a;
+    return ret;
+};
+
+export function __wbg_bar2_84566b6bcf547b19() {
+    const ret = Bar.bar2();
+    return ret;
+};
+
+export function __wbg_getfoo_eae0175044c62418() {
+    const ret = Bar.get_foo();
+    return ret;
+};
+
+export function __wbg_new_d728785ba7e8df96() {
+    const ret = new SomeClass();
+    return addHeapObject(ret);
+};
+
+export function __wbg_setanother_2d160a2b6600e990(arg0, arg1) {
+    getObject(arg0).prop2 = arg1 >>> 0;
+};
+
+export function __wbg_setb_40f909ae19a05c10(arg0, arg1) {
+    getObject(arg0).a = arg1 >>> 0;
+};
+
+export function __wbg_setbar2_c8b4a150c6accea2(arg0) {
+    Bar.set_bar2(arg0 >>> 0);
+};
+
+export function __wbg_setfoo_6c6b6af72f779234(arg0) {
+    Bar.set_foo(arg0 >>> 0);
+};
+
+export function __wbg_setsignal_d386d151e7775c3f(arg0, arg1) {
+    getObject(arg0).signal = arg1 >>> 0;
+};
+
+export function __wbg_setsomeprop_afbca63b5d0f4c92(arg0, arg1) {
+    getObject(arg0).some_prop = arg1 >>> 0;
+};
+
+export function __wbg_signal_b82e5486ce265c55(arg0) {
+    const ret = getObject(arg0).signal;
+    return ret;
+};
+
+export function __wbg_someprop_26178791e2719528(arg0) {
+    const ret = getObject(arg0).some_prop;
+    return ret;
+};
+
+export function __wbindgen_object_drop_ref(arg0) {
+    takeObject(arg0);
+};
+

--- a/crates/cli/tests/reference/import-getter-setter.rs
+++ b/crates/cli/tests/reference/import-getter-setter.rs
@@ -1,0 +1,59 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = Bar, getter = bar)]
+    fn get_foo() -> u32;
+    #[wasm_bindgen(js_namespace = Bar, setter = bar)]
+    fn set_foo(value: u32);
+    #[wasm_bindgen(js_namespace = Bar, getter, js_name = bar2)]
+    fn get_foo2() -> u32;
+    #[wasm_bindgen(js_namespace = Bar, setter, js_name = bar2)]
+    fn set_foo2(value: u32);
+
+    #[wasm_bindgen]
+    #[derive(Debug, Clone, PartialEq)]
+    pub type SomeClass;
+
+    #[wasm_bindgen(method, getter, js_class = "SomeClass", js_name = signal)]
+    pub fn signal(this: &SomeClass) -> u32;
+    #[wasm_bindgen(method, setter, js_class = "SomeClass", js_name = signal)]
+    pub fn set_signal(this: &SomeClass, value: u32);
+
+    #[wasm_bindgen(method, getter, js_class = "SomeClass")]
+    pub fn some_prop(this: &SomeClass) -> u32;
+    #[wasm_bindgen(method, setter, js_class = "SomeClass")]
+    pub fn set_some_prop(this: &SomeClass, value: u32);
+
+    #[wasm_bindgen(method, getter = prop2, js_class = "SomeClass")]
+    pub fn another(this: &SomeClass) -> u32;
+    #[wasm_bindgen(method, setter = prop2, js_class = "SomeClass")]
+    pub fn set_another(this: &SomeClass, value: u32);
+
+    // #[wasm_bindgen(getter, js_class = "SomeClass")]
+    // pub fn static_controller() -> SomeClass;
+    // #[wasm_bindgen(getter, js_class = "SomeClass")]
+    // pub fn set_static_controller(value: &SomeClass);
+
+    #[wasm_bindgen(constructor, js_class = "SomeClass")]
+    pub fn new() -> SomeClass;
+
+    // js_name conflicts with the getter/setter name
+    #[wasm_bindgen(method, getter = a, js_class = "SomeClass", js_name = b)]
+    pub fn c(this: &SomeClass) -> u32;
+    #[wasm_bindgen(method, setter = a, js_class = "SomeClass", js_name = b)]
+    pub fn set_c(this: &SomeClass, value: u32);
+}
+
+#[wasm_bindgen]
+pub fn exported() {
+    set_foo(get_foo());
+    set_foo2(get_foo2());
+
+    let a = SomeClass::new();
+    a.set_signal(a.signal());
+    a.set_some_prop(a.some_prop());
+    a.set_another(a.another());
+    a.set_c(a.c());
+    // let _ = static_signal();
+}

--- a/crates/cli/tests/reference/import-getter-setter.wat
+++ b/crates/cli/tests/reference/import-getter-setter.wat
@@ -1,0 +1,9 @@
+(module $reference_test.wasm
+  (type (;0;) (func))
+  (func $exported (;0;) (type 0))
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "exported" (func $exported))
+  (@custom "target_features" (after code) "\04+\0amultivalue+\0fmutable-globals+\0freference-types+\08sign-ext")
+)
+


### PR DESCRIPTION
This PR just adds tests for imported getters and setters. It shows bugs that I want to fix.

1. Renaming for static getters and setters does not work correctly. See that the setter is always called `set_<name>`.
2. Static getters ignore the name set in the `getter` attribute. Same for setters.
3. The code gen for static getters/setters is not correct. Note that they are called as functions.

I already have a fix ready for 1 and 2, but I wanted to add the tests before that PR, so that it's easier to see how the fix PR changes the existing code gen.