### PR TITLE
Schema cleanup: rename and remove legacy intrinsics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
   `__wbindgen_object_is_undefined` intrinsic in favor of a safe Rust-side equivalent.
   [#4993](https://github.com/wasm-bindgen/wasm-bindgen/pull/4993)
 
+* Renamed `__wbindgen_object_is_null_or_undefined` intrinsic to
+  `__wbindgen_is_null_or_undefined` and removed the `__wbindgen_object_is_undefined`
+  intrinsic, replacing it with a safe Rust-side check. The `is_null_or_undefined` check
+  now uses safe `&JsValue` ABI instead of raw `u32`.
+  [#4994](https://github.com/wasm-bindgen/wasm-bindgen/pull/4994)
 ### Fixed
 
 * Fixed incorrect method naming for stable web-sys methods that reference unstable

--- a/crates/cli-support/src/intrinsic.rs
+++ b/crates/cli-support/src/intrinsic.rs
@@ -42,10 +42,7 @@ intrinsics! {
         IsFunction = "__wbindgen_is_function",
         IsUndefined = "__wbindgen_is_undefined",
         IsNull = "__wbindgen_is_null",
-        // TODO: rename to `__wbindgen_is_null_or_undefined` on next schema bump
-        IsNullOrUndefined = "__wbindgen_object_is_null_or_undefined",
-        // TODO: remove on next schema bump
-        ObjectIsUndefined = "__wbindgen_object_is_undefined",
+        IsNullOrUndefined = "__wbindgen_is_null_or_undefined",
         IsObject = "__wbindgen_is_object",
         IsSymbol = "__wbindgen_is_symbol",
         IsString = "__wbindgen_is_string",

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -4112,12 +4112,6 @@ if (require('worker_threads').isMainThread) {{
                 format!("{} == null", args[0])
             }
 
-            // TODO: remove on next schema bump
-            Intrinsic::ObjectIsUndefined => {
-                assert_eq!(args.len(), 1);
-                format!("{} === undefined", args[0])
-            }
-
             Intrinsic::IsObject => {
                 assert_eq!(args.len(), 1);
                 prelude.push_str(&format!("const val = {};\n", args[0]));

--- a/crates/cli-support/src/wit/mod.rs
+++ b/crates/cli-support/src/wit/mod.rs
@@ -220,13 +220,7 @@ impl<'a> Context<'a> {
             Descriptor::Unit,
             AuxImport::Intrinsic(Intrinsic::ObjectDropRef),
         )?;
-        // TODO: remove on next schema bump
-        self.add_aux_import_to_import_map(
-            "__wbindgen_object_is_undefined",
-            vec![Descriptor::Ref(Box::new(Descriptor::Externref))],
-            Descriptor::Boolean,
-            AuxImport::Intrinsic(Intrinsic::ObjectIsUndefined),
-        )?;
+
         for import in imports_to_delete {
             self.module.imports.delete(import);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ impl JsValue {
     /// Tests whether this JS value is `null` or `undefined`
     #[inline]
     pub fn is_null_or_undefined(&self) -> bool {
-        __wbindgen_object_is_null_or_undefined(self)
+        __wbindgen_is_null_or_undefined(self)
     }
 
     /// Tests whether the type of this JS value is `symbol`
@@ -1217,8 +1217,7 @@ extern "C" {
 
     fn __wbindgen_is_null(js: &JsValue) -> bool;
     fn __wbindgen_is_undefined(js: &JsValue) -> bool;
-    // TODO: rename to `__wbindgen_is_null_or_undefined` on next schema bump
-    fn __wbindgen_object_is_null_or_undefined(js: &JsValue) -> bool;
+    fn __wbindgen_is_null_or_undefined(js: &JsValue) -> bool;
     fn __wbindgen_is_symbol(js: &JsValue) -> bool;
     fn __wbindgen_is_object(js: &JsValue) -> bool;
     fn __wbindgen_is_function(js: &JsValue) -> bool;


### PR DESCRIPTION
## Summary

- Renames `__wbindgen_object_is_null_or_undefined` to `__wbindgen_is_null_or_undefined`, moving it from the raw `u32`-based `externs!` block to the safe `&JsValue`-based `wasm_bindgen` extern block.
- Removes `__wbindgen_object_is_undefined` entirely, replacing its only usage in `OptionFromWasmAbi` for `JsValue` with a safe Rust-side `.is_undefined()` call.
- Removes the corresponding manual import mappings in `wit/mod.rs` since the intrinsics system handles matching by function name automatically.

**Note:** This is a schema-breaking change and should be landed as part of a schema version bump.