### PR TITLE
Fixed webidl output formatting on Windows

### DIFF
--- a/crates/web-sys/README.md
+++ b/crates/web-sys/README.md
@@ -32,9 +32,6 @@ If you don't see a particular web API in `web-sys`, here is how to add it.
 2. Annotate the functions that can throw with `[Throws]`
 3. `cd crates/web-sys`
 4. Run `cargo run --release --package wasm-bindgen-webidl -- webidls src/features ./Cargo.toml`
-
-   If formatting fails, you can run `cargo fmt` in the `crates/web-sys` directory. On Windows, you might also want to run `cargo fmt -- --config newline_style=Unix` depending on your git configuration.
-
 5. Run `git add .` to add all the generated files into git.
 6. Add an entry in CHANGELOG.md like the following
 


### PR DESCRIPTION
I found the reason formatting the output files from `webidl` didn't work on Windows. The `rustfmt` command was invoked with all files given as command arguments. On Windows, there's a 32k character limit to command strings, so it failed to execute the command, because it was too long.

My solution was to invoke the command multiple times with 400 files each. In my testing ~840 files was the limit, but since the command length obviously depends on the file names, I gave us a lot of breathing room by picking 400.

---

I also removed the note about formatting failing, since it isn't relevant anymore. I'll also make another PR to address the newline issue.