### PR TITLE
Prepare v0.2.98 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # `wasm-bindgen` Change Log
 --------------------------------------------------------------------------------
 
-## Unreleased
+## [0.2.98](https://github.com/rustwasm/wasm-bindgen/compare/0.2.97...0.2.98)
+
+Released 2024-12-07
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "wasm-bindgen"
 readme = "README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 rust-version = "1.57"
-version = "0.2.97"
+version = "0.2.98"
 
 [package.metadata.docs.rs]
 features = ["serde-serialize"]
@@ -45,7 +45,7 @@ cfg-if = "1.0.0"
 once_cell = { version = "1.12", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.97", default-features = false }
+wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.98", default-features = false }
 
 [dev-dependencies]
 wasm-bindgen-test = { path = 'crates/test' }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-backend"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend"
 rust-version = "1.57"
-version = "0.2.97"
+version = "0.2.98"
 
 [features]
 default = ["std"]
@@ -25,7 +25,7 @@ log = "0.4"
 proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '2.0', features = ['full'] }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.97" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.98" }
 
 [lints]
 workspace = true

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-cli-support"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli-support"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [dependencies]
 anyhow = "1.0"
@@ -23,12 +23,12 @@ serde_json = "1.0"
 tempfile = "3.0"
 unicode-ident = "1.0.5"
 walrus = { version = "0.23", features = ['parallel'] }
-wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.97' }
-wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.97' }
-wasm-bindgen-shared = { path = "../shared", version = '=0.2.97' }
-wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.97' }
-wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.97' }
-wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.97' }
+wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.98' }
+wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.98' }
+wasm-bindgen-shared = { path = "../shared", version = '=0.2.98' }
+wasm-bindgen-threads-xform = { path = '../threads-xform', version = '=0.2.98' }
+wasm-bindgen-wasm-conventions = { path = '../wasm-conventions', version = '=0.2.98' }
+wasm-bindgen-wasm-interpreter = { path = "../wasm-interpreter", version = '=0.2.98' }
 
 [lints]
 workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-cli"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/cli"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [package.metadata.binstall]
 bin-dir = "wasm-bindgen-{ version }-{ target }/{ bin }{ binary-ext }"
@@ -32,8 +32,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 ureq = { version = "2.7", default-features = false, features = ["brotli", "gzip"] }
 walrus = "0.23"
-wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.97" }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.97" }
+wasm-bindgen-cli-support = { path = "../cli-support", version = "=0.2.98" }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.98" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/cli/tests/reference/web-sys.js
+++ b/crates/cli/tests/reference/web-sys.js
@@ -188,7 +188,7 @@ export function get_media_source() {
 
 const __wbindgen_enum_MediaSourceEnum = ["camera", "screen", "application", "window", "browser", "microphone", "audioCapture", "other"];
 
-export function __wbg_new_6684d1d61b5a2140() { return handleError(function (arg0, arg1) {
+export function __wbg_new_f3433bf7bc73881c() { return handleError(function (arg0, arg1) {
     const ret = new URL(getStringFromWasm0(arg0, arg1));
     return ret;
 }, arguments) };

--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-externref-xform"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/externref-xform"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [dependencies]
 anyhow = "1.0"
 walrus = "0.23"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.97" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.98" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -10,7 +10,7 @@ name = "wasm-bindgen-futures"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/futures"
 rust-version = "1.57"
-version = "0.4.47"
+version = "0.4.48"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -19,9 +19,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 cfg-if = "1.0.0"
 futures-core = { version = '0.3.8', default-features = false, optional = true }
-js-sys = { path = "../js-sys", version = '=0.3.74', default-features = false }
+js-sys = { path = "../js-sys", version = '=0.3.75', default-features = false }
 once_cell = { version = "1.12", default-features = false }
-wasm-bindgen = { path = "../..", version = '=0.2.97', default-features = false }
+wasm-bindgen = { path = "../..", version = '=0.2.98', default-features = false }
 
 [features]
 default = ["std"]
@@ -29,7 +29,7 @@ futures-core-03-stream = ['futures-core']
 std = ["wasm-bindgen/std", "js-sys/std", "web-sys/std", "once_cell/std"]
 
 [target.'cfg(target_feature = "atomics")'.dependencies]
-web-sys = { path = "../web-sys", version = "=0.3.74", default-features = false, features = [
+web-sys = { path = "../web-sys", version = "=0.3.75", default-features = false, features = [
   "MessageEvent",
   "Worker",
 ] }

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -14,7 +14,7 @@ name = "js-sys"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys"
 rust-version = "1.57"
-version = "0.3.74"
+version = "0.3.75"
 
 [lib]
 doctest = false
@@ -26,7 +26,7 @@ std = ["wasm-bindgen/std"]
 
 [dependencies]
 once_cell = { version = "1.12", default-features = false }
-wasm-bindgen = { path = "../..", version = "=0.2.97", default-features = false }
+wasm-bindgen = { path = "../..", version = "=0.2.98", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-futures = { path = '../futures' }

--- a/crates/macro-support/Cargo.toml
+++ b/crates/macro-support/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-macro-support"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro-support"
 rust-version = "1.57"
-version = "0.2.97"
+version = "0.2.98"
 
 [features]
 default = ["std"]
@@ -24,8 +24,8 @@ strict-macro = []
 proc-macro2 = "1.0"
 quote = '1.0'
 syn = { version = '2.0', features = ['visit', 'visit-mut', 'full'] }
-wasm-bindgen-backend = { path = "../backend", version = "=0.2.97", default-features = false }
-wasm-bindgen-shared = { path = "../shared", version = "=0.2.97" }
+wasm-bindgen-backend = { path = "../backend", version = "=0.2.98", default-features = false }
+wasm-bindgen-shared = { path = "../shared", version = "=0.2.98" }
 
 [lints]
 workspace = true

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-macro"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro"
 rust-version = "1.57"
-version = "0.2.97"
+version = "0.2.98"
 
 [lib]
 proc-macro = true
@@ -25,7 +25,7 @@ xxx_debug_only_print_generated_code = []
 
 [dependencies]
 quote = "1.0"
-wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.97", default-features = false }
+wasm-bindgen-macro-support = { path = "../macro-support", version = "=0.2.98", default-features = false }
 
 [dev-dependencies]
 js-sys = { path = "../js-sys" }

--- a/crates/multi-value-xform/Cargo.toml
+++ b/crates/multi-value-xform/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-multi-value-xform"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/multi-value-xform"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [dependencies]
 anyhow = "1.0"
 walrus = "0.23"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.97" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.98" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-shared"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared"
 rust-version = "1.57"
-version = "0.2.97"
+version = "0.2.98"
 
 # Because only a single `wasm_bindgen` version can be used in a dependency
 # graph, pretend we link a native library so that `cargo` will provide better

--- a/crates/test-macro/Cargo.toml
+++ b/crates/test-macro/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test-macro"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 rust-version = "1.57"
-version = "0.3.47"
+version = "0.3.48"
 
 [lib]
 proc-macro = true

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-test"
 repository = "https://github.com/rustwasm/wasm-bindgen"
 rust-version = "1.57"
-version = "0.3.47"
+version = "0.3.48"
 
 [features]
 default = ["std"]
@@ -15,11 +15,11 @@ std = ["wasm-bindgen/std", "js-sys/std", "wasm-bindgen-futures/std", "scoped-tls
 
 [dependencies]
 gg-alloc = { version = "1.0", optional = true }
-js-sys = { path = '../js-sys', version = '=0.3.74', default-features = false }
+js-sys = { path = '../js-sys', version = '=0.3.75', default-features = false }
 scoped-tls = { version = "1.0", optional = true }
-wasm-bindgen = { path = '../..', version = '=0.2.97', default-features = false }
-wasm-bindgen-futures = { path = '../futures', version = '=0.4.47', default-features = false }
-wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.47' }
+wasm-bindgen = { path = '../..', version = '=0.2.98', default-features = false }
+wasm-bindgen-futures = { path = '../futures', version = '=0.4.48', default-features = false }
+wasm-bindgen-test-macro = { path = '../test-macro', version = '=0.3.48' }
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]
 minicov = "0.3"

--- a/crates/threads-xform/Cargo.toml
+++ b/crates/threads-xform/Cargo.toml
@@ -11,12 +11,12 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-threads-xform"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/threads-xform"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [dependencies]
 anyhow = "1.0"
 walrus = "0.23"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.97" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.98" }
 
 [dev-dependencies]
 rayon = "1.0"

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-wasm-conventions"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/wasm-conventions"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [dependencies]
 leb128 = "0.2"

--- a/crates/wasm-interpreter/Cargo.toml
+++ b/crates/wasm-interpreter/Cargo.toml
@@ -11,13 +11,13 @@ license = "MIT OR Apache-2.0"
 name = "wasm-bindgen-wasm-interpreter"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/main/crates/wasm-interpreter"
 rust-version = "1.76"
-version = "0.2.97"
+version = "0.2.98"
 
 [dependencies]
 anyhow = "1.0"
 log = "0.4"
 walrus = "0.23"
-wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.97" }
+wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "0.2.98" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/web-sys/Cargo.toml
+++ b/crates/web-sys/Cargo.toml
@@ -12,7 +12,7 @@ name = "web-sys"
 readme = "./README.md"
 repository = "https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys"
 rust-version = "1.57"
-version = "0.3.74"
+version = "0.3.75"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -23,8 +23,8 @@ doctest = false
 test = false
 
 [dependencies]
-js-sys = { path = '../js-sys', version = '=0.3.74', default-features = false }
-wasm-bindgen = { path = "../..", version = "=0.2.97", default-features = false }
+js-sys = { path = '../js-sys', version = '=0.3.75', default-features = false }
+wasm-bindgen = { path = "../..", version = "=0.2.98", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 futures = "0.3"

--- a/publish.rs
+++ b/publish.rs
@@ -49,6 +49,7 @@ const CRATES_TO_AVOID_PUBLISH: &[&str] = &[
     "example-tests",
     "msrv-cli-test",
     "msrv-library-test",
+    "msrv-resolver-test",
 ];
 
 struct Crate {


### PR DESCRIPTION
Primary motivation for an earlier than usual release:
- https://github.com/rustwasm/wasm-bindgen/pull/4327
- https://github.com/rustwasm/wasm-bindgen/pull/4315

Thanks @taiki-e for helping me figure out a workaround for the feature resolver version issue.