### PR TITLE
Add resolver error message test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -538,6 +538,34 @@ jobs:
         name: doc_api
         path: docs.tar.gz
 
+  msrv-resolver:
+    name: Check for feature resolver v1 error message
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - 1.57
+          - stable
+        target:
+          - x86_64-unknown-linux-gnu
+          - wasm32-unknown-unknown
+        features:
+          - --no-default-features
+          - ""
+    defaults:
+      run:
+        working-directory: crates/msrv/resolver
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }} && rustup target add ${{ matrix.target }}
+    - if: matrix.rust == '1.57'
+      run: |
+        cargo update -p bumpalo --precise 3.12.0
+        cargo update -p log --precise 0.4.18
+        cargo update -p scoped-tls --precise 1.0.0
+    - run: diff <(cargo build --target ${{ matrix.target }} ${{ matrix.features }} --message-format json | jq -r "select(.reason == \"compiler-message\") | .message.message") error-${{ matrix.rust }}.txt
+
   msrv-lib:
     name: Check MSRV for libraries
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
+## Unreleased
+
+### Changed
+
+* Add clear error message to communicate new feature resolver version requirements.
+  [#4312](https://github.com/rustwasm/wasm-bindgen/pull/4312)
+
+--------------------------------------------------------------------------------
+
 ## [0.2.97](https://github.com/rustwasm/wasm-bindgen/compare/0.2.96...0.2.97)
 
 Released 2024-11-30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,11 @@ wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.97", default-featu
   "coverage",
 ] }
 
+[target.'cfg(__wasm_bindgen_resolver_1)'.dependencies]
+wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.97", default-features = false, features = [
+  "xxx_resolver_1",
+] }
+
 [dev-dependencies]
 wasm-bindgen-test = { path = 'crates/test' }
 

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -20,6 +20,7 @@ default = ["std"]
 extra-traits = ["syn/extra-traits"]
 spans = []
 std = []
+xxx_resolver_1 = []
 
 [dependencies]
 bumpalo = "3.0.0"

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1966,8 +1966,8 @@ fn respan(input: TokenStream, span: &dyn ToTokens) -> TokenStream {
 }
 
 fn coverage() -> Option<TokenStream> {
-    #[cfg(feature = "coverage")]
+    #[cfg(all(not(feature = "xxx_resolver_1"), feature = "coverage"))]
     return Some(quote! { #[coverage(off)] });
-    #[cfg(not(feature = "coverage"))]
+    #[cfg(any(feature = "xxx_resolver_1", not(feature = "coverage")))]
     None
 }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -21,6 +21,7 @@ extra-traits = ["syn/extra-traits"]
 spans = ["wasm-bindgen-backend/spans"]
 std = ["wasm-bindgen-backend/std"]
 strict-macro = []
+xxx_resolver_1 = ["wasm-bindgen-backend/xxx_resolver_1"]
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -24,6 +24,7 @@ spans = ["wasm-bindgen-macro-support/spans"]
 std = ["wasm-bindgen-macro-support/std"]
 strict-macro = ["wasm-bindgen-macro-support/strict-macro"]
 xxx_debug_only_print_generated_code = []
+xxx_resolver_1 = ["wasm-bindgen-macro-support/xxx_resolver_1"]
 
 [dependencies]
 quote = "1.0"

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen-macro/0.2")]
 #![cfg_attr(
-    any(feature = "coverage", all(not(feature = "std"), feature = "atomics")),
+    all(
+        not(feature = "xxx_resolver_1"),
+        any(feature = "coverage", all(not(feature = "std"), feature = "atomics"))
+    ),
     feature(allow_internal_unstable),
     allow(internal_features)
 )]
@@ -10,10 +13,23 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
 
+#[cfg(feature = "xxx_resolver_1")]
+compile_error!("Feature resolver version 2 or up is required.\n\
+                Please add `resolver = \"2\"` to your `Cargo.toml`.\n\
+                \n\
+                See <https://doc.rust-lang.org/1.83.0/cargo/reference/resolver.html#feature-resolver-version-2>.");
+
 #[proc_macro_attribute]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
 #[cfg_attr(
-    all(not(feature = "std"), feature = "atomics"),
+    all(not(feature = "xxx_resolver_1"), feature = "coverage"),
+    allow_internal_unstable(coverage_attribute)
+)]
+#[cfg_attr(
+    all(
+        not(feature = "xxx_resolver_1"),
+        not(feature = "std"),
+        feature = "atomics"
+    ),
     allow_internal_unstable(thread_local)
 )]
 pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
@@ -42,7 +58,10 @@ pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// let worker = Worker::new(&wasm_bindgen::link_to!(module = "/src/worker.js"));
 /// ```
 #[proc_macro]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    all(not(feature = "xxx_resolver_1"), feature = "coverage"),
+    allow_internal_unstable(coverage_attribute)
+)]
 pub fn link_to(input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_link_to(input.into()) {
         Ok(tokens) => {
@@ -59,7 +78,10 @@ pub fn link_to(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    all(not(feature = "xxx_resolver_1"), feature = "coverage"),
+    allow_internal_unstable(coverage_attribute)
+)]
 pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand_class_marker(attr.into(), input.into()) {
         Ok(tokens) => {

--- a/crates/msrv/resolver/Cargo.toml
+++ b/crates/msrv/resolver/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+edition = "2021"
+name = "msrv-library-test"
+publish = false
+resolver = "1"
+version = "0.0.0"
+
+[features]
+default = ["std"]
+std = [
+  "wasm-bindgen/std",
+  "js-sys/std",
+  "wasm-bindgen-futures/std",
+  "web-sys/std",
+  "wasm-bindgen-test/std",
+]
+
+[dependencies]
+js-sys = { path = "../../js-sys", default-features = false }
+wasm-bindgen = { path = "../../../", default-features = false }
+wasm-bindgen-futures = { path = "../../futures", default-features = false }
+wasm-bindgen-test = { path = "../../test", default-features = false }
+web-sys = { path = "../../web-sys", default-features = false }

--- a/crates/msrv/resolver/error-1.57.txt
+++ b/crates/msrv/resolver/error-1.57.txt
@@ -1,0 +1,5 @@
+Feature resolver version 2 or up is required.
+Please add `resolver = "2"` to your `Cargo.toml`.
+
+See <https://doc.rust-lang.org/1.83.0/cargo/reference/resolver.html#feature-resolver-version-2>.
+aborting due to previous error

--- a/crates/msrv/resolver/error-stable.txt
+++ b/crates/msrv/resolver/error-stable.txt
@@ -1,0 +1,4 @@
+Feature resolver version 2 or up is required.
+Please add `resolver = "2"` to your `Cargo.toml`.
+
+See <https://doc.rust-lang.org/1.83.0/cargo/reference/resolver.html#feature-resolver-version-2>.

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 
 [features]
 coverage = []
+xxx_resolver_1 = []
 
 [dependencies]
 proc-macro2 = "1.0"

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -2,7 +2,7 @@
 //! going on here.
 
 #![cfg_attr(
-    feature = "coverage",
+    all(not(feature = "xxx_resolver_1"), feature = "coverage"),
     feature(allow_internal_unstable),
     allow(internal_features)
 )]
@@ -18,7 +18,10 @@ use std::sync::atomic::*;
 static CNT: AtomicUsize = AtomicUsize::new(0);
 
 #[proc_macro_attribute]
-#[cfg_attr(feature = "coverage", allow_internal_unstable(coverage_attribute))]
+#[cfg_attr(
+    all(not(feature = "xxx_resolver_1"), feature = "coverage"),
+    allow_internal_unstable(coverage_attribute)
+)]
 pub fn wasm_bindgen_test(
     attr: proc_macro::TokenStream,
     body: proc_macro::TokenStream,

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -26,6 +26,11 @@ wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.47' }
 minicov = "0.3"
 wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.47', features = ["coverage"] }
 
+[target.'cfg(__wasm_bindgen_resolver_1)'.dependencies]
+wasm-bindgen-test-macro = { path = "../test-macro", version = "=0.3.47", features = [
+  "xxx_resolver_1",
+] }
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
 


### PR DESCRIPTION
Currently, the error message when using a feature resolver version below 1 is:
```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> wasm-bindgen-macro-0.2.97/src/lib.rs:4:5
  |
4 |     feature(allow_internal_unstable),
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
error: could not compile `wasm-bindgen-macro` (lib) due to 1 previous error
```
This PR changes the error message to:
```
error: Feature resolver version 2 or up is required.
       Please add `resolver = "2"` to your `Cargo.toml`.
       
       See <https://doc.rust-lang.org/1.83.0/cargo/reference/resolver.html#feature-resolver-version-2>.
  --> wasm-bindgen/crates/macro/src/lib.rs:17:1
   |
17 | / compile_error!("Feature resolver version 2 or up is required.\n\
18 | |                 Please add `resolver = \"2\"` to your `Cargo.toml`.\n\
19 | |                 \n\
20 | |                 See <https://doc.rust-lang.org/1.83.0/cargo/reference/resolver.html#feature-resolver-version-2>.");
   | |__________________________________________________________________________________________________________________^

error: could not compile `wasm-bindgen-macro` (lib) due to 1 previous error
```
This should make it very clear to users what they should do when encountering this error.

Addresses #4304.