### PR TITLE
Remove `critical-section` requirement for `no_std` with atomics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,8 +121,8 @@ jobs:
     - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen -Zbuild-std=core,alloc -- -D warnings
     - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p js-sys -Zbuild-std=core,alloc -- -D warnings
     - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p web-sys -Zbuild-std=core,alloc -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-futures --features once_cell/critical-section -Zbuild-std=core,alloc -- -D warnings
-    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-test --features once_cell/critical-section -Zbuild-std=core,alloc -- -D warnings
+    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-futures -Zbuild-std=core,alloc -- -D warnings
+    - run: cargo clippy --no-deps --no-default-features --target wasm32-unknown-unknown -p wasm-bindgen-test -Zbuild-std=core,alloc -- -D warnings
 
   # Run `cargo clippy` over the project
   clippy_project:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * Add clear error message to communicate new feature resolver version requirements.
   [#4312](https://github.com/rustwasm/wasm-bindgen/pull/4312)
 
+* Remove `once_cell/critical-section` requirement for `no_std` with atomics.
+  [#4322](https://github.com/rustwasm/wasm-bindgen/pull/4322)
+
 ### Fixed
 
 * Fix macro-hygiene for calls to `std::thread_local!`.

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -201,8 +201,8 @@ impl TryToTokens for ast::LinkToModule {
                 #program
                 #extern_fn
 
-                static __VAL: #wasm_bindgen::__rt::once_cell::sync::Lazy<#wasm_bindgen::__rt::alloc::string::String> =
-                    #wasm_bindgen::__rt::once_cell::sync::Lazy::new(|| unsafe {
+                static __VAL: #wasm_bindgen::__rt::LazyLock<#wasm_bindgen::__rt::alloc::string::String> =
+                    #wasm_bindgen::__rt::LazyLock::new(|| unsafe {
                         <#wasm_bindgen::__rt::alloc::string::String as #wasm_bindgen::convert::FromWasmAbi>::from_abi(#name().join())
                     });
 

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -16,7 +16,6 @@ std = ["wasm-bindgen/std", "js-sys/std", "wasm-bindgen-futures/std", "scoped-tls
 [dependencies]
 gg-alloc = { version = "1.0", optional = true }
 js-sys = { path = '../js-sys', version = '=0.3.74', default-features = false }
-once_cell = { version = "1.12", default-features = false }
 scoped-tls = { version = "1.0", optional = true }
 wasm-bindgen = { path = '../..', version = '=0.2.97', default-features = false }
 wasm-bindgen-futures = { path = '../futures', version = '=0.4.47', default-features = false }


### PR DESCRIPTION
When compiling with `no_std` and `target-feature = "atomics"`, the `link_to!` macro, used by `wasm-bindgen-futures`, requires an implementation of [`critical-section`](https://crates.io/crates/critical-section) for `once_cell`. This was a bit unfortunate, but #4277 was already too big so I left it for a follow-up.

This PR adds a custom implementation for `LazyLock`.