### PR TITLE
refactor(wasm-bindgen-cli): Add panic message when more that 1 arg is passed to a getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Added the `web` and `node` targets to the `--experimental-reset-state-function` flag.
   [#4909](https://github.com/wasm-bindgen/wasm-bindgen/pull/4909)
 
+* Added a panic message when a getter as more than one argument. 
+  [#4936](https://github.com/wasm-bindgen/wasm-bindgen/pull/4936)
+
 ### Changed
 
 * `Closure::new()`, `Closure::once()`, and related methods now require `UnwindSafe` bounds on closures when building with `panic=unwind`. New `_aborting` variants (`new_aborting()`, `once_aborting()`, etc.) are provided for closures that don't need panic catching and want to avoid the `UnwindSafe` requirement.

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3621,7 +3621,12 @@ impl<'a> Context<'a> {
             AuxImport::StructuralGetter(field) => {
                 assert!(kind == AdapterJsImportKind::Normal);
                 assert!(!variadic);
-                assert_eq!(args.len(), 1);
+                assert_eq!(
+                    args.len(),
+                    1,
+                    "The getter '{field}' as more than one args ({n})",
+                    n = args.len()
+                );
                 Ok(format!("{}{}", args[0], property_accessor(field)))
             }
 


### PR DESCRIPTION
### Description

I've added a message to the assert that ensure that a getter only as one arg.
### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement

Closes wasm-bindgen/wasm-bindgen#4927