### PR TITLE
Addressed clippy warnings

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -599,7 +599,7 @@ macro_rules! doit {
 
                 inform(invoke::<$($var,)* R> as usize as u32);
 
-                unsafe extern fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                 ) {
@@ -660,7 +660,7 @@ macro_rules! doit {
 
                 inform(invoke::<$($var,)* R> as usize as u32);
 
-                unsafe extern fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
+                unsafe extern "C" fn destroy<$($var: FromWasmAbi,)* R: ReturnWasmAbi>(
                     a: usize,
                     b: usize,
                 ) {

--- a/src/convert/impls.rs
+++ b/src/convert/impls.rs
@@ -44,7 +44,7 @@ impl WasmAbi for i128 {
 
     #[inline]
     fn join(low: u64, high: u64, _: (), _: ()) -> Self {
-        ((high as u128) << 64 | low as u128) as i128
+        (((high as u128) << 64) | low as u128) as i128
     }
 }
 impl WasmAbi for u128 {
@@ -62,7 +62,7 @@ impl WasmAbi for u128 {
 
     #[inline]
     fn join(low: u64, high: u64, _: (), _: ()) -> Self {
-        (high as u128) << 64 | low as u128
+        ((high as u128) << 64) | low as u128
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ macro_rules! externs {
         $(
             #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
             #[allow(unused_variables)]
-            unsafe extern fn $name($($args)*) -> $ret {
+            unsafe extern "C" fn $name($($args)*) -> $ret {
                 panic!("function not implemented on non-wasm32 targets")
             }
         )*


### PR DESCRIPTION
This fixes [`#[warn(clippy::precedence)]`](https://rust-lang.github.io/rust-clippy/master/index.html#precedence) as well as warnings for `extern declarations without an explicit ABI are deprecated` in nightly toolchains.