### PR TITLE
Add error handlers for web workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ### Fixed
 
+* Forward worker errors to test output in the test runner.
+  [#XXXX](https://github.com/wasm-bindgen/wasm-bindgen/pull/XXXX)
+
 ### Removed
 
 ## [0.2.106](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.105...0.2.106)

--- a/crates/cli/src/wasm_bindgen_test_runner/server.rs
+++ b/crates/cli/src/wasm_bindgen_test_runner/server.rs
@@ -259,12 +259,23 @@ pub(crate) fn spawn(
 
                 match test_mode {
                     TestMode::DedicatedWorker { .. } => {
-                        format!("const port = new Worker('worker.js', {{type: '{module}'}});\n")
+                        format!(
+                            r#"const port = new Worker('worker.js', {{type: '{module}'}});
+                            port.onerror = function(e) {{
+                                console.error('Worker error:', e.message, e.filename, e.lineno);
+                                document.getElementById('output').textContent += '\nWorker error: ' + e.message;
+                            }};
+                            "#
+                        )
                     }
                     TestMode::SharedWorker { .. } => {
                         format!(
                             r#"
                             const worker = new SharedWorker("worker.js?random=" + crypto.randomUUID(), {{type: "{module}"}});
+                            worker.onerror = function(e) {{
+                                console.error('Worker error:', e.message, e.filename, e.lineno);
+                                document.getElementById('output').textContent += '\nWorker error: ' + e.message;
+                            }};
                             const port = worker.port;
                             port.start();
                             "#
@@ -274,7 +285,13 @@ pub(crate) fn spawn(
                         format!(
                             r#"
                             const url = "service.js?random=" + crypto.randomUUID();
-                            await navigator.serviceWorker.register(url, {{type: "{module}"}});
+                            const registration = await navigator.serviceWorker.register(url, {{type: "{module}"}});
+                            if (registration.installing) {{
+                                registration.installing.onerror = function(e) {{
+                                    console.error('ServiceWorker error:', e.message);
+                                    document.getElementById('output').textContent += '\nServiceWorker error: ' + e.message;
+                                }};
+                            }}
                             await new Promise((resolve) => {{
                                 navigator.serviceWorker.addEventListener('controllerchange', () => {{
                                     if (navigator.serviceWorker.controller.scriptURL != location.href + url) {{


### PR DESCRIPTION
# Add error handlers for Web Workers

Add `onerror` handlers for DedicatedWorker, SharedWorker, and ServiceWorker in the test runner,
forwarding the underlying error to terminal.

## Motivation

It is very common for me to think web workers are working, when they are not. 

## Solution

Add `onerror` handlers that:
1. Log the error to browser console
2. Append the error message to the `#output` element so it's visible in test output.