### PR TITLE
Improved errors for invalid `self` arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@
 * Updated the WebGPU API to the current draft as of 2024-11-22.
   [#4290](https://github.com/rustwasm/wasm-bindgen/pull/4290)
 
+* Improved error messages for `self` arguments in invalid positions.
+  [#4276](https://github.com/rustwasm/wasm-bindgen/pull/4276)
+
 ### Fixed
 
 * Fixed methods with `self: &Self` consuming the object.

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1016,14 +1016,14 @@ fn function_from_decl(
                 match position {
                     FunctionPosition::Free => {
                         bail_span!(
-                            r,
+                            r.self_token,
                             "the `self` argument is only allowed for functions in `impl` blocks.\n\n\
                             If the function is already in an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?"
                         );
                     }
                     FunctionPosition::Extern => {
                         bail_span!(
-                            r,
+                            r.self_token,
                             "the `self` argument is not allowed for `extern` functions.\n\n\
                             Did you perhaps mean `this`? For more information on importing JavaScript functions, see:\n\
                             https://rustwasm.github.io/docs/wasm-bindgen/examples/import-js.html"

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -932,11 +932,6 @@ enum FunctionPosition<'a> {
     Free,
     Impl { self_ty: &'a Ident },
 }
-impl FunctionPosition<'_> {
-    fn is_impl(&self) -> bool {
-        matches!(self, FunctionPosition::Impl { .. })
-    }
-}
 
 /// Construct a function (and gets the self type if appropriate) for our AST from a syn function.
 #[allow(clippy::too_many_arguments)]
@@ -1062,7 +1057,7 @@ fn function_from_decl(
             };
             (name, js_name_span, true)
         } else {
-            let name = if !position.is_impl()
+            let name = if !matches!(position, FunctionPosition::Impl { .. })
                 && opts.method().is_none()
                 && is_js_keyword(&decl_name.to_string(), skip_keywords)
             {

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -1018,7 +1018,7 @@ fn function_from_decl(
                         bail_span!(
                             r,
                             "the `self` argument is only allowed for functions in `impl` blocks.\n\n\
-                            If the function is already inside an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?"
+                            If the function is already in an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?"
                         );
                     }
                     FunctionPosition::Extern => {

--- a/crates/macro/ui-tests/invalid-self.rs
+++ b/crates/macro/ui-tests/invalid-self.rs
@@ -1,0 +1,23 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub struct A {
+    data: u32,
+}
+
+// oh no, I forgot to add `#[wasm_bindgen]` to the impl block
+impl A {
+    #[wasm_bindgen(js_name = bar)]
+    pub fn foo(&self) {}
+}
+
+#[wasm_bindgen]
+extern "C" {
+    type MyClass;
+
+    // oops, I mixed up `self` and `this`
+    #[wasm_bindgen(method)]
+    fn render(self: &MyClass) -> String;
+}
+
+fn main() {}

--- a/crates/macro/ui-tests/invalid-self.stderr
+++ b/crates/macro/ui-tests/invalid-self.stderr
@@ -1,6 +1,6 @@
 error: the `self` argument is only allowed for functions in `impl` blocks.
 
-       If the function is already inside an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?
+       If the function is already in an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?
   --> ui-tests/invalid-self.rs:11:16
    |
 11 |     pub fn foo(&self) {}

--- a/crates/macro/ui-tests/invalid-self.stderr
+++ b/crates/macro/ui-tests/invalid-self.stderr
@@ -1,0 +1,16 @@
+error: the `self` argument is only allowed for functions in `impl` blocks.
+
+       If the function is already inside an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?
+  --> ui-tests/invalid-self.rs:11:16
+   |
+11 |     pub fn foo(&self) {}
+   |                ^^^^^
+
+error: the `self` argument is not allowed for `extern` functions.
+
+       Did you perhaps mean `this`? For more information on importing JavaScript functions, see:
+       https://rustwasm.github.io/docs/wasm-bindgen/examples/import-js.html
+  --> ui-tests/invalid-self.rs:20:15
+   |
+20 |     fn render(self: &MyClass) -> String;
+   |               ^^^^^^^^^^^^^^

--- a/crates/macro/ui-tests/invalid-self.stderr
+++ b/crates/macro/ui-tests/invalid-self.stderr
@@ -1,10 +1,10 @@
 error: the `self` argument is only allowed for functions in `impl` blocks.
 
        If the function is already in an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?
-  --> ui-tests/invalid-self.rs:11:16
+  --> ui-tests/invalid-self.rs:11:17
    |
 11 |     pub fn foo(&self) {}
-   |                ^^^^^
+   |                 ^^^^
 
 error: the `self` argument is not allowed for `extern` functions.
 
@@ -13,4 +13,4 @@ error: the `self` argument is not allowed for `extern` functions.
   --> ui-tests/invalid-self.rs:20:15
    |
 20 |     fn render(self: &MyClass) -> String;
-   |               ^^^^^^^^^^^^^^
+   |               ^^^^


### PR DESCRIPTION
While writing tests, I forgot to add `#[wasm_bindgen]` on an `impl` block and the proc macro panicked with the message "arguments cannot be `self`". Since this was a panic, I tried to debug the proc macro for like 10 minutes before I noticed the missing `#[wasm_bindgen]` in my test.

This PR improves the error messages for `self` arguments in invalid positions. Instead of panics, users now get proper errors with helpful error messages.

Before:
```
error: custom attribute panicked
  --> ui-tests/invalid-self.rs:10:5
   |
10 |     #[wasm_bindgen(js_name = bar)]
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: arguments cannot be `self`
```

After:
```
error: the `self` argument is only allowed for functions in `impl` blocks.

       If the function is already in an `impl` block, did you perhaps forget to add `#[wasm_bindgen]` to the `impl` block?
  --> ui-tests/invalid-self.rs:11:17
   |
11 |     pub fn foo(&self) {}
   |                 ^^^^
```

For imported/`extern` functions with a `self` argument, I added a similar error message that suggests using `this` instead of `self`.

These new error messages should (1) make these issues easier to fix for our users and (2) make it clear that it's an error with user code and not the macro.

---

To implement the better error messages, I initially added a new parameter to `function_from_decl` to hold the function position (free, extern, impl), but realized that this single parameter could represent `allow_self: bool`, `self_ty: Option<&Ident>`, and `is_from_impl: bool` all in a single parameter. So I did that. In total, I added 1 new parameter and removed 3 old ones from `function_from_decl`. This makes the diff a bit larger, but I couldn't resist when it cleaned up the API of `function_from_decl` so nicely.