### PR TITLE
Error if URL in `<WEBDRIVER>_REMOTE` can't be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 * Align test output closer to native `cargo test`.
   [#4358](https://github.com/rustwasm/wasm-bindgen/pull/4358)
 
+* Error if URL in `<WEBDRIVER>_REMOTE` can't be parsed instead of just ignoring it.
+  [#4362](https://github.com/rustwasm/wasm-bindgen/pull/4362)
+
 ### Fixed
 
 - Fixed using [JavaScript keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords) as identifiers not being handled correctly.
@@ -48,6 +51,9 @@
 
 * Use OS provided temporary directory for tests instead of Cargo's `target` directory.
   [#4361](https://github.com/rustwasm/wasm-bindgen/pull/4361)
+
+* Error if URL in `<WEBDRIVER>_REMOTE` can't be parsed.
+  [#4362](https://github.com/rustwasm/wasm-bindgen/pull/4362)
 
 --------------------------------------------------------------------------------
 

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/headless.rs
@@ -269,10 +269,7 @@ impl Driver {
         for (driver, ctor) in drivers.iter() {
             let env = format!("{}_REMOTE", driver.to_uppercase());
             let url = match env::var(&env) {
-                Ok(var) => match Url::parse(&var) {
-                    Ok(url) => url,
-                    Err(_) => continue,
-                },
+                Ok(var) => Url::parse(&var).context(format!("failed to parse `{env}`"))?,
                 Err(_) => continue,
             };
             return Ok(ctor(Locate::Remote(url)));


### PR DESCRIPTION
Currently when not passing a proper URL into `<WEBDRIVER>_REMOTE`, `wasm-bindgen-test-runner` simply ignores the environment variable.

This PR changes the behavior to instead return an error.