### PR TITLE
Fix examples build on CI

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -11,5 +11,10 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "memfs": "4.17.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Pin `memfs` to version 4.17.0 to fix pnpm workspace install failure in CI

## Problem

The `build_examples` CI job was failing with:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In : "@jsonjoy.com/fs-core@workspace:*" is in the dependencies but no package named "@jsonjoy.com/fs-core" is present in the workspace
```

This happened because `memfs@4.56.8` (a transitive dependency via `webpack-dev-server` → `webpack-dev-middleware` → `memfs`) was published with `workspace:*` dependencies that only work within the memfs monorepo but break when installed in other pnpm workspaces.

## Solution

Add a pnpm override to pin `memfs` to version 4.17.0, which doesn't have this issue.