### PR TITLE
 Mention wasm-stack-trace as an option for better stack traces

### DIFF
--- a/guide/src/reference/debug-info.md
+++ b/guide/src/reference/debug-info.md
@@ -3,9 +3,13 @@
 Currently, debug information in the form of DWARF, is stripped away from the output module.
 To keep it, use [`--keep-debug`](cli.html#--keep-debug) with the CLI.
 
-However, currently there are no known environments that support DWARF information with Wasm.
-You can follow the [Debug C/C++ WebAssembly](https://developer.chrome.com/docs/devtools/wasm) guide
-to get DWARF support in Chrome. This doesn't just demangle symbols in your stacktraces, but also
-allows for live debugging in the dev-tools or in external editors have a debugger bridge to Chrome.
+Most environments don't support DWARF information natively but you can use a JavaScript library
+such as [wasm-stack-trace](https://github.com/membrane-io/wasm-stack-trace) to get file,
+line/column, and demangled symbols in your stack traces.
+
+You can also follow the [Debug C/C++ WebAssembly](https://developer.chrome.com/docs/devtools/wasm) 
+guide to get DWARF support in Chrome. This doesn't just demangle symbols in your stacktraces, but 
+also allows for live debugging in the dev-tools or in external editors have a debugger bridge to
+Chrome.
 
 The `wasm-bindgen-test-runner` currently generates DWARF debug information for tests by default.


### PR DESCRIPTION
We just published a library that hooks up to `prepareStackTrace` to enhance JavaScript `Error` objects with DWARF data (using gimli compiled to wasm). I thought it was worth mentioning in the wasm-bindgen guide for folks looking to improve their debugging experience.

It's pretty easy to use (Add a `<script>` tag to your HTML). This must run _before_ Module compilation so it can't be done in a rust crate.

To illustrate the difference:

<img width="1033" height="225" alt="Screenshot 2025-10-17 at 12 43 26" src="https://github.com/user-attachments/assets/c2e08d64-e866-4895-be0e-1b8bffb2030a" />
