### PR TITLE
fix CI with temporary toolchain lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: dtolnay/rust-toolchain@1.90
+    - uses: dtolnay/rust-toolchain@1.88
     - run: cargo test -p wasm-bindgen-macro
     - run: cargo test -p wasm-bindgen-test-macro
 


### PR DESCRIPTION
Temporary workaround to the current CI failures by locking down the toolchain for now.

At least until the non-determinism in https://github.com/wasm-bindgen/wasm-bindgen/pull/4771 can be tracked down.