### PR TITLE
Add real-time output streaming in headless browser mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,16 @@
 ### Fixed
 
 * Forward worker errors to test output in the test runner.
-  [#XXXX](https://github.com/wasm-bindgen/wasm-bindgen/pull/XXXX)
+  [#4855](https://github.com/wasm-bindgen/wasm-bindgen/pull/4855)
 
 * Fix: Include doc comments in TypeScript definitions for classes
   [#4858](https://github.com/wasm-bindgen/wasm-bindgen/pull/4858)
 
 * Interpreter: support try_table blocks
   [#4862](https://github.com/wasm-bindgen/wasm-bindgen/pull/4862)
+
+* Added real-time output streaming in headless browser mode for easier debugging of hanging tests.
+  [#4845](https://github.com/wasm-bindgen/wasm-bindgen/pull/4845)
 
 ### Removed
 

--- a/crates/cli/src/wasm_bindgen_test_runner/server.rs
+++ b/crates/cli/src/wasm_bindgen_test_runner/server.rs
@@ -235,9 +235,11 @@ pub(crate) fn spawn(
                         method == "warn" || method == "info" ||
                         method == "debug"
                     ) {{
-                        // Don't re-log to console - the output_append path handles test output.
-                        // We only need to process these for potential on_console_* handlers,
-                        // but those are handled in the worker via self[on_method].
+                        // In non-headless mode, forward worker console output to the main
+                        // page's console so it appears in DevTools.
+                        if (!{headless}) {{
+                            console[method].apply(console, args[0]);
+                        }}
                     }} else if (method == "output_append") {{
                         const el = document.getElementById("output");
                         if (!el.dataset.appended) {{

--- a/crates/cli/tests/wasm-bindgen-test-runner/main.rs
+++ b/crates/cli/tests/wasm-bindgen-test-runner/main.rs
@@ -113,6 +113,106 @@ impl Project {
     }
 }
 
+/// Returns the path to a webdriver if one is available, or None if headless
+/// tests should be skipped.
+fn find_webdriver() -> Option<(&'static str, PathBuf)> {
+    // Check for explicit env vars first
+    if let Ok(path) = env::var("CHROMEDRIVER") {
+        return Some(("CHROMEDRIVER", PathBuf::from(path)));
+    }
+    if let Ok(path) = env::var("GECKODRIVER") {
+        return Some(("GECKODRIVER", PathBuf::from(path)));
+    }
+    if let Ok(path) = env::var("SAFARIDRIVER") {
+        return Some(("SAFARIDRIVER", PathBuf::from(path)));
+    }
+
+    // Try to find webdrivers in PATH
+    for (env_name, binary) in [
+        ("CHROMEDRIVER", "chromedriver"),
+        ("GECKODRIVER", "geckodriver"),
+        ("SAFARIDRIVER", "safaridriver"),
+    ] {
+        if let Ok(output) = std::process::Command::new("which").arg(binary).output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Some((env_name, PathBuf::from(path)));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[test]
+fn test_headless_worker_output_not_garbled() {
+    let Some((driver_env, driver_path)) = find_webdriver() else {
+        eprintln!("Skipping headless test: no webdriver found");
+        return;
+    };
+
+    let mut project = Project::new("test_headless_worker_output_not_garbled");
+    project.file(
+        "src/lib.rs",
+        r#"
+            use wasm_bindgen_test::*;
+
+            wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+            #[wasm_bindgen_test]
+            fn test_1() {}
+        "#,
+    );
+
+    project.cargo_toml();
+    let runner = REPO_ROOT.join("crates").join("cli").join("Cargo.toml");
+    let output = Command::new("cargo")
+        .current_dir(&project.root)
+        .arg("test")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .env("CARGO_TARGET_DIR", &*TARGET_DIR)
+        .env(
+            "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+            format!(
+                "cargo run --manifest-path {} --bin wasm-bindgen-test-runner --",
+                runner.display()
+            ),
+        )
+        .env(driver_env, driver_path)
+        .output()
+        .expect("failed to execute cargo test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The output should contain the proper test output, not garbled text
+    // Correct: "running 1 test" and "test test_1 ... ok"
+    // Garbled: "Loading Wasm module...st_1 ... ok" (missing "running 1 test")
+    assert!(
+        stdout.contains("running 1 test") || stderr.contains("running 1 test"),
+        "Expected 'running 1 test' in output.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("test test_1 ... ok") || stderr.contains("test test_1 ... ok"),
+        "Expected 'test test_1 ... ok' in output.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+
+    // Make sure the test actually passed
+    assert!(
+        output.status.success(),
+        "Test should pass.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+}
+
 #[test]
 fn test_wasm_bindgen_test_runner_list() {
     let output = Project::new("test_wasm_bindgen_test_runner_list")
@@ -170,5 +270,261 @@ fn test_worker_console_log_no_duplicates() {
         count, 1,
         "Expected console_log message to appear exactly once, but it appeared {} times.\nstdout:\n{}\nstderr:\n{}",
         count, stdout, stderr
+    );
+}
+
+/// Test that console output appears exactly once for a failing test in headless mode.
+/// When a test panics, the console output should be shown exactly once.
+#[test]
+fn test_worker_console_panic_headless() {
+    let Some((driver_env, driver_path)) = find_webdriver() else {
+        eprintln!("Skipping headless test: no webdriver found");
+        return;
+    };
+
+    let mut project = Project::new("test_worker_console_panic_headless");
+    project.file(
+        "src/lib.rs",
+        r#"
+            #[cfg(test)]
+            mod tests {
+                use wasm_bindgen_test::console_log;
+                wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+                #[wasm_bindgen_test::wasm_bindgen_test]
+                fn test() {
+                    console_log!("hello");
+                    panic!()
+                }
+            }
+        "#,
+    );
+
+    project.cargo_toml();
+    let runner = REPO_ROOT.join("crates").join("cli").join("Cargo.toml");
+    let output = Command::new("cargo")
+        .current_dir(&project.root)
+        .arg("test")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .env("CARGO_TARGET_DIR", &*TARGET_DIR)
+        .env(
+            "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+            format!(
+                "cargo run --manifest-path {} --bin wasm-bindgen-test-runner --",
+                runner.display()
+            ),
+        )
+        .env(driver_env, driver_path)
+        .output()
+        .expect("failed to execute cargo test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    // Count occurrences of "hello" - should be exactly 1 for a failing test
+    let count = combined.matches("hello").count();
+
+    assert_eq!(
+        count, 1,
+        "Expected 'hello' to appear exactly once for failing test, but it appeared {} times.\nstdout:\n{}\nstderr:\n{}",
+        count, stdout, stderr
+    );
+}
+
+/// Test that console output does NOT appear for a passing test in headless mode.
+/// When a test passes, the console output should be captured and not shown.
+#[test]
+fn test_worker_console_no_panic_headless() {
+    let Some((driver_env, driver_path)) = find_webdriver() else {
+        eprintln!("Skipping headless test: no webdriver found");
+        return;
+    };
+
+    let mut project = Project::new("test_worker_console_no_panic_headless");
+    project.file(
+        "src/lib.rs",
+        r#"
+            #[cfg(test)]
+            mod tests {
+                use wasm_bindgen_test::console_log;
+                wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+                #[wasm_bindgen_test::wasm_bindgen_test]
+                fn test() {
+                    console_log!("hello");
+                }
+            }
+        "#,
+    );
+
+    project.cargo_toml();
+    let runner = REPO_ROOT.join("crates").join("cli").join("Cargo.toml");
+    let output = Command::new("cargo")
+        .current_dir(&project.root)
+        .arg("test")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .env("CARGO_TARGET_DIR", &*TARGET_DIR)
+        .env(
+            "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+            format!(
+                "cargo run --manifest-path {} --bin wasm-bindgen-test-runner --",
+                runner.display()
+            ),
+        )
+        .env(driver_env, driver_path)
+        .output()
+        .expect("failed to execute cargo test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    // Count occurrences of "hello" - should be 0 for a passing test (output captured)
+    let count = combined.matches("hello").count();
+
+    assert_eq!(
+        count, 0,
+        "Expected 'hello' to NOT appear for passing test (output should be captured), but it appeared {} times.\nstdout:\n{}\nstderr:\n{}",
+        count, stdout, stderr
+    );
+
+    // Verify test actually passed
+    assert!(
+        output.status.success(),
+        "Test should pass.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
+    );
+}
+
+/// Test that console output appears exactly once for a failing test with --nocapture.
+#[test]
+fn test_worker_console_panic_nocapture() {
+    let Some((driver_env, driver_path)) = find_webdriver() else {
+        eprintln!("Skipping headless test: no webdriver found");
+        return;
+    };
+
+    let mut project = Project::new("test_worker_console_panic_nocapture");
+    project.file(
+        "src/lib.rs",
+        r#"
+            #[cfg(test)]
+            mod tests {
+                use wasm_bindgen_test::console_log;
+                wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+                #[wasm_bindgen_test::wasm_bindgen_test]
+                fn test() {
+                    console_log!("hello");
+                    panic!()
+                }
+            }
+        "#,
+    );
+
+    project.cargo_toml();
+    let runner = REPO_ROOT.join("crates").join("cli").join("Cargo.toml");
+    let output = Command::new("cargo")
+        .current_dir(&project.root)
+        .arg("test")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .arg("--")
+        .arg("--nocapture")
+        .env("CARGO_TARGET_DIR", &*TARGET_DIR)
+        .env(
+            "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+            format!(
+                "cargo run --manifest-path {} --bin wasm-bindgen-test-runner --",
+                runner.display()
+            ),
+        )
+        .env(driver_env, driver_path)
+        .output()
+        .expect("failed to execute cargo test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    // Count occurrences of "hello" - should be exactly 2 (1 from nocapture, 1 from panic)
+    let count = combined.matches("hello").count();
+
+    assert_eq!(
+        count, 2,
+        "Expected 'hello' to appear exactly twice, but it appeared {} times.\nstdout:\n{}\nstderr:\n{}",
+        count, stdout, stderr
+    );
+}
+
+/// Test that console output appears exactly twice for a passing test with --nocapture.
+#[test]
+fn test_worker_console_no_panic_nocapture() {
+    let Some((driver_env, driver_path)) = find_webdriver() else {
+        eprintln!("Skipping headless test: no webdriver found");
+        return;
+    };
+
+    let mut project = Project::new("test_worker_console_no_panic_nocapture");
+    project.file(
+        "src/lib.rs",
+        r#"
+            #[cfg(test)]
+            mod tests {
+                use wasm_bindgen_test::console_log;
+                wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+                #[wasm_bindgen_test::wasm_bindgen_test]
+                fn test() {
+                    console_log!("hello");
+                }
+            }
+        "#,
+    );
+
+    project.cargo_toml();
+    let runner = REPO_ROOT.join("crates").join("cli").join("Cargo.toml");
+    let output = Command::new("cargo")
+        .current_dir(&project.root)
+        .arg("test")
+        .arg("--target")
+        .arg("wasm32-unknown-unknown")
+        .arg("--")
+        .arg("--nocapture")
+        .env("CARGO_TARGET_DIR", &*TARGET_DIR)
+        .env(
+            "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER",
+            format!(
+                "cargo run --manifest-path {} --bin wasm-bindgen-test-runner --",
+                runner.display()
+            ),
+        )
+        .env(driver_env, driver_path)
+        .output()
+        .expect("failed to execute cargo test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    // Count occurrences of "hello" - should be exactly 1 with --nocapture
+    let count = combined.matches("hello").count();
+
+    assert_eq!(
+        count, 1,
+        "Expected 'hello' to appear exactly once, but it appeared {} times.\nstdout:\n{}\nstderr:\n{}",
+        count, stdout, stderr
+    );
+
+    // Verify test actually passed
+    assert!(
+        output.status.success(),
+        "Test should pass.\nstdout:\n{}\nstderr:\n{}",
+        stdout,
+        stderr
     );
 }

--- a/crates/test/tests/dedicated.rs
+++ b/crates/test/tests/dedicated.rs
@@ -1,4 +1,7 @@
+use wasm_bindgen_test::console_log;
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
 
 #[wasm_bindgen_test::wasm_bindgen_test]
-fn test() {}
+fn test() {
+    console_log!("hello");
+}


### PR DESCRIPTION
### Description

Add real-time output streaming in headless browser mode.

#### Motivation

Suppose my code has a bug - a deadlock, an infinite loop, some browser-specific issue. My test hangs. The normal approach is printf debugging: add some web_sys statements, run again, see where it gets to.

In headless mode, when my test hangs, this doesn't work:

```
Waiting for test to finish...
# ... 60 seconds of silence ...
Failed to detect test as having been run. It might have timed out.
```

Output is buffered until completion. If the test never completes, I never see my prints. I don't know which test hung, where it hung, or whether my debug statements even executed.

With this PR, output from the main browser thread streams as it appears:

```
running 3 tests
test foo ... ok
test bar ... ok
test hanging_test ...
```

Now printf debugging works. I can add prints, run, and see where execution stops.

### Checklist

- [x] Verified changelog requirement
