### PR TITLE
Use alloc::vec::Vec instead of Vec for no_std support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 * Internal functions are now removed instead of invalidly imported if they are unused.
   [#4366](https://github.com/rustwasm/wasm-bindgen/pull/4366)
 
-* `web-sys` crate now fully works on `no_std`.
+* Fixed `no_std` support for all APIs in `web-sys`.
   [#4378](https://github.com/rustwasm/wasm-bindgen/pull/4378)
 
 --------------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@
 * Internal functions are now removed instead of invalidly imported if they are unused.
   [#4366](https://github.com/rustwasm/wasm-bindgen/pull/4366)
 
+* `web-sys` crate now fully works on `no_std`.
+  [#4378](https://github.com/rustwasm/wasm-bindgen/pull/4378)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.99](https://github.com/rustwasm/wasm-bindgen/compare/0.2.98...0.2.99)

--- a/crates/web-sys/src/features/gen_AudioBuffer.rs
+++ b/crates/web-sys/src/features/gen_AudioBuffer.rs
@@ -146,5 +146,8 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/getChannelData)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `AudioBuffer`*"]
-    pub fn get_channel_data(this: &AudioBuffer, channel: u32) -> Result<Vec<f32>, JsValue>;
+    pub fn get_channel_data(
+        this: &AudioBuffer,
+        channel: u32,
+    ) -> Result<::alloc::vec::Vec<f32>, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_DomMatrixReadOnly.rs
+++ b/crates/web-sys/src/features/gen_DomMatrixReadOnly.rs
@@ -458,14 +458,14 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly/toFloat32Array)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `DomMatrixReadOnly`*"]
-    pub fn to_float32_array(this: &DomMatrixReadOnly) -> Result<Vec<f32>, JsValue>;
+    pub fn to_float32_array(this: &DomMatrixReadOnly) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     # [wasm_bindgen (catch , method , structural , js_class = "DOMMatrixReadOnly" , js_name = toFloat64Array)]
     #[doc = "The `toFloat64Array()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly/toFloat64Array)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `DomMatrixReadOnly`*"]
-    pub fn to_float64_array(this: &DomMatrixReadOnly) -> Result<Vec<f64>, JsValue>;
+    pub fn to_float64_array(this: &DomMatrixReadOnly) -> Result<::alloc::vec::Vec<f64>, JsValue>;
     # [wasm_bindgen (method , structural , js_class = "DOMMatrixReadOnly" , js_name = toJSON)]
     #[doc = "The `toJSON()` method."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_FetchReadableStreamReadDataArray.rs
+++ b/crates/web-sys/src/features/gen_FetchReadableStreamReadDataArray.rs
@@ -14,7 +14,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `FetchReadableStreamReadDataArray`*"]
     #[wasm_bindgen(method, getter = "value")]
-    pub fn get_value(this: &FetchReadableStreamReadDataArray) -> Option<Vec<u8>>;
+    pub fn get_value(this: &FetchReadableStreamReadDataArray) -> Option<::alloc::vec::Vec<u8>>;
     #[doc = "Change the `value` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `FetchReadableStreamReadDataArray`*"]

--- a/crates/web-sys/src/features/gen_GamepadPose.rs
+++ b/crates/web-sys/src/features/gen_GamepadPose.rs
@@ -32,40 +32,44 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GamepadPose/position)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GamepadPose`*"]
-    pub fn position(this: &GamepadPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn position(this: &GamepadPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "GamepadPose" , js_name = linearVelocity)]
     #[doc = "Getter for the `linearVelocity` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GamepadPose/linearVelocity)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GamepadPose`*"]
-    pub fn linear_velocity(this: &GamepadPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn linear_velocity(this: &GamepadPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "GamepadPose" , js_name = linearAcceleration)]
     #[doc = "Getter for the `linearAcceleration` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GamepadPose/linearAcceleration)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GamepadPose`*"]
-    pub fn linear_acceleration(this: &GamepadPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn linear_acceleration(
+        this: &GamepadPose,
+    ) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "GamepadPose" , js_name = orientation)]
     #[doc = "Getter for the `orientation` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GamepadPose/orientation)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GamepadPose`*"]
-    pub fn orientation(this: &GamepadPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn orientation(this: &GamepadPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "GamepadPose" , js_name = angularVelocity)]
     #[doc = "Getter for the `angularVelocity` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GamepadPose/angularVelocity)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GamepadPose`*"]
-    pub fn angular_velocity(this: &GamepadPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn angular_velocity(this: &GamepadPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "GamepadPose" , js_name = angularAcceleration)]
     #[doc = "Getter for the `angularAcceleration` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/GamepadPose/angularAcceleration)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `GamepadPose`*"]
-    pub fn angular_acceleration(this: &GamepadPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn angular_acceleration(
+        this: &GamepadPose,
+    ) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_GamepadTouch.rs
+++ b/crates/web-sys/src/features/gen_GamepadTouch.rs
@@ -48,7 +48,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn position(this: &GamepadTouch) -> Vec<f32>;
+    pub fn position(this: &GamepadTouch) -> ::alloc::vec::Vec<f32>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "GamepadTouch" , js_name = surfaceDimensions)]
     #[doc = "Getter for the `surfaceDimensions` field of this object."]
@@ -59,5 +59,5 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn surface_dimensions(this: &GamepadTouch) -> Option<Vec<u32>>;
+    pub fn surface_dimensions(this: &GamepadTouch) -> Option<::alloc::vec::Vec<u32>>;
 }

--- a/crates/web-sys/src/features/gen_ImageData.rs
+++ b/crates/web-sys/src/features/gen_ImageData.rs
@@ -32,7 +32,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `ImageData`*"]
-    pub fn data(this: &ImageData) -> ::wasm_bindgen::Clamped<Vec<u8>>;
+    pub fn data(this: &ImageData) -> ::wasm_bindgen::Clamped<::alloc::vec::Vec<u8>>;
     #[wasm_bindgen(catch, constructor, js_class = "ImageData")]
     #[doc = "The `new ImageData(..)` constructor, creating a new instance of `ImageData`."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_MidiMessageEvent.rs
+++ b/crates/web-sys/src/features/gen_MidiMessageEvent.rs
@@ -18,7 +18,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/MIDIMessageEvent/data)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `MidiMessageEvent`*"]
-    pub fn data(this: &MidiMessageEvent) -> Result<Vec<u8>, JsValue>;
+    pub fn data(this: &MidiMessageEvent) -> Result<::alloc::vec::Vec<u8>, JsValue>;
     #[wasm_bindgen(catch, constructor, js_class = "MIDIMessageEvent")]
     #[doc = "The `new MidiMessageEvent(..)` constructor, creating a new instance of `MidiMessageEvent`."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_MidiMessageEventInit.rs
+++ b/crates/web-sys/src/features/gen_MidiMessageEventInit.rs
@@ -44,7 +44,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `MidiMessageEventInit`*"]
     #[wasm_bindgen(method, getter = "data")]
-    pub fn get_data(this: &MidiMessageEventInit) -> Option<Vec<u8>>;
+    pub fn get_data(this: &MidiMessageEventInit) -> Option<::alloc::vec::Vec<u8>>;
     #[doc = "Change the `data` field of this object."]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `MidiMessageEventInit`*"]

--- a/crates/web-sys/src/features/gen_TextEncoder.rs
+++ b/crates/web-sys/src/features/gen_TextEncoder.rs
@@ -32,12 +32,12 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TextEncoder`*"]
-    pub fn encode(this: &TextEncoder) -> Vec<u8>;
+    pub fn encode(this: &TextEncoder) -> ::alloc::vec::Vec<u8>;
     # [wasm_bindgen (method , structural , js_class = "TextEncoder" , js_name = encode)]
     #[doc = "The `encode()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `TextEncoder`*"]
-    pub fn encode_with_input(this: &TextEncoder, input: &str) -> Vec<u8>;
+    pub fn encode_with_input(this: &TextEncoder, input: &str) -> ::alloc::vec::Vec<u8>;
 }

--- a/crates/web-sys/src/features/gen_VrEyeParameters.rs
+++ b/crates/web-sys/src/features/gen_VrEyeParameters.rs
@@ -18,7 +18,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VREyeParameters/offset)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrEyeParameters`*"]
-    pub fn offset(this: &VrEyeParameters) -> Result<Vec<f32>, JsValue>;
+    pub fn offset(this: &VrEyeParameters) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     #[cfg(feature = "VrFieldOfView")]
     # [wasm_bindgen (structural , method , getter , js_class = "VREyeParameters" , js_name = fieldOfView)]
     #[doc = "Getter for the `fieldOfView` field of this object."]

--- a/crates/web-sys/src/features/gen_VrFrameData.rs
+++ b/crates/web-sys/src/features/gen_VrFrameData.rs
@@ -25,28 +25,28 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData/leftProjectionMatrix)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrFrameData`*"]
-    pub fn left_projection_matrix(this: &VrFrameData) -> Result<Vec<f32>, JsValue>;
+    pub fn left_projection_matrix(this: &VrFrameData) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRFrameData" , js_name = leftViewMatrix)]
     #[doc = "Getter for the `leftViewMatrix` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData/leftViewMatrix)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrFrameData`*"]
-    pub fn left_view_matrix(this: &VrFrameData) -> Result<Vec<f32>, JsValue>;
+    pub fn left_view_matrix(this: &VrFrameData) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRFrameData" , js_name = rightProjectionMatrix)]
     #[doc = "Getter for the `rightProjectionMatrix` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData/rightProjectionMatrix)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrFrameData`*"]
-    pub fn right_projection_matrix(this: &VrFrameData) -> Result<Vec<f32>, JsValue>;
+    pub fn right_projection_matrix(this: &VrFrameData) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRFrameData" , js_name = rightViewMatrix)]
     #[doc = "Getter for the `rightViewMatrix` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRFrameData/rightViewMatrix)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrFrameData`*"]
-    pub fn right_view_matrix(this: &VrFrameData) -> Result<Vec<f32>, JsValue>;
+    pub fn right_view_matrix(this: &VrFrameData) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     #[cfg(feature = "VrPose")]
     # [wasm_bindgen (structural , method , getter , js_class = "VRFrameData" , js_name = pose)]
     #[doc = "Getter for the `pose` field of this object."]

--- a/crates/web-sys/src/features/gen_VrPose.rs
+++ b/crates/web-sys/src/features/gen_VrPose.rs
@@ -18,40 +18,40 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRPose/position)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrPose`*"]
-    pub fn position(this: &VrPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn position(this: &VrPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRPose" , js_name = linearVelocity)]
     #[doc = "Getter for the `linearVelocity` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRPose/linearVelocity)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrPose`*"]
-    pub fn linear_velocity(this: &VrPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn linear_velocity(this: &VrPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRPose" , js_name = linearAcceleration)]
     #[doc = "Getter for the `linearAcceleration` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRPose/linearAcceleration)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrPose`*"]
-    pub fn linear_acceleration(this: &VrPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn linear_acceleration(this: &VrPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRPose" , js_name = orientation)]
     #[doc = "Getter for the `orientation` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRPose/orientation)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrPose`*"]
-    pub fn orientation(this: &VrPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn orientation(this: &VrPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRPose" , js_name = angularVelocity)]
     #[doc = "Getter for the `angularVelocity` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRPose/angularVelocity)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrPose`*"]
-    pub fn angular_velocity(this: &VrPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn angular_velocity(this: &VrPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
     # [wasm_bindgen (structural , catch , method , getter , js_class = "VRPose" , js_name = angularAcceleration)]
     #[doc = "Getter for the `angularAcceleration` field of this object."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRPose/angularAcceleration)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrPose`*"]
-    pub fn angular_acceleration(this: &VrPose) -> Result<Option<Vec<f32>>, JsValue>;
+    pub fn angular_acceleration(this: &VrPose) -> Result<Option<::alloc::vec::Vec<f32>>, JsValue>;
 }

--- a/crates/web-sys/src/features/gen_VrStageParameters.rs
+++ b/crates/web-sys/src/features/gen_VrStageParameters.rs
@@ -18,7 +18,9 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/VRStageParameters/sittingToStandingTransform)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `VrStageParameters`*"]
-    pub fn sitting_to_standing_transform(this: &VrStageParameters) -> Result<Vec<f32>, JsValue>;
+    pub fn sitting_to_standing_transform(
+        this: &VrStageParameters,
+    ) -> Result<::alloc::vec::Vec<f32>, JsValue>;
     # [wasm_bindgen (structural , method , getter , js_class = "VRStageParameters" , js_name = sizeX)]
     #[doc = "Getter for the `sizeX` field of this object."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_WaveShaperNode.rs
+++ b/crates/web-sys/src/features/gen_WaveShaperNode.rs
@@ -18,7 +18,7 @@ extern "C" {
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WaveShaperNode/curve)"]
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WaveShaperNode`*"]
-    pub fn curve(this: &WaveShaperNode) -> Option<Vec<f32>>;
+    pub fn curve(this: &WaveShaperNode) -> Option<::alloc::vec::Vec<f32>>;
     # [wasm_bindgen (structural , method , setter , js_class = "WaveShaperNode" , js_name = curve)]
     #[doc = "Setter for the `curve` field of this object."]
     #[doc = ""]

--- a/crates/web-sys/src/features/gen_XrRigidTransform.rs
+++ b/crates/web-sys/src/features/gen_XrRigidTransform.rs
@@ -50,7 +50,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn matrix(this: &XrRigidTransform) -> Vec<f32>;
+    pub fn matrix(this: &XrRigidTransform) -> ::alloc::vec::Vec<f32>;
     #[cfg(web_sys_unstable_apis)]
     # [wasm_bindgen (structural , method , getter , js_class = "XRRigidTransform" , js_name = inverse)]
     #[doc = "Getter for the `inverse` field of this object."]

--- a/crates/web-sys/src/features/gen_XrSession.rs
+++ b/crates/web-sys/src/features/gen_XrSession.rs
@@ -49,7 +49,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn supported_frame_rates(this: &XrSession) -> Option<Vec<f32>>;
+    pub fn supported_frame_rates(this: &XrSession) -> Option<::alloc::vec::Vec<f32>>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "XrRenderState")]
     # [wasm_bindgen (structural , method , getter , js_class = "XRSession" , js_name = renderState)]

--- a/crates/web-sys/src/features/gen_XrView.rs
+++ b/crates/web-sys/src/features/gen_XrView.rs
@@ -38,7 +38,7 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API is unstable and requires `--cfg=web_sys_unstable_apis` to be activated, as"]
     #[doc = "[described in the `wasm-bindgen` guide](https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html)*"]
-    pub fn projection_matrix(this: &XrView) -> Vec<f32>;
+    pub fn projection_matrix(this: &XrView) -> ::alloc::vec::Vec<f32>;
     #[cfg(web_sys_unstable_apis)]
     #[cfg(feature = "XrRigidTransform")]
     # [wasm_bindgen (structural , method , getter , js_class = "XRView" , js_name = transform)]

--- a/crates/web-sys/src/lib.rs
+++ b/crates/web-sys/src/lib.rs
@@ -12,7 +12,7 @@
 //! require.
 
 #![doc(html_root_url = "https://docs.rs/web-sys/0.3")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![allow(deprecated)]
 
 extern crate alloc;

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -7,6 +7,7 @@ use std::ptr;
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Ident, TokenStream};
 use quote::quote;
+use syn::punctuated::Punctuated;
 use wasm_bindgen_backend::util::{ident_ty, raw_ident, rust_ident};
 use weedle::attribute::{
     ExtendedAttribute, ExtendedAttributeIdent, ExtendedAttributeList, ExtendedAttributeNoArgs,
@@ -177,7 +178,7 @@ pub(crate) fn slice_ty(t: syn::Type) -> syn::Type {
     .into()
 }
 
-/// From `T` create `Vec<T>`.
+/// From `T` create `alloc::Vec<T>`.
 pub(crate) fn vec_ty(t: syn::Type) -> syn::Type {
     let arguments = syn::PathArguments::AngleBracketed(syn::AngleBracketedGenericArguments {
         colon2_token: None,
@@ -186,9 +187,16 @@ pub(crate) fn vec_ty(t: syn::Type) -> syn::Type {
         gt_token: Default::default(),
     });
 
-    let ident = raw_ident("Vec");
-    let seg = syn::PathSegment { ident, arguments };
-    let path: syn::Path = seg.into();
+    let mut path = syn::Path {
+        leading_colon: Some(Default::default()),
+        segments: Punctuated::new(),
+    };
+    path.segments.push(raw_ident("alloc").into());
+    path.segments.push(raw_ident("vec").into());
+    path.segments.push(syn::PathSegment {
+        ident: raw_ident("Vec"),
+        arguments,
+    });
     let ty = syn::TypePath { qself: None, path };
     ty.into()
 }


### PR DESCRIPTION
Whilst `no_std` seems _technically_ supported, in practice it's unusable with a bunch of web-sys features due to relying on the implicit `std::vec::Vec` in places. This fixes that by using `alloc::vec::Vec` explicitly, which works in both std and no_std.

A quick test would be to `cargo check -p web-sys --no-default-features --features ImageData` - fails before this PR, succeeds after it.

After this change, we don't actually use `std` anywhere within `web-sys` - it could be permanently `no_std` if so desired. That'd certainly help keep it no_std compatible in the future.