### PR TITLE
Use LF for newlines everywhere

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Normalize line endings to LF
+* text=auto eol=LF
+
 *.webidl linguist-vendored

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -998,8 +998,6 @@ pub fn generate(from: &Path, to: &Path, options: Options) -> Result<String> {
     fn rustfmt(paths: impl IntoIterator<Item = PathBuf>) -> Result<()> {
         // run rustfmt on the generated file - really handy for debugging
         let result = Command::new("rustfmt")
-            .arg("--edition")
-            .arg("2021")
             .args(paths)
             .status()
             .context("rustfmt failed")?;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+newline_style = "Unix"


### PR DESCRIPTION
Related to #4335

I'm addressing the comment [here](https://github.com/rustwasm/wasm-bindgen/pull/4302#discussion_r1874003568) in 2 ways:

1. I added a `rustfmt.toml` to force LF newlines.
2. I added `* text=auto eol=LF` to `.gitattributes`. This causes git to automatically normalize all line ends to LF. Contributors on Windows now don't have to worry about having to configure git to checkout LF or CRLF.

    I have this line in the `.gitattributes` in a bunch of project. It generally makes it easier for Windows and Unix people to co-operate, since everyone checks out/in the exact same files. No newline weirdness. So I can only recommend this.


---

If you think that forcing everyone to use LF is too harsh/could create problems, I can also think of a different way to make the rustfmt call in webidl use the correct newlines. The problem is that the rustfmt tries to detect the existing newlines of a file to determine which ones to use, but the raw output of webidl is a `.rs` file with all tokens in a single line. There is no newline to detect. So it defaults to the native newline, which is the cause of the problem. So the solution could be to detect the newlines from another existing file, and then pass what we detected to rustfmt.