### PR TITLE
Typescript Generic Types

### DIFF
--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -45,7 +45,9 @@ macro_rules! intrinsics {
                                 shim_idx: 0,
                                 arguments: vec![$($arg),*],
                                 ret: $ret,
-                                inner_ret: None
+                                inner_ret: None,
+                                inner_ret_map: None,
+                                args_ty_map: None,
                             }
                         }
                     )*

--- a/crates/cli-support/src/wit/incoming.rs
+++ b/crates/cli-support/src/wit/incoming.rs
@@ -181,6 +181,9 @@ impl InstructionBuilder<'_, '_> {
                 Instruction::I32FromNonNull,
                 &[AdapterType::I32],
             ),
+
+            // cant be reached
+            Descriptor::Generic { .. } => unreachable!(),
         }
         Ok(())
     }

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -32,6 +32,8 @@ pub struct Adapter {
     pub results: Vec<AdapterType>,
     pub inner_results: Vec<AdapterType>,
     pub kind: AdapterKind,
+    pub inner_results_map: Option<AdapterType>,
+    pub params_map: Option<Vec<Option<AdapterType>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -95,6 +97,11 @@ pub enum AdapterType {
     NamedExternref(String),
     Function,
     NonNull,
+    Unit,
+    Generic {
+        ty: Box<AdapterType>,
+        args: Box<[AdapterType]>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -404,6 +411,8 @@ impl NonstandardWitSection {
         results: Vec<AdapterType>,
         inner_results: Vec<AdapterType>,
         kind: AdapterKind,
+        inner_results_map: Option<AdapterType>,
+        params_map: Option<Vec<Option<AdapterType>>>,
     ) -> AdapterId {
         let id = AdapterId(self.adapters.len());
         self.adapters.insert(
@@ -414,6 +423,8 @@ impl NonstandardWitSection {
                 results,
                 inner_results,
                 kind,
+                inner_results_map,
+                params_map,
             },
         );
         id

--- a/crates/shared/src/identifier.rs
+++ b/crates/shared/src/identifier.rs
@@ -40,3 +40,8 @@ pub fn is_valid_ident(name: &str) -> bool {
             }
         })
 }
+
+/// An arbitrary code for describing a type map
+/// This is hash of `TYPE_DESCRIBE_MAP` truncated to u32
+/// using `std::hash::DefaultHasher`
+pub const TYPE_DESCRIBE_MAP: u32 = 2728578646;

--- a/crates/typescript-tests/src/lib.rs
+++ b/crates/typescript-tests/src/lib.rs
@@ -12,6 +12,7 @@ pub mod optional_fields;
 pub mod simple_async_fn;
 pub mod simple_fn;
 pub mod simple_struct;
+pub mod ts_generic_sig;
 pub mod typescript_type;
 pub mod usize;
 pub mod web_sys;

--- a/crates/typescript-tests/src/ts_generic_sig.rs
+++ b/crates/typescript-tests/src/ts_generic_sig.rs
@@ -1,0 +1,291 @@
+#![allow(clippy::all)]
+
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::__rt::*;
+use wasm_bindgen::convert::*;
+use wasm_bindgen::describe::*;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsCast, JsValue};
+
+#[derive(Serialize, Deserialize)]
+pub struct SomeType {
+    pub prop: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SomeGenericType<T> {
+    pub field: T,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct OtherGenericType<T, E> {
+    pub field1: T,
+    pub field2: E,
+}
+
+// some error type
+pub struct Error;
+
+#[wasm_bindgen]
+pub struct TestStruct;
+#[wasm_bindgen]
+impl TestStruct {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        TestStruct
+    }
+    #[wasm_bindgen]
+    pub async fn method1(
+        _arg1: SomeGenericType<u8>,
+        _arg2: OtherGenericType<bool, String>,
+        _arg3: &OtherGenericType<u64, SomeType>,
+    ) -> Result<OtherGenericType<Vec<SomeGenericType<Option<u8>>>, Option<Vec<String>>>, Error>
+    {
+        Ok(OtherGenericType {
+            field1: vec![SomeGenericType { field: Some(0) }],
+            field2: Some(vec![String::new()]),
+        })
+    }
+    #[wasm_bindgen(getter = "someProperty")]
+    pub fn method2(
+        &self,
+    ) -> Result<OtherGenericType<Option<Vec<SomeGenericType<Option<Vec<u8>>>>>, ()>, Error> {
+        Ok(OtherGenericType {
+            field1: Some(vec![SomeGenericType {
+                field: Some(vec![0]),
+            }]),
+            field2: (),
+        })
+    }
+}
+
+#[wasm_bindgen(js_name = "someFn")]
+pub async fn some_fn(
+    _arg1: &OtherGenericType<SomeGenericType<Vec<u16>>, Option<Vec<String>>>,
+    _arg2: Vec<SomeGenericType<Vec<SomeType>>>,
+) -> Result<OtherGenericType<Option<Vec<SomeGenericType<Option<u8>>>>, Option<Vec<String>>>, Error>
+{
+    Ok(OtherGenericType {
+        field1: Some(vec![SomeGenericType { field: Some(0) }]),
+        field2: Some(vec![String::new()]),
+    })
+}
+
+#[wasm_bindgen(js_name = "someOtherFn")]
+pub fn some_other_fn(
+    _arg1: SomeGenericType<Option<SomeType>>,
+) -> Option<Vec<OtherGenericType<SomeType, SomeGenericType<Option<SomeType>>>>> {
+    Some(vec![OtherGenericType {
+        field1: SomeType {
+            prop: String::new(),
+        },
+        field2: SomeGenericType {
+            field: Some(SomeType {
+                prop: String::new(),
+            }),
+        },
+    }])
+}
+
+#[wasm_bindgen(js_name = "anotherFn")]
+pub async fn another_fn(
+    _arg1: OtherGenericType<SomeType, Vec<u32>>,
+) -> OtherGenericType<SomeType, SomeGenericType<Option<SomeType>>> {
+    OtherGenericType {
+        field1: SomeType {
+            prop: String::new(),
+        },
+        field2: SomeGenericType {
+            field: Some(SomeType {
+                prop: String::new(),
+            }),
+        },
+    }
+}
+
+// ---
+// section below is just implementing wasm bindgen traits and ttypescript def for test structs
+
+// a helper macro to impl wasm traits for a given type
+macro_rules! impl_wasm_traits {
+    ($type_name:ident $(< $($generics:ident),+ >)?) => {
+        impl$(<$($generics),+>)? IntoWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Abi = <JsValue as IntoWasmAbi>::Abi;
+            fn into_abi(self) -> Self::Abi {
+                serde_wasm_bindgen::to_value(&self)
+                    .map(<JsValue as JsCast>::unchecked_from_js)
+                    .unwrap_throw()
+                    .into_abi()
+            }
+        }
+        impl$(<$($generics),+>)? OptionIntoWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            fn none() -> Self::Abi {
+                0
+            }
+        }
+        impl$(<$($generics),+>)? FromWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Abi = <JsValue as FromWasmAbi>::Abi;
+            unsafe fn from_abi(js: Self::Abi) -> Self {
+                serde_wasm_bindgen::from_value(JsValue::from_abi(js).into()).unwrap_throw()
+            }
+        }
+        impl$(<$($generics),+>)? OptionFromWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            fn is_none(js: &Self::Abi) -> bool {
+                *js == 0
+            }
+        }
+        impl$(<$($generics),+>)? RefFromWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Abi = <JsValue as RefFromWasmAbi>::Abi;
+            type Anchor = Box<Self>;
+            unsafe fn ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                Box::new(<Self as FromWasmAbi>::from_abi(js))
+            }
+        }
+        impl$(<$($generics),+>)? LongRefFromWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Abi = <JsValue as LongRefFromWasmAbi>::Abi;
+            type Anchor = Box<Self>;
+            unsafe fn long_ref_from_abi(js: Self::Abi) -> Self::Anchor {
+                Box::new(<Self as FromWasmAbi>::from_abi(js))
+            }
+        }
+        impl$(<$($generics),+>)? VectorIntoWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Abi = <Box<[JsValue]> as IntoWasmAbi>::Abi;
+            fn vector_into_abi(vector: Box<[Self]>) -> Self::Abi {
+                js_value_vector_into_abi(vector)
+            }
+        }
+        impl$(<$($generics),+>)? VectorFromWasmAbi for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Abi = <Box<[JsValue]> as FromWasmAbi>::Abi;
+            unsafe fn vector_from_abi(js: Self::Abi) -> Box<[Self]> {
+                js_value_vector_from_abi(js)
+            }
+        }
+        impl$(<$($generics),+>)? WasmDescribeVector for $type_name$(<$($generics),+>)? {
+            fn describe_vector() {
+                inform(VECTOR);
+                <Self as WasmDescribe>::describe();
+            }
+        }
+        impl$(<$($generics),+>)? From<$type_name$(<$($generics),+>)?> for JsValue
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            fn from(value: $type_name$(<$($generics),+>)?) -> Self {
+                serde_wasm_bindgen::to_value(&value).unwrap_throw()
+            }
+        }
+        impl$(<$($generics),+>)? TryFromJsValue for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            type Error = serde_wasm_bindgen::Error;
+            fn try_from_js_value(value: JsValue) -> Result<Self, Self::Error> {
+                serde_wasm_bindgen::from_value(value)
+            }
+        }
+        impl$(<$($generics),+>)? VectorIntoJsValue for $type_name$(<$($generics),+>)?
+        $(where $($generics: serde::Serialize + for<'de> serde::Deserialize<'de>, )+ )?
+        {
+            fn vector_into_jsvalue(vector: Box<[Self]>) -> JsValue {
+                js_value_vector_into_jsvalue(vector)
+            }
+        }
+    };
+}
+
+// impl wasm traits for test types
+impl_wasm_traits!(SomeType);
+impl WasmDescribe for SomeType {
+    fn describe() {
+        inform(NAMED_EXTERNREF);
+        inform(8u32);
+        inform(83u32);
+        inform(111u32);
+        inform(109u32);
+        inform(101u32);
+        inform(84u32);
+        inform(121u32);
+        inform(112u32);
+        inform(101u32);
+    }
+}
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_CONTENT: &str = "export interface SomeType {
+    prop: string;
+}";
+
+impl_wasm_traits!(SomeGenericType<T>);
+impl<T> WasmDescribe for SomeGenericType<T> {
+    fn describe() {
+        inform(NAMED_EXTERNREF);
+        inform(15u32);
+        inform(83u32);
+        inform(111u32);
+        inform(109u32);
+        inform(101u32);
+        inform(71u32);
+        inform(101u32);
+        inform(110u32);
+        inform(101u32);
+        inform(114u32);
+        inform(105u32);
+        inform(99u32);
+        inform(84u32);
+        inform(121u32);
+        inform(112u32);
+        inform(101u32);
+    }
+}
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_CONTENT: &str = "export interface SomeGenericType<T> {
+    field: T;
+}";
+
+impl_wasm_traits!(OtherGenericType<T, E>);
+impl<T, E> WasmDescribe for OtherGenericType<T, E> {
+    fn describe() {
+        inform(NAMED_EXTERNREF);
+        inform(16u32);
+        inform(79u32);
+        inform(116u32);
+        inform(104u32);
+        inform(101u32);
+        inform(114u32);
+        inform(71u32);
+        inform(101u32);
+        inform(110u32);
+        inform(101u32);
+        inform(114u32);
+        inform(105u32);
+        inform(99u32);
+        inform(84u32);
+        inform(121u32);
+        inform(112u32);
+        inform(101u32);
+    }
+}
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_CONTENT: &str = "export interface OtherGenericType<T, E> {
+    field1: T;
+    field2: E;
+}";
+
+impl From<Error> for JsValue {
+    fn from(_value: Error) -> Self {
+        JsValue::from(JsError::new("some error msg"))
+    }
+}

--- a/crates/typescript-tests/src/ts_generic_sig.ts
+++ b/crates/typescript-tests/src/ts_generic_sig.ts
@@ -1,0 +1,88 @@
+import * as wbg from '../pkg/typescript_tests';
+import * as wasm from '../pkg/typescript_tests_bg.wasm';
+import { expect, test } from "@jest/globals";
+
+const wasm_someFn: (a: number, b: number, c: number) => number = wasm.someFn;
+const wbg_someFn: (
+    arg1: wbg.OtherGenericType<wbg.SomeGenericType<Uint16Array>, string[] | null | undefined>,
+    arg2: wbg.SomeGenericType<wbg.SomeType[]>[]
+) => Promise<
+    wbg.OtherGenericType<
+        wbg.SomeGenericType<number | undefined>[] | undefined,
+        string[] | undefined
+    >
+> = wbg.someFn;
+
+const wasm_someOtherFn: (a: number) => [number, number] = wasm.someOtherFn;
+const wbg_someOtherFn: (
+    arg1: wbg.SomeGenericType<wbg.SomeType | null | undefined>
+) => wbg.OtherGenericType<
+    wbg.SomeType,
+    wbg.SomeGenericType<wbg.SomeType | undefined>
+>[] | undefined = wbg.someOtherFn;
+
+const wasm_anotherFn: (a: number) => [number, number] = wasm.anotherFn;
+const wbg_anotherFn: (
+    arg1: wbg.OtherGenericType<wbg.SomeType, Uint32Array>
+) => Promise<
+    wbg.OtherGenericType<
+        wbg.SomeType,
+        wbg.SomeGenericType<wbg.SomeType | undefined>
+    >
+> = wbg.anotherFn;
+
+const wasm_teststruct_method1: (a: any, b: any, c: any) => any = wasm.teststruct_method1;
+const wbg_teststruct_method1: (
+    arg1: wbg.SomeGenericType<number>,
+    arg2: wbg.OtherGenericType<boolean, string>,
+    arg3: wbg.OtherGenericType<bigint, wbg.SomeType>
+) => Promise<
+    wbg.OtherGenericType<
+        wbg.SomeGenericType<number | undefined>[],
+        string[] | undefined
+    >
+> = wbg.TestStruct.method1;
+
+const wasm_teststruct_method2: (a: number) => [number,  number, number] = wasm.teststruct_method2;
+const wbg_teststruct_method2: wbg.OtherGenericType<
+    wbg.SomeGenericType<Uint8Array>[],
+    undefined
+> = new wbg.TestStruct().someProperty;
+
+test("test generics in function signatures", async() => {
+    expect(wbg_teststruct_method2).toStrictEqual({
+        field1: [{ field: [0] }],
+        field2: undefined,
+    })
+
+    expect(await wbg_teststruct_method1(
+        {field: 1},
+        {field1: true, field2: "abcd"},
+        {field1: BigInt(8), field2: {prop: "zxc"}}
+    )).toStrictEqual({
+        field1: [{ field: 0 }],
+        field2: [""],
+    })
+
+    expect(await wbg_anotherFn(
+        {field1: {prop: "abcd"}, field2: Uint32Array.from([1, 2, 3])},
+    )).toStrictEqual({
+        field1: { prop: "" },
+        field2: { field: { prop: "" } }
+    })
+
+    expect(wbg_someOtherFn(
+        {field: {prop: "zxc"}}
+    )).toStrictEqual([{
+        field1: { prop: "" },
+        field2: { field: { prop: "" } }
+    }])
+
+    expect(await wbg_someFn(
+        {field1: {field: Uint16Array.from([1, 2, 3])}, field2: ["zxc", "abcd"]},
+        [{field: [{prop: "abcd"}]}],
+    )).toStrictEqual({
+        field1: [{ field: 0 }],
+        field2: [""],
+    })
+})

--- a/examples/guide-supported-types-examples/Cargo.toml
+++ b/examples/guide-supported-types-examples/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib"]
 [dependencies]
 js-sys = { path = "../../crates/js-sys" }
 wasm-bindgen = { path = "../../" }
+serde = { version = "1.0", features = ["derive", "rc"] }
+serde-wasm-bindgen = { version = "0.6" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
### Motivation

Currently if a function/method has a generic return or arguments type like:
```rust
pub fn some_fn(arg: SomeType<String>) -> SomeType<u8> {}
// or
pub fn some_fn(arg: SomeType<String>) -> Result<SomeType<u8>, JsValue> {}
```
where `SomeType` is just plain struct that impls wasm traits manually (not using wasm_bindgen macro on its definition, ie not js class) the generated typescript bindings wont correctly map the types and doesnt actually include the inner types:
```ts
// for both cases above
export function some_fn(arg: SomeType): SomeType
```
Although user can use `unchecked_return_type` and `unchecked_param_type` attribute to specify them, but this is not really ideal, however if the nested types can be processed regularly like the main type in recursive fashion, this can simply be resolved, so on typescript we would get:
```ts
// for both cases above
export function some_fn(arg: SomeType<string>): SomeType<number>
```
### Proposed Solution
Implement some logic to parse and map the types deeply, possibly recursively, until all nested types are parsed and accounted for in generated typescript.
There is a mapper currently that maps the rust return types to their equivalent js/ts types, but looks like it just checks 1 level deep, and doesnt go deeper than that, however with some tweaks, the same logic can be applied on nested types to correctly map the return type for the js/ts bindings:

## High-Level Implementation Details

We we would use native encoded/decoded `WasmDescribe::inform()` for return and arguments types, meaning we will encode their wasm informs in the `backend::codegen` for `Export` and then decode it at `cli-support::descriptor::Function` which now has 2 new more fields:
`inner_ret_map` and `args_ty_map`, these 2 field hold the `Descriptor` which now has 1 more variant called `Descriptor::Generic`:
```rust
Descriptor::Generic {
        ty: Box<Descriptor>,
        args: Box<[Descriptor]>,
}
```
 that can hold the type map for both args and return type, now at `cli-support::wit::register_export_adapter` we convert those `inner_ret_map` and `args_ty_map` fields into `AdapterType` using a newly added function called `describe_map_to_adapter` where it just maps the given `Descriptor` to its `AdapterType` by also handling of nested generic types.
Lastly when building the ts signature and js doc for the binding function/method, we will convert those generic `AdapterType`s into their corresponding js/ts types and append them to the main parent type.