### PR TITLE
Update coverage guide

### DIFF
--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -33,7 +33,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 # benchmark required end
 
 [target.'cfg(all(target_arch = "wasm32", wasm_bindgen_unstable_test_coverage))'.dependencies]
-minicov = "0.3"
+minicov = "0.3.8"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/guide/src/wasm-bindgen-test/coverage.md
+++ b/guide/src/wasm-bindgen-test/coverage.md
@@ -35,45 +35,15 @@ This feature relies on the [minicov] crate, which provides a profiling runtime f
 
 ### Example
 
-This adapts code taken from the [Rustc book], see that for more examples and general information on test coverage as well.
+_Requires rust >= 1.87.0 and wasm-bindgen-test >= 0.3.57._
+
+Install [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) and run with:
 
 ```sh
-# Run the tests:
-# `--tests` to not run documentation tests, which is currently not supported.
-RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir --cfg=wasm_bindgen_unstable_test_coverage" \
 CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner \
-cargo +nightly test --tests
-# Compile to object files:
-# - Extract a list of compiled artifacts from Cargo and filter them with `jq`.
-# - Figure out the path to the LLVM IR file corresponding to an artifact.
-# - Compile to object file with Clang and store for later usage with `llvm-cov`.
-crate_name=name_of_the_tested_crate_in_snake_case
-objects=()
-IFS=$'\n'
-for file in $(
-    RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime --emit=llvm-ir --cfg=wasm_bindgen_unstable_test_coverage" \
-    cargo +nightly test --tests --no-run --message-format=json | \
-    jq -r "select(.reason == \"compiler-artifact\") | (select(.target.kind == [\"test\"]) // select(.target.name == \"$crate_name\")) | .filenames[0]"
-)
-do
-    if [[ ${file##*.} == "rlib" ]]; then
-        base=$(basename $file .rlib)
-        file=$(dirname $file)/${base#"lib"}.ll
-    else
-        file=$(dirname $file)/$(basename $file .wasm).ll
-    fi
-
-    output = $(basename $file .ll).o
-    clang-19 $file -Wno-override-module -c -o $output
-    objects+=(-object $output)
-done
-# Merge all generated raw profiling data.
-llvm-profdata-19 merge -sparse *.profraw -o coverage.profdata
-# Produce test coverage data in the HTML format and pass the object files we generated earlier.
-llvm-cov-19 show -show-instantiations=false -Xdemangler=rustfilt -output-dir coverage -format=html -instr-profile=coverage.profdata ${objects[@]} -sources src
+CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime -Clink-args=--no-gc-sections --cfg=wasm_bindgen_unstable_test_coverage" \
+cargo +nightly llvm-cov test --target wasm32-unknown-unknown
 ```
-
-[rustc book]: https://doc.rust-lang.org/nightly/rustc/instrument-coverage.html
 
 ## Attribution
 

--- a/justfile
+++ b/justfile
@@ -40,3 +40,13 @@ bench:
     cargo bench --target wasm32-unknown-unknown
     cargo bench --target wasm32-unknown-unknown -p js-sys
     cargo bench --target wasm32-unknown-unknown -p wasm-bindgen-futures
+
+cov *ARGS="":
+  CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime -Clink-args=--no-gc-sections --cfg=wasm_bindgen_unstable_test_coverage" \
+  WASM_BINDGEN_SPLIT_LINKED_MODULES=1 cargo +nightly llvm-cov test \
+  --coverage-target-only \
+  -p js-sys \
+  -p wasm-bindgen \
+  -p wasm-bindgen-futures \
+  -p wasm-bindgen-test \
+  --target wasm32-unknown-unknown {{ARGS}}


### PR DESCRIPTION
### Description
<!-- Please describe the changes introduced by this PR. -->

With the help of https://github.com/wasm-bindgen/wasm-bindgen/pull/4367 and https://github.com/Amanieu/minicov/pull/27, `wasm-bindgen` now can handle cov with `LLVM_PROFILE_FILE` env. Now, coverage can also be easily checked using `cargo-llvm-cov` on `wasm32-uknown-unknown` target. ~https://github.com/taiki-e/cargo-llvm-cov/pull/465~

Due to the limit of https://github.com/Amanieu/minicov/pull/32, now coverage requires rust 1.87.0 and above.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
