### PR TITLE
feat(web-sys): Add `matrixTransform` method to `DOMPointReadOnly`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   and unstable methods (using the new types without `[Throws]}`, matching actual browser behavior).
   [#2578](https://github.com/AbesBend662/AbesBend662.github.io/pull/2578)
 
+* Added `matrixTransform()` method to `DOMPointReadOnly` in `web-sys`.
+  [#4962](https://github.com/wasm-bindgen/wasm-bindgen/pull/4962)
+
 * Added support for erasable generic type parameters on imported JavaScript types,
   using sound type erasure in JS bindgen boundary. Includes updated js-sys bindings
   with generic implementations for many standard JS types and functions including

--- a/crates/web-sys/src/features/gen_DomPointReadOnly.rs
+++ b/crates/web-sys/src/features/gen_DomPointReadOnly.rs
@@ -95,6 +95,25 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `DomPointInit`, `DomPointReadOnly`*"]
     pub fn from_point_with_other(other: &DomPointInit) -> DomPointReadOnly;
+    #[cfg(feature = "DomPoint")]
+    # [wasm_bindgen (catch , method , structural , js_class = "DOMPointReadOnly" , js_name = matrixTransform)]
+    #[doc = "The `matrixTransform()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly/matrixTransform)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomPoint`, `DomPointReadOnly`*"]
+    pub fn matrix_transform(this: &DomPointReadOnly) -> Result<DomPoint, JsValue>;
+    #[cfg(all(feature = "DomMatrixInit", feature = "DomPoint",))]
+    # [wasm_bindgen (catch , method , structural , js_class = "DOMPointReadOnly" , js_name = matrixTransform)]
+    #[doc = "The `matrixTransform()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly/matrixTransform)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomMatrixInit`, `DomPoint`, `DomPointReadOnly`*"]
+    pub fn matrix_transform_with_matrix(
+        this: &DomPointReadOnly,
+        matrix: &DomMatrixInit,
+    ) -> Result<DomPoint, JsValue>;
     # [wasm_bindgen (method , structural , js_class = "DOMPointReadOnly" , js_name = toJSON)]
     #[doc = "The `toJSON()` method."]
     #[doc = ""]

--- a/crates/web-sys/webidls/enabled/DOMPoint.webidl
+++ b/crates/web-sys/webidls/enabled/DOMPoint.webidl
@@ -19,7 +19,9 @@ interface DOMPointReadOnly {
     readonly attribute unrestricted double x;
     readonly attribute unrestricted double y;
     readonly attribute unrestricted double z;
-    readonly attribute unrestricted double w; 
+    readonly attribute unrestricted double w;
+
+    [NewObject, Throws] DOMPoint matrixTransform(optional DOMMatrixInit matrix = {});
 
     [Default] object toJSON();
 };


### PR DESCRIPTION
### Description
Add the `matrixTransform()` method from the W3C Geometry Interfaces Module Level 1 specification to `DOMPointReadOnly`, enabling point transformation by a `DOMMatrixInit`.

### Checklist
- [x] Verified changelog requirement
