### PR TITLE
feat(js-sys): add SharedArrayBuffer.grow() binding

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -2291,11 +2291,18 @@ extern "C" {
     pub fn byte_length(this: &SharedArrayBuffer) -> usize;
 
     /// The `growable` accessor property of `SharedArrayBuffer` instances returns whether
-    /// this `SharedArrayBuffer` can be grow or not.
+    /// this `SharedArrayBuffer` can be grown or not.
     ///
-    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength)
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable)
     #[wasm_bindgen(method, getter)]
     pub fn growable(this: &SharedArrayBuffer) -> bool;
+
+    /// The `grow()` method of `SharedArrayBuffer` instances grows the
+    /// `SharedArrayBuffer` to the specified size, in bytes.
+    ///
+    /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/grow)
+    #[wasm_bindgen(method, catch)]
+    pub fn grow(this: &SharedArrayBuffer, new_byte_length: usize) -> Result<(), JsValue>;
 
     /// The `maxByteLength` accessor property of `SharedArrayBuffer` instances returns the maximum
     /// length (in bytes) that this `SharedArrayBuffer` can be resized to.

--- a/crates/js-sys/tests/wasm/SharedArrayBuffer.rs
+++ b/crates/js-sys/tests/wasm/SharedArrayBuffer.rs
@@ -83,3 +83,15 @@ fn growable() {
     let fixed = SharedArrayBuffer::new(50);
     assert!(!fixed.growable());
 }
+
+#[wasm_bindgen_test]
+fn grow() {
+    if !is_shared_array_buffer_supported() {
+        return;
+    }
+    let options = ArrayBufferOptions::new(100);
+    let buf = SharedArrayBuffer::new_with_options(50, &options);
+    assert_eq!(buf.byte_length(), 50);
+    buf.grow(75).unwrap();
+    assert_eq!(buf.byte_length(), 75);
+}


### PR DESCRIPTION
## Summary
- Adds the missing `grow()` method binding for `SharedArrayBuffer`, which grows a growable `SharedArrayBuffer` to the specified size in bytes.
- Fixes the MDN doc link for the `growable` getter (was pointing to `byteLength`).
- Adds a test for `grow()`.

Closes #3716