### PR TITLE
Use private constructors in type definitions of structs without an exported constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,9 @@
 * Fixed imports for functions using `this` and late binding.
   [#4225](https://github.com/rustwasm/wasm-bindgen/pull/4225)
 
+* Don't expose non-functioning implicit constructors to classes when none are provided.
+  [#4282](https://github.com/rustwasm/wasm-bindgen/pull/4282)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.95](https://github.com/rustwasm/wasm-bindgen/compare/0.2.94...0.2.95)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1016,14 +1016,19 @@ __wbg_set_wasm(wasm);"
         let mut dst = format!("class {} {{\n", name);
         let mut ts_dst = format!("export {}", dst);
 
-        if self.config.debug && !class.has_constructor {
-            dst.push_str(
-                "
-                    constructor() {
-                        throw new Error('cannot invoke `new` directly');
-                    }
-                ",
-            );
+        if !class.has_constructor {
+            // declare the constructor as private to prevent direct instantiation
+            ts_dst.push_str("  private constructor();\n");
+
+            if self.config.debug {
+                dst.push_str(
+                    "
+                        constructor() {
+                            throw new Error('cannot invoke `new` directly');
+                        }
+                    ",
+                );
+            }
         }
 
         if class.wrap_needed {

--- a/crates/cli/tests/reference/builder.d.ts
+++ b/crates/cli/tests/reference/builder.d.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export class ClassBuilder {
+  private constructor();
   free(): void;
   static builder(): ClassBuilder;
 }

--- a/crates/cli/tests/reference/echo.d.ts
+++ b/crates/cli/tests/reference/echo.d.ts
@@ -57,5 +57,6 @@ export function echo_option_vec_string(a?: (string)[]): (string)[] | undefined;
 export function echo_option_struct(a?: Foo): Foo | undefined;
 export function echo_option_vec_struct(a?: (Foo)[]): (Foo)[] | undefined;
 export class Foo {
+  private constructor();
   free(): void;
 }

--- a/crates/cli/tests/reference/getter-setter.d.ts
+++ b/crates/cli/tests/reference/getter-setter.d.ts
@@ -1,6 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export class Foo {
+  private constructor();
   free(): void;
   x: number;
   y?: number;

--- a/crates/cli/tests/reference/raw.d.ts
+++ b/crates/cli/tests/reference/raw.d.ts
@@ -2,6 +2,7 @@
 /* eslint-disable */
 export function test1(test: number): number;
 export class Test {
+  private constructor();
   free(): void;
   static test1(test: number): Test;
   test2(test: number): void;

--- a/crates/typescript-tests/src/custom_section.rs
+++ b/crates/typescript-tests/src/custom_section.rs
@@ -17,3 +17,11 @@ const _: &str = TS_INTERFACE_EXPORT2;
 pub struct Person {
     pub height: u32,
 }
+
+#[wasm_bindgen]
+impl Person {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+      Self { height: 170 }
+    }
+}

--- a/crates/typescript-tests/src/custom_section.rs
+++ b/crates/typescript-tests/src/custom_section.rs
@@ -22,6 +22,6 @@ pub struct Person {
 impl Person {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-      Self { height: 170 }
+        Self { height: 170 }
     }
 }

--- a/crates/typescript-tests/src/getters_setters.rs
+++ b/crates/typescript-tests/src/getters_setters.rs
@@ -3,9 +3,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct ColorWithGetters {
     r: f64,
-    g: f64,
-    b: f64,
-    a: u8,
+    _g: f64,
+    _b: f64,
+    _a: u8,
 }
 
 #[wasm_bindgen]
@@ -14,9 +14,9 @@ impl ColorWithGetters {
     pub fn new() -> Self {
         Self {
             r: 0.0,
-            g: 0.0,
-            b: 0.0,
-            a: 0,
+            _g: 0.0,
+            _b: 0.0,
+            _a: 0,
         }
     }
 
@@ -34,8 +34,8 @@ impl ColorWithGetters {
 #[wasm_bindgen]
 pub struct ColorWithSetters {
     r: f64,
-    g: f64,
-    b: f64,
+    _g: f64,
+    _b: f64,
     a: u8,
 }
 
@@ -45,8 +45,8 @@ impl ColorWithSetters {
     pub fn new() -> Self {
         Self {
             r: 0.0,
-            g: 0.0,
-            b: 0.0,
+            _g: 0.0,
+            _b: 0.0,
             a: 0,
         }
     }
@@ -70,8 +70,8 @@ impl ColorWithSetters {
 #[wasm_bindgen]
 pub struct ColorWithGetterAndSetter {
     r: f64,
-    g: f64,
-    b: f64,
+    _g: f64,
+    _b: f64,
     a: u8,
 }
 
@@ -81,8 +81,8 @@ impl ColorWithGetterAndSetter {
     pub fn new() -> Self {
         Self {
             r: 0.0,
-            g: 0.0,
-            b: 0.0,
+            _g: 0.0,
+            _b: 0.0,
             a: 0,
         }
     }

--- a/crates/typescript-tests/src/getters_setters.rs
+++ b/crates/typescript-tests/src/getters_setters.rs
@@ -3,13 +3,23 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub struct ColorWithGetters {
     r: f64,
-    _g: f64,
-    _b: f64,
-    _a: u8,
+    g: f64,
+    b: f64,
+    a: u8,
 }
 
 #[wasm_bindgen]
 impl ColorWithGetters {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0,
+        }
+    }
+
     #[wasm_bindgen(getter)]
     pub fn r(&self) -> f64 {
         self.r
@@ -24,13 +34,23 @@ impl ColorWithGetters {
 #[wasm_bindgen]
 pub struct ColorWithSetters {
     r: f64,
-    _g: f64,
-    _b: f64,
+    g: f64,
+    b: f64,
     a: u8,
 }
 
 #[wasm_bindgen]
 impl ColorWithSetters {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0,
+        }
+    }
+
     #[wasm_bindgen(setter)]
     pub fn set_r(&mut self, r: f64) {
         self.r = r;
@@ -50,13 +70,23 @@ impl ColorWithSetters {
 #[wasm_bindgen]
 pub struct ColorWithGetterAndSetter {
     r: f64,
-    _g: f64,
-    _b: f64,
+    g: f64,
+    b: f64,
     a: u8,
 }
 
 #[wasm_bindgen]
 impl ColorWithGetterAndSetter {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Self {
+            r: 0.0,
+            g: 0.0,
+            b: 0.0,
+            a: 0,
+        }
+    }
+
     #[wasm_bindgen(getter)]
     pub fn r(&self) -> f64 {
         self.r


### PR DESCRIPTION
## Motivation

A simple empty struct was previously typed as follows:

```rs
#[wasm_bindgen]
struct Foo;
```
```ts
export class Foo {
  free(): void;
}
```

This typing is incorrect. In JavaScript, a missing constructor is equivalent to an empty constructor. <details><summary>Example:</summary>

```js
// omitting the constructor...
class Example { }

// ... is the same as this
class Example {
  constructor() {}
}
```

</details> 

So the above type for `Foo` is actually just a short form for this:

```ts
export class Foo {
  constructor();
  free(): void;
}
```

Obviously, this is not correct. The `Foo` class is not supported to be instantiate-able using the class constructor. In debug mode, WBG even generates a constructor that always throws.

## Changes in this PR

This PR solves this problem by adding a `private constructor` for structs with a `#[wasm_bindgen(constructor)]`. E.g. the above `Foo` struct would get this type definitions:

```ts
export class Foo {
  private constructor();
  free(): void;
}
```

A private constructor in TS declares the constructor as inaccessible to anyone besides the class itself. In particular, a private constructor prevents users in TypeScript from:

1. Instantiating the class directly. E.g. `new Foo()`.
2. Making derived classes. E.g. `class Bar extends Foo {}`.
3. Using `Foo` in generic functions that require a constructor.

See [this TS playground for proof](https://www.typescriptlang.org/play/?#code/CYUwxgNghgTiAEkoGdnwGIHtPwN4Ch4j4AHGASwDcoAXBMTAO2RpgFcwbMYAKASgDchYgDM4IfgC54lTOWBCAvvnwB6VfACMAOkRRGjTDXjlmNfTXK0EWTPgZn4I6bfgBeeIxAB3DNn5CItpiIBKCKurwAEy6YPqGxiAAHnSMwH52SKjwAEKw8MmpwGiuuPDKahoAzLHxRvBsyDbYJozwAOYgXhRgiEx0KWjeABYgcPBQfWbsnNwmaHAAjmzkcMD4ImyMnORMiHDWADwAKgUpXcV4nj5SE4wAnuUAfDwA1tCo0sd80gCSZvowCBjvcSCATk88MIiHAaGwYG0vL53ihkAF8MowAc6DxbHwgA).

With those changes, the type definitions now accurately represent the correct usage of class `Foo` and correctly cause errors on incorrect usage.

## Is this a breaking change?

Probably not. 

Since this is a type-only change, nothing will break at runtime (more than it already is). Users using the implicitly defined constructor most likely isn't intended by WBG since WBG even generates a constructor that always throws in debug mode to prevent exactly this.

So this PR will at most cause new TS compiler errors for incorrect code. From that perspective, I would argue that this PR is not a breaking change.