### PR TITLE
Revert `coverage` feature in `wasm-bindgen-macro`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -558,6 +558,26 @@ jobs:
     - run: rustup update --no-self-update 1.57 && rustup default 1.57 && rustup target add ${{ matrix.target }}
     - run: cargo build --target ${{ matrix.target }} ${{ matrix.features }}
 
+  edition-2018:
+    name: Check edition 2018 compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
+        features:
+          - --no-default-features
+          - ""
+    defaults:
+      run:
+        working-directory: crates/msrv/2018
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update 1.57 && rustup default 1.57 && rustup target add ${{ matrix.target }}
+    - run: cargo build --target ${{ matrix.target }} ${{ matrix.features }}
+
   msrv-cli:
     name: Check MSRV for CLI tools
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,12 +68,12 @@ jobs:
     - run: cargo clippy --no-deps --all-features -p example-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-externref-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -- -D warnings
-    - run: cargo clippy --no-deps --features spans,strict-macro -p wasm-bindgen-macro -- -D warnings
-    - run: cargo clippy --no-deps --features extra-traits,spans,strict-macro -p wasm-bindgen-macro-support -- -D warnings
+    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro -- -D warnings
+    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-macro-support -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-multi-value-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-shared -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p wasm-bindgen-test -- -D warnings
-    - run: cargo clippy --no-deps -p wasm-bindgen-test-macro -- -D warnings
+    - run: cargo clippy --no-deps --all-features -p wasm-bindgen-test-macro -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-threads-xform -- -D warnings
     - run: cargo clippy --no-deps --all-features --target wasm32-unknown-unknown -p typescript-tests -- -D warnings
     - run: cargo clippy --no-deps --all-features -p wasm-bindgen-wasm-conventions -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fixed `js-sys` and `wasm-bindgen-futures` relying on internal paths of `wasm-bindgen` that are not crate feature additive.
   [#4305](https://github.com/rustwasm/wasm-bindgen/pull/4305)
 
+* Fixed `wasm-bindgen` not being compatible with edition 2018.
+  [#4306](https://github.com/rustwasm/wasm-bindgen/pull/4306)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.96](https://github.com/rustwasm/wasm-bindgen/compare/0.2.95...0.2.96)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,11 +52,6 @@ wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.96", default-featu
   "atomics",
 ] }
 
-[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"), wasm_bindgen_unstable_test_coverage))'.dependencies]
-wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.96", default-features = false, features = [
-  "coverage",
-] }
-
 [dev-dependencies]
 wasm-bindgen-test = { path = 'crates/test' }
 

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -15,7 +15,6 @@ version = "0.2.96"
 
 [features]
 atomics = []
-coverage = []
 default = ["std"]
 extra-traits = ["syn/extra-traits"]
 spans = []
@@ -30,5 +29,12 @@ quote = '1.0'
 syn = { version = '2.0', features = ['full'] }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.96" }
 
-[lints]
-workspace = true
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+
+[lints.clippy]
+large_enum_variant = "allow"
+new_without_default = "allow"
+overly_complex_bool_expr = "allow"
+too_many_arguments = "allow"
+type_complexity = "allow"

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1966,8 +1966,8 @@ fn respan(input: TokenStream, span: &dyn ToTokens) -> TokenStream {
 }
 
 fn coverage() -> Option<TokenStream> {
-    #[cfg(feature = "coverage")]
+    #[cfg(wasm_bindgen_unstable_test_coverage)]
     return Some(quote! { #[coverage(off)] });
-    #[cfg(not(feature = "coverage"))]
+    #[cfg(not(wasm_bindgen_unstable_test_coverage))]
     None
 }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -15,7 +15,6 @@ version = "0.2.96"
 
 [features]
 atomics = ["wasm-bindgen-backend/atomics"]
-coverage = ["wasm-bindgen-backend/coverage"]
 default = ["std"]
 extra-traits = ["syn/extra-traits"]
 spans = ["wasm-bindgen-backend/spans"]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -18,7 +18,6 @@ proc-macro = true
 
 [features]
 atomics = ["wasm-bindgen-macro-support/atomics"]
-coverage = ["wasm-bindgen-macro-support/coverage"]
 default = ["std"]
 spans = ["wasm-bindgen-macro-support/spans"]
 std = ["wasm-bindgen-macro-support/std"]
@@ -36,5 +35,12 @@ wasm-bindgen = { path = "../.." }
 wasm-bindgen-futures = { path = "../futures" }
 web-sys = { path = "../web-sys", features = ["Worker"] }
 
-[lints]
-workspace = true
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+
+[lints.clippy]
+large_enum_variant = "allow"
+new_without_default = "allow"
+overly_complex_bool_expr = "allow"
+too_many_arguments = "allow"
+type_complexity = "allow"

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro/0.2")]
 #![cfg_attr(
-    any(feature = "coverage", all(not(feature = "std"), feature = "atomics")),
+    any(
+        wasm_bindgen_unstable_test_coverage,
+        all(not(feature = "std"), feature = "atomics")
+    ),
     feature(allow_internal_unstable),
     allow(internal_features)
 )]
@@ -11,7 +14,10 @@ use proc_macro::TokenStream;
 use quote::quote;
 
 #[proc_macro_attribute]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    wasm_bindgen_unstable_test_coverage,
+    allow_internal_unstable(coverage_attribute)
+)]
 #[cfg_attr(
     all(not(feature = "std"), feature = "atomics"),
     allow_internal_unstable(thread_local)
@@ -42,7 +48,10 @@ pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// let worker = Worker::new(&wasm_bindgen::link_to!(module = "/src/worker.js"));
 /// ```
 #[proc_macro]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    wasm_bindgen_unstable_test_coverage,
+    allow_internal_unstable(coverage_attribute)
+)]
 pub fn link_to(input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_link_to(input.into()) {
         Ok(tokens) => {
@@ -59,7 +68,10 @@ pub fn link_to(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    wasm_bindgen_unstable_test_coverage,
+    allow_internal_unstable(coverage_attribute)
+)]
 pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_class_marker(attr.into(), input.into()) {
         Ok(tokens) => {

--- a/crates/msrv/2018/Cargo.toml
+++ b/crates/msrv/2018/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+edition = "2018"
+name = "edition-2018-test"
+publish = false
+version = "0.0.0"
+
+[features]
+default = ["std"]
+std = [
+  "wasm-bindgen/std",
+  "js-sys/std",
+  "wasm-bindgen-futures/std",
+  "web-sys/std",
+  "wasm-bindgen-test/std",
+]
+
+[dependencies]
+js-sys = { path = "../../js-sys", default-features = false }
+wasm-bindgen = { path = "../../../", default-features = false }
+wasm-bindgen-futures = { path = "../../futures", default-features = false }
+wasm-bindgen-test = { path = "../../test", default-features = false }
+web-sys = { path = "../../web-sys", default-features = false }
+
+# Pinned sub-dependencies for MSRV
+bumpalo = "=3.12.0"
+log = "=0.4.18"
+scoped-tls = { version = "=1.0.0", optional = false }

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -12,9 +12,6 @@ version = "0.3.46"
 [lib]
 proc-macro = true
 
-[features]
-coverage = []
-
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
@@ -30,5 +27,12 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 trybuild = "1.0"
 wasm-bindgen-test = { path = "../test" }
 
-[lints]
-workspace = true
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+
+[lints.clippy]
+large_enum_variant = "allow"
+new_without_default = "allow"
+overly_complex_bool_expr = "allow"
+too_many_arguments = "allow"
+type_complexity = "allow"

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -2,7 +2,7 @@
 //! going on here.
 
 #![cfg_attr(
-    feature = "coverage",
+    wasm_bindgen_unstable_test_coverage,
     feature(allow_internal_unstable),
     allow(internal_features)
 )]
@@ -18,7 +18,10 @@ use std::sync::atomic::*;
 static CNT: AtomicUsize = AtomicUsize::new(0);
 
 #[proc_macro_attribute]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    wasm_bindgen_unstable_test_coverage,
+    allow_internal_unstable(coverage_attribute)
+)]
 pub fn wasm_bindgen_test(
     attr: proc_macro::TokenStream,
     body: proc_macro::TokenStream,
@@ -106,17 +109,12 @@ pub fn wasm_bindgen_test(
     // main test harness. This is the entry point for all tests.
     let name = format_ident!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
     let wasm_bindgen_path = attributes.wasm_bindgen_path;
-    let coverage = if cfg!(feature = "coverage") {
-        Some(quote! { #[coverage(off)] })
-    } else {
-        None
-    };
     tokens.extend(
         quote! {
             const _: () = {
                 #[no_mangle]
                 #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
-                #coverage
+                #[cfg_attr(wasm_bindgen_unstable_test_coverage, coverage(off))]
                 pub extern "C" fn #name(cx: &#wasm_bindgen_path::__rt::Context) {
                     let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
                     #test_body

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -24,7 +24,6 @@ wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.46' }
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]
 minicov = "0.3"
-wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.46', features = ["coverage"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/guide/src/wasm-bindgen-test/coverage.md
+++ b/guide/src/wasm-bindgen-test/coverage.md
@@ -9,7 +9,12 @@ You can ask the runner to generate coverage data from functions marked as `#[was
 
 ## Enabling the feature
 
-To enable this feature, you need to enable `cfg(wasm_bindgen_unstable_test_coverage)`.
+To enable this feature, you need to set `cfg(wasm_bindgen_unstable_test_coverage)` for `wasm-bindgen-test` and its dependencies.
+
+Currently it is particularly difficult to [deliver compile-line arguments to proc-macros when cross-compiling with Cargo][1]. To circumvent this [host-config] can be used.
+
+[1]: https://github.com/rust-lang/cargo/issues/4423
+[host-config]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#host-config
 
 ## Generating the data
 
@@ -21,18 +26,18 @@ Due to the current limitation of `llvm-cov`, we can't collect profiling symbols 
 
 ### Arguments to the test runner
 
-The following environment variables can be used to control the coverage output when [executing the test runner][1]:
+The following environment variables can be used to control the coverage output when [executing the test runner][2]:
 
 - `WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_OUT` to control the file name of the profraw or the directory in which it is placed. It might be necessary to provide the full path if e.g. running tests in a workspace.
 - `WASM_BINDGEN_UNSTABLE_TEST_PROFRAW_PREFIX` to add a custom prefix to the profraw files. This can be useful if you're running the tests automatically in succession.
 
-[1]: usage.html#appendix-using-wasm-bindgen-test-without-wasm-pack
+[2]: usage.html#appendix-using-wasm-bindgen-test-without-wasm-pack
 
 ### Target features
 
-This feature relies on the [minicov] crate, which provides a profiling runtime for WebAssembly. It in turn uses [cc] to compile the runtime to Wasm, which [currently doesn't support accounting for target feature][2]. Use e.g. `CFLAGS_wasm32_unknown_unknown="-matomics -mbulk-memory"` to account for that.
+This feature relies on the [minicov] crate, which provides a profiling runtime for WebAssembly. It in turn uses [cc] to compile the runtime to Wasm, which [currently doesn't support accounting for target feature][3]. Use e.g. `CFLAGS_wasm32_unknown_unknown="-matomics -mbulk-memory"` to account for that.
 
-[2]: https://github.com/rust-lang/cc-rs/issues/268
+[3]: https://github.com/rust-lang/cc-rs/issues/268
 [cc]: https://crates.io/crates/cc
 [minicov]: https://crates.io/crates/minicov
 
@@ -42,10 +47,13 @@ This adapts code taken from the [Rustc book], see that for more examples and gen
 
 ```sh
 # Run the tests:
-# `--tests` to not run documentation tests, which is currently not supported.
+# - `CARGO_HOST_RUSTFLAGS` to pass the configuration to `wasm-bindgen-macro`.
+# - `-Ztarget-applies-to-host -Zhost-config` to enable `CARGO_HOST_RUSTFLAGS`.
+# - `--tests` to not run documentation tests, which is currently not supported.
+CARGO_HOST_RUSTFLAGS=--cfg=wasm_bindgen_unstable_test_coverage \
 RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir --cfg=wasm_bindgen_unstable_test_coverage" \
 CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
-cargo +nightly test --tests
+cargo +nightly test -Ztarget-applies-to-host -Zhost-config --tests
 # Compile to object files:
 # - Extract a list of compiled artifacts from Cargo and filter them with `jq`.
 # - Figure out the path to the LLVM IR file corresponding to an artifact.
@@ -54,8 +62,9 @@ crate_name=name_of_the_tested_crate_in_snake_case
 objects=()
 IFS=$'\n'
 for file in $(
+    CARGO_HOST_RUSTFLAGS=--cfg=wasm_bindgen_unstable_test_coverage \
     RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir --cfg=wasm_bindgen_unstable_test_coverage" \
-    cargo +nightly test --tests --no-run --message-format=json | \
+    cargo +nightly test -Ztarget-applies-to-host -Zhost-config --tests --no-run --message-format=json | \
     jq -r "select(.reason == \"compiler-artifact\") | (select(.target.kind == [\"test\"]) // select(.target.name == \"$crate_name\")) | .filenames[0]"
 )
 do
@@ -80,7 +89,7 @@ llvm-cov-19 show -show-instantiations=false -Xdemangler=rustfilt -output-dir cov
 
 ## Attribution
 
-These methods have originally been pioneered by [Hacken OÜ], see [their guide][3] as well.
+These methods have originally been pioneered by [Hacken OÜ], see [their guide][4] as well.
 
-[3]: https://hknio.github.io/wasmcov
+[4]: https://hknio.github.io/wasmcov
 [Hacken OÜ]: https://hacken.io


### PR DESCRIPTION
`wasm-bindgen` always enabled the `coverage` crate feature of `wasm-bindgen-macro` if the root crate is edition 2018.

Apparently `[target.'cfg(some_flag)'.dependencies]` is always triggered regardless of if the flag is set or not when the root crate is edition 2018. A very strange interaction.

This PR partly reverts #4284, so now test coverage requires the hack again to pass cfg flags to proc macros.

Fixes #4304.