### PR TITLE
Pin all dependencies to each other

### DIFF
--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -19,9 +19,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 cfg-if = "1.0.0"
 futures-core = { version = '0.3.8', default-features = false, optional = true }
-js-sys = { path = "../js-sys", version = '0.3.72', default-features = false }
+js-sys = { path = "../js-sys", version = '=0.3.72', default-features = false }
 once_cell = { version = "1.12", default-features = false }
-wasm-bindgen = { path = "../..", version = '0.2.95', default-features = false }
+wasm-bindgen = { path = "../..", version = '=0.2.95', default-features = false }
 
 [features]
 default = ["std"]
@@ -32,7 +32,7 @@ std = ["wasm-bindgen/std", "js-sys/std", "web-sys/std", "once_cell/std"]
 default-features = false
 features = ["MessageEvent", "Worker"]
 path = "../web-sys"
-version = "0.3.24"
+version = "=0.3.72"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 futures-channel-preview = { version = "0.3.0-alpha.18" }

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -25,7 +25,7 @@ default = ["std"]
 std = ["wasm-bindgen/std"]
 
 [dependencies]
-wasm-bindgen = { path = "../..", version = "0.2.95", default-features = false }
+wasm-bindgen = { path = "../..", version = "=0.2.95", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-futures = { path = '../futures' }

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -15,11 +15,11 @@ std = ["wasm-bindgen/std", "js-sys/std", "wasm-bindgen-futures/std", "once_cell/
 
 [dependencies]
 gg-alloc = { version = "1.0", optional = true }
-js-sys = { path = '../js-sys', version = '0.3.72', default-features = false }
+js-sys = { path = '../js-sys', version = '=0.3.72', default-features = false }
 once_cell = { version = "1.12", default-features = false }
 scoped-tls = { version = "1.0", optional = true }
-wasm-bindgen = { path = '../..', version = '0.2.95', default-features = false }
-wasm-bindgen-futures = { path = '../futures', version = '0.4.45', default-features = false }
+wasm-bindgen = { path = '../..', version = '=0.2.95', default-features = false }
+wasm-bindgen-futures = { path = '../futures', version = '=0.4.45', default-features = false }
 wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.45' }
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -23,8 +23,8 @@ doctest = false
 test = false
 
 [dependencies]
-js-sys = { path = '../js-sys', version = '0.3.72', default-features = false }
-wasm-bindgen = { path = "../..", version = "0.2.95", default-features = false }
+js-sys = { path = '../js-sys', version = '=0.3.72', default-features = false }
+wasm-bindgen = { path = "../..", version = "=0.2.95", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 futures = "0.3"


### PR DESCRIPTION
`js-sys`, `wasm-bindgen-futures`, `web-sys` and `wasm-bindgen-test` were allowed to depend on older versions of each other or `wasm-bindgen`. This has caused some bugs in the past (I failed to find them when searching). While this is unlikely to cause issues in `js-sys` and `web-sys`, it can definitely affect the other two crates.

This changes all dependencies to pin the latest version, to avoid any future mistakes where we make a change that isn't compatible with the minimum version specified.