### PR TITLE
Fix macOS build error in no_interpret.rs

### DIFF
--- a/tests/no_interpret.rs
+++ b/tests/no_interpret.rs
@@ -3,7 +3,8 @@ const _: () = {
         let _ = 1 + 1;
     }
 
-    #[unsafe(link_section = ".init_array")]
+    #[cfg_attr(target_os = "macos", unsafe(link_section = "__DATA,__mod_init_func"))]
+    #[cfg_attr(not(target_os = "macos"), unsafe(link_section = ".init_array"))]
     static __CTOR: unsafe extern "C" fn() = __ctor;
 };
 


### PR DESCRIPTION
# Summary

  tests/no_interpret.rs, introduced in #4562 (commit 9fb5dd638), uses #[unsafe(link_section = ".init_array")] to place a constructor in the ELF init array. However, .init_array is an ELF-specific section name. On macOS (Mach-O), this fails at compile time with:

```
  rustc-LLVM ERROR: Global variable '...' has an invalid section specifier '.init_array':
  mach-o section specifier requires a segment and section separated by a comma.
```

  This means cargo test is broken on macOS for anyone running the full test suite.

 # Fix

  Use cfg_attr to select the platform-appropriate section name:

  - macOS (Mach-O): __DATA,__mod_init_func
  - Everything else (ELF): .init_array

```
  #[cfg_attr(target_os = "macos", unsafe(link_section = "__DATA,__mod_init_func"))]
  #[cfg_attr(not(target_os = "macos"), unsafe(link_section = ".init_array"))]
  static __CTOR: unsafe extern "C" fn() = __ctor;
```

  This is the standard Mach-O equivalent of .init_array for static constructors.

 # Test plan

  - cargo test --test no_interpret passes on macOS (previously failed with LLVM error)
  - No change in behavior on Linux/wasm targets (the not(target_os = "macos") branch is identical to the original code)
