### PR TITLE
Fix a recent lint in rust nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@
 
 ### Fixed
 
-* Fixed nightly clippy warning for direct function pointer cast.
-  [#XXXX](https://github.com/wasm-bindgen/wasm-bindgen/pull/XXXX)
-
 ### Removed
 
 ## [0.2.106](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.105...0.2.106)


### PR DESCRIPTION
### Description

Fix recently nightly clippy warning for function pointer cast.

Rust nightly (and soon stable) emits a new warning when casting function items directly to integers:

```
warning: direct cast of function item into an integer
   --> src/convert/closures.rs:80:46
    |
 80 |                 inform(invoke::<$($var,)* R> as usize as u32);
    |                                              ^^^^^^^^
    |
help: first cast to a pointer `as *const ()`
    |
 80 |                 inform(invoke::<$($var,)* R> as *const () as usize as u32);
    |                                              ++++++++++++
```

This lint ([rust-lang/rust#81686](https://github.com/rust-lang/rust/issues/81686)) warns against directly casting function items to integer types because it's a common source of bugs - users often confuse `u16::max` (a function) with `u16::MAX` (a constant).

The fix is to explicitly cast through a pointer first: `fn as *const () as usize` instead of `fn as usize`.

CC: @Spxg (who might have intentionally reverted this change, for reasons it would benefit me to become aware of)

### Checklist

- [x] Verified changelog requirement
