### PR TITLE
refactor!: gate functionnality requiring unsafe-eval behind a feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,9 +261,9 @@ jobs:
             env:
               RUSTFLAGS: --cfg=web_sys_unstable_apis
           - name: "js-sys"
-            run: cargo test -p js-sys --target wasm32-unknown-unknown
+            run: cargo test -p js-sys --features=unsafe-eval --target wasm32-unknown-unknown
           - name: "js-sys (unstable)"
-            run: cargo test -p js-sys --target wasm32-unknown-unknown
+            run: cargo test -p js-sys --features=unsafe-eval --target wasm32-unknown-unknown
             env:
               RUSTFLAGS: --cfg=js_sys_unstable_apis
           - name: "wasm-bindgen-webidl"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
   [#4893](https://github.com/wasm-bindgen/wasm-bindgen/pull/4893)
 
 * `global` does not use the unsafe-eval `new Function` trick anymore allowing to have CSP strict compliant packages with `wasm-bindgen`.
-  #[4910](https://github.com/wasm-bindgen/wasm-bindgen/pull/4910)
+  [#4910](https://github.com/wasm-bindgen/wasm-bindgen/pull/4910)
+
+* `eval` and `Function` constructors are now gated behind the `unsafe-eval` feature.
+  [#4914](https://github.com/wasm-bindgen/wasm-bindgen/pull/4914)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ once_cell = "1"
 wasm-bindgen-test = { path = 'crates/test' }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-js-sys = { path = 'crates/js-sys' }
+js-sys = { path = 'crates/js-sys', features = ["unsafe-eval"] }
 paste = "1"
 serde_derive = "1.0"
 wasm-bindgen-futures = { path = 'crates/futures' }

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -21,8 +21,12 @@ doctest = false
 test = false
 
 [features]
-default = ["std"]
+# TODO: remove unsafe-eval for 1.0 release
+default = ["std", "unsafe-eval"]
 std = ["wasm-bindgen/std"]
+# It has been agreed to gate functionnality requiring CSP unsafe-eval behind this feature
+# See https://github.com/wasm-bindgen/wasm-bindgen/issues/1647#issuecomment-3775469177
+unsafe-eval = []
 
 [dependencies]
 once_cell = { version = "1.12", default-features = false }

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -256,6 +256,7 @@ extern "C" {
     /// The `eval()` function evaluates JavaScript code represented as a string.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval)
+    #[cfg(feature = "unsafe-eval")]
     #[wasm_bindgen(catch)]
     pub fn eval(js_source_text: &str) -> Result<JsValue, JsValue>;
 
@@ -1949,6 +1950,7 @@ extern "C" {
     /// habits and allowing for more efficient code minification.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    #[cfg(feature = "unsafe-eval")]
     #[wasm_bindgen(constructor)]
     pub fn new_with_args(args: &str, body: &str) -> Function;
 
@@ -1960,6 +1962,7 @@ extern "C" {
     /// habits and allowing for more efficient code minification.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function)
+    #[cfg(feature = "unsafe-eval")]
     #[wasm_bindgen(constructor)]
     pub fn new_no_args(body: &str) -> Function;
 
@@ -2281,6 +2284,7 @@ impl Function {
     }
 }
 
+#[cfg(feature = "unsafe-eval")]
 impl Default for Function {
     fn default() -> Self {
         Self::new_no_args("")

--- a/crates/webidl-tests/Cargo.toml
+++ b/crates/webidl-tests/Cargo.toml
@@ -11,7 +11,7 @@ path = 'lib.rs'
 test = false
 
 [dependencies]
-js-sys = { path = '../js-sys' }
+js-sys = { path = '../js-sys', features = ["unsafe-eval"] }
 wasm-bindgen = { path = '../..' }
 wasm-bindgen-futures = { path = '../futures' }
 


### PR DESCRIPTION
closes https://github.com/wasm-bindgen/wasm-bindgen/issues/1647

### Description
As discussed here: https://github.com/wasm-bindgen/wasm-bindgen/issues/1647#issuecomment-3775469177

- the feature has the same name and is related to a CSP setting that allows unsafe evaluation
- good modern web practices push people to not use unsafe-eval
- by default wasm-bindgen now makes the choice of not requiring such a CSP setting, making it opt-in and allowing to more easily reason about a rust package being compatible with a strict CSP setting

Edit: this PR is obvisouly a breaking change

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
