### PR TITLE
De-duplicate test filtering

### DIFF
--- a/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/deno.rs
@@ -4,9 +4,10 @@ use std::{fs, process};
 
 use anyhow::{Context, Error};
 
+use crate::Tests;
 use crate::{node::SHARED_SETUP, Cli};
 
-pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: &[String]) -> Result<(), Error> {
+pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: Tests) -> Result<(), Error> {
     let mut js_to_execute = format!(
         r#"import * as wasm from "./{module}.js";
 
@@ -21,11 +22,11 @@ pub fn execute(module: &str, tmpdir: &Path, cli: Cli, tests: &[String]) -> Resul
     "#,
         nocapture = cli.nocapture.clone(),
         console_override = SHARED_SETUP,
-        args = cli.into_args(),
+        args = cli.into_args(&tests),
     );
 
-    for test in tests {
-        js_to_execute.push_str(&format!("tests.push('{}')\n", test));
+    for test in tests.tests {
+        js_to_execute.push_str(&format!("tests.push('{}')\n", test.name));
     }
 
     js_to_execute.push_str(

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/node.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use anyhow::{Context, Error};
 
 use crate::Cli;
+use crate::Tests;
 
 // depends on the variable 'wasm' and initializes te WasmBindgenTestContext cx
 pub const SHARED_SETUP: &str = r#"
@@ -48,7 +49,7 @@ pub fn execute(
     module: &str,
     tmpdir: &Path,
     cli: Cli,
-    tests: &[String],
+    tests: Tests,
     module_format: bool,
     coverage: PathBuf,
 ) -> Result<(), Error> {
@@ -96,14 +97,14 @@ pub fn execute(
         coverage = coverage.display(),
         nocapture = cli.nocapture.clone(),
         console_override = SHARED_SETUP,
-        args = cli.into_args(),
+        args = cli.into_args(&tests),
     );
 
     // Note that we're collecting *JS objects* that represent the functions to
     // execute, and then those objects are passed into Wasm for it to execute
     // when it sees fit.
-    for test in tests {
-        js_to_execute.push_str(&format!("tests.push('{}')\n", test));
+    for test in tests.tests {
+        js_to_execute.push_str(&format!("tests.push('{}')\n", test.name));
     }
     // And as a final addendum, exit with a nonzero code if any tests fail.
     js_to_execute.push_str(

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context, Error};
 use rouille::{Request, Response, Server};
 
-use crate::{Cli, TestMode};
+use crate::{Cli, TestMode, Tests};
 
 pub(crate) fn spawn(
     addr: &SocketAddr,
@@ -15,7 +15,7 @@ pub(crate) fn spawn(
     module: &'static str,
     tmpdir: &Path,
     cli: Cli,
-    tests: &[String],
+    tests: Tests,
     test_mode: TestMode,
     isolate_origin: bool,
     coverage: PathBuf,
@@ -71,7 +71,7 @@ pub(crate) fn spawn(
     };
 
     let nocapture = cli.nocapture;
-    let args = cli.into_args();
+    let args = cli.into_args(&tests);
 
     if test_mode.is_worker() {
         let mut worker_script = if test_mode.no_modules() {
@@ -281,8 +281,8 @@ pub(crate) fn spawn(
             "#,
         ));
     }
-    for test in tests {
-        js_to_execute.push_str(&format!("tests.push('{}');\n", test));
+    for test in tests.tests {
+        js_to_execute.push_str(&format!("tests.push('{}');\n", test.name));
     }
     js_to_execute.push_str("main(tests);\n");
 

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -97,7 +97,7 @@ pub fn wasm_bindgen_test(
         quote! {
             const _: () = {
                 #wasm_bindgen_path::__rt::wasm_bindgen::__wbindgen_coverage! {
-                #[export_name = ::core::concat!("__wbgt_", #ignore_name, ::core::module_path!(), "::", ::core::stringify!(#ident))]
+                #[export_name = ::core::concat!("__wbgt_", #ignore_name, "_", ::core::module_path!(), "::", ::core::stringify!(#ident))]
                 #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
                 extern "C" fn __wbgt_test(cx: &#wasm_bindgen_path::__rt::Context) {
                     let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));


### PR DESCRIPTION
This PR de-duplicates the code that filters tests and moves it away from the testing run-time facilities to the test runner.

This also fixes a bug from #4356 where `--exact` had no effect on `--skip`.