### PR TITLE
Fix features on `wasm-bindgen-msrv` crate

### DIFF
--- a/crates/msrv/lib/Cargo.toml
+++ b/crates/msrv/lib/Cargo.toml
@@ -5,13 +5,12 @@ publish = false
 version = "0.0.0"
 
 [features]
-default = ["std"]
-std = [
-  "wasm-bindgen/std",
-  "js-sys/std",
-  "wasm-bindgen-futures/std",
-  "web-sys/std",
-  "wasm-bindgen-test/std",
+default = [
+  "wasm-bindgen/default",
+  "js-sys/default",
+  "wasm-bindgen-futures/default",
+  "web-sys/default",
+  "wasm-bindgen-test/default",
 ]
 
 [dependencies]

--- a/crates/msrv/resolver/Cargo.toml
+++ b/crates/msrv/resolver/Cargo.toml
@@ -6,13 +6,12 @@ resolver = "1"
 version = "0.0.0"
 
 [features]
-default = ["std"]
-std = [
-  "wasm-bindgen/std",
-  "js-sys/std",
-  "wasm-bindgen-futures/std",
-  "web-sys/std",
-  "wasm-bindgen-test/std",
+default = [
+  "wasm-bindgen/default",
+  "js-sys/default",
+  "wasm-bindgen-futures/default",
+  "web-sys/default",
+  "wasm-bindgen-test/default",
 ]
 
 [dependencies]


### PR DESCRIPTION
Implements the change requested [here](https://github.com/rustwasm/wasm-bindgen/pull/4278#pullrequestreview-2486688591). I made this its own PR, because this is a fix for the misconfigured features of the `msrv` crate and has nothing to do with marker traits.