### PR TITLE
Add documentation to `wasm_bindgen` macro, starting with a link to supported attributes

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -5,7 +5,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
 
-/// A list of all the attributes can be found here: https://rustwasm.github.io/wasm-bindgen/reference/attributes/index.html
+/// A list of all the attributes can be found here: https://rustwasm.github.io/docs/wasm-bindgen/reference/attributes/index.html
 #[proc_macro_attribute]
 pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand(attr.into(), input.into()) {

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -5,6 +5,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use quote::quote;
 
+/// A list of all the attributes can be found here: https://rustwasm.github.io/wasm-bindgen/reference/attributes/index.html
 #[proc_macro_attribute]
 pub fn wasm_bindgen(attr: TokenStream, input: TokenStream) -> TokenStream {
     match wasm_bindgen_macro_support::expand(attr.into(), input.into()) {


### PR DESCRIPTION
While working with the `wasm_bindgen` macro I thought that it would be incredible useful to have the link to all supported attributes and their explanation as part of the docs. This way it would be quick and easy to access these resources e.g. straight from an IDE.

I would've added even more documentation to the macro, but at this point I don't think I am knowledgeable enough about it to not include something inaccurate or wrong. 😅 