### PR TITLE
Test `no_std` MSRV in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -540,13 +540,22 @@ jobs:
   msrv-lib:
     name: Check MSRV for libraries
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
+        features:
+          - --no-default-features
+          - ""
     defaults:
       run:
         working-directory: crates/msrv/lib
     steps:
     - uses: actions/checkout@v4
-    - run: rustup update --no-self-update 1.57 && rustup default 1.57
-    - run: cargo build
+    - run: rustup update --no-self-update 1.57 && rustup default 1.57 && rustup target add ${{ matrix.target }}
+    - run: cargo build --target ${{ matrix.target }} ${{ matrix.features }}
 
   msrv-cli:
     name: Check MSRV for CLI tools

--- a/crates/msrv/cli/Cargo.toml
+++ b/crates/msrv/cli/Cargo.toml
@@ -6,9 +6,3 @@ version = "0.0.0"
 
 [dependencies]
 wasm-bindgen-cli = { path = "../../cli" }
-wasm-bindgen-cli-support = { path = "../../cli-support" }
-wasm-bindgen-externref-xform = { path = "../../externref-xform" }
-wasm-bindgen-multi-value-xform = { path = "../../multi-value-xform" }
-wasm-bindgen-threads-xform = { path = "../../threads-xform" }
-wasm-bindgen-wasm-conventions = { path = "../../wasm-conventions" }
-wasm-bindgen-wasm-interpreter = { path = "../../wasm-interpreter" }

--- a/crates/msrv/lib/Cargo.toml
+++ b/crates/msrv/lib/Cargo.toml
@@ -4,21 +4,32 @@ name = "msrv-library-test"
 publish = false
 version = "0.0.0"
 
-[dependencies]
-js-sys = { path = "../../js-sys" }
-wasm-bindgen = { path = "../../../" }
-wasm-bindgen-backend = { path = "../../backend" }
-wasm-bindgen-futures = { path = "../../futures" }
-wasm-bindgen-macro = { path = "../../macro" }
-wasm-bindgen-macro-support = { path = "../../macro-support" }
-wasm-bindgen-shared = { path = "../../shared" }
-wasm-bindgen-test = { path = "../../test" }
-wasm-bindgen-test-macro = { path = "../../test-macro" }
-web-sys = { path = "../../web-sys" }
+[features]
+default = ["std"]
+std = [
+  "wasm-bindgen-backend/std",
+  "wasm-bindgen-macro-support/std",
+  "wasm-bindgen-macro/std",
+  "wasm-bindgen/std",
+  "js-sys/std",
+  "wasm-bindgen-futures/std",
+  "web-sys/std",
+  "wasm-bindgen-test/std",
+]
 
+[dependencies]
+js-sys = { path = "../../js-sys", default-features = false }
+wasm-bindgen = { path = "../../../", default-features = false }
+wasm-bindgen-backend = { path = "../../backend", default-features = false }
+wasm-bindgen-futures = { path = "../../futures", default-features = false }
+wasm-bindgen-macro = { path = "../../macro", default-features = false }
+wasm-bindgen-macro-support = { path = "../../macro-support", default-features = false }
+wasm-bindgen-shared = { path = "../../shared" }
+wasm-bindgen-test = { path = "../../test", default-features = false }
+wasm-bindgen-test-macro = { path = "../../test-macro" }
+web-sys = { path = "../../web-sys", default-features = false }
+
+# Pinned sub-dependencies for MSRV
 bumpalo = "=3.12.0"
 log = "=0.4.18"
-scoped-tls = "=1.0.0"
-
-[patch.crates-io]
-wasm-bindgen = { path = "../../../" }
+scoped-tls = { version = "=1.0.0", optional = false }

--- a/crates/msrv/lib/Cargo.toml
+++ b/crates/msrv/lib/Cargo.toml
@@ -7,9 +7,6 @@ version = "0.0.0"
 [features]
 default = ["std"]
 std = [
-  "wasm-bindgen-backend/std",
-  "wasm-bindgen-macro-support/std",
-  "wasm-bindgen-macro/std",
   "wasm-bindgen/std",
   "js-sys/std",
   "wasm-bindgen-futures/std",
@@ -20,13 +17,8 @@ std = [
 [dependencies]
 js-sys = { path = "../../js-sys", default-features = false }
 wasm-bindgen = { path = "../../../", default-features = false }
-wasm-bindgen-backend = { path = "../../backend", default-features = false }
 wasm-bindgen-futures = { path = "../../futures", default-features = false }
-wasm-bindgen-macro = { path = "../../macro", default-features = false }
-wasm-bindgen-macro-support = { path = "../../macro-support", default-features = false }
-wasm-bindgen-shared = { path = "../../shared" }
 wasm-bindgen-test = { path = "../../test", default-features = false }
-wasm-bindgen-test-macro = { path = "../../test-macro" }
 web-sys = { path = "../../web-sys", default-features = false }
 
 # Pinned sub-dependencies for MSRV

--- a/crates/test/src/rt/scoped_tls.rs
+++ b/crates/test/src/rt/scoped_tls.rs
@@ -37,7 +37,7 @@ impl<T> ScopedKey<T> {
     #[doc(hidden)]
     /// # Safety
     /// `inner` must only be accessed through `ScopedKey`'s API
-    pub const unsafe fn new(inner: &'static Wrapper<Cell<*const ()>>) -> Self {
+    pub(super) const unsafe fn new(inner: &'static Wrapper<Cell<*const ()>>) -> Self {
         Self {
             inner,
             _marker: PhantomData,


### PR DESCRIPTION
We don't test the MSRV of `no_std` for our libraries in the CI. Accidentally, I noticed that we didn't test our crates with the right target as well.

This PR adds tests for both, native and Wasm, and `no_std` to the CI.