### PR TITLE
Whats up with `coherence_leak_check`?

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -561,6 +561,7 @@ macro_rules! doit {
     ($(
         ($($var:ident $arg1:ident $arg2:ident $arg3:ident $arg4:ident)*)
     )*) => ($(
+        #[allow(coherence_leak_check)]
         unsafe impl<$($var,)* R> WasmClosure for dyn Fn($($var),*) -> R + 'static
             where $($var: FromWasmAbi + 'static,)*
                   R: ReturnWasmAbi + 'static,
@@ -620,6 +621,7 @@ macro_rules! doit {
             }
         }
 
+        #[allow(coherence_leak_check)]
         unsafe impl<$($var,)* R> WasmClosure for dyn FnMut($($var),*) -> R + 'static
             where $($var: FromWasmAbi + 'static,)*
                   R: ReturnWasmAbi + 'static,

--- a/src/convert/closures.rs
+++ b/src/convert/closures.rs
@@ -10,7 +10,8 @@ use crate::throw_str;
 
 macro_rules! stack_closures {
     ($( ($cnt:tt $invoke:ident $invoke_mut:ident $($var:ident $arg1:ident $arg2:ident $arg3:ident $arg4:ident)*) )*) => ($(
-        impl<'a, 'b, $($var,)* R> IntoWasmAbi for &'a (dyn Fn($($var),*) -> R + 'b)
+        #[allow(coherence_leak_check)]
+        impl<$($var,)* R> IntoWasmAbi for &'_ (dyn Fn($($var),*) -> R + '_)
             where $($var: FromWasmAbi,)*
                   R: ReturnWasmAbi
         {
@@ -50,7 +51,8 @@ macro_rules! stack_closures {
             ret.return_abi().into()
         }
 
-        impl<'a, $($var,)* R> WasmDescribe for dyn Fn($($var),*) -> R + 'a
+        #[allow(coherence_leak_check)]
+        impl<$($var,)* R> WasmDescribe for dyn Fn($($var),*) -> R + '_
             where $($var: FromWasmAbi,)*
                   R: ReturnWasmAbi
         {
@@ -65,7 +67,8 @@ macro_rules! stack_closures {
             }
         }
 
-        impl<'a, 'b, $($var,)* R> IntoWasmAbi for &'a mut (dyn FnMut($($var),*) -> R + 'b)
+        #[allow(coherence_leak_check)]
+        impl<$($var,)* R> IntoWasmAbi for &'_ mut (dyn FnMut($($var),*) -> R + '_)
             where $($var: FromWasmAbi,)*
                   R: ReturnWasmAbi
         {
@@ -105,7 +108,8 @@ macro_rules! stack_closures {
             ret.return_abi().into()
         }
 
-        impl<'a, $($var,)* R> WasmDescribe for dyn FnMut($($var),*) -> R + 'a
+        #[allow(coherence_leak_check)]
+        impl<$($var,)* R> WasmDescribe for dyn FnMut($($var),*) -> R + '_
             where $($var: FromWasmAbi,)*
                   R: ReturnWasmAbi
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
     feature(thread_local, allow_internal_unstable),
     allow(internal_features)
 )]
-#![allow(coherence_leak_check)]
 #![doc(html_root_url = "https://docs.rs/wasm-bindgen/0.2")]
 
 extern crate alloc;


### PR DESCRIPTION
`wasm-bindgen` had a top-level `allow(coherence_leak_check)`. This PR moves it to only cover the lines needed. I briefly attempted to figure out a way to properly fix this, but it doesn't seem possible right now, see https://github.com/rust-lang/rust/issues/56105#issuecomment-620052214.

To fix this properly it might require something like [negative impls](https://doc.rust-lang.org/1.83.0/unstable-book/language-features/negative-impls.html).