### PR TITLE
feat: allow Option<&T> and &Option<T> for exported Rust structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 ### Added
 
+* Added support for `Option<&T>` and `&Option<T>` as function parameters for
+  exported Rust structs. Both types have the same representation and can be
+  used interchangeably.
+  [#XXXX](https://github.com/wasm-bindgen/wasm-bindgen/pull/XXXX)
+
 * Added `private` attribute on exported types to allow generating
   exports and structs as implicit internal exported types for function
   arguments and returns, without exporting them on the public interface.

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1071,6 +1071,19 @@ fn instruction(
             js.push(format!("ptr{i}"));
         }
 
+        Instruction::I32FromOptionRustBorrow { class } => {
+            let val = js.pop();
+            js.cx.expose_is_like_none();
+            let i = js.tmp();
+            js.prelude(&format!("let ptr{i} = 0;"));
+            js.prelude(&format!("if (!isLikeNone({val})) {{"));
+            js.assert_class(&val, class);
+            js.assert_not_moved(&val);
+            js.prelude(&format!("ptr{i} = {val}.__wbg_ptr;"));
+            js.prelude("}");
+            js.push(format!("ptr{i}"));
+        }
+
         Instruction::I32FromOptionExternref { table_and_alloc } => {
             let val = js.pop();
             js.cx.expose_is_like_none();

--- a/crates/cli-support/src/wit/standard.rs
+++ b/crates/cli-support/src/wit/standard.rs
@@ -204,6 +204,12 @@ pub enum Instruction {
     I32FromOptionRust {
         class: String,
     },
+    /// Pops an `externref` from the stack, pushes 0 if it's "none" or the
+    /// borrowed pointer value if it's "some". Unlike `I32FromOptionRust`, this
+    /// does not take ownership.
+    I32FromOptionRustBorrow {
+        class: String,
+    },
     /// Pops an `externref` from the stack, pushes either 0 if it's "none" or and
     /// index into the owned Wasm table it was stored at if it's "some"
     I32FromOptionExternref {

--- a/guide/src/reference/types/exported-rust-types.md
+++ b/guide/src/reference/types/exported-rust-types.md
@@ -1,8 +1,33 @@
 # Exported `struct Whatever` Rust Types
 
-| `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value | `Option<T>` parameter | `Option<T>` return value | JavaScript representation |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| Yes | Yes | Yes | Yes | Yes | Yes | Instances of a `wasm-bindgen`-generated JavaScript `class Whatever { ... }` |
+| `T` parameter | `&T` parameter | `&mut T` parameter | `T` return value | `Option<T>` parameter | `Option<T>` return value | `Option<&T>` parameter | JavaScript representation |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Yes | Yes | Yes | Yes | Yes | Yes | Yes | Instances of a `wasm-bindgen`-generated JavaScript `class Whatever { ... }` |
+
+## `Option<&T>` Parameters
+
+You can pass optional borrowed references to exported structs. Both `Option<&T>` and
+`&Option<T>` have the same representation and can be used as function parameters:
+
+```rust
+#[wasm_bindgen]
+pub fn process_optional(value: Option<&MyStruct>) -> u32 {
+    match value {
+        Some(s) => s.get_value(),
+        None => 0,
+    }
+}
+```
+
+JavaScript passes either `undefined`/`null` for `None`, or an instance of the struct for `Some`:
+
+```javascript
+// Pass Some value
+const result1 = process_optional(new MyStruct(42)); // returns 42
+
+// Pass None
+const result2 = process_optional(undefined); // returns 0
+```
 
 > **Note**: Public fields implementing `Copy` have automatically generated getters/setters.
 > To generate getters/setters for non-`Copy` public fields, use `#[wasm_bindgen(getter_with_clone)]` for the struct

--- a/tests/wasm/main.rs
+++ b/tests/wasm/main.rs
@@ -49,6 +49,7 @@ pub mod math;
 pub mod no_shims;
 pub mod node;
 pub mod option;
+pub mod option_ref_struct;
 pub mod optional_primitives;
 pub mod reexport;
 pub mod result;

--- a/tests/wasm/option_ref_struct.js
+++ b/tests/wasm/option_ref_struct.js
@@ -1,0 +1,10 @@
+const wasm = require("wasm-bindgen-test");
+
+exports.js_call_rust_with_some = function () {
+  const s = new wasm.OptRefTestStruct(42);
+  return wasm.rust_receive_option_ref(s);
+};
+
+exports.js_call_rust_with_none = function () {
+  return wasm.rust_receive_option_ref(undefined);
+};

--- a/tests/wasm/option_ref_struct.rs
+++ b/tests/wasm/option_ref_struct.rs
@@ -1,0 +1,46 @@
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen]
+pub struct OptRefTestStruct {
+    value: u32,
+}
+
+#[wasm_bindgen]
+impl OptRefTestStruct {
+    #[wasm_bindgen(constructor)]
+    pub fn new(value: u32) -> OptRefTestStruct {
+        OptRefTestStruct { value }
+    }
+
+    pub fn get_value(&self) -> u32 {
+        self.value
+    }
+}
+
+#[wasm_bindgen(module = "tests/wasm/option_ref_struct.js")]
+extern "C" {
+    fn js_call_rust_with_some() -> u32;
+    fn js_call_rust_with_none() -> u32;
+}
+
+// Test receiving Option<&OptRefTestStruct> from JS
+#[wasm_bindgen]
+pub fn rust_receive_option_ref(value: Option<&OptRefTestStruct>) -> u32 {
+    match value {
+        Some(s) => s.value,
+        None => 0,
+    }
+}
+
+#[wasm_bindgen_test]
+fn test_option_ref_some() {
+    let result = js_call_rust_with_some();
+    assert_eq!(result, 42);
+}
+
+#[wasm_bindgen_test]
+fn test_option_ref_none() {
+    let result = js_call_rust_with_none();
+    assert_eq!(result, 0);
+}


### PR DESCRIPTION
Resolves https://github.com/wasm-bindgen/wasm-bindgen/issues/2370.