### PR TITLE
Move `walrus/parallel` to `wasm-bindgen-cli-support`

### DIFF
--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.0"
 unicode-ident = "1.0.5"
-walrus = "0.23"
+walrus = { version = "0.23", features = ['parallel'] }
 wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.97' }
 wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.97' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.97' }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ['derive'] }
 serde_derive = "1.0"
 serde_json = "1.0"
 ureq = { version = "2.7", default-features = false, features = ["brotli", "gzip"] }
-walrus = { version = "0.23", features = ['parallel'] }
+walrus = "0.23"
 wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.97" }
 wasm-bindgen-shared = { path = "../shared", version = "=0.2.97" }
 


### PR DESCRIPTION
This moves the crate feature activation of `walrus/parallel` from `wasm-bindgen-cli` to `wasm-bindgen-cli-support`, so dependents have it enabled as well.

Resolves #4314.