### PR TITLE
Don't emit unexpected cfgs in proc-macros

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,12 +67,12 @@ jobs:
     - run: cargo clippy --no-deps --all-features -p example-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-externref-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro-support -- -D warnings
+    - run: cargo clippy --no-deps --features spans,strict-macro -p wasm-bindgen-macro -- -D warnings
+    - run: cargo clippy --no-deps --features extra-traits,spans,strict-macro -p wasm-bindgen-macro-support -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-multi-value-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-shared -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-test -- -D warnings
-    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-test-macro -- -D warnings
+    - run: cargo clippy --no-deps -p wasm-bindgen-test-macro -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-threads-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p typescript-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-wasm-conventions -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,11 @@ wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.95", default-featu
   "atomics",
 ] }
 
+[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"), wasm_bindgen_unstable_test_coverage))'.dependencies]
+wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.95", default-features = false, features = [
+  "coverage",
+] }
+
 [dev-dependencies]
 wasm-bindgen-test = { path = 'crates/test' }
 

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -28,3 +28,6 @@ proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '2.0', features = ['full'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.2.95"
 
 [features]
 atomics = []
+coverage = []
 default = ["std"]
 extra-traits = ["syn/extra-traits"]
 spans = []
@@ -28,6 +29,3 @@ proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '2.0', features = ['full'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.95" }
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.2.95"
 
 [features]
 atomics = ["wasm-bindgen-backend/atomics"]
+coverage = ["wasm-bindgen-backend/coverage"]
 default = ["std"]
 extra-traits = ["syn/extra-traits"]
 spans = ["wasm-bindgen-backend/spans"]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro = true
 
 [features]
 atomics = ["wasm-bindgen-macro-support/atomics"]
+coverage = ["wasm-bindgen-macro-support/coverage"]
 default = ["std"]
 spans = ["wasm-bindgen-macro-support/spans"]
 std = ["wasm-bindgen-macro-support/std"]
@@ -34,6 +35,3 @@ trybuild = "1.0"
 wasm-bindgen = { path = "../.." }
 wasm-bindgen-futures = { path = "../futures" }
 web-sys = { path = "../web-sys", features = ["Worker"] }
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,9 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro/0.2")]
 #![cfg_attr(
-    any(
-        wasm_bindgen_unstable_test_coverage,
-        all(not(feature = "std"), feature = "atomics")
-    ),
+    any(feature = "coverage", all(not(feature = "std"), feature = "atomics")),
     feature(allow_internal_unstable),
     allow(internal_features)
 )]
@@ -14,10 +11,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 #[proc_macro_attribute]
-#[cfg_attr(
-    wasm_bindgen_unstable_test_coverage,
-    allow_internal_unstable(coverage_attribute)
-)]
+#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
 #[cfg_attr(
     all(not(feature = "std"), feature = "atomics"),
     allow_internal_unstable(thread_local)
@@ -48,10 +42,7 @@ pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// let worker = Worker::new(&wasm_bindgen::link_to!(module = "/src/worker.js"));
 /// ```
 #[proc_macro]
-#[cfg_attr(
-    wasm_bindgen_unstable_test_coverage,
-    allow_internal_unstable(coverage_attribute)
-)]
+#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
 pub fn link_to(input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_link_to(input.into()) {
         Ok(tokens) => {
@@ -68,10 +59,7 @@ pub fn link_to(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-#[cfg_attr(
-    wasm_bindgen_unstable_test_coverage,
-    allow_internal_unstable(coverage_attribute)
-)]
+#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
 pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_class_marker(attr.into(), input.into()) {
         Ok(tokens) => {

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -12,6 +12,9 @@ version = "0.3.45"
 [lib]
 proc-macro = true
 
+[features]
+coverage = []
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -26,6 +29,3 @@ syn = { version = "2.0", default-features = false, features = [
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trybuild = "1.0"
 wasm-bindgen-test = { path = "../test" }
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -2,7 +2,7 @@
 //! going on here.
 
 #![cfg_attr(
-    wasm_bindgen_unstable_test_coverage,
+    feature = "coverage",
     feature(allow_internal_unstable),
     allow(internal_features)
 )]
@@ -18,10 +18,7 @@ use std::sync::atomic::*;
 static CNT: AtomicUsize = AtomicUsize::new(0);
 
 #[proc_macro_attribute]
-#[cfg_attr(
-    wasm_bindgen_unstable_test_coverage,
-    allow_internal_unstable(coverage_attribute)
-)]
+#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
 pub fn wasm_bindgen_test(
     attr: proc_macro::TokenStream,
     body: proc_macro::TokenStream,
@@ -109,7 +106,7 @@ pub fn wasm_bindgen_test(
     // main test harness. This is the entry point for all tests.
     let name = format_ident!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
     let wasm_bindgen_path = attributes.wasm_bindgen_path;
-    let coverage = if cfg!(wasm_bindgen_unstable_test_coverage) {
+    let coverage = if cfg!(feature = "coverage") {
         Some(quote! { #[coverage(off)] })
     } else {
         None

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -109,12 +109,17 @@ pub fn wasm_bindgen_test(
     // main test harness. This is the entry point for all tests.
     let name = format_ident!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
     let wasm_bindgen_path = attributes.wasm_bindgen_path;
+    let coverage = if cfg!(wasm_bindgen_unstable_test_coverage) {
+        Some(quote! { #[coverage(off)] })
+    } else {
+        None
+    };
     tokens.extend(
         quote! {
             const _: () = {
                 #[no_mangle]
                 #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
-                #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
+                #coverage
                 pub extern "C" fn #name(cx: &#wasm_bindgen_path::__rt::Context) {
                     let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
                     #test_body

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -24,6 +24,7 @@ wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.45' }
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]
 minicov = "0.3"
+wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.45', features = ["coverage"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }


### PR DESCRIPTION
This issue has been caused by recent changes in nightly: https://github.com/rust-lang/rust/pull/132577. `unexpected_cfg` is now emitted from proc-macros as well.

~~This PR simply avoids this by checking the `cfg` check in the macro itself, which is required anyway to enable the corresponding unstable features.~~

This changes when the `#[coverage]` attribute is emitted by adding an internal `coverage` crate feature to the proc-macro and their utility crates. This crate feature is enabled by `wasm-bindgen` and `wasm-bindgen-test` when `cfg(wasm_bindgen_unstable_test_coverage)` is enabled.