### PR TITLE
Align test output closer to native `cargo test`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 * Handle stuck and failed WebDriver processes when re-trying to start them.
   [#4340](https://github.com/rustwasm/wasm-bindgen/pull/4340)
 
+* Align test output closer to native `cargo test`.
+  [#4358](https://github.com/rustwasm/wasm-bindgen/pull/4358)
+
 ### Fixed
 
 - Fixed using [JavaScript keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords) as identifiers not being handled correctly.

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -216,15 +216,13 @@ fn main() -> anyhow::Result<()> {
 
     let browser_timeout = env::var("WASM_BINDGEN_TEST_TIMEOUT")
         .map(|timeout| {
-            timeout
+            let timeout = timeout
                 .parse()
-                .expect("Could not parse 'WASM_BINDGEN_TEST_TIMEOUT'")
+                .expect("Could not parse 'WASM_BINDGEN_TEST_TIMEOUT'");
+            println!("Set timeout to {} seconds...", timeout);
+            timeout
         })
         .unwrap_or(20);
-
-    if debug {
-        println!("Set timeout to {} seconds...", browser_timeout);
-    }
 
     // Make the generated bindings available for the tests to execute against.
     shell.status("Executing bindgen...");


### PR DESCRIPTION
The following changes were introduced:
- Remove the name of the crate from each test name.
- Remove the newline between test runs and the summary.
- Add total duration of test run to the summary.
- Remove the "Set timeout to 20 seconds..." message unless the default was overwritten.