### PR TITLE
Apply transformations even if the shim is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@
 * Error if URL in `<WEBDRIVER>_REMOTE` can't be parsed.
   [#4362](https://github.com/rustwasm/wasm-bindgen/pull/4362)
 
+* Internal functions are now removed instead of invalidly imported if they are unused.
+  [#4366](https://github.com/rustwasm/wasm-bindgen/pull/4366)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.99](https://github.com/rustwasm/wasm-bindgen/compare/0.2.98...0.2.99)

--- a/crates/cli/tests/reference/intrinsic-only.d.ts
+++ b/crates/cli/tests/reference/intrinsic-only.d.ts
@@ -1,0 +1,3 @@
+/* tslint:disable */
+/* eslint-disable */
+export function causes_error(): number;

--- a/crates/cli/tests/reference/intrinsic-only.js
+++ b/crates/cli/tests/reference/intrinsic-only.js
@@ -1,0 +1,57 @@
+let wasm;
+export function __wbg_set_wasm(val) {
+    wasm = val;
+}
+
+
+const lTextDecoder = typeof TextDecoder === 'undefined' ? (0, module.require)('util').TextDecoder : TextDecoder;
+
+let cachedTextDecoder = new lTextDecoder('utf-8', { ignoreBOM: true, fatal: true });
+
+cachedTextDecoder.decode();
+
+let cachedUint8ArrayMemory0 = null;
+
+function getUint8ArrayMemory0() {
+    if (cachedUint8ArrayMemory0 === null || cachedUint8ArrayMemory0.byteLength === 0) {
+        cachedUint8ArrayMemory0 = new Uint8Array(wasm.memory.buffer);
+    }
+    return cachedUint8ArrayMemory0;
+}
+
+function getStringFromWasm0(ptr, len) {
+    ptr = ptr >>> 0;
+    return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
+}
+
+function takeFromExternrefTable0(idx) {
+    const value = wasm.__wbindgen_export_0.get(idx);
+    wasm.__externref_table_dealloc(idx);
+    return value;
+}
+/**
+ * @returns {number}
+ */
+export function causes_error() {
+    const ret = wasm.causes_error();
+    if (ret[2]) {
+        throw takeFromExternrefTable0(ret[1]);
+    }
+    return ret[0];
+}
+
+export function __wbindgen_init_externref_table() {
+    const table = wasm.__wbindgen_export_0;
+    const offset = table.grow(4);
+    table.set(0, undefined);
+    table.set(offset + 0, undefined);
+    table.set(offset + 1, null);
+    table.set(offset + 2, true);
+    table.set(offset + 3, false);
+    ;
+};
+
+export function __wbindgen_throw(arg0, arg1) {
+    throw new Error(getStringFromWasm0(arg0, arg1));
+};
+

--- a/crates/cli/tests/reference/intrinsic-only.rs
+++ b/crates/cli/tests/reference/intrinsic-only.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn causes_error() -> Result<f64, JsError> {
+    Ok(1.0)
+}

--- a/crates/cli/tests/reference/intrinsic-only.wat
+++ b/crates/cli/tests/reference/intrinsic-only.wat
@@ -1,0 +1,17 @@
+(module $reference_test.wasm
+  (type (;0;) (func))
+  (type (;1;) (func (result f64 i32 i32)))
+  (type (;2;) (func (param i32)))
+  (import "./reference_test_bg.js" "__wbindgen_init_externref_table" (func (;0;) (type 0)))
+  (func $__externref_table_dealloc (;1;) (type 2) (param i32))
+  (func $"causes_error multivalue shim" (;2;) (type 1) (result f64 i32 i32))
+  (table (;0;) 128 externref)
+  (memory (;0;) 17)
+  (export "memory" (memory 0))
+  (export "causes_error" (func $"causes_error multivalue shim"))
+  (export "__wbindgen_export_0" (table 0))
+  (export "__externref_table_dealloc" (func $__externref_table_dealloc))
+  (export "__wbindgen_start" (func 0))
+  (@custom "target_features" (after code) "\04+\0amultivalue+\0fmutable-globals+\0freference-types+\08sign-ext")
+)
+

--- a/crates/externref-xform/src/lib.rs
+++ b/crates/externref-xform/src/lib.rs
@@ -302,12 +302,6 @@ impl Transform<'_> {
         self.process_elements(module)?;
         assert!(self.cx.new_elements.is_empty());
 
-        // If we didn't actually transform anything, no need to inject or
-        // rewrite anything from below.
-        if self.shims.is_empty() {
-            return Ok(());
-        }
-
         // Perform all instruction transformations to rewrite calls between
         // functions and make sure everything is still hooked up right.
         self.rewrite_calls(module)?;


### PR DESCRIPTION
Currently WBG does some transformations to replace internal instructions after all the post-processing is done. However, if no shim functions were generated, it was assuming that no instructions were used and moves on without the transformations. But with the reference-type transformations, some internal functions were used by some other internal functions! So the transformations is still needed even if no shim functions were generated.

This PR removes this optimizations and WBG now always does the instruction transformations.

Fixes #4365.