### PR TITLE
Sync `wasm-tools` dependencies

### DIFF
--- a/crates/externref-xform/Cargo.toml
+++ b/crates/externref-xform/Cargo.toml
@@ -22,7 +22,7 @@ wasm-bindgen-wasm-conventions = { path = "../wasm-conventions", version = "=0.2.
 rayon = "1.0"
 wasmprinter = "0.214"
 wast = "214"
-wat = "1.0"
+wat = "~1.214"
 
 [lints]
 workspace = true

--- a/crates/wasm-conventions/Cargo.toml
+++ b/crates/wasm-conventions/Cargo.toml
@@ -17,7 +17,7 @@ walrus = "0.23"
 # Matching the version `walrus` depends on.
 anyhow = "1.0"
 log = "0.4"
-wasmparser = "0.212"
+wasmparser = "0.214"
 
 [lints]
 workspace = true


### PR DESCRIPTION
We had a bunch of duplicate dependencies from [`wasm-tools`](https://github.com/bytecodealliance/wasm-tools). This PR fixes this by syncing the versions to what Walrus depends on.