### PR TITLE
fix the rustversion min version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ wasm-bindgen-shared = { path = "crates/shared", version = "=0.2.106" }
 
 [build-dependencies]
 # In older MSRVs, dependencies and crate features can't have the same name.
-rustversion-compat = { package = "rustversion", version = "1.0" }
+rustversion-compat = { package = "rustversion", version = "1.0.6" }
 
 [dev-dependencies]
 once_cell = "1"


### PR DESCRIPTION
### Description

Fix

```sh
cargo init project
cargo add wasm-bindgen
cargo build
# works !

cargo +nightly -Z minimal-versions update
cargo build
# error <--------------------- could not find `cfg` in `rustversion`

# if we do
cargo add rustversion@1.0.6
# to force rustversion minimum at 1.0.6

cargo +nightly -Z minimal-versions update
cargo build
# works !
```

### More infos

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements

- rustversion introduced in https://github.com/wasm-bindgen/wasm-bindgen/pull/4278 with `rustversion::attr!()`
  - https://docs.rs/rustversion/1.0.0/rustversion/attr.attr.html
- Modified in https://github.com/wasm-bindgen/wasm-bindgen/commit/ec939cd396ccaf91bc3d05dd57afb7a8de64cce9 with `rustversion::cfg!()`
  - breaking because introduced in 1.0.6 (https://docs.rs/rustversion/1.0.6/rustversion/macro.cfg.html)

### Checklist

- [x] Verified changelog requirement
