### PR TITLE
Fix the mismatch between definition and access of `encode_into`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fixed incorrect function mapping during post-processing.
   [#4656](https://github.com/wasm-bindgen/wasm-bindgen/pull/4656)
 
+* Fixed wasm-bindgen-cli's `encode_into` argument not working.
+  [#4663](https://github.com/wasm-bindgen/wasm-bindgen/pull/4663)
+
 --------------------------------------------------------------------------------
 
 ## [0.2.102](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.101...0.2.102)

--- a/crates/cli/src/bin/wasm-bindgen.rs
+++ b/crates/cli/src/bin/wasm-bindgen.rs
@@ -76,7 +76,7 @@ struct Args {
         help = "Whether or not to use TextEncoder#encodeInto",
         value_parser = ["test", "always", "never"]
     )]
-    encode_into: Option<EncodeInto>,
+    encode_into: Option<String>,
     #[arg(
         long,
         help = "Don't add WebAssembly fallback imports in generated JavaScript"
@@ -164,7 +164,15 @@ fn rmain(args: &Args) -> Result<(), Error> {
     if let Some(ref name) = args.out_name {
         b.out_name(name);
     }
-    if let Some(mode) = args.encode_into {
+
+    if let Some(mode) = &args.encode_into {
+        let mode = match mode.as_str() {
+            "test" => EncodeInto::Test,
+            "always" => EncodeInto::Always,
+            "never" => EncodeInto::Never,
+            // clap guarantees
+            _ => unreachable!(),
+        };
         b.encode_into(mode);
     }
 


### PR DESCRIPTION
Implementing `ValueEnum` for `EncodeInto` also can fix, but it requires importing `clap` crate into `cli-support`, which is a bit heavy.

resolves https://github.com/wasm-bindgen/wasm-bindgen/issues/4662