### PR TITLE
Update `webpack` away from personal fork

### DIFF
--- a/examples/add/package.json
+++ b/examples/add/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/canvas/package.json
+++ b/examples/canvas/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/char/package.json
+++ b/examples/char/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/closures/package.json
+++ b/examples/closures/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/console_log/package.json
+++ b/examples/console_log/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/dom/package.json
+++ b/examples/dom/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/duck-typed-interfaces/package.json
+++ b/examples/duck-typed-interfaces/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/fetch/package.json
+++ b/examples/fetch/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/guide-supported-types-examples/package.json
+++ b/examples/guide-supported-types-examples/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/hello_world/package.json
+++ b/examples/hello_world/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/import_js/package.json
+++ b/examples/import_js/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/julia_set/package.json
+++ b/examples/julia_set/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/paint/package.json
+++ b/examples/paint/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/performance/package.json
+++ b/examples/performance/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/request-animation-frame/package.json
+++ b/examples/request-animation-frame/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^3.11.3"
   }

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -8,7 +8,7 @@
     "css-loader": "^6.11.0",
     "html-webpack-plugin": "^5.6.0",
     "mini-css-extract-plugin": "^2.9.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/wasm-in-wasm-imports/package.json
+++ b/examples/wasm-in-wasm-imports/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/wasm-in-wasm/package.json
+++ b/examples/wasm-in-wasm/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/weather_report/package.json
+++ b/examples/weather_report/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/webaudio/package.json
+++ b/examples/webaudio/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/webgl/package.json
+++ b/examples/webgl/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/webrtc_datachannel/package.json
+++ b/examples/webrtc_datachannel/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }

--- a/examples/webxr/package.json
+++ b/examples/webxr/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "1.5.0",
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "github:daxpedda/webpack#externref",
+    "webpack": "^5.97.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.4"
   }


### PR DESCRIPTION
Now that a new version of `webpack` with https://github.com/webpack/webpack/pull/18979 is available we switch to that instead of using my personal fork.

Partly reverts #4253.