### PR TITLE
Add `copy_to_uninit()` to all `TypedArray`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Unreleased
 
+### Added
+
+* Add a `copy_to_uninit()` method to all `TypedArray`s. It takes `&mut [MaybeUninit<T>]` and returns `&mut [T]`.
+  [#4340](https://github.com/rustwasm/wasm-bindgen/pull/4340)
+
 ### Changed
 
 * Optional parameters are now typed as `T | undefined | null` to reflect the actual JS behavior.

--- a/crates/js-sys/tests/wasm/TypedArray.rs
+++ b/crates/js-sys/tests/wasm/TypedArray.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 use js_sys::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_test::*;
@@ -169,6 +171,17 @@ fn copy_to() {
     let array = Int32Array::new(&10.into());
     array.fill(5, 0, 10);
     array.copy_to(&mut x);
+    for i in x.iter() {
+        assert_eq!(*i, 5);
+    }
+}
+
+#[wasm_bindgen_test]
+fn copy_to_uninit() {
+    let mut x = [MaybeUninit::uninit(); 10];
+    let array = Int32Array::new(&10.into());
+    array.fill(5, 0, 10);
+    let x = array.copy_to_uninit(&mut x);
     for i in x.iter() {
         assert_eq!(*i, 5);
     }


### PR DESCRIPTION
Currently copying from a `TypedArray`, e.g. `Uint8Array`, to a `[MaybeUninit<T>]` is not possible without going through `raw_copy_to_ptr()`, making it unsafe.

This PR adds a method `copy_to_uninit()` to all `TypedArray`s, making it safe to copy to a `[MaybeUninit<T>]` and also returns a `[T]` because all its values are guaranteed to be initialized now.