### PR TITLE
Switch CLI tests to use the library API

### DIFF
--- a/crates/cli/tests/wasm-bindgen/reference.rs
+++ b/crates/cli/tests/wasm-bindgen/reference.rs
@@ -222,9 +222,9 @@ fn runtest_with_opts(
             .find_map(|f| f.strip_prefix("--target="))
             .unwrap_or("bundler");
 
-        let (mut cmd, out_dir) =
-            project.wasm_bindgen(&format!("{flags} --out-name reference_test"));
-        cmd.assert().success();
+        let out_dir = project
+            .wasm_bindgen(&format!("{flags} --out-name reference_test"))
+            .unwrap();
 
         // suffix the file name with the sanitized flags
         let test = if all_flags.len() > 1 {


### PR DESCRIPTION
Using the CLI "API" added in #4710. They are still doing same work as before, just without having to spawn another subprocess per test.