### PR TITLE
no-modules mode URL detection logic for WebWorkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased
 
+* Added logic to the `no-modules` JavaScript boilerplate in order to support usage within WebWorkers. [#4943](https://github.com/wasm-bindgen/wasm-bindgen/issues/4943)
+
 ### Added
 
 * Added `ScopedClosure<'a, T>` as a unified closure type with lifetime parameter. `ScopedClosure::borrow(&f)` and `ScopedClosure::borrow_mut(&mut f)` create borrowed closures that can capture non-`'static` references, ideal for immediate/synchronous JS callbacks. `Closure<T>` and `StaticClosure<T>` are now type aliases for `ScopedClosure<'static, T>`, maintaining full backwards compatibility. Also added `IntoWasmAbi` implementation for `Closure<T>` enabling pass-by-value ownership transfer to JavaScript.

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -460,6 +460,8 @@ impl<'a> Context<'a> {
             let script_src;
             if (typeof document !== 'undefined' && document.currentScript !== null) {
                 script_src = new URL(document.currentScript.src, location.href).toString();
+            } else if(self && self.location && self.location.href) {
+                script_src = new URL(self.location.href).toString();
             }
             "
             .to_owned();

--- a/crates/cli/tests/reference/targets-target-no-modules-atomics.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-atomics.js
@@ -2,6 +2,8 @@ let wasm_bindgen = (function(exports) {
     let script_src;
     if (typeof document !== 'undefined' && document.currentScript !== null) {
         script_src = new URL(document.currentScript.src, location.href).toString();
+    } else if(self && self.location && self.location.href) {
+        script_src = new URL(self.location.href).toString();
     }
 
     /**

--- a/crates/cli/tests/reference/targets-target-no-modules-mvp.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-mvp.js
@@ -2,6 +2,8 @@ let wasm_bindgen = (function(exports) {
     let script_src;
     if (typeof document !== 'undefined' && document.currentScript !== null) {
         script_src = new URL(document.currentScript.src, location.href).toString();
+    } else if(self && self.location && self.location.href) {
+        script_src = new URL(self.location.href).toString();
     }
 
     /**

--- a/crates/cli/tests/reference/targets-target-no-modules.js
+++ b/crates/cli/tests/reference/targets-target-no-modules.js
@@ -2,6 +2,8 @@ let wasm_bindgen = (function(exports) {
     let script_src;
     if (typeof document !== 'undefined' && document.currentScript !== null) {
         script_src = new URL(document.currentScript.src, location.href).toString();
+    } else if(self && self.location && self.location.href) {
+        script_src = new URL(self.location.href).toString();
     }
 
     /**

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -405,6 +405,7 @@ fn default_module_path_target_no_modules() {
         fs::read_to_string(out_dir.join("default_module_path_target_no_modules.js")).unwrap();
     assert!(contents
         .contains("script_src = new URL(document.currentScript.src, location.href).toString();",));
+    assert!(contents.contains("script_src = new URL(self.location.href).toString();",));
     assert!(contents.contains("module_or_path = script_src.replace(",));
 }
 


### PR DESCRIPTION
### Description
adds the following code to the boilerplate JS generated for `no-modules` mode in order to allow that code to run inside a WebWorker, fixes #4943 

```
    else if(self && self.location && self.location.href) {
        script_src = new URL(self.location.href).toString();
    }
```



### Checklist

- [X] Verified changelog requirement
