### PR TITLE
When KEEP_TEST_BUILD=1 set, save test to consistent path

### DIFF
--- a/crates/cli/src/wasm_bindgen_test_runner.rs
+++ b/crates/cli/src/wasm_bindgen_test_runner.rs
@@ -213,17 +213,18 @@ fn rmain(cli: Cli) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let tmpdir = tempfile::tempdir()?;
 
     // Support a WASM_BINDGEN_KEEP_TEST_BUILD=1 env var for debugging test files
     let tmpdir_path = if env::var("WASM_BINDGEN_KEEP_TEST_BUILD").is_ok() {
-        let path = tmpdir.keep();
+        let path = Path::new("saved_test").to_path_buf();
         println!(
             "Retaining temporary build output folder: {}",
             path.to_string_lossy()
         );
+        fs::create_dir_all(path.clone())?;
         path
     } else {
+        let tmpdir = tempfile::tempdir()?;
         tmpdir.path().to_path_buf()
     };
 


### PR DESCRIPTION
For now, I called the folder `saved_test`.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
