### PR TITLE
Import memory and enable `module()` for Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Add test coverage support for Node.js.
   [#4348](https://github.com/rustwasm/wasm-bindgen/pull/4348)
 
+* Support importing memory and using `wasm_bindgen::module()` in Node.js.
+  [#4349](https://github.com/rustwasm/wasm-bindgen/pull/4349)
+
 ### Changed
 
 * Optional parameters are now typed as `T | undefined | null` to reflect the actual JS behavior.
@@ -50,7 +53,7 @@ Released 2024-12-07
 
 ### Added
 
-* Add support for multi-threading in Node.js.
+* Add support for compiling with `atomics` for Node.js.
   [#4318](https://github.com/rustwasm/wasm-bindgen/pull/4318)
 
 * Add `WASM_BINDGEN_TEST_DRIVER_TIMEOUT` environment variable to control the timeout to start and connect to the test driver.

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -580,10 +580,6 @@ impl OutputMode {
         matches!(self, OutputMode::NoModules { .. })
     }
 
-    fn web(&self) -> bool {
-        matches!(self, OutputMode::Web)
-    }
-
     fn esm_integration(&self) -> bool {
         matches!(
             self,


### PR DESCRIPTION
Revert #4318 in favor of actually importing the memory. This is getting us closer to actually be able to support multi-threading on Node.js.

I briefly attempted to get this into the bundler target as well. But quickly encountered https://github.com/webpack/webpack/issues/8157.