### PR TITLE
Prevent generating duplicate exports for closure conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@
 * Fixed `no_std` support for all APIs in `web-sys`.
   [#4378](https://github.com/rustwasm/wasm-bindgen/pull/4378)
 
+* Prevent generating duplicate exports for closure conversions.
+  [#4380](https://github.com/rustwasm/wasm-bindgen/pull/4380)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.99](https://github.com/rustwasm/wasm-bindgen/compare/0.2.98...0.2.99)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -4270,8 +4270,18 @@ __wbg_set_wasm(wasm);"
                 "memory".to_owned()
             }
             walrus::ExportItem::Function(f) => match &self.module.funcs.get(f).name {
-                Some(s) => to_js_identifier(s),
-                None => default_name,
+                Some(s) => {
+                    let mut name = to_js_identifier(s);
+
+                    // Account for duplicate export names.
+                    // See https://github.com/rustwasm/wasm-bindgen/issues/4371.
+                    if self.module.exports.get_func(&name).is_ok() {
+                        name.push_str(&self.next_export_idx.to_string());
+                    }
+
+                    name
+                }
+                _ => default_name,
             },
             _ => default_name,
         };


### PR DESCRIPTION
We have a report in #4371 where `wasm-bindgen` would generate multiple exported functions with the same name, which is invalid. Specifically these functions were `Closure` converters.

I was debugging this just with the generated Wasm module, because I couldn't build the project locally and there was no minimal re-production, the following is just speculation:

The culprit seems to be:
https://github.com/rustwasm/wasm-bindgen/blob/88452fade69e677f50643651d55e60bddc427491/src/closure.rs#L340-L344

For some reason, while we are interpreting this descriptor, we find multiple ones with exactly the same name, e.g.: `<dyn core[bd1a764364e91139]::ops::function::FnMut<(), Output = _> as wasm_bindgen[79ff92f6c8c42bdb]::closure::WasmClosure>::describe::invoke::<()>`. While finding multiple ones should not be surprising, as we are dealing with a generic, the name shouldn't be the same because as you can see Rust adds some naming scheme to prevent that. So either this is a bug in Rust, which I very much doubt, or the problem is `#[inline(never)]`, which would not be bug in Rust because [the reference clearly states that it is just a suggestion and not a guarantee](https://doc.rust-lang.org/1.83.0/reference/attributes/codegen.html?highlight=inline#the-inline-attribute).

To fix this we simply apply a number at the end to mangle the name further.

Fixes #4371.
Cc @dpc.