### PR TITLE
feat: Support unsafe-single-threaded-traits configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,7 @@ jobs:
           - name: enable-interning
             run: cargo test --target wasm32-unknown-unknown --features enable-interning
           - name: unsafe-single-threaded-traits
-            run: cargo test --target wasm32-unknown-unknown --features unsafe-single-threaded-traits
+            run: RUSTFLAGS="--cfg unsafe_single_threaded_traits" cargo test --target wasm32-unknown-unknown
     name: "Run wasm-bindgen crate tests (${{ matrix.runs.name }})"
     runs-on: ubuntu-latest
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,6 @@ serde-serialize = ["serde", "serde_json", "std"]
 spans = []
 std = []
 
-# UNSAFE: Enables Send and Sync implementations for JS types (JsValue, Closure, etc.)
-# This is only safe in single-threaded WebAssembly environments where JavaScript
-# values cannot actually be accessed from multiple threads. Using this with
-# threading features (atomics, shared memory) is not supported and will fail to compile.
-unsafe-single-threaded-traits = ["wasm-bindgen-futures/unsafe-single-threaded-traits"]
-
 # Whether or not the `#[wasm_bindgen]` macro is strict and generates an error on
 # all unused attributes
 strict-macro = ["wasm-bindgen-macro/strict-macro"]
@@ -78,6 +72,7 @@ workspace = true
 unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(wasm_bindgen_unstable_test_coverage)',
   'cfg(xxx_debug_only_print_generated_code)',
+  'cfg(unsafe_single_threaded_traits)',
 ] }
 
 [workspace.lints.clippy]

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -27,7 +27,6 @@ wasm-bindgen = { path = "../..", version = '=0.2.105', default-features = false 
 default = ["std"]
 futures-core-03-stream = ['futures-core']
 std = ["wasm-bindgen/std", "js-sys/std", "web-sys/std"]
-unsafe-single-threaded-traits = ["wasm-bindgen/unsafe-single-threaded-traits"]
 
 [target.'cfg(target_feature = "atomics")'.dependencies]
 web-sys = { path = "../web-sys", version = "=0.3.82", default-features = false, features = [

--- a/crates/futures/src/lib.rs
+++ b/crates/futures/src/lib.rs
@@ -114,11 +114,11 @@ pub struct JsFuture {
 // However, in single-threaded WebAssembly environments, this is safe because
 // the Rc cannot actually be accessed from multiple threads. The Inner struct
 // contains JsValue and Closure, which are both made Send by the
-// unsafe-single-threaded-traits feature.
-#[cfg(feature = "unsafe-single-threaded-traits")]
+// unsafe_single_threaded_traits cfg.
+#[cfg(unsafe_single_threaded_traits)]
 unsafe impl Send for JsFuture {}
 
-#[cfg(feature = "unsafe-single-threaded-traits")]
+#[cfg(unsafe_single_threaded_traits)]
 unsafe impl Sync for JsFuture {}
 
 impl fmt::Debug for JsFuture {

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -257,11 +257,11 @@ pub struct Closure<T: ?Sized> {
 // be accessed from multiple threads. The Send/Sync bounds on T ensure that the
 // closure's captured data would be safe to send in a truly multi-threaded context,
 // maintaining Rust's safety guarantees. The JsClosure reference itself is made
-// Send/Sync through the unsafe-single-threaded-traits feature.
-#[cfg(feature = "unsafe-single-threaded-traits")]
+// Send/Sync through the unsafe_single_threaded_traits cfg.
+#[cfg(unsafe_single_threaded_traits)]
 unsafe impl<T: ?Sized> Send for Closure<T> {}
 
-#[cfg(feature = "unsafe-single-threaded-traits")]
+#[cfg(unsafe_single_threaded_traits)]
 unsafe impl<T: ?Sized> Sync for Closure<T> {}
 
 fn _assert_compiles<T>(mut pin: core::pin::Pin<&mut Closure<T>>) {

--- a/tests/atomics_conflict.rs
+++ b/tests/atomics_conflict.rs
@@ -1,8 +1,8 @@
-//! Compile-time test: verify that unsafe-single-threaded-traits is incompatible with atomics
+//! Compile-time test: verify that unsafe_single_threaded_traits is incompatible with atomics
 //!
 //! # Purpose
 //!
-//! This test verifies that the `unsafe-single-threaded-traits` feature cannot be
+//! This test verifies that the `unsafe_single_threaded_traits` cfg cannot be
 //! used when the `atomics` target feature is enabled. The incompatibility is enforced
 //! by a `compile_error!` in `src/lib.rs`.
 //!
@@ -10,16 +10,16 @@
 //!
 //! - When building WITHOUT atomics (normal case): This test compiles fine
 //! - When building WITH atomics (CI tests): This test will still compile fine because
-//!   the `unsafe-single-threaded-traits` feature won't be enabled
-//! - When building WITH BOTH atomics AND the feature enabled: Compilation fails with:
-//!   "The `unsafe-single-threaded-traits` feature cannot be used with the `atomics` target feature..."
+//!   the `unsafe_single_threaded_traits` cfg won't be enabled
+//! - When building WITH BOTH atomics AND the cfg enabled: Compilation fails with:
+//!   "The `unsafe_single_threaded_traits` cfg cannot be used with the `atomics` target feature..."
 //!
 //! CI runs tests with the following matrix:
 //! - mvp target (no atomics)
 //! - atomics target (`-Ctarget-feature=+atomics`)
 //!
-//! If someone attempts to enable `unsafe-single-threaded-traits` in a build that has
-//! atomics, the compile_error! in src/lib.rs:52-57 will trigger and prevent compilation.
+//! If someone attempts to enable `unsafe_single_threaded_traits` in a build that has
+//! atomics, the compile_error! in src/lib.rs will trigger and prevent compilation.
 
 use wasm_bindgen::prelude::*;
 
@@ -30,18 +30,18 @@ fn test_basic_usage() {
     let _ = JsValue::NULL;
 }
 
-#[cfg(feature = "unsafe-single-threaded-traits")]
+#[cfg(unsafe_single_threaded_traits)]
 #[test]
-fn test_feature_enabled_without_atomics() {
-    // If this compiles, the feature is enabled but atomics are not.
+fn test_cfg_enabled_without_atomics() {
+    // If this compiles, the cfg is enabled but atomics are not.
     // This is the intended use case.
     fn assert_send<T: Send>() {}
     assert_send::<JsValue>();
 }
 
-#[cfg(all(feature = "unsafe-single-threaded-traits", target_feature = "atomics"))]
+#[cfg(all(unsafe_single_threaded_traits, target_feature = "atomics"))]
 compile_error!(
     "ERROR: This test should never compile!\n\
      If you see this error, the compile_error! in src/lib.rs failed to trigger.\n\
-     The unsafe-single-threaded-traits feature MUST NOT be used with atomics."
+     The unsafe_single_threaded_traits cfg MUST NOT be used with atomics."
 );

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -61,7 +61,7 @@ pub mod structural;
 pub mod truthy_falsy;
 pub mod try_from_js_value;
 
-#[cfg(feature = "unsafe-single-threaded-traits")]
+#[cfg(unsafe_single_threaded_traits)]
 pub mod unsafe_send_sync;
 pub mod usize;
 pub mod validate_prt;

--- a/tests/wasm/unsafe_send_sync.rs
+++ b/tests/wasm/unsafe_send_sync.rs
@@ -1,9 +1,9 @@
-//! Tests for the unsafe-single-threaded-traits feature
+//! Tests for the unsafe_single_threaded_traits cfg
 //!
-//! This test file verifies that when the feature is enabled, JS types
+//! This test file verifies that when the cfg is enabled, JS types
 //! become Send and Sync, allowing futures to be Send.
 
-#![cfg(feature = "unsafe-single-threaded-traits")]
+#![cfg(unsafe_single_threaded_traits)]
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;


### PR DESCRIPTION
Adds an `unsafe-single-threaded-traits` configuration that auto-implements send and sync for JS types under the single threaded assumption.

This has come up for Cloudflare workers when we want to run Axum or other http router systems that require these traits and we end up doing a whole bunch of custom wrapping code, when really we just require this "hack".

Carefully noted safety and included a compiler error if building with threads.