### PR TITLE
Better handle stuck WebDriver processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * Adding `getter`, `setter`, and `constructor` methods to enums now results in a compiler error. This was previously erroneously allowed and resulted in invalid JS code gen.
   [#4278](https://github.com/rustwasm/wasm-bindgen/pull/4278)
 
+* Handle stuck and failed WebDriver processes when re-trying to start them.
+  [#4340](https://github.com/rustwasm/wasm-bindgen/pull/4340)
+
 ### Fixed
 
 - Fixed using [JavaScript keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords) as identifiers not being handled correctly.


### PR DESCRIPTION
The first problem with Safari was that it could simply fail to bind the port, in which case we should keep re-trying. This was addressed in https://github.com/rustwasm/wasm-bindgen/pull/4320.

However there is a second problem: sometimes MacOS decides that the WebDriver doesn't have permissions. In which case the process gets stuck and we never figure out that it failed and therefor also don't retry.

This PR adds an additional detection mechanism where it reads the Stderr output, if something is in there when we just started, it means that the WebDriver failed to start and we just kill it and try again.

Inspired by https://github.com/flutter/engine/pull/48791.