### PR TITLE
Update a broken CONTRIBUTING.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <span> | </span>
     <a href="https://docs.rs/wasm-bindgen">API Docs</a>
     <span> | </span>
-    <a href="https://github.com/wasm-bindgen/wasm-bindgen/blob/master/CONTRIBUTING.md">Contributing</a>
+    <a href="https://github.com/wasm-bindgen/wasm-bindgen/blob/main/CONTRIBUTING.md">Contributing</a>
     <span> | </span>
     <a href="https://discord.gg/xMZ7CCY">Chat</a>
   </h3>


### PR DESCRIPTION
### Description
Fixes a broken CONTRIBUTING.md link. Normally GitHub redirects from master to main automaitcally, but when navigating directly from the README.md it doesn't seem to do that (and page reload is required). Probably a GitHub bug.

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
