### PR TITLE
Interpreter: Fix handling of block instruction

### DIFF
--- a/crates/cli-support/src/interpreter/mod.rs
+++ b/crates/cli-support/src/interpreter/mod.rs
@@ -365,7 +365,9 @@ impl Frame<'_> {
                     }
                 }
 
-                Instr::Block(block) => return self.eval(block.seq),
+                Instr::Block(block) => {
+                    self.eval(block.seq)?;
+                }
 
                 Instr::Try(block) => {
                     self.eval(block.seq)?;

--- a/crates/cli-support/src/interpreter/smoke_tests.rs
+++ b/crates/cli-support/src/interpreter/smoke_tests.rs
@@ -243,17 +243,74 @@ fn try_block() {
         (module
             (import "__wbindgen_placeholder__" "__wbindgen_describe"
               (func $__wbindgen_describe (param i32)))
+            (global (mut i32) (i32.const 0))
 
             (func $foo
+                (local i32)
+
+                ;; decrement the stack pointer, setting our local to the
+                ;; lowest address of our stack
+                global.get 0
+                i32.const 16
+                i32.sub
+                local.set 0
+                local.get 0
+                global.set 0
+
                 try
                     i32.const 1
                     call $__wbindgen_describe
                 catch_all
                 end
+
+                ;; increment our stack pointer
+                local.get 0
+                i32.const 16
+                i32.add
+                global.set 0
             )
 
             (export "foo" (func $foo))
         )
     "#;
     interpret(wat, "foo", &[1]);
+}
+
+#[test]
+fn blocks() {
+    let wat = r#"
+        (module
+            (import "__wbindgen_placeholder__" "__wbindgen_describe"
+              (func $__wbindgen_describe (param i32)))
+
+            (global (mut i32) (i32.const 0))
+            (memory 1)
+
+            (func $foo
+                (local i32)
+
+                ;; decrement the stack pointer, setting our local to the
+                ;; lowest address of our stack
+                global.get 0
+                i32.const 16
+                i32.sub
+                local.set 0
+                local.get 0
+                global.set 0
+
+                (block
+                    i32.const 0
+                    call $__wbindgen_describe
+                )
+
+                ;; increment our stack pointer
+                local.get 0
+                i32.const 16
+                i32.add
+                global.set 0
+            )
+            (export "foo" (func $foo))
+        )
+    "#;
+    interpret(wat, "foo", &[0]);
 }


### PR DESCRIPTION
Previously we would quit after executing the body of the block and never execute the rest of the function.
