### PR TITLE
Only use `wasm_bindgen::__rt` in proc-macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
+## Unreleased
+
+### Fixed
+
+* Fixed `js-sys` and `wasm-bindgen-futures` relying on internal paths of `wasm-bindgen` that are not crate feature additive.
+  [#4305](https://github.com/rustwasm/wasm-bindgen/pull/4305)
+
+--------------------------------------------------------------------------------
+
 ## [0.2.96](https://github.com/rustwasm/wasm-bindgen/compare/0.2.95...0.2.96)
 
 Released 2024-11-29

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -25,6 +25,7 @@ default = ["std"]
 std = ["wasm-bindgen/std"]
 
 [dependencies]
+once_cell = { version = "1.12", default-features = false }
 wasm-bindgen = { path = "../..", version = "=0.2.96", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.3.46"
 
 [features]
 default = ["std"]
-std = ["wasm-bindgen/std", "js-sys/std", "wasm-bindgen-futures/std", "once_cell/std", "scoped-tls"]
+std = ["wasm-bindgen/std", "js-sys/std", "wasm-bindgen-futures/std", "scoped-tls"]
 
 [dependencies]
 gg-alloc = { version = "1.0", optional = true }


### PR DESCRIPTION
We should never use our own `wasm_bindgen::__rt` paths outside of proc-macros.

This caused breakage in `js-sys` and `wasm-bindgen-futures` when not enabling the `std` crate feature of `wasm-bindgen` but disabling their own.

Cc @kpreid.
Fixes #4303.