### PR TITLE
Add environment variables to configure tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 * Added support for `no_std` to `link_to!`, `static_string` (via `thread_local_v2`) and `throw`.
   [#4277](https://github.com/rustwasm/wasm-bindgen/pull/4277)
 
+* Added environment variables to configure tests: `WASM_BINDGEN_USE_BROWSER`, `WASM_BINDGEN_USE_DEDICATED_WORKER`, `WASM_BINDGEN_USE_SHARED_WORKER` `WASM_BINDGEN_USE_SERVICE_WORKER`, `WASM_BINDGEN_USE_DENO` and `WASM_BINDGEN_USE_NODE_EXPERIMENTAL`. The use of `wasm_bindgen_test_configure!` will overwrite any environment variable.
+  [#4295](https://github.com/rustwasm/wasm-bindgen/pull/4295)
+
 ### Changed
 
 * String enums now generate private TypeScript types but only if used.

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -54,6 +54,17 @@ impl TestMode {
             | Self::ServiceWorker { no_modules } => no_modules,
         }
     }
+
+    fn env(self) -> &'static str {
+        match self {
+            TestMode::Node { .. } => "WASM_BINDGEN_USE_NODE_EXPERIMENTAL",
+            TestMode::Deno => "WASM_BINDGEN_USE_DENO",
+            TestMode::Browser { .. } => "WASM_BINDGEN_USE_BROWSER",
+            TestMode::DedicatedWorker { .. } => "WASM_BINDGEN_USE_DEDICATED_WORKER",
+            TestMode::SharedWorker { .. } => "WASM_BINDGEN_USE_SHARED_WORKER",
+            TestMode::ServiceWorker { .. } => "WASM_BINDGEN_USE_SERVICE_WORKER",
+        }
+    }
 }
 
 struct TmpDirDeleteGuard(PathBuf);
@@ -138,25 +149,40 @@ fn main() -> anyhow::Result<()> {
     // to read later on.
 
     let custom_section = wasm.customs.remove_raw("__wasm_bindgen_test_unstable");
+    let no_modules = std::env::var("WASM_BINDGEN_USE_NO_MODULE").is_ok();
     let test_mode = match custom_section {
-        Some(section) if section.data.contains(&0x01) => TestMode::Browser {
-            no_modules: std::env::var("WASM_BINDGEN_USE_NO_MODULE").is_ok(),
-        },
-        Some(section) if section.data.contains(&0x02) => TestMode::DedicatedWorker {
-            no_modules: std::env::var("WASM_BINDGEN_USE_NO_MODULE").is_ok(),
-        },
-        Some(section) if section.data.contains(&0x03) => TestMode::SharedWorker {
-            no_modules: std::env::var("WASM_BINDGEN_USE_NO_MODULE").is_ok(),
-        },
-        Some(section) if section.data.contains(&0x04) => TestMode::ServiceWorker {
-            no_modules: std::env::var("WASM_BINDGEN_USE_NO_MODULE").is_ok(),
-        },
-        Some(section) if section.data.contains(&0x05) => TestMode::Node {
-            no_modules: std::env::var("WASM_BINDGEN_USE_NO_MODULE").is_ok(),
-        },
+        Some(section) if section.data.contains(&0x01) => TestMode::Browser { no_modules },
+        Some(section) if section.data.contains(&0x02) => TestMode::DedicatedWorker { no_modules },
+        Some(section) if section.data.contains(&0x03) => TestMode::SharedWorker { no_modules },
+        Some(section) if section.data.contains(&0x04) => TestMode::ServiceWorker { no_modules },
+        Some(section) if section.data.contains(&0x05) => TestMode::Node { no_modules },
         Some(_) => bail!("invalid __wasm_bingen_test_unstable value"),
-        None if std::env::var("WASM_BINDGEN_USE_DENO").is_ok() => TestMode::Deno,
-        None => TestMode::Node { no_modules: true },
+        None => {
+            let mut modes = Vec::new();
+            let mut add_mode =
+                |mode: TestMode| std::env::var(mode.env()).is_ok().then(|| modes.push(mode));
+            add_mode(TestMode::Deno);
+            add_mode(TestMode::Browser { no_modules });
+            add_mode(TestMode::DedicatedWorker { no_modules });
+            add_mode(TestMode::SharedWorker { no_modules });
+            add_mode(TestMode::ServiceWorker { no_modules });
+            add_mode(TestMode::Node { no_modules });
+
+            match modes.len() {
+                0 => TestMode::Node { no_modules: true },
+                1 => modes[0],
+                _ => {
+                    bail!(
+                        "only one test mode must be set, found: `{}`",
+                        modes
+                            .into_iter()
+                            .map(TestMode::env)
+                            .collect::<Vec<_>>()
+                            .join("`, `")
+                    )
+                }
+            }
+        }
     };
 
     let headless = env::var("NO_HEADLESS").is_err();

--- a/guide/src/wasm-bindgen-test/browsers.md
+++ b/guide/src/wasm-bindgen-test/browsers.md
@@ -1,46 +1,41 @@
 # Testing in Headless Browsers
 
-## Configure Your Test Crate
+## Configure via Environment Variables
 
-Add this to the root of your test crate, e.g. `$MY_CRATE/tests/web.rs`:
+By default tests run on Node.js. To target browsers you can use the `WASM_BINDGEN_USE_BROWSER` environment variable:
 
-```rust
-use wasm_bindgen_test::wasm_bindgen_test_configure;
-
-wasm_bindgen_test_configure!(run_in_browser);
+```sh
+WASM_BINDGEN_USE_BROWSER=1 cargo test --target wasm32-unknown-unknown
 ```
 
-Or if you need to run your tests inside a web worker, you can also
-configured it using the `wasm_bindgen_test_configure` macro as following
-snippet.
+The following configurations are available:
+- `WASM_BINDGEN_USE_DEDICATED_WORKER`: for dedicated workers
+- `WASM_BINDGEN_USE_SHARED_WORKER`: for shared workers
+- `WASM_BINDGEN_USE_SERVICE_WORKER`: for service workers
+- `WASM_BINDGEN_USE_DENO`: for Deno
+- `WASM_BINDGEN_USE_NODE_EXPERIMENTAL`: for Node.js but as an ES module
+
+## Force Configuration
+
+Tests can also be forced to run in a certain environment by using the
+`wasm_bindgen_test_configure!` macro:
 
 ```rust
 use wasm_bindgen_test::wasm_bindgen_test_configure;
 
-// Run in dedicated worker.
+// Run in a browser.
+wasm_bindgen_test_configure!(run_in_browser);
+// Or run in a dedicated worker.
 wasm_bindgen_test_configure!(run_in_dedicated_worker);
-// Or run in shared worker.
+// Or run in a shared worker.
 wasm_bindgen_test_configure!(run_in_shared_worker);
-// Or run in service worker.
+// Or run in a service worker.
 wasm_bindgen_test_configure!(run_in_service_worker);
 // Or run in Node.js but as an ES module.
 wasm_bindgen_test_configure!(run_in_node_experimental);
 ```
 
-Note that although a particular test crate must target either headless browsers
-or Node.js, you can have test suites for both Node.js and browsers for your
-project by using multiple test crates. For example:
-
-```
-$MY_CRATE/
-`-- tests
-    |-- node.rs              # The tests in this suite use the default Node.js.
-    |-- node_module.rs       # The tests in this suite are configured for Node.js but as an ES module.
-    |-- dedicated_worker.rs  # The tests in this suite are configured for dedicated workers.
-    |-- shared_worker.rs     # The tests in this suite are configured for shared workers.
-    |-- service_worker.rs    # The tests in this suite are configured for service workers.
-    `-- web.rs               # The tests in this suite are configured for browsers.
-```
+Note that this will ignore any environment variable set.
 
 ## Configuring Which Browser is Used
 


### PR DESCRIPTION
At the moment the only way to configure the test environment is via the `wasm_bindgen_test_configure!` macro (apart from Deno). This can make testing setups quite difficult, requiring many test targets to test various environments.

This PR adds environment variables to configure the test environment:
- `WASM_BINDGEN_USE_DEDICATED_WORKER`: for dedicated workers
- `WASM_BINDGEN_USE_SHARED_WORKER`: for shared workers
- `WASM_BINDGEN_USE_SERVICE_WORKER`: for service workers
- `WASM_BINDGEN_USE_DENO`: for Deno
- `WASM_BINDGEN_USE_NODE_EXPERIMENTAL`: for Node.js but as an ES module

However, `wasm_bindgen_test_configure!` will overwrite any environment variable and force a specific test environment.