### PR TITLE
fix: web-sys tests broken on Safari

### DIFF
--- a/crates/web-sys/tests/wasm/element.js
+++ b/crates/web-sys/tests/wasm/element.js
@@ -50,6 +50,10 @@ export function new_html() {
   return document.createElement("html");
 }
 
+export function attach_element(element) {
+  document.body.appendChild(element);
+}
+
 export function new_input() {
     return document.createElement("input");
 }

--- a/crates/web-sys/tests/wasm/html_element.rs
+++ b/crates/web-sys/tests/wasm/html_element.rs
@@ -5,6 +5,7 @@ use web_sys::HtmlElement;
 #[wasm_bindgen(module = "/tests/wasm/element.js")]
 extern "C" {
     fn new_html() -> HtmlElement;
+    fn attach_element(element: &HtmlElement);
 }
 
 #[wasm_bindgen_test]
@@ -119,6 +120,8 @@ fn test_html_element() {
         "true",
         "Should be content_editable"
     );
+    // Safari does not consider an element "editable" unless it is connected to the DOM
+    attach_element(&element);
     assert!(element.is_content_editable(), "Should be content_editable");
 
     element.set_spellcheck(false);


### PR DESCRIPTION
### Description
Safari does not consider an element to be "editable" unless it is attached to the DOM. This leads to the very confusing situation where `editable == true` and `isEditable() == false`. The fix is just to attach the element before calling `isEditable()`.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
