### PR TITLE
Add guide for running doctest

### DIFF
--- a/guide/src/wasm-bindgen-test/usage.md
+++ b/guide/src/wasm-bindgen-test/usage.md
@@ -128,14 +128,8 @@ Run the tests by passing `--target wasm32-unknown-unknown` to `cargo test`:
 cargo test --target wasm32-unknown-unknown
 ```
 
-If you also need to run doctests, add the [`-Zdoctest-xcompile`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile) flag:
+If you also need to run doctests, add the unstable [`-Zdoctest-xcompile`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile) flag. This requires using the Rust nightly channel like this:
 
 ```
-cargo -Zdoctest-xcompile test --target wasm32-unknown-unknown
-```
-
-If you are in the stable channel, you can switch to nightly like this:
-
-```
-cargo +nightly -Zdoctest-xcompile test --target wasm32-unknown-unknown
+cargo +nightly test --target wasm32-unknown-unknown -Zdoctest-xcompile
 ```

--- a/guide/src/wasm-bindgen-test/usage.md
+++ b/guide/src/wasm-bindgen-test/usage.md
@@ -127,3 +127,15 @@ Run the tests by passing `--target wasm32-unknown-unknown` to `cargo test`:
 ```
 cargo test --target wasm32-unknown-unknown
 ```
+
+If you also need to run doctests, add the [`-Zdoctest-xcompile`](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile) flag:
+
+```
+cargo -Zdoctest-xcompile test --target wasm32-unknown-unknown
+```
+
+If you are in the stable channel, you can switch to nightly like this:
+
+```
+cargo +nightly -Zdoctest-xcompile test --target wasm32-unknown-unknown
+```


### PR DESCRIPTION
This is what I learned recently when trying to run doctests:
<img width="822" alt="image" src="https://github.com/user-attachments/assets/bf740cc7-85e4-4fcb-94ee-38288ac6d7e8" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/186e1458-6351-43d3-b6f2-b45b39f187f1" />

