### PR TITLE
TryFromJsRef trait Proposal

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -93,6 +93,7 @@ struct ExportedClass {
     has_constructor: bool,
     wrap_needed: bool,
     unwrap_needed: bool,
+    peek_needed: bool,
     /// Whether to generate helper methods for inspecting the class
     is_inspectable: bool,
     /// All readable properties of the class
@@ -1090,6 +1091,19 @@ __wbg_set_wasm(wasm);"
                         return 0;
                     }}
                     return jsValue.__destroy_into_raw();
+                }}
+                ",
+            ));
+        }
+
+        if class.peek_needed {
+            dst.push_str(&format!(
+                "
+                static __peek(jsValue) {{
+                    if (!(jsValue instanceof {name})) {{
+                        return 0;
+                    }}
+                    return jsValue.__wbg_ptr;
                 }}
                 ",
             ));
@@ -2570,6 +2584,10 @@ __wbg_set_wasm(wasm);"
         require_class(&mut self.exported_classes, name).unwrap_needed = true;
     }
 
+    fn require_class_peek(&mut self, name: &str) {
+        require_class(&mut self.exported_classes, name).peek_needed = true;
+    }
+
     fn add_module_import(&mut self, module: String, name: &str, actual: &str) {
         let rename = if name == actual {
             None
@@ -3559,6 +3577,14 @@ __wbg_set_wasm(wasm);"
                 assert_eq!(args.len(), 1);
                 self.require_class_unwrap(class);
                 Ok(format!("{}.__unwrap({})", class, args[0]))
+            }
+
+            AuxImport::PeekExportedClassPointer(class) => {
+                assert!(kind == AdapterJsImportKind::Normal);
+                assert!(!variadic);
+                assert_eq!(args.len(), 1);
+                self.require_class_peek(class);
+                Ok(format!("{}.__peek({})", class, args[0]))
             }
         }
     }

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -1064,6 +1064,14 @@ impl<'a> Context<'a> {
             AuxImport::UnwrapExportedClass(struct_.name.to_string()),
         )?;
 
+        let peek_fn = wasm_bindgen_shared::peek_function(struct_.name);
+        self.add_aux_import_to_import_map(
+            &peek_fn,
+            vec![Descriptor::Externref],
+            Descriptor::I32,
+            AuxImport::PeekExportedClassPointer(struct_.name.to_string()),
+        )?;
+
         Ok(())
     }
 

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -368,6 +368,11 @@ pub enum AuxImport {
     /// instance of the given exported class. The class name is one that is
     /// exported from the Rust/wasm.
     UnwrapExportedClass(String),
+
+    /// This import is a generated shim which will non-destructively peek the raw
+    /// pointer from a JsValue that wraps the given exported class.
+    /// Returns 0 if the value is not an instance of the class.
+    PeekExportedClassPointer(String),
 }
 
 /// Values that can be imported verbatim to hook up to an import.

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -204,6 +204,13 @@ pub fn unwrap_function(struct_name: &str) -> String {
     name
 }
 
+pub fn peek_function(struct_name: &str) -> String {
+    let mut name = "__wbg_".to_string();
+    name.extend(struct_name.chars().flat_map(|s| s.to_lowercase()));
+    name.push_str("_peek");
+    name
+}
+
 pub fn free_function_export_name(function_name: &str) -> String {
     function_name.to_string()
 }


### PR DESCRIPTION
I found myself needing something like this when trying to pass a custom object through the FFI boundary without transferring ownership to Rust:

```rust
pub trait TryFromJsRef {
    /// The type returned in the event of a conversion error.
    type Error;

    /// Performs the conversion.
    fn try_from_js_ref(value: &JsValue) -> Result<&Self, Self::Error>;
}
```

When I call a method that takes a `&JsValue` and use `try_from_js_value` to get my object internally, it consumes the object, and the second call to the same function fails. So, I feel an equivalent `try_from_js_ref` is needed, unless there is already a canonical way to achieve that that I'm not aware of.

This PR implements it. Reviews & feedback are welcome!