### PR TITLE
Fixed flags in 'Catching Panics' docs

### DIFF
--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -24,7 +24,7 @@ is rejected with the `PanicError`.
 Build your project with the required flags:
 
 ```bash
-cargo +nightly build --target wasm32-unknown-unknown -Zbuild-std
+RUSTFLAGS="-Cpanic=unwind" cargo +nightly build --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
 ```
 
 Or set these in `.cargo/config.toml`:
@@ -35,6 +35,7 @@ build-std = ["std", "panic_unwind"]
 
 [build]
 target = "wasm32-unknown-unknown"
+rustflags = ["-C", "panic=unwind"]
 
 [profile.release]
 panic = "unwind"


### PR DESCRIPTION
### Description
The current flags are insufficient for building with `panic=unwind` enabled. Adding these flags caused it to finally work.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
