### PR TITLE
Fix: Include doc comments in TypeScript definitions for classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 * Forward worker errors to test output in the test runner.
   [#XXXX](https://github.com/wasm-bindgen/wasm-bindgen/pull/XXXX)
 
+* Fix: Include doc comments in TypeScript definitions for classes
+  [#4858](https://github.com/wasm-bindgen/wasm-bindgen/pull/4858)
+
 ### Removed
 
 ## [0.2.106](https://github.com/wasm-bindgen/wasm-bindgen/compare/0.2.105...0.2.106)

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1294,6 +1294,12 @@ wasm = wasmInstance.exports;
             "if (Symbol.dispose) {identifier}.prototype[Symbol.dispose] = {identifier}.prototype.free;\n"
         ));
 
+        let ts_comments = if class.generate_typescript {
+            Some(class.comments.clone())
+        } else {
+            None
+        };
+
         define_export(
             &mut self.exports,
             name,
@@ -1307,7 +1313,7 @@ wasm = wasmInstance.exports;
                 } else {
                     String::new()
                 },
-                ts_comments: None,
+                ts_comments,
                 private: class.private,
             }),
         )?;

--- a/crates/cli/tests/reference/function-attrs.d.ts
+++ b/crates/cli/tests/reference/function-attrs.d.ts
@@ -1,6 +1,9 @@
 /* tslint:disable */
 /* eslint-disable */
 
+/**
+ * Description for HoldsNumber
+ */
 export class HoldsNumber {
   private constructor();
   free(): void;

--- a/crates/cli/tests/reference/private.d.ts
+++ b/crates/cli/tests/reference/private.d.ts
@@ -9,6 +9,9 @@ declare enum HiddenEnum {
   Variant2 = 1,
 }
 
+/**
+ * A hidden struct that is not exported but can be used as an argument type
+ */
 declare class HiddenStruct {
   private constructor();
   free(): void;
@@ -25,6 +28,9 @@ export enum PublicEnum {
   B = 1,
 }
 
+/**
+ * A public struct that is exported
+ */
 export class PublicStruct {
   private constructor();
   free(): void;

--- a/crates/cli/tests/reference/wasm-export-colon.d.ts
+++ b/crates/cli/tests/reference/wasm-export-colon.d.ts
@@ -1,6 +1,12 @@
 /* tslint:disable */
 /* eslint-disable */
 
+/**
+ * Runtime test harness support instantiated in JS.
+ *
+ * The node.js entry script instantiates a `Context` here which is used to
+ * drive test execution.
+ */
 export class WasmBindgenTestContext {
   free(): void;
   [Symbol.dispose](): void;


### PR DESCRIPTION
Class doc comments were hardcoded to `None` for the `ts_comments` field, so they would appear in the javascript output but omitted in the typescript.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
