### PR TITLE
`#[wasm_bindgen_test]`: Add an `#[allow(dead_code)]` to the original function

### DIFF
--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -136,6 +136,10 @@ pub fn wasm_bindgen_test(
                 quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), #ignore)] }
             )
         }
+    } else {
+        tokens.extend(quote! {
+            #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), allow(dead_code))]
+        });
     }
 
     tokens.extend(leading_tokens);


### PR DESCRIPTION
I've been working on a PR for [Yew](https://github.com/yewstack/yew), and our clippy tests were failing because `wasm-bindgen-test` would leave the test function unused if the compilation target wasn't Wasm. This PR attempts to address that with a simple fix.