### PR TITLE
Fix CLI binary names

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -28,7 +28,7 @@ mod server;
 mod shell;
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(name = "wasm-bindgen-test-runner", version, about, long_about = None)]
 struct Cli {
     #[arg(
         index = 1,

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -6,6 +6,7 @@ use wasm_bindgen_cli_support::{Bindgen, EncodeInto};
 
 #[derive(Debug, Parser)]
 #[command(
+    name = "wasm-bindgen",
     version,
     about,
     long_about = None,

--- a/crates/cli/src/bin/wasm2es6js.rs
+++ b/crates/cli/src/bin/wasm2es6js.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(
+    name = "wasm2es6js",
     version,
     about,
     long_about = None,

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -120,7 +120,7 @@ fn version_useful() {
         .arg("-V")
         .assert()
         .stdout(str::ends_with("\n"))
-        .stdout(str::starts_with("wasm-bindgen-cli "))
+        .stdout(str::starts_with("wasm-bindgen "))
         .success();
 }
 


### PR DESCRIPTION
Since #4354, `-V` and `-h` would always show the name of the binary being `wasm-bindgen-cli` instead of `wasm-bindgen`, `wasm-bindgen-test-runner` and `wasm2es6js`. This PR fixes that.

Follow-up to #4354.