### PR TITLE
Remove `WASM_BINDGEN_THREADS_MAX_MEMORY` and `WASM_BINDGEN_THREADS_STACK_SIZE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Error if URL in `<WEBDRIVER>_REMOTE` can't be parsed instead of just ignoring it.
   [#4362](https://github.com/rustwasm/wasm-bindgen/pull/4362)
 
+* Remove `WASM_BINDGEN_THREADS_MAX_MEMORY` and `WASM_BINDGEN_THREADS_STACK_SIZE`. The maximum memory size can be set via `-Clink-arg=--max-memory=<size>`. The stack size of a thread can be set when initializing the thread via the `default` function.
+  [#4363](https://github.com/rustwasm/wasm-bindgen/pull/4363)
+
 ### Fixed
 
 - Fixed using [JavaScript keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords) as identifiers not being handled correctly.

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -158,7 +158,7 @@ impl<'a> Context<'a> {
             used_string_enums: Default::default(),
             exported_classes: Some(Default::default()),
             config,
-            threads_enabled: config.threads.is_enabled(module),
+            threads_enabled: wasm_bindgen_threads_xform::is_enabled(module),
             module,
             npm_dependencies: Default::default(),
             next_export_idx: 0,

--- a/crates/threads-xform/tests/all.rs
+++ b/crates/threads-xform/tests/all.rs
@@ -23,9 +23,7 @@ fn runtest(test: &Test) -> Result<String> {
         .generate_producers_section(false)
         .parse(&wasm)?;
 
-    let config = wasm_bindgen_threads_xform::Config::new();
-
-    config.run(&mut module)?;
+    wasm_bindgen_threads_xform::run(&mut module)?;
     walrus::passes::gc::run(&mut module);
 
     let features = wasmparser::WasmFeatures::default() | wasmparser::WasmFeatures::THREADS;


### PR DESCRIPTION
Currently, when compiling with `atomics`, the maximum memory size can be set via `WASM_BINDGEN_THREADS_MAX_MEMORY` and the stack size of a thread can be set via `WASM_BINDGEN_THREADS_STACK_SIZE`.

Both are not needed anymore. The maximum memory size can be set via `-Clink-arg=--max-memory=<size>`. The stack size of a thread can be set when initializing the thread via the `default` function, which was introduced in #3995.

Additionally, I removed the `WASM_BINDGEN_THREADS`, which would not actually set the memory to `shared`, making it just set a maximum memory size without any real useful other effect.