### PR TITLE
Improved contributing docs in `web-sys` README

### DIFF
--- a/crates/web-sys/README.md
+++ b/crates/web-sys/README.md
@@ -2,9 +2,9 @@
 
 Raw bindings to Web APIs for projects using `wasm-bindgen`.
 
-* [The `web-sys` section of the `wasm-bindgen`
+- [The `web-sys` section of the `wasm-bindgen`
   guide](https://rustwasm.github.io/wasm-bindgen/web-sys/index.html)
-* [API Documentation](https://rustwasm.github.io/wasm-bindgen/api/web_sys/)
+- [API Documentation](https://rustwasm.github.io/wasm-bindgen/api/web_sys/)
 
 ## Crate features
 
@@ -30,19 +30,23 @@ If you don't see a particular web API in `web-sys`, here is how to add it.
    [very bottom](https://w3c.github.io/mediasession/#idl-index) of _that_ page
    is the IDL.
 2. Annotate the functions that can throw with `[Throws]`
-3. Run `cargo run --release --package wasm-bindgen-webidl -- webidls src/features ./Cargo.toml`
-4. Run `git add .` to add all the generated files into git.
-5. Add an entry in CHANGELOG.md like the following
+3. `cd crates/web-sys`
+4. Run `cargo run --release --package wasm-bindgen-webidl -- webidls src/features ./Cargo.toml`
+
+   If formatting fails, you can run `cargo fmt` in the `crates/web-sys` directory. On Windows, you might also want to run `cargo fmt -- --config newline_style=Unix` depending on your git configuration.
+
+5. Run `git add .` to add all the generated files into git.
+6. Add an entry in CHANGELOG.md like the following
+
    ```md
    ...
-   
-   ## Unreleased
-   
-   ### Added
-   
-   ...
-   
-   * Added <your addition>
-     [#1234](https://github.com/rustwasm/wasm-bindgen/pull/1234)  # <- link to your PR
-   ```
 
+   ## Unreleased
+
+   ### Added
+
+   ...
+
+   * Added <your addition>
+     [#1234](https://github.com/rustwasm/wasm-bindgen/pull/1234) # <- link to your PR
+   ```


### PR DESCRIPTION
Changes:
1. Steps did not mention that you need to cd into `crates/web-sys` for the commands to work.
1. The command failed to format the generated files, because the path of one file was too long. `cargo fmt` worked, so I added a note for that.
1. While `cargo fmt` did work, it also used CRLF on Windows. I have git setup to check out everything as is (and WBG is LF) to make contributing to cross-platform repos easier. So `cargo fmt` resulted in ~2k changed files because of the different line endings. I added a note with how to fix that.
1. Formatting.