### PR TITLE
Wrap core RefCell instead of reimplementing via `unsafe`

### DIFF
--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -4,6 +4,8 @@ use crate::JsValue;
 #[cfg(all(target_arch = "wasm32", feature = "std", panic = "unwind"))]
 use core::any::Any;
 use core::borrow::{Borrow, BorrowMut};
+#[cfg(target_feature = "atomics")]
+use core::cell::UnsafeCell;
 use core::cell::{Cell, RefCell};
 use core::convert::Infallible;
 use core::ops::{Deref, DerefMut};


### PR DESCRIPTION
### Description

We can still achieve goals stated in the docs of `WasmRefCell` by simply using non-panicking versions of `RefCell` methods and throwing our own error instead.

This removes couple more usages of `unsafe` and simplifies the implementation, win-win.

### Checklist

- [x] Verified changelog requirement - not required
