### PR TITLE
feat: classless this type

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -25,6 +25,8 @@ pub struct Builder<'a, 'b> {
     /// Whether or not this is building a method of a Rust class instance, and
     /// whether or not the method consumes `self` or not.
     method: Option<bool>,
+    /// Whether this is a classless this function (receives JS `this` as first param)
+    classless_this: bool,
     /// Whether or not we're catching exceptions from the main function
     /// invocation. Currently only used for imports.
     catch: bool,
@@ -99,12 +101,17 @@ impl<'a, 'b> Builder<'a, 'b> {
             cx,
             constructor: None,
             method: None,
+            classless_this: false,
             catch: false,
         }
     }
 
     pub fn method(&mut self, consumed: bool) {
         self.method = Some(consumed);
+    }
+
+    pub fn classless_this(&mut self) {
+        self.classless_this = true;
     }
 
     pub fn constructor(&mut self, class: &str) {
@@ -170,6 +177,9 @@ impl<'a, 'b> Builder<'a, 'b> {
             } else {
                 js.args.push("this.__wbg_ptr".into());
             }
+        } else if self.classless_this {
+            let _ = params.next();
+            js.args.push("this".into());
         }
         for (i, param) in params.enumerate() {
             let arg = match args_data {

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2894,6 +2894,9 @@ wasm = wasmInstance.exports;
                 ret_desc = &export.fn_ret_desc;
                 match &export.kind {
                     AuxExportKind::Function(_) => {}
+                    AuxExportKind::FunctionThis(_) => {
+                        builder.classless_this();
+                    }
                     AuxExportKind::Constructor(class) => builder.constructor(class),
                     AuxExportKind::Method { receiver, .. } => match receiver {
                         AuxReceiverKind::None => {}
@@ -2966,7 +2969,7 @@ wasm = wasmInstance.exports;
                 let ts_docs = format_doc_comments(&export.comments, ts_doc_opts);
 
                 match &export.kind {
-                    AuxExportKind::Function(name) => {
+                    AuxExportKind::Function(name) | AuxExportKind::FunctionThis(name) => {
                         if let Some(ts_sig) = ts_sig {
                             self.typescript.push_str(&ts_docs);
                             self.typescript.push_str("export function ");

--- a/crates/cli-support/src/wit/nonstandard.rs
+++ b/crates/cli-support/src/wit/nonstandard.rs
@@ -124,6 +124,9 @@ pub enum AuxExportKind {
     /// A free function that's just listed on the exported module
     Function(String),
 
+    /// A free function that receives JS `this` as its first parameter
+    FunctionThis(String),
+
     /// A function that's used to create an instance of a class. The function
     /// actually return just an integer which is put on an JS object currently.
     Constructor(String),

--- a/crates/macro-support/src/ast.rs
+++ b/crates/macro-support/src/ast.rs
@@ -237,6 +237,8 @@ pub struct Operation {
 pub enum OperationKind {
     /// A standard method, nothing special
     Regular,
+    /// A free function that receives JS `this` as its first parameter
+    RegularThis,
     /// A method for getting the value of the provided Ident or String
     Getter(Option<String>),
     /// A method for setting the value of the provided Ident or String

--- a/crates/macro-support/src/encode.rs
+++ b/crates/macro-support/src/encode.rs
@@ -609,6 +609,7 @@ fn from_ast_method_kind<'a>(
                     OperationKind::Getter(g.unwrap_or_else(|| function.infer_getter_property()))
                 }
                 ast::OperationKind::Regular => OperationKind::Regular,
+                ast::OperationKind::RegularThis => OperationKind::RegularThis,
                 ast::OperationKind::Setter(s) => {
                     let s = s.as_ref().map(|s| intern.intern_str(s));
                     OperationKind::Setter(match s {

--- a/crates/shared/src/lib.rs
+++ b/crates/shared/src/lib.rs
@@ -88,6 +88,7 @@ macro_rules! shared_api {
 
         enum OperationKind<'a> {
             Regular,
+            RegularThis,
             Getter(&'a str),
             Setter(&'a str),
             IndexingGetter,

--- a/crates/shared/src/schema_hash_approval.rs
+++ b/crates/shared/src/schema_hash_approval.rs
@@ -8,7 +8,7 @@
 // If the schema in this library has changed then:
 //  1. Bump the version in `crates/shared/Cargo.toml`
 //  2. Change the `SCHEMA_VERSION` in this library to this new Cargo.toml version
-const APPROVED_SCHEMA_FILE_HASH: &str = "5685178079664468453";
+const APPROVED_SCHEMA_FILE_HASH: &str = "17505529295227384102";
 
 #[test]
 fn schema_version() {

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -92,6 +92,7 @@
       - [`skip_jsdoc`](./reference/attributes/on-rust-exports/skip_jsdoc.md)
       - [`start`](./reference/attributes/on-rust-exports/start.md)
       - [`main`](./reference/attributes/on-rust-exports/main.md)
+      - [`this`](./reference/attributes/on-rust-exports/this.md)
       - [`typescript_custom_section`](./reference/attributes/on-rust-exports/typescript_custom_section.md)
       - [`getter` and `setter`](./reference/attributes/on-rust-exports/getter-and-setter.md)
       - [`inspectable`](./reference/attributes/on-rust-exports/inspectable.md)

--- a/guide/src/reference/attributes/on-rust-exports/this.md
+++ b/guide/src/reference/attributes/on-rust-exports/this.md
@@ -1,0 +1,29 @@
+# `this`
+
+Typically, `this` bindings are achieved via `impl` block definitions for methods.
+
+But since all regular JavaScript functions may accept arbitrary `this` bindings, it is possible to support this as well for free functions.
+
+The `#[wasm_bindgen(this)]` attribute can be applied to exported Rust functions to make them receive the JavaScript `this` value as their first parameter. This allows creating functions that can be called with `.call()` or `.apply()` to set the `this` context.
+
+```rust
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(this)]
+pub fn get_property(this: &JsValue, property: &str) -> JsValue {
+    js_sys::Reflect::get(this, &property.into()).unwrap()
+}
+
+#[wasm_bindgen(this)]
+pub fn add_to_count(foo: &JsValue, value: u32) -> u32 {
+    let current = js_sys::Reflect::get(foo, &"count".into())
+        .unwrap()
+        .as_f64()
+        .unwrap() as u32;
+    current + value
+}
+```
+
+With the above called via `get_property.call({ str: 'foo' }, 'str')` or `add_to_count.apply({ count: 1 }, [7])` respectively.
+
+Can only be used on functions, not methods or static methods within `impl` blocks, and the function must have at least one parameter.

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -255,3 +255,20 @@ exports.js_test_class_defined_in_macro = () => {
     macroClass.a = 5;
     assert.strictEqual(macroClass.a, 5);
 };
+
+exports.js_classless_this = () => {
+    const obj1 = { number: 42 };
+    const result1 = wasm.classless_this_get_number.call(obj1);
+    assert.strictEqual(result1, 42);
+
+    const obj2 = { count: 10 };
+    const result2 = wasm.classless_this_add.call(obj2, 5);
+    assert.strictEqual(result2, 15);
+
+    const result3 = wasm.classless_this_add.apply(obj2, [7]);
+    assert.strictEqual(result3, 17);
+
+    const obj3 = { test: 'value' };
+    const result4 = wasm.classless_this_consume_jsvalue.call(obj3);
+    assert.strictEqual(result4, true);
+};

--- a/tests/wasm/classes.rs
+++ b/tests/wasm/classes.rs
@@ -36,6 +36,7 @@ extern "C" {
     fn js_test_inspectable_classes();
     fn js_test_inspectable_classes_can_override_generated_methods();
     fn js_test_class_defined_in_macro();
+    fn js_classless_this();
 }
 
 #[wasm_bindgen_test]
@@ -666,4 +667,31 @@ impl InsideMacro {
 #[wasm_bindgen_test]
 fn class_defined_in_macro() {
     js_test_class_defined_in_macro();
+}
+
+#[wasm_bindgen_test]
+fn classless_this() {
+    js_classless_this();
+}
+
+#[wasm_bindgen(this)]
+pub fn classless_this_get_number(this: &JsValue) -> u32 {
+    js_sys::Reflect::get(this, &"number".into())
+        .unwrap()
+        .as_f64()
+        .unwrap() as u32
+}
+
+#[wasm_bindgen(this)]
+pub fn classless_this_add(this: &JsValue, value: u32) -> u32 {
+    let current = js_sys::Reflect::get(this, &"count".into())
+        .unwrap()
+        .as_f64()
+        .unwrap() as u32;
+    current + value
+}
+
+#[wasm_bindgen(this)]
+pub fn classless_this_consume_jsvalue(foo_this: JsValue) -> bool {
+    foo_this.is_object()
 }


### PR DESCRIPTION
This adds a new feature for exported functions that are not class methods / static methods, to support a typed `this` argument as the first argument.

We could have implemented this based on the special arg name `this: ...` like TypeScript does but I wasn't sure if that would be a breaking change. Would be interested to hear opinions on that.

Instead what I've done for now is added a new `#[wasm_bindgen(this)]` attribute which can be applied to an exported function to imply that it's first argument in Rust is the JS `this` argument.

A validation error is thrown when trying to attach this to a `impl` block definition or a function without at least one arg.