### PR TITLE
Add support for multi-threading in Node.js

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,15 +206,16 @@ jobs:
   test_threads:
     name: "Run wasm-bindgen crate tests with multithreading"
     runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
     steps:
     - uses: actions/checkout@v4
     - run: rustup default nightly-2024-07-06
     - run: rustup target add wasm32-unknown-unknown
     - run: rustup component add rust-src
-    # Note: we only run the browser tests here, because wasm-bindgen doesn't support threading in Node yet.
     - run: |
         RUSTFLAGS='-C target-feature=+atomics,+bulk-memory,+mutable-globals' \
-          cargo test --target wasm32-unknown-unknown --test headless -Z build-std=std,panic_abort
+          cargo test --target wasm32-unknown-unknown -Z build-std=std,panic_abort
 
   # I don't know why this is failing so comment this out for now, but ideally
   # this would be figured out at some point and solved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Unreleased
 
+### Added
+
+* Add support for multi-threading in Node.js.
+  [#4318](https://github.com/rustwasm/wasm-bindgen/pull/4318)
+
 ### Changed
 
 * Add clear error message to communicate new feature resolver version requirements.

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -440,6 +440,8 @@ impl<'a> Context<'a> {
             // With normal CommonJS node we need to defer requiring the wasm
             // until the end so most of our own exports are hooked up
             OutputMode::Node { module: false } => {
+                self.nodejs_memory();
+
                 js.push_str(&self.generate_node_imports());
 
                 js.push_str("let wasm;\n");
@@ -483,6 +485,8 @@ impl<'a> Context<'a> {
             // and let the bundler/runtime take care of it.
             // With Node we manually read the Wasm file from the filesystem and instantiate it.
             OutputMode::Bundler { .. } | OutputMode::Node { module: true } => {
+                self.nodejs_memory();
+
                 for (id, js) in iter_by_import(&self.wasm_import_definitions, self.module) {
                     let import = self.module.imports.get_mut(*id);
                     import.module = format!("./{}_bg.js", module_name);
@@ -1003,6 +1007,14 @@ __wbg_set_wasm(wasm);"
         );
 
         Ok((js, ts))
+    }
+
+    fn nodejs_memory(&mut self) {
+        if let Some(mem) = self.module.memories.iter_mut().next() {
+            if let Some(id) = mem.import.take() {
+                self.module.imports.delete(id);
+            }
+        }
     }
 
     fn write_classes(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
Our Node.js shim doesn't provide a way to pass in a `WebAssembly.Memory` or `SharedArrayBuffer`, so we just set the memory to not be imported but simply instantiated in Wasm.

I don't know the historical context behind LLVM emitting the memory as an import by default when using atomics.