### PR TITLE
Add `WASM_BINDGEN_TEST_DRIVER_TIMEOUT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,19 @@
 
 ### Added
 
-* Add support for multi-threading in Node.js.
-  [#4318](https://github.com/rustwasm/wasm-bindgen/pull/4318)
-
 * Add clear error message to communicate new feature resolver version requirements.
   [#4312](https://github.com/rustwasm/wasm-bindgen/pull/4312)
 
-* Remove `once_cell/critical-section` requirement for `no_std` with atomics.
-  [#4322](https://github.com/rustwasm/wasm-bindgen/pull/4322)
+* Add support for multi-threading in Node.js.
+  [#4318](https://github.com/rustwasm/wasm-bindgen/pull/4318)
+
+* Add `WASM_BINDGEN_TEST_DRIVER_TIMEOUT` environment variable to control the timeout to start and connect to the test driver.
+  [#4320](https://github.com/rustwasm/wasm-bindgen/pull/4320)
 
 ### Changed
+
+* Remove `once_cell/critical-section` requirement for `no_std` with atomics.
+  [#4322](https://github.com/rustwasm/wasm-bindgen/pull/4322)
 
 * `static FOO: Option<T>` now returns `None` if undeclared in JS instead of throwing an error in JS.
   [#4319](https://github.com/rustwasm/wasm-bindgen/pull/4319)

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -55,7 +55,12 @@ pub struct LegacyNewSessionParameters {
 /// binary, controlling it, running tests, scraping output, displaying output,
 /// etc. It will return `Ok` if all tests finish successfully, and otherwise it
 /// will return an error if some tests failed.
-pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error> {
+pub fn run(
+    server: &SocketAddr,
+    shell: &Shell,
+    driver_timeout: u64,
+    test_timeout: u64,
+) -> Result<(), Error> {
     let driver = Driver::find()?;
     let mut drop_log: Box<dyn FnMut()> = Box::new(|| ());
     let driver_url = match driver.location() {
@@ -64,7 +69,7 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
             // Wait for the driver to come online and bind its port before we try to
             // connect to it.
             let start = Instant::now();
-            let max = Duration::new(5, 0);
+            let max = Duration::new(driver_timeout, 0);
 
             let (driver_addr, mut child) = 'outer: loop {
                 // Allow tests to run in parallel (in theory) by finding any open port
@@ -173,7 +178,7 @@ pub fn run(server: &SocketAddr, shell: &Shell, timeout: u64) -> Result<(), Error
     //       information.
     shell.status("Waiting for test to finish...");
     let start = Instant::now();
-    let max = Duration::new(timeout, 0);
+    let max = Duration::new(test_timeout, 0);
     while start.elapsed() < max {
         if client.text(&id, &output)?.contains("test result: ") {
             break;

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -214,7 +214,15 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
+    let driver_timeout = env::var("WASM_BINDGEN_TEST_DRIVER_TIMEOUT")
+        .map(|timeout| {
+            timeout
+                .parse()
+                .expect("Could not parse 'WASM_BINDGEN_TEST_DRIVER_TIMEOUT'")
+        })
+        .unwrap_or(5);
+
+    let browser_timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
         .map(|timeout| {
             timeout
                 .parse()
@@ -223,7 +231,7 @@ fn main() -> anyhow::Result<()> {
         .unwrap_or(20);
 
     if debug {
-        println!("Set timeout to {} seconds...", timeout);
+        println!("Set timeout to {} seconds...", browser_timeout);
     }
 
     // Make the generated bindings available for the tests to execute against.
@@ -307,7 +315,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             thread::spawn(|| srv.run());
-            headless::run(&addr, &shell, timeout)?;
+            headless::run(&addr, &shell, driver_timeout, browser_timeout)?;
         }
     }
     Ok(())


### PR DESCRIPTION
This adds a new environment variable to `wasm-bindgen-test-runner`: `WASM_BINDGEN_TEST_DRIVER_TIMEOUT`. It controls how long the timeout for starting and connecting to the test driver should be before giving up.

The default is 5 seconds, which was the value until now.