### PR TITLE
Document all features of `wasm-bindgen`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ std = ["wasm-bindgen-macro/std", "once_cell/std"]
 # all unused attributes
 strict-macro = ["wasm-bindgen-macro/strict-macro"]
 
-# Enables gg-alloc as system allocator when using wasm-bindgen-test to check that large pointers
+# INTERNAL ONLY: Enables gg-alloc as system allocator when using wasm-bindgen-test to check that large pointers
 # are handled correctly
 gg-alloc = ["wasm-bindgen-test/gg-alloc"]
 
-# This is only for debugging wasm-bindgen! No stability guarantees, so enable
+# INTERNAL ONLY: This is only for debugging wasm-bindgen! No stability guarantees, so enable
 # this at your own peril!
 xxx_debug_only_print_generated_code = ["wasm-bindgen-macro/xxx_debug_only_print_generated_code"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,40 @@
 //! attribute and tool. Crates pull in the `#[wasm_bindgen]` attribute through
 //! this crate and this crate also provides JS bindings through the `JsValue`
 //! interface.
+//!
+//! ## Features
+//!
+//! ### `enable-interning`
+//!
+//! Enables the internal cache for [`wasm_bindgen::intern`].
+//!
+//! ### `gg-alloc`
+//!
+//! Uses [`gg-allow`](https://crates.io/crates/gg-alloc) as the global allocator
+//! when using `wasm-bindgen-test` to ensure that pointers outside the `i32`
+//! range are handled correctly.
+//!
+//! ### `std` (default)
+//!
+//! TODO:
+//!
+//! ### `strict-macro`
+//!
+//! All warnings the `#[wasm_bindgen]` macro emits are turned into hard errors.
+//! This mainly affects unused attribute options.
+//!
+//! ### Deprecated features
+//!
+//! #### `serde-serialize`
+//!
+//! **Deprecated:** Use the [`serde-wasm-bindgen`](https://docs.rs/serde-wasm-bindgen/latest/serde_wasm_bindgen/) crate instead.
+//!
+//! Enables the `JsValue::from_serde` and `JsValue::into_serde` methods for
+//! serializing and deserializing Rust types to and from JavaScript.
+//!
+//! #### `spans`
+//!
+//! **Deprecated:** This feature became a no-op in wasm-bindgen v0.2.20 (Sep 7, 2018).
 
 #![no_std]
 #![cfg_attr(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,14 @@
 //!
 //! Enables the internal cache for [`wasm_bindgen::intern`].
 //!
-//! ### `gg-alloc`
-//!
-//! Uses [`gg-allow`](https://crates.io/crates/gg-alloc) as the global allocator
-//! when using `wasm-bindgen-test` to ensure that pointers outside the `i32`
-//! range are handled correctly.
+//! This feature currently enables the `std` feature, meaning that it is not
+//! compatible with `no_std` environments.
 //!
 //! ### `std` (default)
 //!
-//! TODO:
+//! Enabling this feature will make the crate depend on the Rust standard library.
+//!
+//! Disable this feature to use this crate in `no_std` environments.
 //!
 //! ### `strict-macro`
 //!


### PR DESCRIPTION
This documents all features and puts them into 3 categories:

1. User-facing features. These are features users are allowed to use and that we actively support. E.g. `strict-macro`.
2. Deprecated features. These are features users are not supposed to use anymore, but nonetheless allowed.
3. Internal features. Features for testing and debugging that happen to public.

I documented all user-facing and deprecated feature and put a note on all internal features.