### PR TITLE
Nodejs initSync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ members = [
   "examples/closures",
   "examples/console_log",
   "examples/nodejs_and_deno",
+  "examples/nodejs-threads",
   "examples/dom",
   "examples/duck-typed-interfaces",
   "examples/explicit-resource-management",

--- a/crates/cli/tests/reference/targets-target-nodejs-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-atomics.js
@@ -54,9 +54,58 @@ exports.__wbindgen_init_externref_table = function() {
 
 exports.memory = new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
 
-const wasmPath = `${__dirname}/reference_test_bg.wasm`;
-const wasmBytes = require('fs').readFileSync(wasmPath);
-const wasmModule = new WebAssembly.Module(wasmBytes);
-const wasm = exports.__wasm = new WebAssembly.Instance(wasmModule, imports).exports;
+let __wbg_memory;
+exports.__wbg_get_imports = function(customMemory) {
+    __wbg_memory = customMemory !== undefined ? customMemory : new WebAssembly.Memory({initial:18,maximum:16384,shared:true});
+    const imports = {};
+    const mod = {};
+    for (const key of Object.keys(exports)) {
+        if (key.startsWith('__wbg_') || key.startsWith('__wbindgen_')) {
+            mod[key] = exports[key];
+        }
+    }
+    mod.memory = __wbg_memory;
+    imports['./reference_test_bg.js'] = mod;
+    return imports;
+};
 
-wasm.__wbindgen_start();
+let wasm;
+let wasmModule;
+let __initialized = false;
+
+exports.initSync = function(opts) {
+    if (opts === undefined) opts = {};
+    if (__initialized) return wasm;
+
+    let module = opts.module;
+    let memory = opts.memory;
+    let thread_stack_size = opts.thread_stack_size;
+
+    if (module === undefined) {
+        const wasmPath = `${__dirname}/reference_test_bg.wasm`;
+        module = require('fs').readFileSync(wasmPath);
+    }
+
+    if (!(module instanceof WebAssembly.Module)) {
+        wasmModule = new WebAssembly.Module(module);
+    } else {
+        wasmModule = module;
+    }
+
+    const wasmImports = exports.__wbg_get_imports(memory);
+    const instance = new WebAssembly.Instance(wasmModule, wasmImports);
+    wasm = instance.exports;
+    exports.__wasm = wasm;
+    exports.__wbindgen_wasm_module = wasmModule;
+    if (typeof thread_stack_size !== 'undefined' && (typeof thread_stack_size !== 'number' || thread_stack_size === 0 || thread_stack_size % 65536 !== 0)) { throw new Error('invalid stack size'); }
+    wasm.__wbindgen_start(thread_stack_size);
+
+    __initialized = true;
+    return wasm;
+};
+
+// Auto-initialize for backwards compatibility (only on main thread)
+// Worker threads should call initSync({ module, memory }) explicitly
+if (require('worker_threads').isMainThread) {
+    exports.initSync();
+}

--- a/examples/nodejs-threads/Cargo.toml
+++ b/examples/nodejs-threads/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["The wasm-bindgen Developers"]
+edition = "2021"
+name = "nodejs-threads"
+publish = false
+version = "0.0.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = { path = "../../" }
+
+[lints]
+workspace = true

--- a/examples/nodejs-threads/README.md
+++ b/examples/nodejs-threads/README.md
@@ -1,0 +1,40 @@
+# Node.js worker_threads Example
+
+This example demonstrates using wasm-bindgen with Node.js CommonJS and `worker_threads` for multithreading.
+
+## Features Tested
+
+1. **Main thread auto-initialization** - Backwards compatibility with existing code
+2. **Worker thread initialization** - Using `initSync({ module, memory })`
+3. **Shared atomic counter** - Verifies memory is actually shared between threads
+4. **Memory growth detection** - Tests the byteLength fix for SharedArrayBuffer
+
+## Building
+
+```bash
+./build.sh
+```
+
+## Running
+
+```bash
+node test.js
+```
+
+## How It Works
+
+When targeting Node.js CJS with threads enabled, wasm-bindgen generates:
+
+- `initSync(opts)` - Initialize the WASM module synchronously
+- `__wbg_get_imports(memory)` - Get the imports object with optional custom memory
+- `__wbindgen_wasm_module` - The compiled WebAssembly.Module for sharing with workers
+
+Main thread auto-initializes on `require()`. Worker threads should call:
+
+```javascript
+const wasm = require('./pkg/nodejs_threads.js');
+wasm.initSync({
+    module: workerData.wasmModule,  // from main thread
+    memory: workerData.memory       // from main thread
+});
+```

--- a/examples/nodejs-threads/build.sh
+++ b/examples/nodejs-threads/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Build with atomics support
+RUSTFLAGS='-Ctarget-feature=+atomics,+bulk-memory -Clink-args=--shared-memory -Clink-args=--max-memory=1073741824 -Clink-args=--import-memory' \
+    cargo +nightly build --target wasm32-unknown-unknown --release -Z build-std=std,panic_abort
+
+# Run wasm-bindgen with nodejs target
+cargo run -p wasm-bindgen-cli -- \
+    --target nodejs \
+    --out-dir pkg \
+    ../../target/wasm32-unknown-unknown/release/nodejs_threads.wasm
+
+echo "Build complete! Output in pkg/"

--- a/examples/nodejs-threads/rust-toolchain.toml
+++ b/examples/nodejs-threads/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]
+profile = "minimal"
+targets = ["wasm32-unknown-unknown"]

--- a/examples/nodejs-threads/src/lib.rs
+++ b/examples/nodejs-threads/src/lib.rs
@@ -1,0 +1,27 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+use wasm_bindgen::prelude::*;
+
+// A static atomic counter that can be safely accessed from multiple threads
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+#[wasm_bindgen]
+pub fn increment() -> u32 {
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+#[wasm_bindgen]
+pub fn get_counter() -> u32 {
+    COUNTER.load(Ordering::SeqCst)
+}
+
+#[wasm_bindgen]
+pub fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+// Test that we can grow memory and still access it correctly
+#[wasm_bindgen]
+pub fn allocate_and_sum(size: usize) -> u32 {
+    let v: Vec<u32> = (0..size as u32).collect();
+    v.iter().sum()
+}

--- a/examples/nodejs-threads/test.js
+++ b/examples/nodejs-threads/test.js
@@ -1,0 +1,131 @@
+/**
+ * Integration test for Node.js CJS with worker_threads support.
+ *
+ * Tests:
+ * 1. Main thread auto-initialization (backwards compatibility)
+ * 2. Worker thread initialization with initSync({ module, memory })
+ * 3. Shared atomic counter between threads
+ * 4. Memory growth detection with SharedArrayBuffer (byteLength fix)
+ */
+
+const { Worker, isMainThread, parentPort, workerData } = require('worker_threads');
+const assert = require('assert');
+const path = require('path');
+
+if (isMainThread) {
+    // Main thread tests
+    async function runTests() {
+        console.log('=== Node.js worker_threads Integration Test ===\n');
+
+        // Test 1: Main thread auto-initialization
+        console.log('Test 1: Main thread auto-initialization');
+        const wasm = require('./pkg/nodejs_threads.js');
+
+        assert.strictEqual(typeof wasm.add, 'function', 'add function should be exported');
+        assert.strictEqual(wasm.add(2, 3), 5, 'add(2, 3) should return 5');
+        console.log('  ✓ Main thread initialized and functions work\n');
+
+        // Test 2: Verify initSync and __wbg_get_imports are exported
+        console.log('Test 2: initSync and __wbg_get_imports exports');
+        assert.strictEqual(typeof wasm.initSync, 'function', 'initSync should be exported');
+        assert.strictEqual(typeof wasm.__wbg_get_imports, 'function', '__wbg_get_imports should be exported');
+        assert.ok(wasm.__wbindgen_wasm_module instanceof WebAssembly.Module, '__wbindgen_wasm_module should be a Module');
+        console.log('  ✓ initSync and __wbg_get_imports are exported\n');
+
+        // Test 3: Atomic counter starts at 0
+        console.log('Test 3: Atomic counter initial state');
+        assert.strictEqual(wasm.get_counter(), 0, 'Counter should start at 0');
+        console.log('  ✓ Counter starts at 0\n');
+
+        // Test 4: Increment counter from main thread
+        console.log('Test 4: Increment from main thread');
+        const prev = wasm.increment();
+        assert.strictEqual(prev, 0, 'First increment should return 0');
+        assert.strictEqual(wasm.get_counter(), 1, 'Counter should be 1 after increment');
+        console.log('  ✓ Counter incremented to 1\n');
+
+        // Test 5: Worker thread initialization and shared memory
+        console.log('Test 5: Worker thread with shared memory');
+
+        const workerResult = await new Promise((resolve, reject) => {
+            const worker = new Worker(__filename, {
+                workerData: {
+                    wasmModule: wasm.__wbindgen_wasm_module,
+                    memory: wasm.memory
+                }
+            });
+
+            worker.on('message', resolve);
+            worker.on('error', reject);
+            worker.on('exit', (code) => {
+                if (code !== 0) reject(new Error(`Worker exited with code ${code}`));
+            });
+        });
+
+        assert.strictEqual(workerResult.success, true, 'Worker should succeed');
+        assert.strictEqual(workerResult.addResult, 10, 'Worker add(4, 6) should be 10');
+        console.log('  ✓ Worker thread initialized and ran successfully\n');
+
+        // Test 6: Verify shared counter was modified by worker
+        console.log('Test 6: Shared counter across threads');
+        const finalCount = wasm.get_counter();
+        assert.strictEqual(finalCount, 2, 'Counter should be 2 (main + worker each incremented once)');
+        console.log(`  ✓ Counter is ${finalCount} (modified by both threads)\n`);
+
+        // Test 7: Memory growth and cached view invalidation
+        console.log('Test 7: Memory growth detection (byteLength fix)');
+        const initialSize = wasm.memory.buffer.byteLength;
+        console.log(`  Initial memory size: ${initialSize} bytes`);
+
+        // Allocate a large amount to trigger memory growth
+        // This should work correctly with the byteLength fix
+        const largeSize = 1000000; // 1 million u32s = 4MB
+        const sum = wasm.allocate_and_sum(largeSize);
+        const expectedSum = (largeSize - 1) * largeSize / 2; // Sum of 0..n-1
+        assert.strictEqual(sum, expectedSum, `allocate_and_sum should return ${expectedSum}`);
+
+        const finalSize = wasm.memory.buffer.byteLength;
+        console.log(`  Final memory size: ${finalSize} bytes`);
+
+        if (finalSize > initialSize) {
+            console.log('  ✓ Memory grew and cached views were correctly invalidated\n');
+        } else {
+            console.log('  ✓ Memory did not need to grow (already large enough)\n');
+        }
+
+        console.log('=== All tests passed! ===');
+    }
+
+    runTests().catch(err => {
+        console.error('Test failed:', err);
+        process.exit(1);
+    });
+
+} else {
+    // Worker thread
+    const wasm = require('./pkg/nodejs_threads.js');
+
+    try {
+        // Initialize with shared module and memory
+        wasm.initSync({
+            module: workerData.wasmModule,
+            memory: workerData.memory
+        });
+
+        // Verify functions work
+        const addResult = wasm.add(4, 6);
+
+        // Increment the shared counter
+        wasm.increment();
+
+        parentPort.postMessage({
+            success: true,
+            addResult: addResult
+        });
+    } catch (err) {
+        parentPort.postMessage({
+            success: false,
+            error: err.message
+        });
+    }
+}


### PR DESCRIPTION
# Motivation

  Suppose you want to use workers in Node.js. For example, you are writing threaded Rust code with doctests (which by default run in Node).

 # Problem

  In order to run workers in Node.js, you need a method that can initialize the WASM module on a worker thread with shared memory. The worker thread receives the compiled `WebAssembly.Module` and `WebAssembly.Memory` from the main thread, and needs to instantiate them.

  The `web` target already has `initSync(opts)` for this purpose:

  ```javascript
  // Worker thread (web target)
  wasm_bindgen.initSync({ module, memory });
```

  However, the Node.js CommonJS target (--target nodejs) lacks this API. Instead, it immediately instantiates the module on require(), with no way to pass in shared memory or a pre-compiled module.

 # Solution

  Implement initSync and __wbg_get_imports for Node.js CommonJS when threads are enabled.

  Generated API:
  - initSync(opts) - Initialize the WASM module with optional { module, memory, thread_stack_size }
  - __wbg_get_imports(memory) - Get the imports object with optional custom memory
  - __wbindgen_wasm_module - The compiled WebAssembly.Module for sharing with workers

  # Backwards compatibility:
  - Main thread auto-initializes on require() (existing behavior preserved)
  - Only generates new API when threads are enabled

  # Usage:
```rust
  // Main thread
  const wasm = require('./pkg/my_module.js');
  const { Worker } = require('worker_threads');

  new Worker('./worker.js', {
    workerData: {
      wasmModule: wasm.__wbindgen_wasm_module,
      memory: wasm.memory
    }
  });

  // Worker thread
  const wasm = require('./pkg/my_module.js');
  wasm.initSync({
    module: workerData.wasmModule,
    memory: workerData.memory
  });
```

  # Applications

  This API is basically assumed by https://github.com/drewcrawford/wasm_safe_thread.