### PR TITLE
Fix duplicate string enum handling

### DIFF
--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -5,7 +5,7 @@ use crate::intrinsic::Intrinsic;
 use crate::transforms::threads::ThreadCount;
 use crate::{decode, wasm_conventions, Bindgen, PLACEHOLDER_MODULE};
 use anyhow::{anyhow, bail, ensure, Error};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{hash_map::Entry, BTreeSet, HashMap};
 use std::str;
 use walrus::ir::VisitorMut;
 use walrus::{ConstExpr, ElementItems, ExportId, FunctionId, ImportId, MemoryId, Module};
@@ -1083,15 +1083,28 @@ impl<'a> Context<'a> {
                 .as_ref()
                 .map(|ns| ns.iter().map(|s| s.to_string()).collect()),
         };
-        let mut result = Ok(());
-        self.aux
-            .string_enums
-            .entry(aux.name.clone())
-            .and_modify(|existing| {
-                result = Err(anyhow!("duplicate string enums:\n{existing:?}\n{aux:?}"));
-            })
-            .or_insert(aux);
-        result
+        match self.aux.string_enums.entry(aux.name.clone()) {
+            Entry::Occupied(mut e) => {
+                let existing = e.get_mut();
+                if existing.variant_values != aux.variant_values {
+                    // Merge variant lists
+                    let mut seen = std::collections::HashSet::new();
+                    for v in &existing.variant_values {
+                        seen.insert(v.clone());
+                    }
+                    for v in &aux.variant_values {
+                        if !seen.contains(v) {
+                            seen.insert(v.clone());
+                            existing.variant_values.push(v.clone());
+                        }
+                    }
+                }
+            }
+            Entry::Vacant(v) => {
+                v.insert(aux);
+            }
+        }
+        Ok(())
     }
 
     fn enum_(&mut self, enum_: decode::Enum<'_>) -> Result<(), Error> {
@@ -1518,9 +1531,9 @@ impl<'a> Context<'a> {
 
         // ... then the returned value being translated back
 
-        let inner_ret_output = if let Some(sig_inner_ret) = &signature.inner_ret {
+        let inner_ret_output = if signature.inner_ret.is_some() {
             let mut inner_ret = args.cx.instruction_builder(true);
-            inner_ret.outgoing(sig_inner_ret)?;
+            inner_ret.outgoing(&signature.inner_ret.unwrap())?;
             inner_ret.output
         } else {
             vec![]


### PR DESCRIPTION
### Description

Fixes duplicate string enum handling in WIT bindgen.

Previously, when the same string enum appeared multiple times (e.g. from different WIT interfaces or components), bindgen would error with "duplicate string enums". This PR changes that behavior so duplicate string enums are **merged** instead of rejected:

- If the same enum name is seen again with identical variant values, it is a no-op.
- If the variant values differ, the variant lists are merged and deduplicated by value.

WIT packages that reference the same string enum from multiple places can now bindgen successfully.

**Example:** `GpuBlendFactor` was reported twice with different variant lists (one with 17 variants including `src1`, `one-minus-src1`, etc., another with 13). Previously this errored with "duplicate string enums"; now the variant lists are merged and deduplicated.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
