### PR TITLE
Wrap JS exceptions whenever panic=unwind

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,24 +182,6 @@ jobs:
         node-version: '25'
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
     - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
-  test_wasm_bindgen_unwind_legacy_eh_reinit:
-    name: "Run wasm-bindgen crate tests with panic=unwind with legacy eh"
-    runs-on: ubuntu-latest
-    env:
-      WASM_BINDGEN_SPLIT_LINKED_MODULES: 1
-      WASM_BINDGEN_ABORT_REINIT: 1
-      RUSTFLAGS: -Cpanic=unwind
-    steps:
-    - uses: actions/checkout@v6
-    - uses: dtolnay/rust-toolchain@nightly
-      with:
-        targets: wasm32-unknown-unknown
-        components: rust-src
-    - uses: actions/setup-node@v6
-      with:
-        node-version: '22'
-    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --lib --bins --tests
-    - run: cargo test --target wasm32-unknown-unknown -Zbuild-std --test wasm --features std,wasm-bindgen-futures/std
 
   # I don't know why this is failing so comment this out for now, but ideally
   # this would be figured out at some point and solved.

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -815,8 +815,7 @@ fn instruction(
         Instruction::CallExport(_)
         | Instruction::CallAdapter(_)
         | Instruction::DeferFree { .. } => {
-            let mut should_check_aborted = js.cx.config.abort_reinit
-                && js.cx.aux.wrapped_js_tag.is_some()
+            let mut should_check_aborted = js.cx.aux.wrapped_js_tag.is_some()
                 && matches!(
                     instr,
                     Instruction::CallExport(_) | Instruction::DeferFree { .. }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -1392,7 +1392,7 @@ if (require('worker_threads').isMainThread) {{
         }
 
         let mut free = format!("wasm.{}(ptr, 0)", wasm_bindgen_shared::free_function(name));
-        free = binding::maybe_wrap_try_catch(&free, self.config.abort_reinit);
+        free = binding::maybe_wrap_try_catch(&free, self.aux.wrapped_js_tag.is_some());
         dst.push_str(&format!(
             "\
             __destroy_into_raw() {{

--- a/justfile
+++ b/justfile
@@ -55,19 +55,6 @@ test-wasm-bindgen-unwind *ARGS="":
         --target wasm32-unknown-unknown \
         {{ARGS}}
 
-test-wasm-bindgen-unwind-reinit *ARGS="":
-    RUSTFLAGS="-Cpanic=unwind" \
-    RUSTDOCFLAGS="-Cpanic=unwind" \
-    NODE_ARGS="--stack-trace-limit=100" \
-    RUST_BACKTRACE=1 \
-    WASM_BINDGEN_TEST_ONLY_NODE=1 \
-    WASM_BINDGEN_SPLIT_LINKED_MODULES=1 \
-    WASM_BINDGEN_ABORT_REINIT=1 \
-    cargo +nightly test \
-        -Zbuild-std=std,panic_unwind \
-        --target wasm32-unknown-unknown \
-        {{ARGS}}
-
 test-wasm-bindgen-unwind-eh *ARGS="":
     RUSTFLAGS="-Cpanic=unwind -Cllvm-args=-wasm-use-legacy-eh=false" \
     RUSTDOCFLAGS="-Cpanic=unwind" \


### PR DESCRIPTION
Following further discussion with guybedford, we have decided we want this termination behavior to be a separate feature from abort-reinit and it should happen for now whenever unwinding is enabled. This is a followup to #4963 that ungates the change.
