### PR TITLE
Add `--list`, `--ignored` and `--exact` to `wasm-bindgen-test-runner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Support importing memory and using `wasm_bindgen::module()` in Node.js.
   [#4349](https://github.com/rustwasm/wasm-bindgen/pull/4349)
 
-* Add `--list` and `ignored` to `wasm-bindgen-test-runner`, analogous to `cargo test`.
+* Add `--list`, `--ignored` and `--exact` to `wasm-bindgen-test-runner`, analogous to `cargo test`.
   [#4356](https://github.com/rustwasm/wasm-bindgen/pull/4356)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Support importing memory and using `wasm_bindgen::module()` in Node.js.
   [#4349](https://github.com/rustwasm/wasm-bindgen/pull/4349)
 
+* Add `--list` argument to `wasm-bindgen-test-runner`.
+  [#4356](https://github.com/rustwasm/wasm-bindgen/pull/4356)
+
 ### Changed
 
 * Optional parameters are now typed as `T | undefined | null` to reflect the actual JS behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Support importing memory and using `wasm_bindgen::module()` in Node.js.
   [#4349](https://github.com/rustwasm/wasm-bindgen/pull/4349)
 
-* Add `--list` argument to `wasm-bindgen-test-runner`.
+* Add `--list` and `ignored` to `wasm-bindgen-test-runner`, analogous to `cargo test`.
   [#4356](https://github.com/rustwasm/wasm-bindgen/pull/4356)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Support importing memory and using `wasm_bindgen::module()` in Node.js.
   [#4349](https://github.com/rustwasm/wasm-bindgen/pull/4349)
 
-* Add `--list`, `--ignored` and `--exact` to `wasm-bindgen-test-runner`, analogous to `cargo test`.
+* Add `--list`, `--ignored`, `--exact` and `--nocapture` to `wasm-bindgen-test-runner`, analogous to `cargo test`.
   [#4356](https://github.com/rustwasm/wasm-bindgen/pull/4356)
 
 ### Changed
@@ -36,6 +36,9 @@
 
 * Remove `WASM_BINDGEN_THREADS_MAX_MEMORY` and `WASM_BINDGEN_THREADS_STACK_SIZE`. The maximum memory size can be set via `-Clink-arg=--max-memory=<size>`. The stack size of a thread can be set when initializing the thread via the `default` function.
   [#4363](https://github.com/rustwasm/wasm-bindgen/pull/4363)
+
+* `console.*()` calls in tests are now always intercepted by default. To show them use `--nocapture`. When shown they are always printed in-place instead of after test results, analogous to `cargo test`.
+  [#4356](https://github.com/rustwasm/wasm-bindgen/pull/4356)
 
 ### Fixed
 

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
@@ -13,6 +13,7 @@ pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: &[String]) -> Resul
     let mut js_to_execute = format!(
         r#"import * as wasm from "./{module}.js";
 
+        const nocapture = {nocapture};
         {console_override}
 
         window.__wbg_test_invoke = f => f();
@@ -21,6 +22,7 @@ pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: &[String]) -> Resul
 
         const tests = [];
     "#,
+        nocapture = cli.nocapture.clone(),
         console_override = SHARED_SETUP,
         args = cli.into_args(),
     );

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -210,14 +210,15 @@ pub fn run(
             println!("output div contained:\n{}", tab(&output));
         }
     }
-    if !logs.is_empty() {
-        println!("console.log div contained:\n{}", tab(&logs));
-    }
-    if !errors.is_empty() {
-        println!("console.log div contained:\n{}", tab(&errors));
-    }
 
     if !output.contains("test result: ok") {
+        if !logs.is_empty() {
+            println!("console.log div contained:\n{}", tab(&logs));
+        }
+        if !errors.is_empty() {
+            println!("console.log div contained:\n{}", tab(&errors));
+        }
+
         bail!("some tests failed")
     }
 

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index-headless.html
@@ -18,10 +18,14 @@
          }
      };
 
+     // {NOCAPTURE}
      const wrap = method => {
          const og = orig(`console_${method}`);
          const on_method = `on_console_${method}`;
          console[method] = function (...args) {
+             if (nocapture) {
+                 orig("output").apply(this, args);
+             }
              if (window[on_method]) {
                  window[on_method](args);
              }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -51,6 +51,11 @@ struct Cli {
     list: bool,
     #[arg(
         long,
+        help = "don't capture `console.*()` of each task, allow printing directly"
+    )]
+    nocapture: bool,
+    #[arg(
+        long,
         value_enum,
         value_name = "terse",
         help = "Configure formatting of output"

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -34,10 +34,10 @@ struct Cli {
         help = "The file to test. `cargo test` passes this argument for you."
     )]
     file: PathBuf,
-    #[arg(long = "include-ignored", help = "Run ignored tests")]
+    #[arg(long, help = "Run ignored tests")]
     include_ignored: bool,
     #[arg(
-        long = "skip",
+        long,
         value_name = "FILTER",
         help = "Skip tests whose names contain FILTER (this flag can be used multiple times)"
     )]

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -13,6 +13,7 @@
 
 use anyhow::{bail, Context};
 use clap::Parser;
+use clap::ValueEnum;
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -42,6 +43,15 @@ struct Cli {
         help = "Skip tests whose names contain FILTER (this flag can be used multiple times)"
     )]
     skip: Vec<String>,
+    #[arg(long, help = "List all tests and benchmarks")]
+    list: bool,
+    #[arg(
+        long,
+        value_enum,
+        value_name = "terse",
+        help = "Configure formatting of output"
+    )]
+    format: Option<FormatSetting>,
     #[arg(
         index = 2,
         value_name = "FILTER",
@@ -85,10 +95,6 @@ fn main() -> anyhow::Result<()> {
         .map(Path::new)
         .context("file to test is not a valid file, can't extract file name")?;
 
-    let tmpdir = tempfile::tempdir()?;
-
-    let module = "wasm-bindgen-test";
-
     // Collect all tests that the test harness is supposed to run. We assume
     // that any exported function with the prefix `__wbg_test` is a test we need
     // to execute.
@@ -98,11 +104,36 @@ fn main() -> anyhow::Result<()> {
     let mut tests = Vec::new();
 
     for export in wasm.exports.iter() {
-        if !export.name.starts_with("__wbgt_") {
-            continue;
+        if export.name.starts_with("__wbgt_") {
+            tests.push(export.name.to_string());
         }
-        tests.push(export.name.to_string());
     }
+
+    if cli.list {
+        'outer: for test in tests {
+            if let Some(filter) = &cli.filter {
+                if !test.contains(filter) {
+                    continue;
+                }
+            }
+
+            for skip in &cli.skip {
+                if test.contains(skip) {
+                    continue 'outer;
+                }
+            }
+
+            println!("{}: test", test.split_once("::").unwrap().1);
+        }
+
+        // Returning cleanly has the strange effect of outputting
+        // an additional empty line with spaces in it.
+        std::process::exit(0);
+    }
+
+    let tmpdir = tempfile::tempdir()?;
+
+    let module = "wasm-bindgen-test";
 
     // Right now there's a bug where if no tests are present then the
     // `wasm-bindgen-test` runtime support isn't linked in, so just bail out
@@ -347,4 +378,11 @@ fn coverage_args(file_name: &Path) -> PathBuf {
         }
         None => PathBuf::from(generated(file_name, &prefix)),
     }
+}
+
+/// Possible values for the `--format` option.
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum FormatSetting {
+    /// Display one character per test
+    Terse,
 }

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -90,12 +90,14 @@ pub fn wasm_bindgen_test(
         quote! { cx.execute_sync(test_name, #ident, #should_panic_par, #ignore_par); }
     };
 
+    let ignore_name = if ignore.is_some() { "$" } else { "" };
+
     let wasm_bindgen_path = attributes.wasm_bindgen_path;
     tokens.extend(
         quote! {
             const _: () = {
                 #wasm_bindgen_path::__rt::wasm_bindgen::__wbindgen_coverage! {
-                #[export_name = ::core::concat!("__wbgt_", ::core::module_path!(), "::", ::core::stringify!(#ident))]
+                #[export_name = ::core::concat!("__wbgt_", #ignore_name, ::core::module_path!(), "::", ::core::stringify!(#ident))]
                 #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
                 extern "C" fn __wbgt_test(cx: &#wasm_bindgen_path::__rt::Context) {
                     let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -4,12 +4,8 @@
 extern crate proc_macro;
 
 use proc_macro2::*;
-use quote::format_ident;
 use quote::quote;
 use quote::quote_spanned;
-use std::sync::atomic::*;
-
-static CNT: AtomicUsize = AtomicUsize::new(0);
 
 #[proc_macro_attribute]
 pub fn wasm_bindgen_test(
@@ -94,18 +90,14 @@ pub fn wasm_bindgen_test(
         quote! { cx.execute_sync(test_name, #ident, #should_panic_par, #ignore_par); }
     };
 
-    // We generate a `#[no_mangle]` with a known prefix so the test harness can
-    // later slurp up all of these functions and pass them as arguments to the
-    // main test harness. This is the entry point for all tests.
-    let name = format_ident!("__wbgt_{}_{}", ident, CNT.fetch_add(1, Ordering::SeqCst));
     let wasm_bindgen_path = attributes.wasm_bindgen_path;
     tokens.extend(
         quote! {
             const _: () = {
                 #wasm_bindgen_path::__rt::wasm_bindgen::__wbindgen_coverage! {
-                #[no_mangle]
+                #[export_name = ::core::concat!("__wbgt_", ::core::module_path!(), "::", ::core::stringify!(#ident))]
                 #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
-                pub extern "C" fn #name(cx: &#wasm_bindgen_path::__rt::Context) {
+                extern "C" fn __wbgt_test(cx: &#wasm_bindgen_path::__rt::Context) {
                     let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
                     #test_body
                 }

--- a/crates/test/src/rt/node.rs
+++ b/crates/test/src/rt/node.rs
@@ -19,6 +19,8 @@ extern "C" {
     type NodeError;
     #[wasm_bindgen(method, getter, js_class = "Error", structural)]
     fn stack(this: &NodeError) -> String;
+    #[wasm_bindgen(js_name = __wbgtest_og_console_log)]
+    fn og_console_log(s: &str);
 }
 
 impl Node {
@@ -30,7 +32,7 @@ impl Node {
 
 impl super::Formatter for Node {
     fn writeln(&self, line: &str) {
-        super::js_console_log(line);
+        og_console_log(line);
     }
 
     fn log_test(&self, name: &str, result: &TestResult) {


### PR DESCRIPTION
This PR intends to add support for `nextest` to `wasm-bindgen-test-runner`. For the requirements see [the `nextest` documentation](https://nexte.st/docs/design/custom-test-harnesses/).

- Add `--list` and the corresponding `--format`. We only support the `terse` format and only together with `--list`.
- Add `--ignored`.
- Add `--exact`.
- Add `--nocapture`. Browsers now show `console.*()` calls in-place instead of after test results, analogous to `cargo test`.

While this PR now makes `wasm-bindgen-test-runner` work with `cargo nextest`, there are a couple of caveats:
- Spawning the driver takes a non-trivial amount of time. This can already be addressed by using `*DRIVER_REMOTE`. That said, `geckodriver` doesn't support parallel sessions.
- Creating sessions takes a non-trivial amount of time. The solution here probably involves creating some sort of session manager that can be spawned via `wasm-bindgen-test-runner`.
- `wasm-bindgen` takes a non-trivial amount of time when not compiled with the `release` profile. While this isn't an issue for users, its an issue for our CI. We can still improve the situation further by caching the post-processed output.

Replaces #3920.
Addresses #3891.