### PR TITLE
Note that feature resolver version 2 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Libraries that are released on [crates.io](https://crates.io) have a MSRV of v1.
 
 CLI tools and their corresponding support libraries have a MSRV of v1.76. Changes to the MSRV will be accompanied by a patch version bump.
 
+[Feature resolver version 2](https://doc.rust-lang.org/1.83.0/cargo/reference/resolver.html#feature-resolver-version-2) is required.
+
 ## License
 
 This project is licensed under either of


### PR DESCRIPTION
Feature resolver version 1 seems to be unable to handle `[target.'cfg(...)'.dependencies]` with `target_feature`s or cfg flags. So we now require feature resolver version 2.

This might be very controversial, but unfortunately I couldn't find a way to resolve our current implementation without it. If you are affected, please let us know in #4304!

Addresses #4304.