### PR TITLE
Fix macro-hygiene for calls to `std::thread_local!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 * Add clear error message to communicate new feature resolver version requirements.
   [#4312](https://github.com/rustwasm/wasm-bindgen/pull/4312)
 
+### Fixed
+
+* Fix macro-hygiene for calls to `std::thread_local!`.
+  [#4315](https://github.com/rustwasm/wasm-bindgen/pull/4315)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.97](https://github.com/rustwasm/wasm-bindgen/compare/0.2.96...0.2.97)

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -1711,7 +1711,7 @@ impl ToTokens for ast::ImportStatic {
                         fn init() -> #ty {
                             #init
                         }
-                        thread_local!(static _VAL: #ty = init(););
+                        #wasm_bindgen::__rt::std::thread_local!(static _VAL: #ty = init(););
                         #wasm_bindgen::JsStatic {
                             __inner: &_VAL,
                         }
@@ -1763,7 +1763,7 @@ fn thread_local_import(
 
     match thread_local {
         ast::ThreadLocal::V1 => quote! {
-            thread_local! {
+            #wasm_bindgen::__rt::std::thread_local! {
                 #[automatically_derived]
                 #[deprecated = "use with `#[wasm_bindgen(thread_local_v2)]` instead"]
                 #vis static #name: #actual_ty = {
@@ -1774,7 +1774,7 @@ fn thread_local_import(
         ast::ThreadLocal::V2 => {
             #[cfg(feature = "std")]
             let inner = quote! {
-                thread_local!(static _VAL: #actual_ty = init(););
+                #wasm_bindgen::__rt::std::thread_local!(static _VAL: #actual_ty = init(););
                 #wasm_bindgen::JsThreadLocal {
                     __inner: &_VAL,
                 }

--- a/src/convert/slices.rs
+++ b/src/convert/slices.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "std")]
-use std::prelude::v1::*;
-
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;


### PR DESCRIPTION
Calls by proc-macros to `std::thread_local!` were not respecting macro-hygiene. This PR fixes that by accessing `std` through `wasm_bindgen::__rt::std`.