### PR TITLE
Fix passing large arrays with JS values into Wasm detaching memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
     3. The name of an imported function if the function is not a method and does not have a `js_namespace` or `module` attribute.
   - Using JS keywords on imports in places other than the above will no longer cause the keywords to be escaped as `_{keyword}`.
 
+* Fixed passing large arrays into Rust failing because of internal memory allocations invalidating the memory buffer.
+  [#4353](https://github.com/rustwasm/wasm-bindgen/pull/4353)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.99](https://github.com/rustwasm/wasm-bindgen/compare/0.2.98...0.2.99)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1621,26 +1621,25 @@ __wbg_set_wasm(wasm);"
                 let add = self.expose_add_to_externref_table(table, alloc)?;
                 self.global(&format!(
                     "
-                        function {}(array, malloc) {{
+                        function {ret}(array, malloc) {{
                             const ptr = malloc(array.length * 4, 4) >>> 0;
-                            const mem = {}();
                             for (let i = 0; i < array.length; i++) {{
-                                mem.setUint32(ptr + 4 * i, {}(array[i]), true);
+                                const add = {add}(array[i]);
+                                {mem}().setUint32(ptr + 4 * i, add, true);
                             }}
                             WASM_VECTOR_LEN = array.length;
                             return ptr;
                         }}
                     ",
-                    ret, mem, add,
                 ));
             }
             _ => {
                 self.expose_add_heap_object();
                 self.global(&format!(
                     "
-                        function {}(array, malloc) {{
+                        function {ret}(array, malloc) {{
                             const ptr = malloc(array.length * 4, 4) >>> 0;
-                            const mem = {}();
+                            const mem = {mem}();
                             for (let i = 0; i < array.length; i++) {{
                                 mem.setUint32(ptr + 4 * i, addHeapObject(array[i]), true);
                             }}
@@ -1648,7 +1647,6 @@ __wbg_set_wasm(wasm);"
                             return ptr;
                         }}
                     ",
-                    ret, mem,
                 ));
             }
         }

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -666,9 +666,9 @@ function addToExternrefTable0(obj) {
 
 function passArrayJsValueToWasm0(array, malloc) {
     const ptr = malloc(array.length * 4, 4) >>> 0;
-    const mem = getDataViewMemory0();
     for (let i = 0; i < array.length; i++) {
-        mem.setUint32(ptr + 4 * i, addToExternrefTable0(array[i]), true);
+        const add = addToExternrefTable0(array[i]);
+        getDataViewMemory0().setUint32(ptr + 4 * i, add, true);
     }
     WASM_VECTOR_LEN = array.length;
     return ptr;

--- a/crates/cli/tests/reference/typescript-type.js
+++ b/crates/cli/tests/reference/typescript-type.js
@@ -49,9 +49,9 @@ function addToExternrefTable0(obj) {
 
 function passArrayJsValueToWasm0(array, malloc) {
     const ptr = malloc(array.length * 4, 4) >>> 0;
-    const mem = getDataViewMemory0();
     for (let i = 0; i < array.length; i++) {
-        mem.setUint32(ptr + 4 * i, addToExternrefTable0(array[i]), true);
+        const add = addToExternrefTable0(array[i]);
+        getDataViewMemory0().setUint32(ptr + 4 * i, add, true);
     }
     WASM_VECTOR_LEN = array.length;
     return ptr;

--- a/tests/wasm/js_vec.js
+++ b/tests/wasm/js_vec.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const wasm = require('wasm-bindgen-test');
+
+// Test if passing large arrays which cause allocation in Wasm are properly handled.
+exports.pass_array_with_allocation = () => {
+    const values = new Array(10_000).fill(1)
+    assert.strictEqual(wasm.test_sum(values), 10_000);
+};

--- a/tests/wasm/js_vec.rs
+++ b/tests/wasm/js_vec.rs
@@ -1,0 +1,24 @@
+use js_sys::Number;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen(module = "tests/wasm/js_vec.js")]
+extern "C" {
+    fn pass_array_with_allocation();
+}
+
+#[wasm_bindgen]
+pub fn test_sum(param: Vec<Number>) -> f64 {
+    let mut sum = 0.;
+
+    for data in param {
+        sum += data.value_of();
+    }
+
+    sum
+}
+
+#[wasm_bindgen_test]
+fn test() {
+    pass_array_with_allocation();
+}

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -40,6 +40,7 @@ pub mod inner_self;
 pub mod intrinsics;
 pub mod js_keywords;
 pub mod js_objects;
+pub mod js_vec;
 pub mod jscast;
 pub mod link_to;
 pub mod macro_rules;


### PR DESCRIPTION
When passing arrays with JS values from JS to Wasm we have to insert each entry into the reference type table. Each insertion can cause allocation, which invalidates the memory buffer and throws.

This PR fixes it by getting a new memory view after every insertion. This will likely degrade performance especially when passing large arrays. To fix this we have to find a way to pass a larger set of reference values without having to call into Rust each time.

Fixes #4352.