### PR TITLE
Call original console methods in worker scripts

### DIFF
--- a/crates/cli/src/wasm_bindgen_test_runner/server.rs
+++ b/crates/cli/src/wasm_bindgen_test_runner/server.rs
@@ -137,8 +137,10 @@ pub(crate) fn spawn(
             r#"
             const nocapture = {nocapture};
             const wrap = method => {{
+                const og = self.console[method];
                 const on_method = `on_console_${{method}}`;
                 self.console[method] = function (...args) {{
+                    og.apply(this, args);
                     if (nocapture) {{
                         self.__wbg_test_output_writeln(args);
                     }}


### PR DESCRIPTION
### Description

Worker console methods (log/debug/info/warn/error) are wrapped to relay output to the main thread, but the original console methods are never called. This means worker logs don't appear in browser DevTools when inspecting the worker context.

This aligns worker behavior with `index-headless.html` which correctly saves and calls the original method via `og.apply(this, args)`.

#### Motivation

When debugging worker-specific issues with `NO_HEADLESS=1`, it's useful to see logs directly in the worker's DevTools console rather than only through the postMessage relay.

### Checklist

- [x] Verified changelog requirement