### PR TITLE
Add missing isPointInFill and isPointInStroke methods 

### DIFF
--- a/crates/web-sys/src/features/gen_SvgGeometryElement.rs
+++ b/crates/web-sys/src/features/gen_SvgGeometryElement.rs
@@ -38,4 +38,34 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `SvgGeometryElement`*"]
     pub fn get_total_length(this: &SvgGeometryElement) -> f32;
+    # [wasm_bindgen (method , structural , js_class = "SVGGeometryElement" , js_name = isPointInFill)]
+    #[doc = "The `isPointInFill()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInFill)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SvgGeometryElement`*"]
+    pub fn is_point_in_fill(this: &SvgGeometryElement) -> bool;
+    #[cfg(feature = "DomPointInit")]
+    # [wasm_bindgen (method , structural , js_class = "SVGGeometryElement" , js_name = isPointInFill)]
+    #[doc = "The `isPointInFill()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInFill)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomPointInit`, `SvgGeometryElement`*"]
+    pub fn is_point_in_fill_with_point(this: &SvgGeometryElement, point: &DomPointInit) -> bool;
+    # [wasm_bindgen (method , structural , js_class = "SVGGeometryElement" , js_name = isPointInStroke)]
+    #[doc = "The `isPointInStroke()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `SvgGeometryElement`*"]
+    pub fn is_point_in_stroke(this: &SvgGeometryElement) -> bool;
+    #[cfg(feature = "DomPointInit")]
+    # [wasm_bindgen (method , structural , js_class = "SVGGeometryElement" , js_name = isPointInStroke)]
+    #[doc = "The `isPointInStroke()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomPointInit`, `SvgGeometryElement`*"]
+    pub fn is_point_in_stroke_with_point(this: &SvgGeometryElement, point: &DomPointInit) -> bool;
 }

--- a/crates/web-sys/webidls/enabled/SVGGeometryElement.webidl
+++ b/crates/web-sys/webidls/enabled/SVGGeometryElement.webidl
@@ -17,4 +17,7 @@ interface SVGGeometryElement : SVGGraphicsElement {
   float getTotalLength();
   [NewObject, Throws]
   SVGPoint getPointAtLength(float distance);
+
+  boolean isPointInFill(optional DOMPointInit point);
+  boolean isPointInStroke(optional DOMPointInit point);
 };


### PR DESCRIPTION
Add missing isPointInFill and isPointInStroke methods to SVGGeometryElement idl. 

Fixes #4507

---

For the fix, I read the contributing guidelines regarding the web-sys package. Once I figured out how the interfaces are built from the IDLs, I found the [SVGGeometryElement IDL](https://www.w3.org/TR/SVG2/types.html#InterfaceSVGGeometryElement) on w3.org and added the missing interfaces. Then, I compiled using the [instructions](https://rustwasm.github.io/docs/wasm-bindgen/contributing/web-sys/supporting-more-web-apis.html) for adding new web-sys APIs.

The generated interfaces looked correct to me so I figured I'd go ahead and make a PR. Hope this helps. Let me know if this isn't quite correct!