### PR TITLE
Fix Closure interaction with Pin

### DIFF
--- a/src/closure.rs
+++ b/src/closure.rs
@@ -248,9 +248,13 @@ extern "C" {
 /// ```
 pub struct Closure<T: ?Sized> {
     js: JsClosure,
-     // careful: must be Box<T> not just T because unsized PhantomData
-     // seems to have weird interaction with Pin<>
+    // careful: must be Box<T> not just T because unsized PhantomData
+    // seems to have weird interaction with Pin<>
     _marker: PhantomData<Box<T>>,
+}
+
+fn _assert_compiles<T>(mut pin: core::pin::Pin<&mut Closure<T>>) {
+    let _ = &mut *pin;
 }
 
 impl<T> Closure<T>


### PR DESCRIPTION
This is hell of a bug-at-a-distance, and I almost suspect it might be a Rust bug since for all other intents and purposes `Closure<T>` was still considered `Sized` even without this fix.

I'll look into it a bit more, but for now... Fixes #4732.