### PR TITLE
Add support for cfg_attr for struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 * Add bindings to `Date.to_locale_time_string_with_options`.
   [#4384](https://github.com/rustwasm/wasm-bindgen/pull/4384)
 
+* `#[wasm_bindgen]` now correctly applies `#[cfg(...)]`s in `struct`s.
+  [#4351](https://github.com/rustwasm/wasm-bindgen/pull/4351)
+
+
 ### Changed
 
 * Optional parameters are now typed as `T | undefined | null` to reflect the actual JS behavior.

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -15,6 +15,7 @@ pub use crate::parser::BindgenAttrs;
 use crate::parser::{ConvertToAst, MacroParse};
 use backend::{Diagnostic, TryToTokens};
 use proc_macro2::TokenStream;
+use quote::quote;
 use quote::ToTokens;
 use quote::TokenStreamExt;
 use syn::parse::{Parse, ParseStream, Result as SynResult};
@@ -27,39 +28,22 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
     // if struct is encountered, add `derive` attribute and let everything happen there (workaround
     // to help parsing cfg_attr correctly).
     let item = syn::parse2::<syn::Item>(input)?;
-    if let syn::Item::Struct(mut s) = item {
-        s.attrs.insert(
-            0,
-            syn::Attribute {
-                pound_token: Default::default(),
-                style: syn::AttrStyle::Outer,
-                bracket_token: Default::default(),
-                meta: syn::parse_quote! {
-                    derive(wasm_bindgen::prelude::BindgenedStruct)
-                },
-            },
-        );
-        if !attr.is_empty() {
-            s.attrs.insert(
-                1,
-                syn::Attribute {
-                    pound_token: Default::default(),
-                    style: syn::AttrStyle::Outer,
-                    bracket_token: Default::default(),
-                    meta: syn::parse_quote! {
-                        wasm_bindgen(#attr)
-                    },
-                },
-            );
-        }
+    if let syn::Item::Struct(s) = item {
+        let opts: BindgenAttrs = syn::parse2(attr.clone())?;
+        let wasm_bindgen = opts
+            .wasm_bindgen()
+            .cloned()
+            .unwrap_or_else(|| syn::parse_quote! { wasm_bindgen });
 
-        let mut tokens = proc_macro2::TokenStream::new();
-        s.to_tokens(&mut tokens);
-        return Ok(tokens);
+        let item = quote! {
+            #[derive(#wasm_bindgen::__rt::BindgenedStruct)]
+            #[wasm_bindgen(#attr)]
+            #s
+        };
+        return Ok(item);
     }
 
     let opts = syn::parse2(attr)?;
-
     let mut tokens = proc_macro2::TokenStream::new();
     let mut program = backend::ast::Program::default();
     item.macro_parse(&mut program, (Some(opts), &mut tokens))?;

--- a/crates/macro-support/src/lib.rs
+++ b/crates/macro-support/src/lib.rs
@@ -40,7 +40,6 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
             },
         );
         if !attr.is_empty() {
-            let meta: syn::Meta = syn::parse2(attr)?;
             s.attrs.insert(
                 1,
                 syn::Attribute {
@@ -48,7 +47,7 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Diag
                     style: syn::AttrStyle::Outer,
                     bracket_token: Default::default(),
                     meta: syn::parse_quote! {
-                        wasm_bindgen(#meta)
+                        wasm_bindgen(#attr)
                     },
                 },
             );

--- a/crates/macro-support/src/parser.rs
+++ b/crates/macro-support/src/parser.rs
@@ -216,7 +216,7 @@ macro_rules! methods {
     };
 
     (@method $name:ident, $variant:ident(Span, String, Span)) => {
-        fn $name(&self) -> Option<(&str, Span)> {
+        pub(crate) fn $name(&self) -> Option<(&str, Span)> {
             self.attrs
                 .iter()
                 .find_map(|a| match &a.1 {
@@ -230,7 +230,7 @@ macro_rules! methods {
     };
 
     (@method $name:ident, $variant:ident(Span, JsNamespace, Vec<Span>)) => {
-        fn $name(&self) -> Option<(JsNamespace, &[Span])> {
+        pub(crate) fn $name(&self) -> Option<(JsNamespace, &[Span])> {
             self.attrs
                 .iter()
                 .find_map(|a| match &a.1 {
@@ -245,7 +245,7 @@ macro_rules! methods {
 
     (@method $name:ident, $variant:ident(Span, $($other:tt)*)) => {
         #[allow(unused)]
-        fn $name(&self) -> Option<&$($other)*> {
+        pub(crate) fn $name(&self) -> Option<&$($other)*> {
             self.attrs
                 .iter()
                 .find_map(|a| match &a.1 {
@@ -260,7 +260,7 @@ macro_rules! methods {
 
     (@method $name:ident, $variant:ident($($other:tt)*)) => {
         #[allow(unused)]
-        fn $name(&self) -> Option<&$($other)*> {
+        pub(crate) fn $name(&self) -> Option<&$($other)*> {
             self.attrs
                 .iter()
                 .find_map(|a| match &a.1 {
@@ -513,10 +513,10 @@ impl ConvertToAst<&ast::Program> for &mut syn::ItemStruct {
                  type parameters currently"
             );
         }
-        let struct_attrs = BindgenAttrs::find(&mut self.attrs)?;
+        let attrs = BindgenAttrs::find(&mut self.attrs)?;
 
         let mut fields = Vec::new();
-        let js_name = struct_attrs
+        let js_name = attrs
             .js_name()
             .map(|s| s.0.to_string())
             .unwrap_or(self.ident.unraw().to_string());
@@ -528,8 +528,8 @@ impl ConvertToAst<&ast::Program> for &mut syn::ItemStruct {
             );
         }
 
-        let is_inspectable = struct_attrs.inspectable().is_some();
-        let getter_with_clone = struct_attrs.getter_with_clone();
+        let is_inspectable = attrs.inspectable().is_some();
+        let getter_with_clone = attrs.getter_with_clone();
         for (i, field) in self.fields.iter_mut().enumerate() {
             match field.vis {
                 syn::Visibility::Public(..) => {}
@@ -571,9 +571,9 @@ impl ConvertToAst<&ast::Program> for &mut syn::ItemStruct {
             });
             attrs.check_used();
         }
-        let generate_typescript = struct_attrs.skip_typescript().is_none();
+        let generate_typescript = attrs.skip_typescript().is_none();
         let comments: Vec<String> = extract_doc_comments(&self.attrs);
-        struct_attrs.check_used();
+        attrs.check_used();
         Ok(ast::Struct {
             rust_name: self.ident.clone(),
             js_name,

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -60,3 +60,16 @@ pub fn __wasm_bindgen_class_marker(attr: TokenStream, input: TokenStream) -> Tok
         Err(diagnostic) => (quote! { #diagnostic }).into(),
     }
 }
+
+#[proc_macro_derive(BindgenedStruct, attributes(wasm_bindgen))]
+pub fn __wasm_bindgen_struct_marker(item: TokenStream) -> TokenStream {
+    match wasm_bindgen_macro_support::expand_struct_marker(item.into()) {
+        Ok(tokens) => {
+            if cfg!(feature = "xxx_debug_only_print_generated_code") {
+                println!("{}", tokens);
+            }
+            tokens.into()
+        }
+        Err(diagnostic) => (quote! { #diagnostic }).into(),
+    }
+}

--- a/crates/macro/ui-tests/import-keyword.stderr
+++ b/crates/macro/ui-tests/import-keyword.stderr
@@ -57,3 +57,17 @@ error: enum cannot use the JS keyword `switch` as its name
    |
 63 | pub enum switch {
    |          ^^^^^^
+
+warning: type `class` should have an upper camel case name
+  --> ui-tests/import-keyword.rs:59:12
+   |
+59 | pub struct class;
+   |            ^^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Class`
+   |
+   = note: `#[warn(non_camel_case_types)]` on by default
+
+warning: type `true` should have an upper camel case name
+  --> ui-tests/import-keyword.rs:61:12
+   |
+61 | pub struct r#true; // forbid value-like keywords
+   |            ^^^^^^ help: convert the identifier to upper camel case: `True`

--- a/crates/macro/ui-tests/pub-not-copy.stderr
+++ b/crates/macro/ui-tests/pub-not-copy.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: std::marker::Copy` is not satisfied
- --> ui-tests/pub-not-copy.rs:5:16
+ --> $DIR/pub-not-copy.rs:5:16
   |
 3 | #[wasm_bindgen]
   | --------------- in this procedural macro expansion
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `String: std::marker::Copy` is not satisfied
   |                ^^^^^^ the trait `std::marker::Copy` is not implemented for `String`
   |
 note: required by a bound in `assert_copy`
- --> ui-tests/pub-not-copy.rs:3:1
+ --> $DIR/pub-not-copy.rs:3:1
   |
 3 | #[wasm_bindgen]
   | ^^^^^^^^^^^^^^^ required by this bound in `assert_copy`

--- a/crates/macro/ui-tests/pub-not-copy.stderr
+++ b/crates/macro/ui-tests/pub-not-copy.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: std::marker::Copy` is not satisfied
- --> $DIR/pub-not-copy.rs:5:16
+ --> ui-tests/pub-not-copy.rs:5:16
   |
 3 | #[wasm_bindgen]
   | --------------- in this procedural macro expansion
@@ -8,8 +8,8 @@ error[E0277]: the trait bound `String: std::marker::Copy` is not satisfied
   |                ^^^^^^ the trait `std::marker::Copy` is not implemented for `String`
   |
 note: required by a bound in `assert_copy`
- --> $DIR/pub-not-copy.rs:3:1
+ --> ui-tests/pub-not-copy.rs:3:1
   |
 3 | #[wasm_bindgen]
   | ^^^^^^^^^^^^^^^ required by this bound in `assert_copy`
-  = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `wasm_bindgen::prelude::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/pub-not-copy.stderr
+++ b/crates/macro/ui-tests/pub-not-copy.stderr
@@ -12,4 +12,4 @@ note: required by a bound in `assert_copy`
   |
 3 | #[wasm_bindgen]
   | ^^^^^^^^^^^^^^^ required by this bound in `assert_copy`
-  = note: this error originates in the derive macro `wasm_bindgen::prelude::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the derive macro `wasm_bindgen::__rt::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/macro/ui-tests/struct-fields.stderr
+++ b/crates/macro/ui-tests/struct-fields.stderr
@@ -12,7 +12,7 @@ note: required by a bound in `__wbg_get_bar_a::assert_copy`
    |
 8  | #[wasm_bindgen]
    | ^^^^^^^^^^^^^^^ required by this bound in `assert_copy`
-   = note: this error originates in the attribute macro `wasm_bindgen` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `wasm_bindgen::prelude::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: Clone` is not satisfied
   --> ui-tests/struct-fields.rs:12:12

--- a/crates/macro/ui-tests/struct-fields.stderr
+++ b/crates/macro/ui-tests/struct-fields.stderr
@@ -12,7 +12,7 @@ note: required by a bound in `__wbg_get_bar_a::assert_copy`
    |
 8  | #[wasm_bindgen]
    | ^^^^^^^^^^^^^^^ required by this bound in `assert_copy`
-   = note: this error originates in the derive macro `wasm_bindgen::prelude::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the derive macro `wasm_bindgen::__rt::BindgenedStruct` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Foo: Clone` is not satisfied
   --> ui-tests/struct-fields.rs:12:12

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,6 @@ pub mod prelude {
     pub use crate::JsCast;
     pub use crate::JsValue;
     pub use crate::UnwrapThrowExt;
-    pub use wasm_bindgen_macro::BindgenedStruct;
     #[doc(hidden)]
     pub use wasm_bindgen_macro::__wasm_bindgen_class_marker;
     pub use wasm_bindgen_macro::wasm_bindgen;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ pub mod prelude {
     pub use crate::JsCast;
     pub use crate::JsValue;
     pub use crate::UnwrapThrowExt;
+    pub use wasm_bindgen_macro::BindgenedStruct;
     #[doc(hidden)]
     pub use wasm_bindgen_macro::__wasm_bindgen_class_marker;
     pub use wasm_bindgen_macro::wasm_bindgen;

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -19,6 +19,8 @@ pub extern crate std;
 
 pub mod marker;
 
+pub use wasm_bindgen_macro::BindgenedStruct;
+
 /// Wrapper around [`Lazy`] adding `Send + Sync` when `atomics` is not enabled.
 pub struct LazyCell<T, F = fn() -> T>(Wrapper<Lazy<T, F>>);
 

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -170,6 +170,13 @@ exports.js_renamed_field = () => {
     x.foo();
 }
 
+exports.js_conditional_skip = () => {
+    const x = new wasm.ConditionalSkipClass();
+    assert.strictEqual(x.skipped_field, undefined);
+    assert.ok(x.not_skipped_field === 42);
+    assert.strictEqual(x.needs_clone, 'foo');
+}
+
 exports.js_conditional_bindings = () => {
     const x = new wasm.ConditionalBindings();
     x.free();

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -480,7 +480,10 @@ fn renamed_field() {
     js_renamed_field();
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(
+    target_arch = "wasm32",
+    wasm_bindgen(inspectable, js_name = "ConditionalSkipClass")
+)]
 pub struct ConditionalSkip {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub skipped_field: [u8; 8],

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -481,6 +481,16 @@ fn renamed_field() {
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub struct ConditionalSkip {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub skipped_field: [u8; 8],
+
+    /// cfg_attr annotated field
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
+    pub needs_clone: String,
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub struct ConditionalBindings {}
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -24,6 +24,7 @@ extern "C" {
     fn js_access_fields();
     fn js_renamed_export();
     fn js_renamed_field();
+    fn js_conditional_skip();
     fn js_conditional_bindings();
 
     fn js_assert_none(a: Option<OptionClass>);
@@ -485,12 +486,34 @@ fn renamed_field() {
     wasm_bindgen(inspectable, js_name = "ConditionalSkipClass")
 )]
 pub struct ConditionalSkip {
+    /// [u8; 8] cannot be passed to JS, so this won't compile without `skip`
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub skipped_field: [u8; 8],
 
-    /// cfg_attr annotated field
+    /// this field shouldn't be skipped as predicate is false
+    #[cfg_attr(all(target_arch = "wasm32", target_arch = "x86"), wasm_bindgen(skip))]
+    pub not_skipped_field: u32,
+
+    /// String struct field requires `getter_with_clone` to compile
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
     pub needs_clone: String,
+}
+
+#[wasm_bindgen(js_class = "ConditionalSkipClass")]
+impl ConditionalSkip {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> ConditionalSkip {
+        ConditionalSkip {
+            skipped_field: [0u8; 8],
+            not_skipped_field: 42,
+            needs_clone: "foo".to_string(),
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+fn conditional_skip() {
+    js_conditional_skip();
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]


### PR DESCRIPTION
closes #2703

Overview

- During #[wasm_bindgen] attribute macro expansion on struct, instead of generating ast for Program, it puts a #[derive(BindgenedStruct)] on it and preserves all the wasm_bindgen atributes as-is.
- When #[derive(BindgenedStruct)] is expanded, cfg_attr are already evaluated, so macro can just processes the leftover attributes and generate the glue code required, as it's done now. Attributes are then automatically removed by the compiler, since macro is defined as #[proc_macro_derive(BindgenedStruct, attributes(wasm_bindgen))].
