### PR TITLE
Fix 105 release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -543,7 +543,7 @@ jobs:
     permissions:
       contents: write #  to push changes in repo (jamesives/github-pages-deploy-action)
 
-    if: github.repository == 'wasm-bindgen/wasm-bindgen' && github.ref == 'refs/heads/main'
+    if: github.repository == 'wasm-bindgen/wasm-bindgen' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     needs:
       - doc_api
       - doc_book


### PR DESCRIPTION
The release workflow is currently gated behind mutually contradictory conditions - the `deploy` is gated on `github.ref == 'refs/heads/main'`, which then includes a crates.io deploy step which is individually gated on `startsWith(github.ref, 'refs/tags/')`. Since both of these conditions can never be simultaneously true, the automated deployment never happens.

This updates the workflow to gate the deploy workflow on `github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')` to ensure that pushing up a tag on its own will still run the deploy workflow.

This fix will still require a manual workflow run on the tag, since it doesn't also update the workflow condition to support  e.g.:

```
tags:
      - '*'
      - '!dev'
```

But running the workflow manually for now seems fine too,  we just need to get something working first and foremost.