### PR TITLE
Fixes incorrect stringification of multi-argument console calls

### DIFF
--- a/crates/cli/src/wasm_bindgen_test_runner/server.rs
+++ b/crates/cli/src/wasm_bindgen_test_runner/server.rs
@@ -145,7 +145,7 @@ pub(crate) fn spawn(
                 self.console[method] = function (...args) {{
                     og.apply(this, args);
                     if (nocapture) {{
-                        self.__wbg_test_output_writeln(args);
+                        self.__wbg_test_output_writeln(...args);
                     }}
                     if (self[on_method]) {{
                         self[on_method](args);
@@ -156,8 +156,8 @@ pub(crate) fn spawn(
 
             self.__wbg_test_invoke = f => f();
             self.__wbg_test_output = "";
-            self.__wbg_test_output_writeln = function (line) {{
-                self.__wbg_test_output += line + "\n";
+            self.__wbg_test_output_writeln = function (...args) {{
+                self.__wbg_test_output += args.map(String).join(' ') + "\n";
                 port.postMessage(["__wbgtest_output", self.__wbg_test_output]);
             }}
 


### PR DESCRIPTION
# Fix array-to-string coercion in worker console output

## Summary

Fixes incorrect stringification of multi-argument console calls in worker mode when `nocapture=true`.

## Problem

When `console.log("a", "b")` is called in a worker with nocapture enabled, the output was `"a,b"` instead of `"a b"`. This happened because `args` (an array) was passed directly to `__wbg_test_output_writeln`, which concatenates with `+`, triggering JavaScript's implicit array-to-string coercion (which joins with commas).

## Fix

Change `args` to `args.map(String).join(' ')` to match the expected console output format where arguments are space-separated.

## Files Changed

- `crates/cli/src/wasm_bindgen_test_runner/server.rs` - Line 146
