### PR TITLE
add Logan Gatlin as a collaborator

### DIFF
--- a/guide/src/contributing/team.md
+++ b/guide/src/contributing/team.md
@@ -19,6 +19,7 @@ We welcome new members - if you are interested in joining the team, see the [mem
 * [Spxg](https://github.com/spxg)
 * [Drew Crawford](https://github.com/drewcrawford)
 * [Magic Akari](https://github.com/magic-akari)
+* [Logan Gatlin](https://github.com/logan-gatlin)
 
 ## Former Members
 


### PR DESCRIPTION
Adds @logan-gatlin, based on the approvals in the issue https://github.com/wasm-bindgen/wasm-bindgen/issues/4934.