### PR TITLE
transition away from deprecated setters internally

### DIFF
--- a/crates/web-sys/src/features/gen_AesCbcParams.rs
+++ b/crates/web-sys/src/features/gen_AesCbcParams.rs
@@ -38,8 +38,8 @@ impl AesCbcParams {
     pub fn new(name: &str, iv: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.iv(iv);
+        ret.set_name(name);
+        ret.set_iv(iv);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AesCtrParams.rs
+++ b/crates/web-sys/src/features/gen_AesCtrParams.rs
@@ -48,9 +48,9 @@ impl AesCtrParams {
     pub fn new(name: &str, counter: &::js_sys::Object, length: u8) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.counter(counter);
-        ret.length(length);
+        ret.set_name(name);
+        ret.set_counter(counter);
+        ret.set_length(length);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AesDerivedKeyParams.rs
+++ b/crates/web-sys/src/features/gen_AesDerivedKeyParams.rs
@@ -38,8 +38,8 @@ impl AesDerivedKeyParams {
     pub fn new(name: &str, length: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.length(length);
+        ret.set_name(name);
+        ret.set_length(length);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AesGcmParams.rs
+++ b/crates/web-sys/src/features/gen_AesGcmParams.rs
@@ -58,8 +58,8 @@ impl AesGcmParams {
     pub fn new(name: &str, iv: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.iv(iv);
+        ret.set_name(name);
+        ret.set_iv(iv);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AesKeyAlgorithm.rs
+++ b/crates/web-sys/src/features/gen_AesKeyAlgorithm.rs
@@ -38,8 +38,8 @@ impl AesKeyAlgorithm {
     pub fn new(name: &str, length: u16) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.length(length);
+        ret.set_name(name);
+        ret.set_length(length);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AesKeyGenParams.rs
+++ b/crates/web-sys/src/features/gen_AesKeyGenParams.rs
@@ -38,8 +38,8 @@ impl AesKeyGenParams {
     pub fn new(name: &str, length: u16) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.length(length);
+        ret.set_name(name);
+        ret.set_length(length);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_Algorithm.rs
+++ b/crates/web-sys/src/features/gen_Algorithm.rs
@@ -28,7 +28,7 @@ impl Algorithm {
     pub fn new(name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AllowedBluetoothDevice.rs
+++ b/crates/web-sys/src/features/gen_AllowedBluetoothDevice.rs
@@ -84,9 +84,9 @@ impl AllowedBluetoothDevice {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.allowed_services(allowed_services);
-        ret.device_id(device_id);
-        ret.may_use_gatt(may_use_gatt);
+        ret.set_allowed_services(allowed_services);
+        ret.set_device_id(device_id);
+        ret.set_may_use_gatt(may_use_gatt);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AllowedUsbDevice.rs
+++ b/crates/web-sys/src/features/gen_AllowedUsbDevice.rs
@@ -80,8 +80,8 @@ impl AllowedUsbDevice {
     pub fn new(product_id: u8, vendor_id: u8) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.product_id(product_id);
-        ret.vendor_id(vendor_id);
+        ret.set_product_id(product_id);
+        ret.set_vendor_id(vendor_id);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AnimationPropertyDetails.rs
+++ b/crates/web-sys/src/features/gen_AnimationPropertyDetails.rs
@@ -62,9 +62,9 @@ impl AnimationPropertyDetails {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.property(property);
-        ret.running_on_compositor(running_on_compositor);
-        ret.values(values);
+        ret.set_property(property);
+        ret.set_running_on_compositor(running_on_compositor);
+        ret.set_values(values);
         ret
     }
     #[deprecated = "Use `set_property()` instead."]

--- a/crates/web-sys/src/features/gen_AnimationPropertyValueDetails.rs
+++ b/crates/web-sys/src/features/gen_AnimationPropertyValueDetails.rs
@@ -61,8 +61,8 @@ impl AnimationPropertyValueDetails {
     pub fn new(composite: CompositeOperation, offset: f64) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.composite(composite);
-        ret.offset(offset);
+        ret.set_composite(composite);
+        ret.set_offset(offset);
         ret
     }
     #[cfg(feature = "CompositeOperation")]

--- a/crates/web-sys/src/features/gen_AttributeNameValue.rs
+++ b/crates/web-sys/src/features/gen_AttributeNameValue.rs
@@ -38,8 +38,8 @@ impl AttributeNameValue {
     pub fn new(name: &str, value: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.value(value);
+        ret.set_name(name);
+        ret.set_value(value);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_AudioBufferOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioBufferOptions.rs
@@ -48,8 +48,8 @@ impl AudioBufferOptions {
     pub fn new(length: u32, sample_rate: f32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.length(length);
-        ret.sample_rate(sample_rate);
+        ret.set_length(length);
+        ret.set_sample_rate(sample_rate);
         ret
     }
     #[deprecated = "Use `set_length()` instead."]

--- a/crates/web-sys/src/features/gen_AudioDataCopyToOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioDataCopyToOptions.rs
@@ -100,7 +100,7 @@ impl AudioDataCopyToOptions {
     pub fn new(plane_index: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.plane_index(plane_index);
+        ret.set_plane_index(plane_index);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AudioDataInit.rs
+++ b/crates/web-sys/src/features/gen_AudioDataInit.rs
@@ -144,12 +144,12 @@ impl AudioDataInit {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.data(data);
-        ret.format(format);
-        ret.number_of_channels(number_of_channels);
-        ret.number_of_frames(number_of_frames);
-        ret.sample_rate(sample_rate);
-        ret.timestamp(timestamp);
+        ret.set_data(data);
+        ret.set_format(format);
+        ret.set_number_of_channels(number_of_channels);
+        ret.set_number_of_frames(number_of_frames);
+        ret.set_sample_rate(sample_rate);
+        ret.set_timestamp(timestamp);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AudioDecoderConfig.rs
+++ b/crates/web-sys/src/features/gen_AudioDecoderConfig.rs
@@ -98,9 +98,9 @@ impl AudioDecoderConfig {
     pub fn new(codec: &str, number_of_channels: u32, sample_rate: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.codec(codec);
-        ret.number_of_channels(number_of_channels);
-        ret.sample_rate(sample_rate);
+        ret.set_codec(codec);
+        ret.set_number_of_channels(number_of_channels);
+        ret.set_sample_rate(sample_rate);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AudioDecoderInit.rs
+++ b/crates/web-sys/src/features/gen_AudioDecoderInit.rs
@@ -62,8 +62,8 @@ impl AudioDecoderInit {
     pub fn new(error: &::js_sys::Function, output: &::js_sys::Function) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error(error);
-        ret.output(output);
+        ret.set_error(error);
+        ret.set_output(output);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AudioEncoderConfig.rs
+++ b/crates/web-sys/src/features/gen_AudioEncoderConfig.rs
@@ -98,7 +98,7 @@ impl AudioEncoderConfig {
     pub fn new(codec: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.codec(codec);
+        ret.set_codec(codec);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AudioEncoderInit.rs
+++ b/crates/web-sys/src/features/gen_AudioEncoderInit.rs
@@ -62,8 +62,8 @@ impl AudioEncoderInit {
     pub fn new(error: &::js_sys::Function, output: &::js_sys::Function) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error(error);
-        ret.output(output);
+        ret.set_error(error);
+        ret.set_output(output);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AudioSinkOptions.rs
+++ b/crates/web-sys/src/features/gen_AudioSinkOptions.rs
@@ -47,7 +47,7 @@ impl AudioSinkOptions {
     pub fn new(type_: AudioSinkType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.type_(type_);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AuthenticationExtensionsPrfValues.rs
+++ b/crates/web-sys/src/features/gen_AuthenticationExtensionsPrfValues.rs
@@ -62,7 +62,7 @@ impl AuthenticationExtensionsPrfValues {
     pub fn new(first: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.first(first);
+        ret.set_first(first);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AuthenticationResponseJson.rs
+++ b/crates/web-sys/src/features/gen_AuthenticationResponseJson.rs
@@ -158,11 +158,11 @@ impl AuthenticationResponseJson {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.client_extension_results(client_extension_results);
-        ret.id(id);
-        ret.raw_id(raw_id);
-        ret.response(response);
-        ret.type_(type_);
+        ret.set_client_extension_results(client_extension_results);
+        ret.set_id(id);
+        ret.set_raw_id(raw_id);
+        ret.set_response(response);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AuthenticatorAssertionResponseJson.rs
+++ b/crates/web-sys/src/features/gen_AuthenticatorAssertionResponseJson.rs
@@ -124,9 +124,9 @@ impl AuthenticatorAssertionResponseJson {
     pub fn new(authenticator_data: &str, client_data_json: &str, signature: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.authenticator_data(authenticator_data);
-        ret.client_data_json(client_data_json);
-        ret.signature(signature);
+        ret.set_authenticator_data(authenticator_data);
+        ret.set_client_data_json(client_data_json);
+        ret.set_signature(signature);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_AuthenticatorAttestationResponseJson.rs
+++ b/crates/web-sys/src/features/gen_AuthenticatorAttestationResponseJson.rs
@@ -151,11 +151,11 @@ impl AuthenticatorAttestationResponseJson {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.attestation_object(attestation_object);
-        ret.authenticator_data(authenticator_data);
-        ret.client_data_json(client_data_json);
-        ret.public_key_algorithm(public_key_algorithm);
-        ret.transports(transports);
+        ret.set_attestation_object(attestation_object);
+        ret.set_authenticator_data(authenticator_data);
+        ret.set_client_data_json(client_data_json);
+        ret.set_public_key_algorithm(public_key_algorithm);
+        ret.set_transports(transports);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_BasicCardResponse.rs
+++ b/crates/web-sys/src/features/gen_BasicCardResponse.rs
@@ -80,7 +80,7 @@ impl BasicCardResponse {
     pub fn new(card_number: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.card_number(card_number);
+        ret.set_card_number(card_number);
         ret
     }
     #[cfg(feature = "PaymentAddress")]

--- a/crates/web-sys/src/features/gen_BluetoothAdvertisingEventInit.rs
+++ b/crates/web-sys/src/features/gen_BluetoothAdvertisingEventInit.rs
@@ -238,7 +238,7 @@ impl BluetoothAdvertisingEventInit {
     pub fn new(device: &BluetoothDevice) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.device(device);
+        ret.set_device(device);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_BluetoothPermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_BluetoothPermissionDescriptor.rs
@@ -122,7 +122,7 @@ impl BluetoothPermissionDescriptor {
     pub fn new(name: PermissionName) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_BluetoothPermissionStorage.rs
+++ b/crates/web-sys/src/features/gen_BluetoothPermissionStorage.rs
@@ -44,7 +44,7 @@ impl BluetoothPermissionStorage {
     pub fn new(allowed_devices: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.allowed_devices(allowed_devices);
+        ret.set_allowed_devices(allowed_devices);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_ClientRectsAndTexts.rs
+++ b/crates/web-sys/src/features/gen_ClientRectsAndTexts.rs
@@ -41,8 +41,8 @@ impl ClientRectsAndTexts {
     pub fn new(rect_list: &DomRectList, text_list: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.rect_list(rect_list);
-        ret.text_list(text_list);
+        ret.set_rect_list(rect_list);
+        ret.set_text_list(text_list);
         ret
     }
     #[cfg(feature = "DomRectList")]

--- a/crates/web-sys/src/features/gen_ClipboardPermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_ClipboardPermissionDescriptor.rs
@@ -65,7 +65,7 @@ impl ClipboardPermissionDescriptor {
     pub fn new(name: PermissionName) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_CollectedClientData.rs
+++ b/crates/web-sys/src/features/gen_CollectedClientData.rs
@@ -113,10 +113,10 @@ impl CollectedClientData {
     pub fn new(challenge: &str, hash_algorithm: &str, origin: &str, type_: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.challenge(challenge);
-        ret.hash_algorithm(hash_algorithm);
-        ret.origin(origin);
-        ret.type_(type_);
+        ret.set_challenge(challenge);
+        ret.set_hash_algorithm(hash_algorithm);
+        ret.set_origin(origin);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_challenge()` instead."]

--- a/crates/web-sys/src/features/gen_CryptoKeyPair.rs
+++ b/crates/web-sys/src/features/gen_CryptoKeyPair.rs
@@ -43,8 +43,8 @@ impl CryptoKeyPair {
     pub fn new(private_key: &CryptoKey, public_key: &CryptoKey) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.private_key(private_key);
-        ret.public_key(public_key);
+        ret.set_private_key(private_key);
+        ret.set_public_key(public_key);
         ret
     }
     #[cfg(feature = "CryptoKey")]

--- a/crates/web-sys/src/features/gen_DecoderDoctorNotification.rs
+++ b/crates/web-sys/src/features/gen_DecoderDoctorNotification.rs
@@ -97,9 +97,9 @@ impl DecoderDoctorNotification {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.decoder_doctor_report_id(decoder_doctor_report_id);
-        ret.is_solved(is_solved);
-        ret.type_(type_);
+        ret.set_decoder_doctor_report_id(decoder_doctor_report_id);
+        ret.set_is_solved(is_solved);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_decode_issue()` instead."]

--- a/crates/web-sys/src/features/gen_DhKeyDeriveParams.rs
+++ b/crates/web-sys/src/features/gen_DhKeyDeriveParams.rs
@@ -41,8 +41,8 @@ impl DhKeyDeriveParams {
     pub fn new(name: &str, public: &CryptoKey) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.public(public);
+        ret.set_name(name);
+        ret.set_public(public);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_EcKeyAlgorithm.rs
+++ b/crates/web-sys/src/features/gen_EcKeyAlgorithm.rs
@@ -38,8 +38,8 @@ impl EcKeyAlgorithm {
     pub fn new(name: &str, named_curve: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.named_curve(named_curve);
+        ret.set_name(name);
+        ret.set_named_curve(named_curve);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_EcKeyGenParams.rs
+++ b/crates/web-sys/src/features/gen_EcKeyGenParams.rs
@@ -38,8 +38,8 @@ impl EcKeyGenParams {
     pub fn new(name: &str, named_curve: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.named_curve(named_curve);
+        ret.set_name(name);
+        ret.set_named_curve(named_curve);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_EcKeyImportParams.rs
+++ b/crates/web-sys/src/features/gen_EcKeyImportParams.rs
@@ -38,7 +38,7 @@ impl EcKeyImportParams {
     pub fn new(name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_EcdhKeyDeriveParams.rs
+++ b/crates/web-sys/src/features/gen_EcdhKeyDeriveParams.rs
@@ -41,8 +41,8 @@ impl EcdhKeyDeriveParams {
     pub fn new(name: &str, public: &CryptoKey) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.public(public);
+        ret.set_name(name);
+        ret.set_public(public);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_EcdsaParams.rs
+++ b/crates/web-sys/src/features/gen_EcdsaParams.rs
@@ -38,8 +38,8 @@ impl EcdsaParams {
     pub fn new(name: &str, hash: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
+        ret.set_name(name);
+        ret.set_hash(hash);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_EncodedAudioChunkInit.rs
+++ b/crates/web-sys/src/features/gen_EncodedAudioChunkInit.rs
@@ -101,9 +101,9 @@ impl EncodedAudioChunkInit {
     pub fn new(data: &::js_sys::Object, timestamp: f64, type_: EncodedAudioChunkType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.data(data);
-        ret.timestamp(timestamp);
-        ret.type_(type_);
+        ret.set_data(data);
+        ret.set_timestamp(timestamp);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_EncodedVideoChunkInit.rs
+++ b/crates/web-sys/src/features/gen_EncodedVideoChunkInit.rs
@@ -101,9 +101,9 @@ impl EncodedVideoChunkInit {
     pub fn new(data: &::js_sys::Object, timestamp: f64, type_: EncodedVideoChunkType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.data(data);
-        ret.timestamp(timestamp);
-        ret.type_(type_);
+        ret.set_data(data);
+        ret.set_timestamp(timestamp);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_FakePluginMimeEntry.rs
+++ b/crates/web-sys/src/features/gen_FakePluginMimeEntry.rs
@@ -48,7 +48,7 @@ impl FakePluginMimeEntry {
     pub fn new(type_: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.type_(type_);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_description()` instead."]

--- a/crates/web-sys/src/features/gen_FakePluginTagInit.rs
+++ b/crates/web-sys/src/features/gen_FakePluginTagInit.rs
@@ -108,8 +108,8 @@ impl FakePluginTagInit {
     pub fn new(handler_uri: &str, mime_entries: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.handler_uri(handler_uri);
-        ret.mime_entries(mime_entries);
+        ret.set_handler_uri(handler_uri);
+        ret.set_mime_entries(mime_entries);
         ret
     }
     #[deprecated = "Use `set_description()` instead."]

--- a/crates/web-sys/src/features/gen_FetchEventInit.rs
+++ b/crates/web-sys/src/features/gen_FetchEventInit.rs
@@ -81,7 +81,7 @@ impl FetchEventInit {
     pub fn new(request: &Request) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.request(request);
+        ret.set_request(request);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_FileSystemPermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_FileSystemPermissionDescriptor.rs
@@ -87,8 +87,8 @@ impl FileSystemPermissionDescriptor {
     pub fn new(name: PermissionName, handle: &FileSystemHandle) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.handle(handle);
+        ret.set_name(name);
+        ret.set_handle(handle);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_FontFaceSetIteratorResult.rs
+++ b/crates/web-sys/src/features/gen_FontFaceSetIteratorResult.rs
@@ -38,8 +38,8 @@ impl FontFaceSetIteratorResult {
     pub fn new(done: bool, value: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.done(done);
-        ret.value(value);
+        ret.set_done(done);
+        ret.set_value(value);
         ret
     }
     #[deprecated = "Use `set_done()` instead."]

--- a/crates/web-sys/src/features/gen_GpuBindGroupDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuBindGroupDescriptor.rs
@@ -83,8 +83,8 @@ impl GpuBindGroupDescriptor {
     pub fn new(entries: &::wasm_bindgen::JsValue, layout: &GpuBindGroupLayout) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.entries(entries);
-        ret.layout(layout);
+        ret.set_entries(entries);
+        ret.set_layout(layout);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuBindGroupEntry.rs
+++ b/crates/web-sys/src/features/gen_GpuBindGroupEntry.rs
@@ -62,8 +62,8 @@ impl GpuBindGroupEntry {
     pub fn new(binding: u32, resource: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.binding(binding);
-        ret.resource(resource);
+        ret.set_binding(binding);
+        ret.set_resource(resource);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuBindGroupLayoutDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuBindGroupLayoutDescriptor.rs
@@ -62,7 +62,7 @@ impl GpuBindGroupLayoutDescriptor {
     pub fn new(entries: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.entries(entries);
+        ret.set_entries(entries);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuBindGroupLayoutEntry.rs
+++ b/crates/web-sys/src/features/gen_GpuBindGroupLayoutEntry.rs
@@ -172,8 +172,8 @@ impl GpuBindGroupLayoutEntry {
     pub fn new(binding: u32, visibility: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.binding(binding);
-        ret.visibility(visibility);
+        ret.set_binding(binding);
+        ret.set_visibility(visibility);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuBlendState.rs
+++ b/crates/web-sys/src/features/gen_GpuBlendState.rs
@@ -67,8 +67,8 @@ impl GpuBlendState {
     pub fn new(alpha: &GpuBlendComponent, color: &GpuBlendComponent) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.alpha(alpha);
-        ret.color(color);
+        ret.set_alpha(alpha);
+        ret.set_color(color);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuBufferBinding.rs
+++ b/crates/web-sys/src/features/gen_GpuBufferBinding.rs
@@ -83,7 +83,7 @@ impl GpuBufferBinding {
     pub fn new(buffer: &GpuBuffer) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.buffer(buffer);
+        ret.set_buffer(buffer);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuBufferDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuBufferDescriptor.rs
@@ -98,8 +98,8 @@ impl GpuBufferDescriptor {
     pub fn new(size: f64, usage: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.size(size);
-        ret.usage(usage);
+        ret.set_size(size);
+        ret.set_usage(usage);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuCanvasConfiguration.rs
+++ b/crates/web-sys/src/features/gen_GpuCanvasConfiguration.rs
@@ -143,8 +143,8 @@ impl GpuCanvasConfiguration {
     pub fn new(device: &GpuDevice, format: GpuTextureFormat) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.device(device);
-        ret.format(format);
+        ret.set_device(device);
+        ret.set_format(format);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuColorDict.rs
+++ b/crates/web-sys/src/features/gen_GpuColorDict.rs
@@ -98,10 +98,10 @@ impl GpuColorDict {
     pub fn new(a: f64, b: f64, g: f64, r: f64) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.a(a);
-        ret.b(b);
-        ret.g(g);
-        ret.r(r);
+        ret.set_a(a);
+        ret.set_b(b);
+        ret.set_g(g);
+        ret.set_r(r);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuColorTargetState.rs
+++ b/crates/web-sys/src/features/gen_GpuColorTargetState.rs
@@ -85,7 +85,7 @@ impl GpuColorTargetState {
     pub fn new(format: GpuTextureFormat) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.format(format);
+        ret.set_format(format);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuComputePassTimestampWrites.rs
+++ b/crates/web-sys/src/features/gen_GpuComputePassTimestampWrites.rs
@@ -83,7 +83,7 @@ impl GpuComputePassTimestampWrites {
     pub fn new(query_set: &GpuQuerySet) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.query_set(query_set);
+        ret.set_query_set(query_set);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuComputePipelineDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuComputePipelineDescriptor.rs
@@ -83,8 +83,8 @@ impl GpuComputePipelineDescriptor {
     pub fn new(layout: &::wasm_bindgen::JsValue, compute: &GpuProgrammableStage) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.layout(layout);
-        ret.compute(compute);
+        ret.set_layout(layout);
+        ret.set_compute(compute);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuCopyExternalImageDestInfo.rs
+++ b/crates/web-sys/src/features/gen_GpuCopyExternalImageDestInfo.rs
@@ -121,7 +121,7 @@ impl GpuCopyExternalImageDestInfo {
     pub fn new(texture: &GpuTexture) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.texture(texture);
+        ret.set_texture(texture);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuCopyExternalImageSourceInfo.rs
+++ b/crates/web-sys/src/features/gen_GpuCopyExternalImageSourceInfo.rs
@@ -80,7 +80,7 @@ impl GpuCopyExternalImageSourceInfo {
     pub fn new(source: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.source(source);
+        ret.set_source(source);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuDepthStencilState.rs
+++ b/crates/web-sys/src/features/gen_GpuDepthStencilState.rs
@@ -215,7 +215,7 @@ impl GpuDepthStencilState {
     pub fn new(format: GpuTextureFormat) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.format(format);
+        ret.set_format(format);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuExtent3dDict.rs
+++ b/crates/web-sys/src/features/gen_GpuExtent3dDict.rs
@@ -80,7 +80,7 @@ impl GpuExtent3dDict {
     pub fn new(width: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.width(width);
+        ret.set_width(width);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuExternalTextureDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuExternalTextureDescriptor.rs
@@ -62,7 +62,7 @@ impl GpuExternalTextureDescriptor {
     pub fn new(source: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.source(source);
+        ret.set_source(source);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuFragmentState.rs
+++ b/crates/web-sys/src/features/gen_GpuFragmentState.rs
@@ -101,8 +101,8 @@ impl GpuFragmentState {
     pub fn new(module: &GpuShaderModule, targets: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.module(module);
-        ret.targets(targets);
+        ret.set_module(module);
+        ret.set_targets(targets);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuPipelineDescriptorBase.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineDescriptorBase.rs
@@ -62,7 +62,7 @@ impl GpuPipelineDescriptorBase {
     pub fn new(layout: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.layout(layout);
+        ret.set_layout(layout);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuPipelineErrorInit.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineErrorInit.rs
@@ -47,7 +47,7 @@ impl GpuPipelineErrorInit {
     pub fn new(reason: GpuPipelineErrorReason) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.reason(reason);
+        ret.set_reason(reason);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuPipelineLayoutDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuPipelineLayoutDescriptor.rs
@@ -65,7 +65,7 @@ impl GpuPipelineLayoutDescriptor {
     pub fn new(bind_group_layouts: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.bind_group_layouts(bind_group_layouts);
+        ret.set_bind_group_layouts(bind_group_layouts);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuProgrammableStage.rs
+++ b/crates/web-sys/src/features/gen_GpuProgrammableStage.rs
@@ -83,7 +83,7 @@ impl GpuProgrammableStage {
     pub fn new(module: &GpuShaderModule) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.module(module);
+        ret.set_module(module);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuQuerySetDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuQuerySetDescriptor.rs
@@ -83,8 +83,8 @@ impl GpuQuerySetDescriptor {
     pub fn new(count: u32, type_: GpuQueryType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.count(count);
-        ret.type_(type_);
+        ret.set_count(count);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderBundleEncoderDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderBundleEncoderDescriptor.rs
@@ -141,7 +141,7 @@ impl GpuRenderBundleEncoderDescriptor {
     pub fn new(color_formats: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.color_formats(color_formats);
+        ret.set_color_formats(color_formats);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderPassColorAttachment.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassColorAttachment.rs
@@ -147,9 +147,9 @@ impl GpuRenderPassColorAttachment {
     pub fn new(load_op: GpuLoadOp, store_op: GpuStoreOp, view: &GpuTextureView) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.load_op(load_op);
-        ret.store_op(store_op);
-        ret.view(view);
+        ret.set_load_op(load_op);
+        ret.set_store_op(store_op);
+        ret.set_view(view);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderPassDepthStencilAttachment.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassDepthStencilAttachment.rs
@@ -199,7 +199,7 @@ impl GpuRenderPassDepthStencilAttachment {
     pub fn new(view: &GpuTextureView) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.view(view);
+        ret.set_view(view);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderPassDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassDescriptor.rs
@@ -147,7 +147,7 @@ impl GpuRenderPassDescriptor {
     pub fn new(color_attachments: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.color_attachments(color_attachments);
+        ret.set_color_attachments(color_attachments);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderPassLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassLayout.rs
@@ -100,7 +100,7 @@ impl GpuRenderPassLayout {
     pub fn new(color_formats: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.color_formats(color_formats);
+        ret.set_color_formats(color_formats);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderPassTimestampWrites.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPassTimestampWrites.rs
@@ -83,7 +83,7 @@ impl GpuRenderPassTimestampWrites {
     pub fn new(query_set: &GpuQuerySet) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.query_set(query_set);
+        ret.set_query_set(query_set);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuRenderPipelineDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuRenderPipelineDescriptor.rs
@@ -163,8 +163,8 @@ impl GpuRenderPipelineDescriptor {
     pub fn new(layout: &::wasm_bindgen::JsValue, vertex: &GpuVertexState) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.layout(layout);
-        ret.vertex(vertex);
+        ret.set_layout(layout);
+        ret.set_vertex(vertex);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuShaderModuleCompilationHint.rs
+++ b/crates/web-sys/src/features/gen_GpuShaderModuleCompilationHint.rs
@@ -62,7 +62,7 @@ impl GpuShaderModuleCompilationHint {
     pub fn new(entry_point: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.entry_point(entry_point);
+        ret.set_entry_point(entry_point);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuShaderModuleDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuShaderModuleDescriptor.rs
@@ -80,7 +80,7 @@ impl GpuShaderModuleDescriptor {
     pub fn new(code: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.code(code);
+        ret.set_code(code);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuStorageTextureBindingLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuStorageTextureBindingLayout.rs
@@ -89,7 +89,7 @@ impl GpuStorageTextureBindingLayout {
     pub fn new(format: GpuTextureFormat) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.format(format);
+        ret.set_format(format);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuTexelCopyBufferInfo.rs
+++ b/crates/web-sys/src/features/gen_GpuTexelCopyBufferInfo.rs
@@ -101,7 +101,7 @@ impl GpuTexelCopyBufferInfo {
     pub fn new(buffer: &GpuBuffer) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.buffer(buffer);
+        ret.set_buffer(buffer);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuTexelCopyTextureInfo.rs
+++ b/crates/web-sys/src/features/gen_GpuTexelCopyTextureInfo.rs
@@ -103,7 +103,7 @@ impl GpuTexelCopyTextureInfo {
     pub fn new(texture: &GpuTexture) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.texture(texture);
+        ret.set_texture(texture);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuTextureDescriptor.rs
+++ b/crates/web-sys/src/features/gen_GpuTextureDescriptor.rs
@@ -175,9 +175,9 @@ impl GpuTextureDescriptor {
     pub fn new(format: GpuTextureFormat, size: &::wasm_bindgen::JsValue, usage: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.format(format);
-        ret.size(size);
-        ret.usage(usage);
+        ret.set_format(format);
+        ret.set_size(size);
+        ret.set_usage(usage);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuUncapturedErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_GpuUncapturedErrorEventInit.rs
@@ -101,7 +101,7 @@ impl GpuUncapturedErrorEventInit {
     pub fn new(error: &GpuError) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error(error);
+        ret.set_error(error);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuVertexAttribute.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexAttribute.rs
@@ -83,9 +83,9 @@ impl GpuVertexAttribute {
     pub fn new(format: GpuVertexFormat, offset: f64, shader_location: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.format(format);
-        ret.offset(offset);
-        ret.shader_location(shader_location);
+        ret.set_format(format);
+        ret.set_offset(offset);
+        ret.set_shader_location(shader_location);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuVertexBufferLayout.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexBufferLayout.rs
@@ -82,8 +82,8 @@ impl GpuVertexBufferLayout {
     pub fn new(array_stride: f64, attributes: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.array_stride(array_stride);
-        ret.attributes(attributes);
+        ret.set_array_stride(array_stride);
+        ret.set_attributes(attributes);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_GpuVertexState.rs
+++ b/crates/web-sys/src/features/gen_GpuVertexState.rs
@@ -101,7 +101,7 @@ impl GpuVertexState {
     pub fn new(module: &GpuShaderModule) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.module(module);
+        ret.set_module(module);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_HidConnectionEventInit.rs
+++ b/crates/web-sys/src/features/gen_HidConnectionEventInit.rs
@@ -101,7 +101,7 @@ impl HidConnectionEventInit {
     pub fn new(device: &HidDevice) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.device(device);
+        ret.set_device(device);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_HidDeviceRequestOptions.rs
+++ b/crates/web-sys/src/features/gen_HidDeviceRequestOptions.rs
@@ -44,7 +44,7 @@ impl HidDeviceRequestOptions {
     pub fn new(filters: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.filters(filters);
+        ret.set_filters(filters);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_HidInputReportEventInit.rs
+++ b/crates/web-sys/src/features/gen_HidInputReportEventInit.rs
@@ -137,9 +137,9 @@ impl HidInputReportEventInit {
     pub fn new(data: &::js_sys::DataView, device: &HidDevice, report_id: u8) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.data(data);
-        ret.device(device);
-        ret.report_id(report_id);
+        ret.set_data(data);
+        ret.set_device(device);
+        ret.set_report_id(report_id);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_HkdfParams.rs
+++ b/crates/web-sys/src/features/gen_HkdfParams.rs
@@ -63,10 +63,10 @@ impl HkdfParams {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
-        ret.info(info);
-        ret.salt(salt);
+        ret.set_name(name);
+        ret.set_hash(hash);
+        ret.set_info(info);
+        ret.set_salt(salt);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_HmacDerivedKeyParams.rs
+++ b/crates/web-sys/src/features/gen_HmacDerivedKeyParams.rs
@@ -48,8 +48,8 @@ impl HmacDerivedKeyParams {
     pub fn new(name: &str, hash: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
+        ret.set_name(name);
+        ret.set_hash(hash);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_HmacImportParams.rs
+++ b/crates/web-sys/src/features/gen_HmacImportParams.rs
@@ -38,8 +38,8 @@ impl HmacImportParams {
     pub fn new(name: &str, hash: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
+        ret.set_name(name);
+        ret.set_hash(hash);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_HmacKeyAlgorithm.rs
+++ b/crates/web-sys/src/features/gen_HmacKeyAlgorithm.rs
@@ -51,9 +51,9 @@ impl HmacKeyAlgorithm {
     pub fn new(name: &str, hash: &KeyAlgorithm, length: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
-        ret.length(length);
+        ret.set_name(name);
+        ret.set_hash(hash);
+        ret.set_length(length);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_HmacKeyGenParams.rs
+++ b/crates/web-sys/src/features/gen_HmacKeyGenParams.rs
@@ -48,8 +48,8 @@ impl HmacKeyGenParams {
     pub fn new(name: &str, hash: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
+        ret.set_name(name);
+        ret.set_hash(hash);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_IirFilterOptions.rs
+++ b/crates/web-sys/src/features/gen_IirFilterOptions.rs
@@ -72,8 +72,8 @@ impl IirFilterOptions {
     pub fn new(feedback: &::wasm_bindgen::JsValue, feedforward: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.feedback(feedback);
-        ret.feedforward(feedforward);
+        ret.set_feedback(feedback);
+        ret.set_feedforward(feedforward);
         ret
     }
     #[deprecated = "Use `set_channel_count()` instead."]

--- a/crates/web-sys/src/features/gen_ImageDecodeResult.rs
+++ b/crates/web-sys/src/features/gen_ImageDecodeResult.rs
@@ -65,8 +65,8 @@ impl ImageDecodeResult {
     pub fn new(complete: bool, image: &VideoFrame) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.complete(complete);
-        ret.image(image);
+        ret.set_complete(complete);
+        ret.set_image(image);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_ImageDecoderInit.rs
+++ b/crates/web-sys/src/features/gen_ImageDecoderInit.rs
@@ -156,8 +156,8 @@ impl ImageDecoderInit {
     pub fn new(data: &::wasm_bindgen::JsValue, type_: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.data(data);
-        ret.type_(type_);
+        ret.set_data(data);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_IntersectionObserverEntryInit.rs
+++ b/crates/web-sys/src/features/gen_IntersectionObserverEntryInit.rs
@@ -83,11 +83,11 @@ impl IntersectionObserverEntryInit {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.bounding_client_rect(bounding_client_rect);
-        ret.intersection_rect(intersection_rect);
-        ret.root_bounds(root_bounds);
-        ret.target(target);
-        ret.time(time);
+        ret.set_bounding_client_rect(bounding_client_rect);
+        ret.set_intersection_rect(intersection_rect);
+        ret.set_root_bounds(root_bounds);
+        ret.set_target(target);
+        ret.set_time(time);
         ret
     }
     #[cfg(feature = "DomRectInit")]

--- a/crates/web-sys/src/features/gen_JsonWebKey.rs
+++ b/crates/web-sys/src/features/gen_JsonWebKey.rs
@@ -198,7 +198,7 @@ impl JsonWebKey {
     pub fn new(kty: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.kty(kty);
+        ret.set_kty(kty);
         ret
     }
     #[deprecated = "Use `set_alg()` instead."]

--- a/crates/web-sys/src/features/gen_KeyAlgorithm.rs
+++ b/crates/web-sys/src/features/gen_KeyAlgorithm.rs
@@ -28,7 +28,7 @@ impl KeyAlgorithm {
     pub fn new(name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_KeyIdsInitData.rs
+++ b/crates/web-sys/src/features/gen_KeyIdsInitData.rs
@@ -28,7 +28,7 @@ impl KeyIdsInitData {
     pub fn new(kids: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.kids(kids);
+        ret.set_kids(kids);
         ret
     }
     #[deprecated = "Use `set_kids()` instead."]

--- a/crates/web-sys/src/features/gen_L10nElement.rs
+++ b/crates/web-sys/src/features/gen_L10nElement.rs
@@ -78,9 +78,9 @@ impl L10nElement {
     pub fn new(l10n_id: &str, local_name: &str, namespace_uri: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.l10n_id(l10n_id);
-        ret.local_name(local_name);
-        ret.namespace_uri(namespace_uri);
+        ret.set_l10n_id(l10n_id);
+        ret.set_local_name(local_name);
+        ret.set_namespace_uri(namespace_uri);
         ret
     }
     #[deprecated = "Use `set_l10n_args()` instead."]

--- a/crates/web-sys/src/features/gen_MediaDecodingConfiguration.rs
+++ b/crates/web-sys/src/features/gen_MediaDecodingConfiguration.rs
@@ -55,7 +55,7 @@ impl MediaDecodingConfiguration {
     pub fn new(type_: MediaDecodingType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.type_(type_);
+        ret.set_type(type_);
         ret
     }
     #[cfg(feature = "AudioConfiguration")]

--- a/crates/web-sys/src/features/gen_MediaElementAudioSourceOptions.rs
+++ b/crates/web-sys/src/features/gen_MediaElementAudioSourceOptions.rs
@@ -31,7 +31,7 @@ impl MediaElementAudioSourceOptions {
     pub fn new(media_element: &HtmlMediaElement) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.media_element(media_element);
+        ret.set_media_element(media_element);
         ret
     }
     #[cfg(feature = "HtmlMediaElement")]

--- a/crates/web-sys/src/features/gen_MediaEncodingConfiguration.rs
+++ b/crates/web-sys/src/features/gen_MediaEncodingConfiguration.rs
@@ -55,7 +55,7 @@ impl MediaEncodingConfiguration {
     pub fn new(type_: MediaEncodingType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.type_(type_);
+        ret.set_type(type_);
         ret
     }
     #[cfg(feature = "AudioConfiguration")]

--- a/crates/web-sys/src/features/gen_MediaImage.rs
+++ b/crates/web-sys/src/features/gen_MediaImage.rs
@@ -80,7 +80,7 @@ impl MediaImage {
     pub fn new(src: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.src(src);
+        ret.set_src(src);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_MediaKeyMessageEventInit.rs
+++ b/crates/web-sys/src/features/gen_MediaKeyMessageEventInit.rs
@@ -71,8 +71,8 @@ impl MediaKeyMessageEventInit {
     pub fn new(message: &::js_sys::ArrayBuffer, message_type: MediaKeyMessageType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.message(message);
-        ret.message_type(message_type);
+        ret.set_message(message);
+        ret.set_message_type(message_type);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_MediaRecorderErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_MediaRecorderErrorEventInit.rs
@@ -61,7 +61,7 @@ impl MediaRecorderErrorEventInit {
     pub fn new(error: &DomException) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error(error);
+        ret.set_error(error);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_MediaSessionActionDetails.rs
+++ b/crates/web-sys/src/features/gen_MediaSessionActionDetails.rs
@@ -101,7 +101,7 @@ impl MediaSessionActionDetails {
     pub fn new(action: MediaSessionAction) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.action(action);
+        ret.set_action(action);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_MediaStreamAudioSourceOptions.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamAudioSourceOptions.rs
@@ -31,7 +31,7 @@ impl MediaStreamAudioSourceOptions {
     pub fn new(media_stream: &MediaStream) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.media_stream(media_stream);
+        ret.set_media_stream(media_stream);
         ret
     }
     #[cfg(feature = "MediaStream")]

--- a/crates/web-sys/src/features/gen_MediaStreamTrackEventInit.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamTrackEventInit.rs
@@ -61,7 +61,7 @@ impl MediaStreamTrackEventInit {
     pub fn new(track: &MediaStreamTrack) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.track(track);
+        ret.set_track(track);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_MediaStreamTrackGeneratorInit.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamTrackGeneratorInit.rs
@@ -44,7 +44,7 @@ impl MediaStreamTrackGeneratorInit {
     pub fn new(kind: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.kind(kind);
+        ret.set_kind(kind);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_MediaStreamTrackProcessorInit.rs
+++ b/crates/web-sys/src/features/gen_MediaStreamTrackProcessorInit.rs
@@ -65,7 +65,7 @@ impl MediaStreamTrackProcessorInit {
     pub fn new(track: &MediaStreamTrack) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.track(track);
+        ret.set_track(track);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_NotificationAction.rs
+++ b/crates/web-sys/src/features/gen_NotificationAction.rs
@@ -48,8 +48,8 @@ impl NotificationAction {
     pub fn new(action: &str, title: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.action(action);
-        ret.title(title);
+        ret.set_action(action);
+        ret.set_title(title);
         ret
     }
     #[deprecated = "Use `set_action()` instead."]

--- a/crates/web-sys/src/features/gen_NotificationEventInit.rs
+++ b/crates/web-sys/src/features/gen_NotificationEventInit.rs
@@ -61,7 +61,7 @@ impl NotificationEventInit {
     pub fn new(notification: &Notification) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.notification(notification);
+        ret.set_notification(notification);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_OfflineAudioCompletionEventInit.rs
+++ b/crates/web-sys/src/features/gen_OfflineAudioCompletionEventInit.rs
@@ -61,7 +61,7 @@ impl OfflineAudioCompletionEventInit {
     pub fn new(rendered_buffer: &AudioBuffer) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.rendered_buffer(rendered_buffer);
+        ret.set_rendered_buffer(rendered_buffer);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_OfflineAudioContextOptions.rs
+++ b/crates/web-sys/src/features/gen_OfflineAudioContextOptions.rs
@@ -48,8 +48,8 @@ impl OfflineAudioContextOptions {
     pub fn new(length: u32, sample_rate: f32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.length(length);
-        ret.sample_rate(sample_rate);
+        ret.set_length(length);
+        ret.set_sample_rate(sample_rate);
         ret
     }
     #[deprecated = "Use `set_length()` instead."]

--- a/crates/web-sys/src/features/gen_PaymentMethodChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_PaymentMethodChangeEventInit.rs
@@ -68,7 +68,7 @@ impl PaymentMethodChangeEventInit {
     pub fn new(method_name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.method_name(method_name);
+        ret.set_method_name(method_name);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_Pbkdf2Params.rs
+++ b/crates/web-sys/src/features/gen_Pbkdf2Params.rs
@@ -63,10 +63,10 @@ impl Pbkdf2Params {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.hash(hash);
-        ret.iterations(iterations);
-        ret.salt(salt);
+        ret.set_name(name);
+        ret.set_hash(hash);
+        ret.set_iterations(iterations);
+        ret.set_salt(salt);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_PerformanceObserverInit.rs
+++ b/crates/web-sys/src/features/gen_PerformanceObserverInit.rs
@@ -38,7 +38,7 @@ impl PerformanceObserverInit {
     pub fn new(entry_types: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.entry_types(entry_types);
+        ret.set_entry_types(entry_types);
         ret
     }
     #[deprecated = "Use `set_buffered()` instead."]

--- a/crates/web-sys/src/features/gen_PermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_PermissionDescriptor.rs
@@ -31,7 +31,7 @@ impl PermissionDescriptor {
     pub fn new(name: PermissionName) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[cfg(feature = "PermissionName")]

--- a/crates/web-sys/src/features/gen_PlaneLayout.rs
+++ b/crates/web-sys/src/features/gen_PlaneLayout.rs
@@ -62,8 +62,8 @@ impl PlaneLayout {
     pub fn new(offset: u32, stride: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.offset(offset);
-        ret.stride(stride);
+        ret.set_offset(offset);
+        ret.set_stride(stride);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_PresentationConnectionAvailableEventInit.rs
+++ b/crates/web-sys/src/features/gen_PresentationConnectionAvailableEventInit.rs
@@ -66,7 +66,7 @@ impl PresentationConnectionAvailableEventInit {
     pub fn new(connection: &PresentationConnection) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.connection(connection);
+        ret.set_connection(connection);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_PresentationConnectionCloseEventInit.rs
+++ b/crates/web-sys/src/features/gen_PresentationConnectionCloseEventInit.rs
@@ -78,7 +78,7 @@ impl PresentationConnectionCloseEventInit {
     pub fn new(reason: PresentationConnectionClosedReason) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.reason(reason);
+        ret.set_reason(reason);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_PromiseRejectionEventInit.rs
+++ b/crates/web-sys/src/features/gen_PromiseRejectionEventInit.rs
@@ -68,7 +68,7 @@ impl PromiseRejectionEventInit {
     pub fn new(promise: &::js_sys::Promise) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.promise(promise);
+        ret.set_promise(promise);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialCreationOptions.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialCreationOptions.rs
@@ -191,10 +191,10 @@ impl PublicKeyCredentialCreationOptions {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.challenge(challenge);
-        ret.pub_key_cred_params(pub_key_cred_params);
-        ret.rp(rp);
-        ret.user(user);
+        ret.set_challenge(challenge);
+        ret.set_pub_key_cred_params(pub_key_cred_params);
+        ret.set_rp(rp);
+        ret.set_user(user);
         ret
     }
     #[cfg(feature = "AttestationConveyancePreference")]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialCreationOptionsJson.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialCreationOptionsJson.rs
@@ -273,10 +273,10 @@ impl PublicKeyCredentialCreationOptionsJson {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.challenge(challenge);
-        ret.pub_key_cred_params(pub_key_cred_params);
-        ret.rp(rp);
-        ret.user(user);
+        ret.set_challenge(challenge);
+        ret.set_pub_key_cred_params(pub_key_cred_params);
+        ret.set_rp(rp);
+        ret.set_user(user);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialDescriptor.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialDescriptor.rs
@@ -51,8 +51,8 @@ impl PublicKeyCredentialDescriptor {
     pub fn new(id: &::js_sys::Object, type_: PublicKeyCredentialType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.id(id);
-        ret.type_(type_);
+        ret.set_id(id);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_id()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialDescriptorJson.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialDescriptorJson.rs
@@ -80,8 +80,8 @@ impl PublicKeyCredentialDescriptorJson {
     pub fn new(id: &str, type_: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.id(id);
-        ret.type_(type_);
+        ret.set_id(id);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialEntity.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialEntity.rs
@@ -40,7 +40,7 @@ impl PublicKeyCredentialEntity {
     pub fn new(name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[deprecated = "Use `set_icon()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialParameters.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialParameters.rs
@@ -41,8 +41,8 @@ impl PublicKeyCredentialParameters {
     pub fn new(alg: i32, type_: PublicKeyCredentialType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.alg(alg);
-        ret.type_(type_);
+        ret.set_alg(alg);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_alg()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialRequestOptions.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialRequestOptions.rs
@@ -158,7 +158,7 @@ impl PublicKeyCredentialRequestOptions {
     pub fn new(challenge: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.challenge(challenge);
+        ret.set_challenge(challenge);
         ret
     }
     #[deprecated = "Use `set_allow_credentials()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialRequestOptionsJson.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialRequestOptionsJson.rs
@@ -211,7 +211,7 @@ impl PublicKeyCredentialRequestOptionsJson {
     pub fn new(challenge: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.challenge(challenge);
+        ret.set_challenge(challenge);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialRpEntity.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialRpEntity.rs
@@ -50,7 +50,7 @@ impl PublicKeyCredentialRpEntity {
     pub fn new(name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[deprecated = "Use `set_icon()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialUserEntity.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialUserEntity.rs
@@ -60,9 +60,9 @@ impl PublicKeyCredentialUserEntity {
     pub fn new(name: &str, display_name: &str, id: &::js_sys::Object) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.display_name(display_name);
-        ret.id(id);
+        ret.set_name(name);
+        ret.set_display_name(display_name);
+        ret.set_id(id);
         ret
     }
     #[deprecated = "Use `set_icon()` instead."]

--- a/crates/web-sys/src/features/gen_PublicKeyCredentialUserEntityJson.rs
+++ b/crates/web-sys/src/features/gen_PublicKeyCredentialUserEntityJson.rs
@@ -80,9 +80,9 @@ impl PublicKeyCredentialUserEntityJson {
     pub fn new(display_name: &str, id: &str, name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.display_name(display_name);
-        ret.id(id);
-        ret.name(name);
+        ret.set_display_name(display_name);
+        ret.set_id(id);
+        ret.set_name(name);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_PushSubscriptionInit.rs
+++ b/crates/web-sys/src/features/gen_PushSubscriptionInit.rs
@@ -68,8 +68,8 @@ impl PushSubscriptionInit {
     pub fn new(endpoint: &str, scope: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.endpoint(endpoint);
-        ret.scope(scope);
+        ret.set_endpoint(endpoint);
+        ret.set_scope(scope);
         ret
     }
     #[deprecated = "Use `set_app_server_key()` instead."]

--- a/crates/web-sys/src/features/gen_QueuingStrategyInit.rs
+++ b/crates/web-sys/src/features/gen_QueuingStrategyInit.rs
@@ -28,7 +28,7 @@ impl QueuingStrategyInit {
     pub fn new(high_water_mark: f64) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.high_water_mark(high_water_mark);
+        ret.set_high_water_mark(high_water_mark);
         ret
     }
     #[deprecated = "Use `set_high_water_mark()` instead."]

--- a/crates/web-sys/src/features/gen_ReadableWritablePair.rs
+++ b/crates/web-sys/src/features/gen_ReadableWritablePair.rs
@@ -43,8 +43,8 @@ impl ReadableWritablePair {
     pub fn new(readable: &ReadableStream, writable: &WritableStream) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.readable(readable);
-        ret.writable(writable);
+        ret.set_readable(readable);
+        ret.set_writable(writable);
         ret
     }
     #[cfg(feature = "ReadableStream")]

--- a/crates/web-sys/src/features/gen_RegistrationResponseJson.rs
+++ b/crates/web-sys/src/features/gen_RegistrationResponseJson.rs
@@ -158,11 +158,11 @@ impl RegistrationResponseJson {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.client_extension_results(client_extension_results);
-        ret.id(id);
-        ret.raw_id(raw_id);
-        ret.response(response);
-        ret.type_(type_);
+        ret.set_client_extension_results(client_extension_results);
+        ret.set_id(id);
+        ret.set_raw_id(raw_id);
+        ret.set_response(response);
+        ret.set_type(type_);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_RequestMediaKeySystemAccessNotification.rs
+++ b/crates/web-sys/src/features/gen_RequestMediaKeySystemAccessNotification.rs
@@ -43,8 +43,8 @@ impl RequestMediaKeySystemAccessNotification {
     pub fn new(key_system: &str, status: MediaKeySystemStatus) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.key_system(key_system);
-        ret.status(status);
+        ret.set_key_system(key_system);
+        ret.set_status(status);
         ret
     }
     #[deprecated = "Use `set_key_system()` instead."]

--- a/crates/web-sys/src/features/gen_RsaHashedImportParams.rs
+++ b/crates/web-sys/src/features/gen_RsaHashedImportParams.rs
@@ -28,7 +28,7 @@ impl RsaHashedImportParams {
     pub fn new(hash: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.hash(hash);
+        ret.set_hash(hash);
         ret
     }
     #[deprecated = "Use `set_hash()` instead."]

--- a/crates/web-sys/src/features/gen_RsaOaepParams.rs
+++ b/crates/web-sys/src/features/gen_RsaOaepParams.rs
@@ -38,7 +38,7 @@ impl RsaOaepParams {
     pub fn new(name: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_RsaOtherPrimesInfo.rs
+++ b/crates/web-sys/src/features/gen_RsaOtherPrimesInfo.rs
@@ -48,9 +48,9 @@ impl RsaOtherPrimesInfo {
     pub fn new(d: &str, r: &str, t: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.d(d);
-        ret.r(r);
-        ret.t(t);
+        ret.set_d(d);
+        ret.set_r(r);
+        ret.set_t(t);
         ret
     }
     #[deprecated = "Use `set_d()` instead."]

--- a/crates/web-sys/src/features/gen_RsaPssParams.rs
+++ b/crates/web-sys/src/features/gen_RsaPssParams.rs
@@ -38,8 +38,8 @@ impl RsaPssParams {
     pub fn new(name: &str, salt_length: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
-        ret.salt_length(salt_length);
+        ret.set_name(name);
+        ret.set_salt_length(salt_length);
         ret
     }
     #[deprecated = "Use `set_name()` instead."]

--- a/crates/web-sys/src/features/gen_RtcDataChannelEventInit.rs
+++ b/crates/web-sys/src/features/gen_RtcDataChannelEventInit.rs
@@ -61,7 +61,7 @@ impl RtcDataChannelEventInit {
     pub fn new(channel: &RtcDataChannel) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.channel(channel);
+        ret.set_channel(channel);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_RtcIceCandidateInit.rs
+++ b/crates/web-sys/src/features/gen_RtcIceCandidateInit.rs
@@ -48,7 +48,7 @@ impl RtcIceCandidateInit {
     pub fn new(candidate: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.candidate(candidate);
+        ret.set_candidate(candidate);
         ret
     }
     #[deprecated = "Use `set_candidate()` instead."]

--- a/crates/web-sys/src/features/gen_RtcIdentityAssertionResult.rs
+++ b/crates/web-sys/src/features/gen_RtcIdentityAssertionResult.rs
@@ -41,8 +41,8 @@ impl RtcIdentityAssertionResult {
     pub fn new(assertion: &str, idp: &RtcIdentityProviderDetails) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.assertion(assertion);
-        ret.idp(idp);
+        ret.set_assertion(assertion);
+        ret.set_idp(idp);
         ret
     }
     #[deprecated = "Use `set_assertion()` instead."]

--- a/crates/web-sys/src/features/gen_RtcIdentityProvider.rs
+++ b/crates/web-sys/src/features/gen_RtcIdentityProvider.rs
@@ -41,8 +41,8 @@ impl RtcIdentityProvider {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.generate_assertion(generate_assertion);
-        ret.validate_assertion(validate_assertion);
+        ret.set_generate_assertion(generate_assertion);
+        ret.set_validate_assertion(validate_assertion);
         ret
     }
     #[deprecated = "Use `set_generate_assertion()` instead."]

--- a/crates/web-sys/src/features/gen_RtcIdentityProviderDetails.rs
+++ b/crates/web-sys/src/features/gen_RtcIdentityProviderDetails.rs
@@ -38,7 +38,7 @@ impl RtcIdentityProviderDetails {
     pub fn new(domain: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.domain(domain);
+        ret.set_domain(domain);
         ret
     }
     #[deprecated = "Use `set_domain()` instead."]

--- a/crates/web-sys/src/features/gen_RtcIdentityValidationResult.rs
+++ b/crates/web-sys/src/features/gen_RtcIdentityValidationResult.rs
@@ -38,8 +38,8 @@ impl RtcIdentityValidationResult {
     pub fn new(contents: &str, identity: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.contents(contents);
-        ret.identity(identity);
+        ret.set_contents(contents);
+        ret.set_identity(identity);
         ret
     }
     #[deprecated = "Use `set_contents()` instead."]

--- a/crates/web-sys/src/features/gen_RtcRtpCapabilities.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpCapabilities.rs
@@ -41,8 +41,8 @@ impl RtcRtpCapabilities {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.codecs(codecs);
-        ret.header_extensions(header_extensions);
+        ret.set_codecs(codecs);
+        ret.set_header_extensions(header_extensions);
         ret
     }
     #[deprecated = "Use `set_codecs()` instead."]

--- a/crates/web-sys/src/features/gen_RtcRtpCodecCapability.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpCodecCapability.rs
@@ -58,8 +58,8 @@ impl RtcRtpCodecCapability {
     pub fn new(clock_rate: u32, mime_type: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.clock_rate(clock_rate);
-        ret.mime_type(mime_type);
+        ret.set_clock_rate(clock_rate);
+        ret.set_mime_type(mime_type);
         ret
     }
     #[deprecated = "Use `set_channels()` instead."]

--- a/crates/web-sys/src/features/gen_RtcRtpContributingSource.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpContributingSource.rs
@@ -48,8 +48,8 @@ impl RtcRtpContributingSource {
     pub fn new(source: u32, timestamp: f64) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.source(source);
-        ret.timestamp(timestamp);
+        ret.set_source(source);
+        ret.set_timestamp(timestamp);
         ret
     }
     #[deprecated = "Use `set_audio_level()` instead."]

--- a/crates/web-sys/src/features/gen_RtcRtpHeaderExtensionCapability.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpHeaderExtensionCapability.rs
@@ -28,7 +28,7 @@ impl RtcRtpHeaderExtensionCapability {
     pub fn new(uri: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.uri(uri);
+        ret.set_uri(uri);
         ret
     }
     #[deprecated = "Use `set_uri()` instead."]

--- a/crates/web-sys/src/features/gen_RtcRtpSourceEntry.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpSourceEntry.rs
@@ -71,9 +71,9 @@ impl RtcRtpSourceEntry {
     pub fn new(source: u32, timestamp: f64, source_type: RtcRtpSourceEntryType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.source(source);
-        ret.timestamp(timestamp);
-        ret.source_type(source_type);
+        ret.set_source(source);
+        ret.set_timestamp(timestamp);
+        ret.set_source_type(source_type);
         ret
     }
     #[deprecated = "Use `set_audio_level()` instead."]

--- a/crates/web-sys/src/features/gen_RtcRtpSynchronizationSource.rs
+++ b/crates/web-sys/src/features/gen_RtcRtpSynchronizationSource.rs
@@ -58,8 +58,8 @@ impl RtcRtpSynchronizationSource {
     pub fn new(source: u32, timestamp: f64) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.source(source);
-        ret.timestamp(timestamp);
+        ret.set_source(source);
+        ret.set_timestamp(timestamp);
         ret
     }
     #[deprecated = "Use `set_audio_level()` instead."]

--- a/crates/web-sys/src/features/gen_RtcSessionDescriptionInit.rs
+++ b/crates/web-sys/src/features/gen_RtcSessionDescriptionInit.rs
@@ -41,7 +41,7 @@ impl RtcSessionDescriptionInit {
     pub fn new(type_: RtcSdpType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.type_(type_);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_sdp()` instead."]

--- a/crates/web-sys/src/features/gen_RtcTrackEventInit.rs
+++ b/crates/web-sys/src/features/gen_RtcTrackEventInit.rs
@@ -103,9 +103,9 @@ impl RtcTrackEventInit {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.receiver(receiver);
-        ret.track(track);
-        ret.transceiver(transceiver);
+        ret.set_receiver(receiver);
+        ret.set_track(track);
+        ret.set_transceiver(transceiver);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_SFrameTransformErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_SFrameTransformErrorEventInit.rs
@@ -137,8 +137,8 @@ impl SFrameTransformErrorEventInit {
     pub fn new(error_type: SFrameTransformErrorEventType, frame: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error_type(error_type);
-        ret.frame(frame);
+        ret.set_error_type(error_type);
+        ret.set_frame(frame);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_SerialInputSignals.rs
+++ b/crates/web-sys/src/features/gen_SerialInputSignals.rs
@@ -103,10 +103,10 @@ impl SerialInputSignals {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.clear_to_send(clear_to_send);
-        ret.data_carrier_detect(data_carrier_detect);
-        ret.data_set_ready(data_set_ready);
-        ret.ring_indicator(ring_indicator);
+        ret.set_clear_to_send(clear_to_send);
+        ret.set_data_carrier_detect(data_carrier_detect);
+        ret.set_data_set_ready(data_set_ready);
+        ret.set_ring_indicator(ring_indicator);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_SerialOptions.rs
+++ b/crates/web-sys/src/features/gen_SerialOptions.rs
@@ -138,7 +138,7 @@ impl SerialOptions {
     pub fn new(baud_rate: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.baud_rate(baud_rate);
+        ret.set_baud_rate(baud_rate);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_ShadowRootInit.rs
+++ b/crates/web-sys/src/features/gen_ShadowRootInit.rs
@@ -31,7 +31,7 @@ impl ShadowRootInit {
     pub fn new(mode: ShadowRootMode) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.mode(mode);
+        ret.set_mode(mode);
         ret
     }
     #[cfg(feature = "ShadowRootMode")]

--- a/crates/web-sys/src/features/gen_SpeechSynthesisErrorEventInit.rs
+++ b/crates/web-sys/src/features/gen_SpeechSynthesisErrorEventInit.rs
@@ -116,8 +116,8 @@ impl SpeechSynthesisErrorEventInit {
     pub fn new(utterance: &SpeechSynthesisUtterance, error: SpeechSynthesisErrorCode) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.utterance(utterance);
-        ret.error(error);
+        ret.set_utterance(utterance);
+        ret.set_error(error);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_SpeechSynthesisEventInit.rs
+++ b/crates/web-sys/src/features/gen_SpeechSynthesisEventInit.rs
@@ -101,7 +101,7 @@ impl SpeechSynthesisEventInit {
     pub fn new(utterance: &SpeechSynthesisUtterance) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.utterance(utterance);
+        ret.set_utterance(utterance);
         ret
     }
     #[deprecated = "Use `set_bubbles()` instead."]

--- a/crates/web-sys/src/features/gen_TaskPriorityChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_TaskPriorityChangeEventInit.rs
@@ -101,7 +101,7 @@ impl TaskPriorityChangeEventInit {
     pub fn new(previous_priority: TaskPriority) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.previous_priority(previous_priority);
+        ret.set_previous_priority(previous_priority);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_TokenBinding.rs
+++ b/crates/web-sys/src/features/gen_TokenBinding.rs
@@ -38,7 +38,7 @@ impl TokenBinding {
     pub fn new(status: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.status(status);
+        ret.set_status(status);
         ret
     }
     #[deprecated = "Use `set_id()` instead."]

--- a/crates/web-sys/src/features/gen_TouchInit.rs
+++ b/crates/web-sys/src/features/gen_TouchInit.rs
@@ -141,8 +141,8 @@ impl TouchInit {
     pub fn new(identifier: i32, target: &EventTarget) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.identifier(identifier);
-        ret.target(target);
+        ret.set_identifier(identifier);
+        ret.set_target(target);
         ret
     }
     #[deprecated = "Use `set_client_x()` instead."]

--- a/crates/web-sys/src/features/gen_UsbConnectionEventInit.rs
+++ b/crates/web-sys/src/features/gen_UsbConnectionEventInit.rs
@@ -101,7 +101,7 @@ impl UsbConnectionEventInit {
     pub fn new(device: &UsbDevice) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.device(device);
+        ret.set_device(device);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_UsbControlTransferParameters.rs
+++ b/crates/web-sys/src/features/gen_UsbControlTransferParameters.rs
@@ -127,11 +127,11 @@ impl UsbControlTransferParameters {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.index(index);
-        ret.recipient(recipient);
-        ret.request(request);
-        ret.request_type(request_type);
-        ret.value(value);
+        ret.set_index(index);
+        ret.set_recipient(recipient);
+        ret.set_request(request);
+        ret.set_request_type(request_type);
+        ret.set_value(value);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_UsbDeviceRequestOptions.rs
+++ b/crates/web-sys/src/features/gen_UsbDeviceRequestOptions.rs
@@ -44,7 +44,7 @@ impl UsbDeviceRequestOptions {
     pub fn new(filters: &::wasm_bindgen::JsValue) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.filters(filters);
+        ret.set_filters(filters);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_UsbPermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_UsbPermissionDescriptor.rs
@@ -65,7 +65,7 @@ impl UsbPermissionDescriptor {
     pub fn new(name: PermissionName) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_VideoDecoderConfig.rs
+++ b/crates/web-sys/src/features/gen_VideoDecoderConfig.rs
@@ -192,7 +192,7 @@ impl VideoDecoderConfig {
     pub fn new(codec: &str) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.codec(codec);
+        ret.set_codec(codec);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_VideoDecoderInit.rs
+++ b/crates/web-sys/src/features/gen_VideoDecoderInit.rs
@@ -62,8 +62,8 @@ impl VideoDecoderInit {
     pub fn new(error: &::js_sys::Function, output: &::js_sys::Function) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error(error);
-        ret.output(output);
+        ret.set_error(error);
+        ret.set_output(output);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_VideoEncoderConfig.rs
+++ b/crates/web-sys/src/features/gen_VideoEncoderConfig.rs
@@ -230,9 +230,9 @@ impl VideoEncoderConfig {
     pub fn new(codec: &str, height: u32, width: u32) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.codec(codec);
-        ret.height(height);
-        ret.width(width);
+        ret.set_codec(codec);
+        ret.set_height(height);
+        ret.set_width(width);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_VideoEncoderInit.rs
+++ b/crates/web-sys/src/features/gen_VideoEncoderInit.rs
@@ -62,8 +62,8 @@ impl VideoEncoderInit {
     pub fn new(error: &::js_sys::Function, output: &::js_sys::Function) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.error(error);
-        ret.output(output);
+        ret.set_error(error);
+        ret.set_output(output);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_VideoFrameBufferInit.rs
+++ b/crates/web-sys/src/features/gen_VideoFrameBufferInit.rs
@@ -218,10 +218,10 @@ impl VideoFrameBufferInit {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.coded_height(coded_height);
-        ret.coded_width(coded_width);
-        ret.format(format);
-        ret.timestamp(timestamp);
+        ret.set_coded_height(coded_height);
+        ret.set_coded_width(coded_width);
+        ret.set_format(format);
+        ret.set_timestamp(timestamp);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_WidevineCdmManifest.rs
+++ b/crates/web-sys/src/features/gen_WidevineCdmManifest.rs
@@ -96,13 +96,13 @@ impl WidevineCdmManifest {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.description(description);
-        ret.name(name);
-        ret.version(version);
-        ret.x_cdm_codecs(x_cdm_codecs);
-        ret.x_cdm_host_versions(x_cdm_host_versions);
-        ret.x_cdm_interface_versions(x_cdm_interface_versions);
-        ret.x_cdm_module_versions(x_cdm_module_versions);
+        ret.set_description(description);
+        ret.set_name(name);
+        ret.set_version(version);
+        ret.set_x_cdm_codecs(x_cdm_codecs);
+        ret.set_x_cdm_host_versions(x_cdm_host_versions);
+        ret.set_x_cdm_interface_versions(x_cdm_interface_versions);
+        ret.set_x_cdm_module_versions(x_cdm_module_versions);
         ret
     }
     #[deprecated = "Use `set_description()` instead."]

--- a/crates/web-sys/src/features/gen_WriteParams.rs
+++ b/crates/web-sys/src/features/gen_WriteParams.rs
@@ -61,7 +61,7 @@ impl WriteParams {
     pub fn new(type_: WriteCommandType) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.type_(type_);
+        ret.set_type(type_);
         ret
     }
     #[deprecated = "Use `set_data()` instead."]

--- a/crates/web-sys/src/features/gen_XrInputSourceEventInit.rs
+++ b/crates/web-sys/src/features/gen_XrInputSourceEventInit.rs
@@ -121,8 +121,8 @@ impl XrInputSourceEventInit {
     pub fn new(frame: &XrFrame, input_source: &XrInputSource) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.frame(frame);
-        ret.input_source(input_source);
+        ret.set_frame(frame);
+        ret.set_input_source(input_source);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_XrInputSourcesChangeEventInit.rs
+++ b/crates/web-sys/src/features/gen_XrInputSourcesChangeEventInit.rs
@@ -141,9 +141,9 @@ impl XrInputSourcesChangeEventInit {
     ) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.added(added);
-        ret.removed(removed);
-        ret.session(session);
+        ret.set_added(added);
+        ret.set_removed(removed);
+        ret.set_session(session);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_XrPermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_XrPermissionDescriptor.rs
@@ -103,7 +103,7 @@ impl XrPermissionDescriptor {
     pub fn new(name: PermissionName) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_XrReferenceSpaceEventInit.rs
+++ b/crates/web-sys/src/features/gen_XrReferenceSpaceEventInit.rs
@@ -121,7 +121,7 @@ impl XrReferenceSpaceEventInit {
     pub fn new(reference_space: &XrReferenceSpace) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.reference_space(reference_space);
+        ret.set_reference_space(reference_space);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_XrSessionEventInit.rs
+++ b/crates/web-sys/src/features/gen_XrSessionEventInit.rs
@@ -101,7 +101,7 @@ impl XrSessionEventInit {
     pub fn new(session: &XrSession) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.session(session);
+        ret.set_session(session);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/web-sys/src/features/gen_XrSessionSupportedPermissionDescriptor.rs
+++ b/crates/web-sys/src/features/gen_XrSessionSupportedPermissionDescriptor.rs
@@ -67,7 +67,7 @@ impl XrSessionSupportedPermissionDescriptor {
     pub fn new(name: PermissionName) -> Self {
         #[allow(unused_mut)]
         let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
-        ret.name(name);
+        ret.set_name(name);
         ret
     }
     #[cfg(web_sys_unstable_apis)]

--- a/crates/webidl/src/generator.rs
+++ b/crates/webidl/src/generator.rs
@@ -832,9 +832,10 @@ impl Dictionary {
         for field in fields.iter() {
             if field.required {
                 let name = rust_ident(&field.name);
+                let set_name = rust_ident(&format!("set_{}", field.name));
                 let ty = &field.ty;
                 required_args.push(quote!( #name: #ty ));
-                required_calls.push(quote!( ret.#name(#name); ));
+                required_calls.push(quote!( ret.#set_name(#name); ));
                 add_features(&mut required_features, &field.ty);
             }
         }


### PR DESCRIPTION
The old builder style setters are now deprecated, favoring the new `.set_field(...)` over the old `.field(...)`. We should make use of the new setters internall.

In `wgpu`, we vendor the WebGPU bindings from this crate into `wgpu` itself. This triggers the deprecation warnings, and upgrading to the latest `main`, we see about 100 of them strewn throughout the generated bindings. This change aims to remove those warnings.