### PR TITLE
add emscripten support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,10 @@
 [target.'cfg(target_arch = "wasm32")']
 runner = 'cargo run -p wasm-bindgen-cli --bin wasm-bindgen-test-runner --'
+
+[build]
+[target.'cfg(all(target_arch = "wasm32", target_os = "emscripten"))']
+rustflags = [
+    "-Cllvm-args=-enable-emscripten-cxx-exceptions=0", 
+    "-Clink-arg=-Wno-undefined",    
+    "-Crelocation-model=static",                                                                                                                                                                                                     
+]

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -162,7 +162,7 @@ impl TryToTokens for ast::Program {
         let prefix_json_bytes = syn::LitByteStr::new(&prefix_json_bytes, Span::call_site());
 
         (quote! {
-            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
             #[automatically_derived]
             const _: () = {
                 use #wasm_bindgen::__rt::{flat_len, flat_byte_slices};
@@ -281,12 +281,12 @@ impl ToTokens for ast::Struct {
                     let ptr = #wasm_bindgen::convert::IntoWasmAbi::into_abi(value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
                     extern "C" {
                         fn #new_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))))]
                     unsafe fn #new_fn(_: u32) -> u32 {
                         panic!("cannot convert to JsValue outside of the Wasm target")
                     }
@@ -298,7 +298,7 @@ impl ToTokens for ast::Struct {
                 }
             }
 
-            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
@@ -388,12 +388,12 @@ impl ToTokens for ast::Struct {
                     let idx = #wasm_bindgen::convert::IntoWasmAbi::into_abi(&value);
 
                     #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+                    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
                     extern "C" {
                         fn #unwrap_fn(ptr: u32) -> u32;
                     }
 
-                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+                    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))))]
                     unsafe fn #unwrap_fn(_: u32) -> u32 {
                         panic!("cannot convert from JsValue outside of the Wasm target")
                     }
@@ -501,8 +501,9 @@ impl ToTokens for ast::StructField {
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
-                #[cfg_attr(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")), no_mangle)]
+                #[cfg_attr(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")), no_mangle)]
                 #[doc(hidden)]
+
                 pub unsafe extern "C" fn #getter(js: u32)
                     -> #wasm_bindgen::convert::WasmRet<<#ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi>
                 {
@@ -540,7 +541,7 @@ impl ToTokens for ast::StructField {
         let (args, names) = splat(wasm_bindgen, &Ident::new("val", rust_name.span()), &abi);
 
         (quote! {
-            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
@@ -847,7 +848,7 @@ impl TryToTokens for ast::Export {
                 #wasm_bindgen::__wbindgen_coverage! {
                 #(#attrs)*
                 #[cfg_attr(
-                    all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+                    all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")),
                     export_name = #export_name,
                 )]
                 pub unsafe extern "C" fn #generated_name(#(#args),*) -> #wasm_bindgen::convert::WasmRet<#projection::Abi> {
@@ -1124,11 +1125,11 @@ impl ToTokens for ast::ImportType {
                 impl JsCast for #rust_name {
                     fn instanceof(val: &JsValue) -> bool {
                         #[link(wasm_import_module = "__wbindgen_placeholder__")]
-                        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+                        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
                         extern "C" {
                             fn #instanceof_shim(val: u32) -> u32;
                         }
-                        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+                        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))))]
                         unsafe fn #instanceof_shim(_: u32) -> u32 {
                             panic!("cannot check instanceof on non-wasm targets");
                         }
@@ -1838,12 +1839,12 @@ fn static_init(wasm_bindgen: &syn::Path, ty: &syn::Type, shim_name: &Ident) -> T
     };
     quote! {
         #[link(wasm_import_module = "__wbindgen_placeholder__")]
-        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
         extern "C" {
             fn #shim_name() -> #abi_ret;
         }
 
-        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))))]
         unsafe fn #shim_name() -> #abi_ret {
             panic!("cannot access imported statics on non-wasm targets")
         }
@@ -1888,7 +1889,7 @@ impl<T: ToTokens> ToTokens for Descriptor<'_, T> {
         let attrs = &self.attrs;
         let wasm_bindgen = &self.wasm_bindgen;
         (quote! {
-            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+            #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
             #[automatically_derived]
             const _: () = {
                 #wasm_bindgen::__wbindgen_coverage! {
@@ -1916,14 +1917,14 @@ fn extern_fn(
     abi_ret: TokenStream,
 ) -> TokenStream {
     quote! {
-        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
         #(#attrs)*
         #[link(wasm_import_module = "__wbindgen_placeholder__")]
         extern "C" {
             fn #import_name(#(#abi_arguments),*) -> #abi_ret;
         }
 
-        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+        #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))))]
         unsafe fn #import_name(#(#abi_arguments),*) -> #abi_ret {
             #(
                 drop(#abi_argument_names);

--- a/crates/backend/src/codegen.rs
+++ b/crates/backend/src/codegen.rs
@@ -503,7 +503,6 @@ impl ToTokens for ast::StructField {
                 #wasm_bindgen::__wbindgen_coverage! {
                 #[cfg_attr(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")), no_mangle)]
                 #[doc(hidden)]
-
                 pub unsafe extern "C" fn #getter(js: u32)
                     -> #wasm_bindgen::convert::WasmRet<<#ty as #wasm_bindgen::convert::IntoWasmAbi>::Abi>
                 {

--- a/crates/cli-support/Cargo.toml
+++ b/crates/cli-support/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.0"
 walrus = { version = "0.23", features = ['parallel'] }
+regex = "1"
 wasm-bindgen-externref-xform = { path = '../externref-xform', version = '=0.2.100' }
 wasm-bindgen-multi-value-xform = { path = '../multi-value-xform', version = '=0.2.100' }
 wasm-bindgen-shared = { path = "../shared", version = '=0.2.100' }

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1661,7 +1661,7 @@ impl Invocation {
                     *log_error = false;
                 }
                 let ret = cx.invoke_import(import, kind, args, variadic, prelude, import_deps);
-                return ret
+                return ret;
             }
         }
     }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -209,7 +209,8 @@ impl<'a> Context<'a> {
             OutputMode::Bundler { .. }
             | OutputMode::Node { module: true }
             | OutputMode::Web
-            | OutputMode::Deno => match export {
+            | OutputMode::Deno 
+            | OutputMode::Emscripten => match export {
                 ExportJs::Class(class) => {
                     assert_eq!(export_name, definition_name);
                     format!("export {}\n", class)
@@ -598,7 +599,7 @@ __wbg_set_wasm(wasm);"
             // browsers don't support natively importing Wasm right now so we
             // expose the same initialization function as `--target no-modules`
             // as the default export of the module.
-            OutputMode::Web => {
+            OutputMode::Web | OutputMode::Emscripten => {
                 self.imports_post.push_str("let wasm;\n");
                 init = self.gen_init(needs_manual_start, Some(&mut imports))?;
                 footer.push_str("export { initSync };\n");
@@ -698,7 +699,8 @@ __wbg_set_wasm(wasm);"
             OutputMode::Bundler { .. }
             | OutputMode::Node { module: true }
             | OutputMode::Web
-            | OutputMode::Deno => {
+            | OutputMode::Deno
+            | OutputMode::Emscripten => {
                 for (module, items) in crate::sorted_iter(&self.js_imports) {
                     imports.push_str("import { ");
                     for (i, (item, rename)) in items.iter().enumerate() {
@@ -1771,7 +1773,8 @@ __wbg_set_wasm(wasm);"
             OutputMode::Deno
             | OutputMode::Web
             | OutputMode::NoModules { .. }
-            | OutputMode::Bundler { browser_only: true } => {
+            | OutputMode::Bundler { browser_only: true } 
+            | OutputMode::Emscripten => {
                 self.global(&format!("const cached{0} = (typeof {0} !== 'undefined' ? new {0}{1} : {{ {2}: () => {{ throw Error('{0} not available') }} }} );", s, args, op))
             }
         };
@@ -1785,7 +1788,8 @@ __wbg_set_wasm(wasm);"
                 OutputMode::Deno
                 | OutputMode::Web
                 | OutputMode::NoModules { .. }
-                | OutputMode::Bundler { browser_only: true } => self.global(&format!(
+                | OutputMode::Bundler { browser_only: true }
+                | OutputMode::Emscripten => self.global(&format!(
                     "if (typeof {} !== 'undefined') {{ {} }};",
                     s, init
                 )),
@@ -3522,7 +3526,8 @@ __wbg_set_wasm(wasm);"
                         OutputMode::Web
                         | OutputMode::Bundler { .. }
                         | OutputMode::Deno
-                        | OutputMode::Node { module: true } => "import.meta.url",
+                        | OutputMode::Node { module: true }
+                        | OutputMode::Emscripten => "import.meta.url",
                         OutputMode::Node { module: false } => {
                             "require('url').pathToFileURL(__filename)"
                         }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2566,7 +2566,7 @@ __wbg_set_wasm(wasm);"
                     real.original = state;
                     CLOSURE_DTORS.register(real, state, state);
                     return real;
-                }},\n
+                }}
                 ",
             ));
         }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -66,6 +66,7 @@ enum OutputMode {
     NoModules { global: String },
     Node { module: bool },
     Deno,
+    Emscripten,    
 }
 
 enum Input {
@@ -222,6 +223,13 @@ impl Bindgen {
         match &mut self.mode {
             OutputMode::NoModules { global } => *global = name.to_string(),
             _ => bail!("can only specify `--no-modules-global` with `--target no-modules`"),
+        }
+        Ok(self)
+    }
+
+    pub fn emscripten(&mut self, emscripten: bool) -> Result<&mut Bindgen, Error> {
+        if emscripten {
+            self.switch_mode(OutputMode::Emscripten, "--target emscripten")?;
         }
         Ok(self)
     }
@@ -559,6 +567,10 @@ impl OutputMode {
     fn no_modules(&self) -> bool {
         matches!(self, OutputMode::NoModules { .. })
     }
+    
+    // fn emscripten(&self) -> bool {
+    //     matches!(self, OutputMode::Emscripten { .. })
+    // }
 
     fn esm_integration(&self) -> bool {
         matches!(

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -66,7 +66,7 @@ enum OutputMode {
     NoModules { global: String },
     Node { module: bool },
     Deno,
-    Emscripten,    
+    Emscripten,
 }
 
 enum Input {

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -51,7 +51,6 @@ pub struct Output {
 struct Generated {
     mode: OutputMode,
     js: String,
-    js_emscripten_library: String,
     ts: String,
     start: Option<String>,
     snippets: HashMap<String, Vec<String>>,
@@ -441,7 +440,7 @@ impl Bindgen {
             .unwrap();
         let mut cx = js::Context::new(&mut module, self, &adapters, &aux)?;
         cx.generate()?;
-        let (js, js_emscripten_library, ts, start) = cx.finalize(stem)?;
+        let (js, ts, start) = cx.finalize(stem)?;
         let generated = Generated {
             snippets: aux.snippets.clone(),
             local_modules: aux.local_modules.clone(),
@@ -449,7 +448,6 @@ impl Bindgen {
             typescript: self.typescript,
             npm_dependencies: cx.npm_dependencies.clone(),
             js,
-            js_emscripten_library,
             ts,
             start,
         };
@@ -728,10 +726,8 @@ export * from \"./{js_name}\";
             }
             write(out_dir.join(&js_name), reset_indentation(&gen.js))?;
         } else if matches!(self.generated.mode, OutputMode::Emscripten) {
-            let wbg_path = out_dir.join("library_wbg.js");
-            let pre_js_path = out_dir.join("wbg_pre.js");
-            write(&wbg_path, reset_indentation(&gen.js_emscripten_library))?;
-            write(&pre_js_path, reset_indentation(&gen.js))?;
+            let emscripten_js_path = out_dir.join("library_bindgen.js");
+            write(&emscripten_js_path, reset_indentation(&gen.js))?;
         } else {
             write(&js_path, reset_indentation(&gen.js))?;
         }

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -567,10 +567,6 @@ impl OutputMode {
     fn no_modules(&self) -> bool {
         matches!(self, OutputMode::NoModules { .. })
     }
-    
-    // fn emscripten(&self) -> bool {
-    //     matches!(self, OutputMode::Emscripten { .. })
-    // }
 
     fn esm_integration(&self) -> bool {
         matches!(

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/emscripten_test.js
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/emscripten_test.js
@@ -1,0 +1,55 @@
+(function() {{
+    var elem = document.querySelector('#output');
+    window.extraLibraryFuncs = [];
+    window.addToLibrary = function(LibraryWbg) {
+        window.wasmExports = {__wbindgen_start:() => {}};
+        window.cachedTextEncoder = {encodeInto:() => {}};
+        window.Module = {};
+
+        try {
+            LibraryWbg.$initBindgen();
+        } catch (e) {
+            elem.innerText = 'test setup failed: ' + e;
+        }
+
+        function testExtraLibraryFuncs () {
+            ['$initBindgen', '$addOnInit', '$CLOSURE_DTORS', '$getStringFromWasm0'].forEach((value) => {
+                if (!extraLibraryFuncs.includes(value)) {
+                    return { status: false, e: `test result: ${value} not found`};
+                }
+            });
+            return {status: true, e: 'test result: ok'};
+        }
+
+        function testLibraryWbg () {
+            if (typeof Module.hello !== 'function') {
+                return {status: false, e:'test result: hello() is not found'};
+            }
+            if (typeof Module.Interval !== 'function') {
+                return {status: false, e:'test result: Interval is not found'};
+            }
+
+            const keys = Object.keys(LibraryWbg);
+            const testNames = ['clearInterval', 'setInterval', 'log'];
+            
+            for (const name of testNames) {
+              const regex = new RegExp(`^__wbg_${name}`);
+              const res = keys.find(key => regex.test(key));
+              if (!res) {
+                return {status: false, e:`test result: ${name} not found`};
+              }
+            }
+            return {status: true, e:'test result: ok'};     
+        }
+
+        const tests = [testExtraLibraryFuncs(), testLibraryWbg()];
+        for (const res of tests) {
+            if (!res.status) {
+                elem.innerText = res.e;
+                return;
+            }
+        }       
+        elem.innerText = 'test result: ok';
+
+    };
+}}());

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/index-emscripten.html
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/index-emscripten.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+  </head>
+  <body>
+    <pre id="output">Loading scripts...</pre>
+    <pre id="console_log"></pre>
+    <pre id="console_info"></pre>
+    <pre id="console_warn"></pre>
+    <pre id="console_error"></pre>
+    <!-- {IMPORT_SCRIPTS} -->
+  </body>
+</html>

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -111,16 +111,27 @@ fn main() -> anyhow::Result<()> {
 
     let shell = shell::Shell::new();
 
-    let file_name = cli
+    let mut file_name = cli
         .file
         .file_name()
         .map(Path::new)
         .context("file to test is not a valid file, can't extract file name")?;
 
+    let mut file_name_buf= PathBuf::from(cli.file.clone());
+
+    // Repoint the file to be read from "name.js" to "name.wasm" in the case of emscripten.
+    // Rustc generates a .js and a .wasm file when targeting emscripten. It lists the .js
+    // file as the primary executor which is inconsitent with what is expected here.
+    if file_name.extension().unwrap() == "js" {
+        file_name_buf.pop();
+        file_name_buf.push(file_name.file_stem().unwrap());
+        file_name_buf.set_extension("wasm");
+        file_name = Path::new(&file_name_buf);
+    }
     // Collect all tests that the test harness is supposed to run. We assume
     // that any exported function with the prefix `__wbg_test` is a test we need
     // to execute.
-    let wasm = fs::read(&cli.file).context("failed to read Wasm file")?;
+    let wasm = fs::read(&file_name_buf).context("failed to read Wasm file")?;
     let mut wasm =
         walrus::Module::from_buffer(&wasm).context("failed to deserialize Wasm module")?;
     let mut tests = Tests::new();
@@ -203,6 +214,7 @@ fn main() -> anyhow::Result<()> {
         Some(section) if section.data.contains(&0x03) => TestMode::SharedWorker { no_modules },
         Some(section) if section.data.contains(&0x04) => TestMode::ServiceWorker { no_modules },
         Some(section) if section.data.contains(&0x05) => TestMode::Node { no_modules },
+        Some(section) if section.data.contains(&0x06) => TestMode::Emscripten {},
         Some(_) => bail!("invalid __wasm_bingen_test_unstable value"),
         None => {
             let mut modes = Vec::new();
@@ -295,6 +307,9 @@ fn main() -> anyhow::Result<()> {
             } else {
                 b.web(true)?
             }
+        },
+        TestMode::Emscripten {} => {
+            b.emscripten(true)?
         }
     };
 
@@ -315,6 +330,19 @@ fn main() -> anyhow::Result<()> {
     match test_mode {
         TestMode::Node { no_modules } => {
             node::execute(module, tmpdir.path(), cli, tests, !no_modules, coverage)?
+        }
+        TestMode::Emscripten => {
+            let srv = server::spawn_emscripten(
+                &"127.0.0.1:0".parse().unwrap(), 
+                tmpdir.path(), 
+                std::env::var("WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION").is_err()).context("failed to spawn server")?;
+            let addr = srv.server_addr();
+            println!(
+                "Tests are now available at http://{}",
+                addr
+            );
+            thread::spawn(|| srv.run());
+            headless::run(&addr, &shell, driver_timeout, browser_timeout)?;
         }
         TestMode::Deno => deno::execute(module, tmpdir.path(), cli, tests)?,
         TestMode::Browser { .. }
@@ -372,6 +400,7 @@ enum TestMode {
     DedicatedWorker { no_modules: bool },
     SharedWorker { no_modules: bool },
     ServiceWorker { no_modules: bool },
+    Emscripten,
 }
 
 impl TestMode {
@@ -384,7 +413,7 @@ impl TestMode {
 
     fn no_modules(self) -> bool {
         match self {
-            Self::Deno => true,
+            Self::Deno | Self::Emscripten => true,
             Self::Browser { no_modules }
             | Self::Node { no_modules }
             | Self::DedicatedWorker { no_modules }
@@ -401,6 +430,7 @@ impl TestMode {
             TestMode::DedicatedWorker { .. } => "WASM_BINDGEN_USE_DEDICATED_WORKER",
             TestMode::SharedWorker { .. } => "WASM_BINDGEN_USE_SHARED_WORKER",
             TestMode::ServiceWorker { .. } => "WASM_BINDGEN_USE_SERVICE_WORKER",
+            TestMode::Emscripten { .. } => "WASM_BINDGEN_USE_EMSCRIPTEN",
         }
     }
 }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/main.rs
@@ -117,7 +117,7 @@ fn main() -> anyhow::Result<()> {
         .map(Path::new)
         .context("file to test is not a valid file, can't extract file name")?;
 
-    let mut file_name_buf= PathBuf::from(cli.file.clone());
+    let mut file_name_buf = PathBuf::from(cli.file.clone());
 
     // Repoint the file to be read from "name.js" to "name.wasm" in the case of emscripten.
     // Rustc generates a .js and a .wasm file when targeting emscripten. It lists the .js
@@ -307,10 +307,8 @@ fn main() -> anyhow::Result<()> {
             } else {
                 b.web(true)?
             }
-        },
-        TestMode::Emscripten {} => {
-            b.emscripten(true)?
         }
+        TestMode::Emscripten {} => b.emscripten(true)?,
     };
 
     if std::env::var("WASM_BINDGEN_SPLIT_LINKED_MODULES").is_ok() {
@@ -333,14 +331,13 @@ fn main() -> anyhow::Result<()> {
         }
         TestMode::Emscripten => {
             let srv = server::spawn_emscripten(
-                &"127.0.0.1:0".parse().unwrap(), 
-                tmpdir.path(), 
-                std::env::var("WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION").is_err()).context("failed to spawn server")?;
+                &"127.0.0.1:0".parse().unwrap(),
+                tmpdir.path(),
+                std::env::var("WASM_BINDGEN_TEST_NO_ORIGIN_ISOLATION").is_err(),
+            )
+            .context("failed to spawn server")?;
             let addr = srv.server_addr();
-            println!(
-                "Tests are now available at http://{}",
-                addr
-            );
+            println!("Tests are now available at http://{}", addr);
             thread::spawn(|| srv.run());
             headless::run(&addr, &shell, driver_timeout, browser_timeout)?;
         }

--- a/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
+++ b/crates/cli/src/bin/wasm-bindgen-test-runner/server.rs
@@ -353,7 +353,7 @@ pub(crate) fn spawn(
         response
     })
     .map_err(|e| anyhow!("{}", e))?;
-    return Ok(srv);    
+    return Ok(srv);
 }
 
 pub(crate) fn spawn_emscripten(
@@ -366,13 +366,11 @@ pub(crate) fn spawn_emscripten(
     let tmpdir = tmpdir.to_path_buf();
     let srv = Server::new(addr, move |request| {
         if request.url() == "/" {
-            let s = 
-                include_str!("index-emscripten.html");
-            let s = 
-                s.replace(
-                    "<!-- {IMPORT_SCRIPTS} -->",
-                    "<script src=\"run.js\"></script>\n     <script src=\"library_bindgen.js\"></script>",
-                );
+            let s = include_str!("index-emscripten.html");
+            let s = s.replace(
+                "<!-- {IMPORT_SCRIPTS} -->",
+                "<script src=\"run.js\"></script>\n     <script src=\"library_bindgen.js\"></script>",
+            );
 
             let response = Response::from_data("text/html", s);
 

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,6 +22,8 @@ struct Args {
     #[arg(long, help = "Deprecated, use `--target no-modules`")]
     no_modules: bool,
     #[arg(long, help = "Output a TypeScript definition file (on by default)")]
+    emscripten: bool,
+    #[arg(long, help = "testing, also see if `--target emscripten` is hooked up properly")]
     typescript: bool,
     #[arg(long, help = "Don't emit a *.d.ts file")]
     no_typescript: bool,
@@ -110,6 +112,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
             "nodejs" => b.nodejs(true)?,
             "deno" => b.deno(true)?,
             "experimental-nodejs-module" => b.nodejs_module(true)?,
+            "emscripten" => b.emscripten(true)?,
             s => bail!("invalid encode-into mode: `{}`", s),
         };
     }
@@ -118,6 +121,7 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .web(args.web)?
         .browser(args.browser)?
         .no_modules(args.no_modules)?
+        .emscripten(args.emscripten)?
         .debug(args.debug)
         .demangle(!args.no_demangle)
         .keep_lld_exports(args.keep_lld_exports)

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -22,8 +22,6 @@ struct Args {
     #[arg(long, help = "Deprecated, use `--target no-modules`")]
     no_modules: bool,
     #[arg(long, help = "Output a TypeScript definition file (on by default)")]
-    emscripten: bool,
-    #[arg(long, help = "testing, also see if `--target emscripten` is hooked up properly")]
     typescript: bool,
     #[arg(long, help = "Don't emit a *.d.ts file")]
     no_typescript: bool,
@@ -121,7 +119,6 @@ fn rmain(args: &Args) -> Result<(), Error> {
         .web(args.web)?
         .browser(args.browser)?
         .no_modules(args.no_modules)?
-        .emscripten(args.emscripten)?
         .debug(args.debug)
         .demangle(!args.no_demangle)
         .keep_lld_exports(args.keep_lld_exports)

--- a/crates/test-macro/src/lib.rs
+++ b/crates/test-macro/src/lib.rs
@@ -98,7 +98,7 @@ pub fn wasm_bindgen_test(
             const _: () = {
                 #wasm_bindgen_path::__rt::wasm_bindgen::__wbindgen_coverage! {
                 #[export_name = ::core::concat!("__wbgt_", #ignore_name, "_", ::core::module_path!(), "::", ::core::stringify!(#ident))]
-                #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+                #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
                 extern "C" fn __wbgt_test(cx: &#wasm_bindgen_path::__rt::Context) {
                     let test_name = ::core::concat!(::core::module_path!(), "::", ::core::stringify!(#ident));
                     #test_body
@@ -110,7 +110,7 @@ pub fn wasm_bindgen_test(
 
     if let Some(path) = attributes.unsupported {
         tokens.extend(
-            quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), #path)] },
+            quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))), #path)] },
         );
 
         if let Some(should_panic) = should_panic {
@@ -121,7 +121,7 @@ pub fn wasm_bindgen_test(
             };
 
             tokens.extend(
-                quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), #should_panic)] }
+                quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))), #should_panic)] }
             )
         }
 
@@ -133,7 +133,7 @@ pub fn wasm_bindgen_test(
             };
 
             tokens.extend(
-                quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))), #ignore)] }
+                quote! { #[cfg_attr(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))), #ignore)] }
             )
         }
     }

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -106,6 +106,14 @@ macro_rules! wasm_bindgen_test_configure {
             $crate::wasm_bindgen_test_configure!($($others)*);
         };
     );
+    (run_in_emscripten $($others:tt)*) => (
+        const _: () = {
+            #[link_section = "__wasm_bindgen_test_unstable"]
+            #[cfg(target_arch = "wasm32")]
+            pub static __WBG_TEST_run_in_emscripten: [u8; 1] = [0x06];
+            $crate::wasm_bindgen_test_configure!($($others)*);
+        };
+    );
     () => ()
 }
 

--- a/src/externref.rs
+++ b/src/externref.rs
@@ -106,7 +106,7 @@ fn internal_error(msg: &str) -> ! {
             std::process::abort();
         } else if #[cfg(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none")
+            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
         ))] {
             core::arch::wasm32::unreachable();
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,14 +75,14 @@ use crate::convert::{FromWasmAbi, TryFromJsValue, WasmRet, WasmSlice};
 
 macro_rules! externs {
     ($(#[$attr:meta])* extern "C" { $(fn $name:ident($($args:tt)*) -> $ret:ty;)* }) => (
-        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+        #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))]
         $(#[$attr])*
         extern "C" {
             $(fn $name($($args)*) -> $ret;)*
         }
 
         $(
-            #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+            #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten"))))]
             #[allow(unused_variables)]
             unsafe extern fn $name($($args)*) -> $ret {
                 panic!("function not implemented on non-wasm32 targets")
@@ -1408,7 +1408,7 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[cfg_attr(
         any(
             debug_assertions,
-            not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))
+            not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))
         ),
         track_caller
     )]
@@ -1417,7 +1417,7 @@ pub trait UnwrapThrowExt<T>: Sized {
             debug_assertions,
             all(
                 target_arch = "wasm32",
-                any(target_os = "unknown", target_os = "none")
+                any(target_os = "unknown", target_os = "none", target_os = "emscripten")
             )
         )) {
             let loc = core::panic::Location::caller();
@@ -1440,7 +1440,7 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[cfg_attr(
         any(
             debug_assertions,
-            not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))
+            not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))
         ),
         track_caller
     )]
@@ -1453,7 +1453,7 @@ impl<T> UnwrapThrowExt<T> for Option<T> {
 
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none")
+            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
         )) {
             if let Some(val) = self {
                 val
@@ -1474,7 +1474,7 @@ impl<T> UnwrapThrowExt<T> for Option<T> {
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none")
+            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
         )) {
             if let Some(val) = self {
                 val
@@ -1507,7 +1507,7 @@ where
 
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none")
+            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
         )) {
             match self {
                 Ok(val) => val,
@@ -1537,7 +1537,7 @@ where
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none")
+            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
         )) {
             match self {
                 Ok(val) => val,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1408,7 +1408,10 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[cfg_attr(
         any(
             debug_assertions,
-            not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))
+            not(all(
+                target_arch = "wasm32",
+                any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+            ))
         ),
         track_caller
     )]
@@ -1417,7 +1420,11 @@ pub trait UnwrapThrowExt<T>: Sized {
             debug_assertions,
             all(
                 target_arch = "wasm32",
-                any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+                any(
+                    target_os = "unknown",
+                    target_os = "none",
+                    target_os = "emscripten"
+                )
             )
         )) {
             let loc = core::panic::Location::caller();
@@ -1440,7 +1447,10 @@ pub trait UnwrapThrowExt<T>: Sized {
     #[cfg_attr(
         any(
             debug_assertions,
-            not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none", target_os = "emscripten")))
+            not(all(
+                target_arch = "wasm32",
+                any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+            ))
         ),
         track_caller
     )]
@@ -1453,7 +1463,11 @@ impl<T> UnwrapThrowExt<T> for Option<T> {
 
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+            any(
+                target_os = "unknown",
+                target_os = "none",
+                target_os = "emscripten"
+            )
         )) {
             if let Some(val) = self {
                 val
@@ -1474,7 +1488,11 @@ impl<T> UnwrapThrowExt<T> for Option<T> {
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+            any(
+                target_os = "unknown",
+                target_os = "none",
+                target_os = "emscripten"
+            )
         )) {
             if let Some(val) = self {
                 val
@@ -1507,7 +1525,11 @@ where
 
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+            any(
+                target_os = "unknown",
+                target_os = "none",
+                target_os = "emscripten"
+            )
         )) {
             match self {
                 Ok(val) => val,
@@ -1537,7 +1559,11 @@ where
     fn expect_throw(self, message: &str) -> T {
         if cfg!(all(
             target_arch = "wasm32",
-            any(target_os = "unknown", target_os = "none", target_os = "emscripten")
+            any(
+                target_os = "unknown",
+                target_os = "none",
+                target_os = "emscripten"
+            )
         )) {
             match self {
                 Ok(val) => val,

--- a/tests/headless/main.rs
+++ b/tests/headless/main.rs
@@ -1,4 +1,4 @@
-#![cfg(target_arch = "wasm32")]
+#![cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 
 extern crate wasm_bindgen;
 extern crate wasm_bindgen_test;

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -1,4 +1,4 @@
-#![cfg(target_arch = "wasm32")]
+#![cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #![allow(renamed_and_removed_lints)] // clippy::drop_ref will be renamed to drop_ref
 #![allow(clippy::drop_ref, clippy::drop_non_drop)]
 

--- a/tests/wasm32-emscripten/main.rs
+++ b/tests/wasm32-emscripten/main.rs
@@ -1,0 +1,57 @@
+#![cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+
+extern crate wasm_bindgen;
+extern crate wasm_bindgen_test;
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_emscripten);
+
+#[wasm_bindgen]
+extern "C" {
+    fn setInterval(closure: &Closure<dyn FnMut()>, millis: u32) -> f64;
+    fn clearInterval(token: f64);
+
+    #[wasm_bindgen(js_namespace = console)]
+    fn log(s: &str);
+}
+
+#[wasm_bindgen]
+pub struct Interval {
+    closure: Closure<dyn FnMut()>,
+    token: f64,
+}
+
+impl Interval {
+    pub fn new<F: 'static>(millis: u32, f: F) -> Interval
+    where
+        F: FnMut()
+    {
+        // Construct a new closure.
+        let closure = Closure::new(f);
+
+        // Pass the closure to JS, to run every n milliseconds.
+        let token = setInterval(&closure, millis);
+
+        Interval { closure, token }
+    }
+}
+
+// When the Interval is destroyed, clear its `setInterval` timer.
+impl Drop for Interval {
+    fn drop(&mut self) {
+        clearInterval(self.token);
+    }
+}
+
+// Keep logging "hello" every second until the resulting `Interval` is dropped.
+#[wasm_bindgen]
+pub fn hello() -> Interval {
+    Interval::new(1_000, || log("hello"))
+}
+
+#[wasm_bindgen_test]
+fn hello_test() {
+    hello();
+}

--- a/tests/wasm32-emscripten/main.rs
+++ b/tests/wasm32-emscripten/main.rs
@@ -26,7 +26,7 @@ pub struct Interval {
 impl Interval {
     pub fn new<F: 'static>(millis: u32, f: F) -> Interval
     where
-        F: FnMut()
+        F: FnMut(),
     {
         // Construct a new closure.
         let closure = Closure::new(f);


### PR DESCRIPTION
Adds `--target emscripten` option, which will output JS that Emscripten can consume and integrate into its own JS.

This is still a work-in-progress, but it's getting kind of beefy, so I thought it would be best to start review on this soon. There's still feature work to be done (i.e. I don't think futures work). My preference would be to submit this with only the current set of supporting features, mark `--target emscripten` as experimental, and then send smaller PRs to add more support.

Also adds a basic test. This test builds some rust code and links it with Emscripten, but the test runner invokes wasm-bindgen. It then tests to make sure the output looks reasonable. Normally, the wasm-bindgen cli tool is invoked by Emscripten at link time. Because cargo does not support binary dependencies, and because wasm-bindgen is effectively being used as a dependency of Emscripten, it's very difficult to do end-to-end testing in the wasm-bindgen repository. I'd like to add more comprehensive testing, but I think it's more appropriate to either Emscripten or to a new repository separate from wasm-bindgen and Emscripten that can depend on both of those repositories at HEAD.

It turns out wasm-bindgen also does not support Emscripten exceptions or PIC, so we've disabled both of those compiler options. This is mostly due to lack of features in the interpreter. Exception support is something I'd like to eventually add. PIC appears to be off by default for `wasm32-unknown-unknown` and on by default for `wasm32-unknown-emscripten`. PIC can be supported through changes to wasm-bindgen's interpreter, but that seemed a bit out of scope for this PR.

I've also made a corresponding PR to Emscripten: https://github.com/emscripten-core/emscripten/pull/23493

I've also made a PR to wasm-pack: https://github.com/rustwasm/wasm-pack/pull/1469. However, there has been no activity in wasm-pack by maintainers for ~4 months, and I suspect it's unlikely to get attention in the near future. The purpose of the wasm-pack PR is to provide a more straightforward workflow for Rust users already familiar with targeting Wasm.