### PR TITLE
Use cross-platform code in favor of accurate exit codes

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
@@ -1,13 +1,10 @@
-use std::fs;
 use std::path::Path;
 use std::process::Command;
+use std::{fs, process};
 
 use anyhow::{Context, Error};
 
-use crate::{
-    node::{exec, SHARED_SETUP},
-    Cli,
-};
+use crate::{node::SHARED_SETUP, Cli};
 
 pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: &[String]) -> Result<(), Error> {
     let mut js_to_execute = format!(
@@ -60,10 +57,15 @@ if (!ok) Deno.exit(1);"#,
             .arg(&js_path)
             .args(args),
     )*/
-    exec(
-        Command::new("deno")
-            .arg("run")
-            .arg("--allow-read")
-            .arg(&js_path),
-    )
+    let status = Command::new("deno")
+        .arg("run")
+        .arg("--allow-read")
+        .arg(&js_path)
+        .status()?;
+
+    if !status.success() {
+        process::exit(status.code().unwrap_or(1))
+    } else {
+        Ok(())
+    }
 }


### PR DESCRIPTION
The current setup uses `execvp` on Linux and exit code 3 on failure on Windows.

I'm guessing `execvp` is used to return the exit code as accurately as possible, including any signals.

Not sure about the exit code 3 on Windows, but I found [this in the Windows documentation](https://learn.microsoft.com/en-us/previous-versions/k089yyh0(v=vs.140)?redirectedfrom=MSDN#:~:text=If%20the%20Windows%20error%20reporting%20handler%20is%20not%20invoked%2C%20then%20abort%20calls%20_exit%20to%20terminate%20the%20process%20with%20exit%20code%203%20and%20returns%20control%20to%20the%20parent%20process%20or%20the%20operating%20system.%20_exit%20does%20not%20flush%20stream%20buffers%20or%20do%20atexit/_onexit%20processing.). I'm not sure about the details, but I tried just returning 1 and it works fine as well. [Std also uses exit code 1 for Windows](https://github.com/rust-lang/rust/blob/1.83.0/library/std/src/sys/pal/windows/c.rs#L18-L20).