### PR TITLE
Make abort-reinit work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-      WASM_BINDGEN_ABORT_REINIT: 1
       RUSTFLAGS: -Cpanic=unwind
     steps:
     - uses: actions/checkout@v6
@@ -198,8 +197,8 @@ jobs:
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
-    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
-    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests --features abort-reinit
+    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,abort-reinit,wasm-bindgen-futures/std
 
   # I don't know why this is failing so comment this out for now, but ideally
   # this would be figured out at some point and solved.
@@ -253,7 +252,7 @@ jobs:
         targets: wasm32-unknown-unknown
     - uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
     - run: cargo test
     - run: cargo test -p wasm-bindgen-cli-support
     - run: cargo test -p wasm-bindgen-cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ features = ["serde-serialize"]
 test = false
 
 [features]
+__all_features = []
+abort-reinit = []
 default = ["std"]
 enable-interning = ["std"]
 serde-serialize = ["serde", "serde_json", "std"]

--- a/crates/cli-support/src/externref.rs
+++ b/crates/cli-support/src/externref.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use walrus::ElementItems;
 use walrus::{ir::Value, ConstExpr, ElementKind, Module};
 
-pub fn process(module: &mut Module) -> Result<()> {
+pub fn process(module: &mut Module, abort_reinit: bool) -> Result<()> {
     let mut cfg = Context::new(module)?;
     let section = module
         .customs
@@ -63,7 +63,7 @@ pub fn process(module: &mut Module) -> Result<()> {
     // slice-related instructions, though, so let's just cop out and only enable
     // these coarsely.
     aux.externref_table = Some(meta.table);
-    if module_needs_externref_metadata(&aux, section) {
+    if abort_reinit || module_needs_externref_metadata(&aux, section) {
         aux.externref_alloc = meta.alloc;
         aux.externref_drop = meta.drop;
         aux.externref_drop_slice = meta.drop_slice;

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -96,6 +96,9 @@ pub enum TsReference {
 }
 
 pub fn wrap_try_catch(call: &str) -> String {
+    // TODO: Is it concerning that this still executes drops?
+    // If we raise a WebAssembly.RuntimeError, does that not execute drops? Hard
+    // to guarantee for reentrant calls.
     format!(
         "\
         try {{
@@ -104,6 +107,8 @@ pub fn wrap_try_catch(call: &str) -> String {
             if (e instanceof WebAssembly.Exception && e.is(__wbindgen_wrapped_jstag)) {{
                 throw e.getArg(__wbindgen_wrapped_jstag, 0);
             }}
+            getInt32ArrayMemory0()[wasm.__terminated_address/4] = 1;
+            __wbg_reset_state();
             throw e;
         }}
         "

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3158,6 +3158,9 @@ if (require('worker_threads').isMainThread) {{
     }
 
     pub fn generate(&mut self) -> Result<(), Error> {
+        if self.config.abort_reinit {
+            self.expose_int32_memory(crate::wasm_conventions::get_memory(self.module)?);
+        }
         self.prestore_global_import_identifiers()?;
 
         self.generate_jstag_import();
@@ -3254,7 +3257,15 @@ if (require('worker_threads').isMainThread) {{
             return;
         };
 
-        // Find the import ID for the wrapped JSTag
+        // Create a top-level constant for the wrapped tag. This is needed by
+        // the JS-side try-catch wrappers and the throw/rethrow intrinsics
+        // regardless of whether the wasm import survives GC.
+        self.global(
+            "const __wbindgen_wrapped_jstag = new WebAssembly.Tag({ parameters: ['externref'] });",
+        );
+
+        // If the wasm import for the tag still exists (i.e. it's used by catch
+        // wrappers inside wasm), wire it up to the JS constant.
         let import_id = self.module.imports.iter().find_map(|import| {
             let walrus::ImportKind::Tag(tag_id) = import.kind else {
                 return None;
@@ -3266,18 +3277,10 @@ if (require('worker_threads').isMainThread) {{
             }
         });
 
-        let Some(id) = import_id else {
-            return;
-        };
-
-        // Create a top-level constant for the wrapped tag
-        self.global(
-            "const __wbindgen_wrapped_jstag = new WebAssembly.Tag({ parameters: ['externref'] });",
-        );
-
-        // Use the constant for the import
-        self.wasm_import_definitions
-            .insert(id, "__wbindgen_wrapped_jstag".to_string());
+        if let Some(id) = import_id {
+            self.wasm_import_definitions
+                .insert(id, "__wbindgen_wrapped_jstag".to_string());
+        }
     }
 
     /// Registers import names for all `Global` imports first before we actually

--- a/crates/cli-support/src/lib.rs
+++ b/crates/cli-support/src/lib.rs
@@ -90,7 +90,6 @@ impl Bindgen {
         let externref =
             env::var("WASM_BINDGEN_ANYREF").is_ok() || env::var("WASM_BINDGEN_EXTERNREF").is_ok();
         let multi_value = env::var("WASM_BINDGEN_MULTI_VALUE").is_ok();
-        let abort_reinit = env::var("WASM_BINDGEN_ABORT_REINIT").is_ok();
         Bindgen {
             input: Input::None,
             out_name: None,
@@ -112,7 +111,7 @@ impl Bindgen {
             omit_default_module_path: true,
             split_linked_modules: false,
             generate_reset_state: false,
-            abort_reinit,
+            abort_reinit: false,
         }
     }
 
@@ -344,6 +343,16 @@ impl Bindgen {
             self.multi_value = true;
         }
 
+        // Enable abort_reinit if __terminated_address is exported
+        if module
+            .exports
+            .iter()
+            .any(|export| export.name == "__terminated_address")
+        {
+            self.abort_reinit = true;
+            self.generate_reset_state = true;
+        }
+
         // Check that no exported symbol is called "default" if we target web.
         if matches!(self.mode, OutputMode::Web)
             && module.exports.iter().any(|export| export.name == "default")
@@ -430,7 +439,7 @@ impl Bindgen {
         // export of all our externref intrinsics which will get cleaned up in the
         // GC pass before JS generation.
         if self.externref {
-            externref::process(&mut module)?;
+            externref::process(&mut module, self.abort_reinit)?;
         } else {
             let ids = module
                 .exports

--- a/crates/cli-support/src/transforms/catch_handler.rs
+++ b/crates/cli-support/src/transforms/catch_handler.rs
@@ -59,7 +59,7 @@ pub fn run(
     eh_version: ExceptionHandlingVersion,
     abort_reinit: bool,
 ) -> Result<(), Error> {
-    if aux.imports_with_catch.is_empty() {
+    if aux.imports_with_catch.is_empty() && !abort_reinit {
         return Ok(());
     }
 

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -539,3 +539,189 @@ fn constructor_cannot_return_option_struct() {
         .wasm_bindgen("--target web")
         .unwrap_err();
 }
+
+#[test]
+fn abort_reinit() {
+    let mut project = Project::new("abort_reinit");
+    project
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+                use wasm_bindgen::throw_str;
+
+                #[wasm_bindgen(inline_js = "export function js_throw_error() { throw new Error('JS import threw'); }")]
+                extern "C" {
+                    // No `catch` — a JS throw here should unwind, not abort.
+                    fn js_throw_error();
+                }
+
+                static mut COUNTER: u32 = 0;
+
+                #[wasm_bindgen]
+                pub fn simple_add(a: u32, b: u32) -> u32 {
+                    a + b
+                }
+
+                #[wasm_bindgen]
+                pub fn increment_counter() {
+                    unsafe { COUNTER += 1; }
+                }
+
+                #[wasm_bindgen]
+                pub fn get_counter() -> u32 {
+                    unsafe { COUNTER }
+                }
+
+                #[wasm_bindgen]
+                pub fn trigger_unreachable() {
+                    #[cfg(target_arch = "wasm32")]
+                    unsafe { core::arch::wasm32::unreachable(); }
+                }
+
+                #[wasm_bindgen]
+                pub fn trigger_panic() {
+                    panic!("deliberate panic");
+                }
+
+                #[wasm_bindgen]
+                pub fn trigger_throw_str() {
+                    throw_str("deliberate throw_str");
+                }
+
+                #[wasm_bindgen]
+                pub fn call_throwing_import() {
+                    js_throw_error();
+                }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            &format!(
+                "
+                    [package]
+                    name = \"abort_reinit\"
+                    authors = []
+                    version = \"1.0.0\"
+                    edition = '2021'
+
+                    [dependencies]
+                    wasm-bindgen = {{ path = '{}', features = ['abort-reinit'] }}
+
+                    [lib]
+                    crate-type = ['cdylib']
+
+                    [workspace]
+
+                    [profile.dev]
+                    codegen-units = 1
+                ",
+                REPO_ROOT.display(),
+            ),
+        );
+
+    // abort-reinit requires panic=unwind and nightly build-std
+    project
+        .cargo_cmd
+        .env("RUSTUP_TOOLCHAIN", "nightly")
+        .env("RUSTFLAGS", "-Cpanic=unwind")
+        .arg("-Zbuild-std=std,panic_unwind");
+
+    let out_dir = project.wasm_bindgen("--target nodejs").unwrap();
+
+    // Write the Node.js test script into the output directory
+    fs::write(
+        out_dir.join("test_abort_reinit.js"),
+        r#"
+const assert = require('node:assert/strict');
+
+// Monkeypatch WebAssembly.Instance to capture the wasm exports (memory and
+// __terminated_address) before the generated JS module hides them.
+let wasmExports = null;
+const OrigInstance = WebAssembly.Instance;
+WebAssembly.Instance = function(module, imports) {
+    const instance = new OrigInstance(module, imports);
+    wasmExports = instance.exports;
+    return instance;
+};
+
+const wasm = require('./abort_reinit.js');
+WebAssembly.Instance = OrigInstance;
+
+// Test 1: Basic functionality works
+assert.strictEqual(wasm.simple_add(2, 3), 5);
+console.log('Test 1 passed: basic functionality works');
+
+// Test 2: Recoverable exception (panic) does not trigger reinit, state preserved
+wasm.increment_counter();
+wasm.increment_counter();
+assert.strictEqual(wasm.get_counter(), 2);
+
+assert.throws(() => wasm.trigger_panic(), (e) => {
+    assert(!(e instanceof WebAssembly.RuntimeError), 'panic should not be WebAssembly.RuntimeError');
+    assert.match(e.message || String(e), /deliberate panic/);
+    return true;
+});
+
+assert.strictEqual(wasm.get_counter(), 2, 'counter should be preserved after panic (no reinit)');
+assert.strictEqual(wasm.simple_add(10, 20), 30);
+console.log('Test 2 passed: panic is recoverable, state preserved');
+
+// Test 3: Recoverable exception (throw_str) does not trigger reinit, state preserved
+assert.strictEqual(wasm.get_counter(), 2);
+
+assert.throws(() => wasm.trigger_throw_str(), (e) => {
+    assert(!(e instanceof WebAssembly.RuntimeError), 'throw_str should not be WebAssembly.RuntimeError');
+    const msg = (typeof e === 'string') ? e : (e.message || String(e));
+    assert.match(msg, /deliberate throw_str/);
+    return true;
+});
+
+assert.strictEqual(wasm.get_counter(), 2, 'counter should be preserved after throw_str (no reinit)');
+assert.strictEqual(wasm.simple_add(7, 8), 15);
+console.log('Test 3 passed: throw_str is recoverable, state preserved');
+
+// Test 4: JS throw from non-catch import does not trigger reinit, state preserved
+assert.throws(() => wasm.call_throwing_import(), (e) => {
+    assert(!(e instanceof WebAssembly.RuntimeError), 'JS throw should not be WebAssembly.RuntimeError');
+    assert.match(e.message || String(e), /JS import threw/);
+    return true;
+});
+
+assert.strictEqual(wasm.get_counter(), 2, 'counter should be preserved after import throw (no reinit)');
+console.log('Test 4 passed: import throw is recoverable, state preserved');
+
+// Test 5: Fatal error triggers reinit, state is reset, wasm works after
+wasm.increment_counter();
+assert.strictEqual(wasm.get_counter(), 3);
+
+// Read __terminated_address from the captured wasm exports before abort
+const terminatedAddr = wasmExports.__terminated_address;
+const oldMemory = new Int32Array(wasmExports.memory.buffer);
+assert.strictEqual(oldMemory[terminatedAddr / 4], 0, '__terminated_address should be 0 before abort');
+
+assert.throws(() => wasm.trigger_unreachable(), (e) => {
+    assert(e instanceof WebAssembly.RuntimeError, 'fatal error should be WebAssembly.RuntimeError');
+    return true;
+});
+
+// The old memory view still points at the pre-reinit buffer where
+// __terminated_address was set to 1 by the catch handler.
+assert.strictEqual(oldMemory[terminatedAddr / 4], 1, '__terminated_address should be 1 after abort');
+
+assert.strictEqual(wasm.get_counter(), 0, 'counter should be reset to 0 after reinit');
+assert.strictEqual(wasm.simple_add(100, 200), 300);
+console.log('Test 5 passed: fatal error triggers reinit, state reset, wasm works');
+
+console.log('All abort-reinit tests passed!');
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("test_abort_reinit.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("All abort-reinit tests passed!"));
+}

--- a/justfile
+++ b/justfile
@@ -62,10 +62,10 @@ test-wasm-bindgen-unwind-reinit *ARGS="":
     RUST_BACKTRACE=1 \
     WASM_BINDGEN_TEST_ONLY_NODE=1 \
     WASM_BINDGEN_SPLIT_LINKED_MODULES=1 \
-    WASM_BINDGEN_ABORT_REINIT=1 \
     cargo +nightly test \
         -Zbuild-std=std,panic_unwind \
         --target wasm32-unknown-unknown \
+        --features abort-reinit \
         {{ARGS}}
 
 test-wasm-bindgen-unwind-eh *ARGS="":

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -635,6 +635,17 @@ pub fn link_mem_intrinsics() {
 #[cfg_attr(target_feature = "atomics", thread_local)]
 static GLOBAL_EXNDATA: ThreadLocalWrapper<Cell<[u32; 2]>> = ThreadLocalWrapper(Cell::new([0; 2]));
 
+#[cfg(all(
+    feature = "abort-reinit",
+    panic = "abort",
+    not(feature = "__all_features")
+))]
+compile_error!("the `abort-reinit` feature requires `panic = \"unwind\"`");
+
+#[cfg(all(feature = "abort-reinit", panic = "unwind"))]
+#[no_mangle]
+pub static mut __terminated_address: u32 = 0;
+
 #[no_mangle]
 pub unsafe extern "C" fn __wbindgen_exn_store(idx: u32) {
     debug_assert_eq!(GLOBAL_EXNDATA.0.get()[0], 0);

--- a/tests/wasm/classes.js
+++ b/tests/wasm/classes.js
@@ -242,7 +242,7 @@ exports.js_test_inspectable_classes = () => {
     // Non-inspectable classes in Node.js have no special console.log formatting
     const not_inspectable_output = console_log_to_string(not_inspectable);
     assert.match(not_inspectable_output, new RegExp(
-        `^NotInspectable \\{ __wbg_ptr: ${not_inspectable.__wbg_ptr} \\}$`
+        `^NotInspectable \\{ __wbg_ptr: ${not_inspectable.__wbg_ptr}\(, __wbg_inst: 0\)? \\}$`
     ));
     inspectable.free();
     not_inspectable.free();


### PR DESCRIPTION
This changes abort-reinit to a --cfg instead of an environment variable. I added the __terminated_address export and make a compile error if -Cpanic=unwind is not set. Then in the cli I look for the __terminated_address to decide to enable the feature. It now implies generate_reset_state as well.

I updated wrap_try_catch to set the terminated_address to 1 and call reset_state if it catches an unwrapped exception.

The test can't be in the main test suite because it tests aborts which would reset the test suite so I added the test in crates/cli/tests/wasm-bindgen/main.rs. I also fixed some bugs that occur when no #[catch] imports are present due to the way that catch_handler was set up. These bugs are covered by the added test.

This probably should have a changelog.

- [ ] Verified changelog requirement
