### PR TITLE
Migrate from once_cell to native LazyCell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ xxx_debug_only_print_generated_code = []
 
 [dependencies]
 cfg-if = "1.0.0"
-once_cell = { version = "1.12", default-features = false }
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 wasm-bindgen-macro = { path = "crates/macro", version = "=0.2.113" }
@@ -54,7 +53,6 @@ wasm-bindgen-shared = { path = "crates/shared", version = "=0.2.113" }
 rustversion-compat = { package = "rustversion", version = "1.0.6" }
 
 [dev-dependencies]
-once_cell = "1"
 wasm-bindgen-test = { path = 'crates/test' }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/futures/Cargo.toml
+++ b/crates/futures/Cargo.toml
@@ -21,7 +21,6 @@ cfg-if = "1.0.0"
 futures-core = { version = '0.3.8', default-features = false, optional = true }
 futures-util = { version = '0.3.31', default-features = false, features = ["std"], optional = true }
 js-sys = { path = "../js-sys", version = '=0.3.90', default-features = false }
-once_cell = { version = "1.12", default-features = false }
 wasm-bindgen = { path = "../..", version = '=0.2.113', default-features = false }
 
 [features]

--- a/crates/futures/src/queue.rs
+++ b/crates/futures/src/queue.rs
@@ -113,7 +113,7 @@ impl Queue {
     }
 
     pub(crate) fn with<R>(f: impl FnOnce(&Self) -> R) -> R {
-        use once_cell::unsync::Lazy;
+        use core::cell::LazyCell as Lazy;
 
         struct Wrapper<T>(Lazy<T>);
 

--- a/crates/js-sys/Cargo.toml
+++ b/crates/js-sys/Cargo.toml
@@ -29,7 +29,6 @@ std = ["wasm-bindgen/std"]
 unsafe-eval = []
 
 [dependencies]
-once_cell = { version = "1.12", default-features = false }
 wasm-bindgen = { path = "../..", version = "=0.2.113", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -13059,7 +13059,7 @@ impl<T: JsGeneric> Promising for Promise<T> {
 /// This allows access to the global properties and global names by accessing
 /// the `Object` returned.
 pub fn global() -> Object {
-    use once_cell::unsync::Lazy;
+    use core::cell::LazyCell as Lazy;
 
     struct Wrapper<T>(Lazy<T>);
 

--- a/crates/webidl/Cargo.toml
+++ b/crates/webidl/Cargo.toml
@@ -12,7 +12,6 @@ env_logger = "0.11.5"
 heck = "0.5"
 lazy_static = "1.4.0"
 log = "0.4.1"
-once_cell = "1.12"
 proc-macro2 = "1.0"
 quote = '1.0'
 sourcefile = "0.2"

--- a/crates/webidl/src/constants.rs
+++ b/crates/webidl/src/constants.rs
@@ -1,7 +1,7 @@
-use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::iter::FromIterator;
+use std::sync::LazyLock as Lazy;
 
 pub(crate) static BUILTIN_IDENTS: Lazy<BTreeSet<&'static str>> = Lazy::new(|| {
     BTreeSet::from_iter(vec![

--- a/tests/non_wasm_test.rs
+++ b/tests/non_wasm_test.rs
@@ -1,8 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, LazyLock as Lazy, Mutex};
 
-use once_cell::sync::Lazy;
 use wasm_bindgen_test::wasm_bindgen_test;
 
 static TEST: Lazy<Arc<(Mutex<bool>, Condvar)>> =


### PR DESCRIPTION
Since we bumped MSRV, we no longer need an extra dependency.

Note that this only applies to `LazyCell` - `LazyLock` has higher MSRV than we declare, but we only use it in webidl generator and tests, both of which are private usages.