### PR TITLE
fix: extra "env" "__cpp_exception" import is inlined if detected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,43 +148,40 @@ jobs:
         node-version: '20'
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std=std,panic_abort --config="target.wasm32-unknown-unknown.rustflags='${{ matrix.envs.RUSTFLAGS }}'"
 
-  # Disabled: Rust nightly now emits `(import "env" "__cpp_exception" ...)` for
-  # exception handling tags, but wasm-bindgen passes this through as a bare "env"
-  # module import which browsers reject. See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4929
-  # test_wasm_bindgen_unwind_legacy_eh:
-  #   name: "Run wasm-bindgen crate tests with panic=unwind with legacy eh"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-  #     RUSTFLAGS: -Cpanic=unwind
-  #   steps:
-  #   - uses: actions/checkout@v6
-  #   - uses: dtolnay/rust-toolchain@nightly
-  #     with:
-  #       targets: wasm32-unknown-unknown
-  #       components: rust-src
-  #   - uses: actions/setup-node@v6
-  #     with:
-  #       node-version: '20'
-  #   - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
-  #   - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
-  # test_wasm_bindgen_unwind_exnref_eh:
-  #   name: "Run wasm-bindgen crate tests with panic=unwind with exnref eh"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-  #     RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh=false
-  #   steps:
-  #   - uses: actions/checkout@v6
-  #   - uses: dtolnay/rust-toolchain@nightly
-  #     with:
-  #       targets: wasm32-unknown-unknown
-  #       components: rust-src
-  #   - uses: actions/setup-node@v6
-  #     with:
-  #       node-version: '25'
-  #   - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
-  #   - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
+  test_wasm_bindgen_unwind_legacy_eh:
+    name: "Run wasm-bindgen crate tests with panic=unwind with legacy eh"
+    runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+      RUSTFLAGS: -Cpanic=unwind
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        targets: wasm32-unknown-unknown
+        components: rust-src
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '20'
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
+  test_wasm_bindgen_unwind_exnref_eh:
+    name: "Run wasm-bindgen crate tests with panic=unwind with exnref eh"
+    runs-on: ubuntu-latest
+    env:
+      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
+      RUSTFLAGS: -Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh=false
+    steps:
+    - uses: actions/checkout@v6
+    - uses: dtolnay/rust-toolchain@nightly
+      with:
+        targets: wasm32-unknown-unknown
+        components: rust-src
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '25'
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
 
   # I don't know why this is failing so comment this out for now, but ideally
   # this would be figured out at some point and solved.

--- a/justfile
+++ b/justfile
@@ -35,7 +35,7 @@ test-wasm-bindgen *ARGS="":
     NODE_ARGS="--stack-trace-limit=100" RUST_BACKTRACE=1 WASM_BINDGEN_TEST_ONLY_NODE=1 WASM_BINDGEN_SPLIT_LINKED_MODULES=1 cargo test --target wasm32-unknown-unknown {{ARGS}}
 
 test-wasm-bindgen-unwind *ARGS="":
-    RUSTFLAGS="-Cpanic=unwind" NODE_ARGS="--stack-trace-limit=100" RUST_BACKTRACE=1 WASM_BINDGEN_TEST_ONLY_NODE=1 WASM_BINDGEN_SPLIT_LINKED_MODULES=1 cargo +nightly test --features std -Zbuild-std --target wasm32-unknown-unknown {{ARGS}}
+    RUSTFLAGS="-Cpanic=unwind" RUSTDOCFLAGS="-Cpanic=unwind" NODE_ARGS="--stack-trace-limit=100" RUST_BACKTRACE=1 WASM_BINDGEN_TEST_ONLY_NODE=1 WASM_BINDGEN_SPLIT_LINKED_MODULES=1 cargo +nightly test --features std -Zbuild-std=std,panic_unwind --target wasm32-unknown-unknown {{ARGS}}
 
 test-wasm-bindgen-futures *ARGS="":
     NODE_ARGS="--stack-trace-limit=100" RUST_BACKTRACE=1 cargo test --target wasm32-unknown-unknown -p wasm-bindgen-futures {{ARGS}}


### PR DESCRIPTION
### Description
See [#4931](https://github.com/wasm-bindgen/wasm-bindgen/pull/4931).
If this tag import is found in the binary, inline it. I also export it in case JS wants access to it later.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
