### PR TITLE
Support __instance_terminated on panic=abort

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -103,6 +103,10 @@ pub struct Context<'a> {
     /// If exception handling / unwinding is enabled.
     unwind_enabled: bool,
 
+    /// The resolved memory export name for the instance termination
+    /// FinalizationRegistry. `Some` when the registry has been generated.
+    instance_termination_mem: Option<String>,
+
     /// Mapping from qualified name (used in WasmDescribe) to rust_name (used as exported_classes key).
     pub(crate) qualified_to_rust_name: HashMap<String, String>,
 
@@ -219,6 +223,7 @@ impl<'a> Context<'a> {
             config,
             threads_enabled: threads_xform::is_enabled(module),
             unwind_enabled: has_local_exception_tags(module),
+            instance_termination_mem: None,
             module,
             npm_dependencies: Default::default(),
             wit,
@@ -796,10 +801,15 @@ export const __wbg_memory: WebAssembly.Memory;
     }
 
     fn generate_module_wasm_loading(&self, module_name: &str, needs_manual_start: bool) -> String {
+        let register_instance = if self.instance_termination_mem.is_some() {
+            "__wbg_register_instance(wasm);\n"
+        } else {
+            ""
+        };
         format!(
             r#"import source wasmModule from "./{module_name}_bg.wasm";
-            const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
-            let wasm = wasmInstance.exports;
+            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+            {register_instance}wasm = wasm.exports;
             {start}
             "#,
             start = if needs_manual_start {
@@ -811,13 +821,24 @@ export const __wbg_memory: WebAssembly.Memory;
     }
 
     fn generate_bundler_wasm_loading(&self) -> String {
-        r#"
-        let wasm;
-        export function __wbg_set_wasm(val) {
-            wasm = val;
+        if self.instance_termination_mem.is_some() {
+            r#"
+            let wasm;
+            export function __wbg_set_wasm(val, instance) {
+                wasm = val;
+                if (instance) __wbg_register_instance(instance);
+            }
+            "#
+            .to_string()
+        } else {
+            r#"
+            let wasm;
+            export function __wbg_set_wasm(val) {
+                wasm = val;
+            }
+            "#
+            .to_string()
         }
-        "#
-        .to_string()
     }
 
     fn generate_bundler_start(&self, module_name: &str, needs_manual_start: bool) -> String {
@@ -885,11 +906,16 @@ export const __wbg_memory: WebAssembly.Memory;
                 .unwrap()
             }
         }
+        let register_instance = if self.instance_termination_mem.is_some() {
+            "__wbg_register_instance(instance);\n"
+        } else {
+            ""
+        };
         format!(
             "let wasmModule, wasm;
             function __wbg_finalize_init(instance, module{init_stack_size_arg}) {{
                 wasm = instance.exports;
-                wasmModule = module;
+                {register_instance}wasmModule = module;
                 {init_memviews}{init_stack_size_check}{start}return wasm;
             }}
 
@@ -1019,10 +1045,15 @@ export const __wbg_memory: WebAssembly.Memory;
     fn generate_deno_wasm_loading(&self, module_name: &str, needs_manual_start: bool) -> String {
         // Deno added support for .wasm imports in 2024 in https://github.com/denoland/deno/issues/2552.
         // It's fairly recent, so use old-school Wasm loading for broader compat for now.
+        let register_instance = if self.instance_termination_mem.is_some() {
+            "__wbg_register_instance(wasm);\n"
+        } else {
+            ""
+        };
         format!(
             "const wasmUrl = new URL('{module_name}_bg.wasm', import.meta.url);
-            const wasmInstantiated = await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports());
-            const wasm = wasmInstantiated.instance.exports;
+            let wasm = (await WebAssembly.instantiateStreaming(fetch(wasmUrl), __wbg_get_imports())).instance;
+            {register_instance}wasm = wasm.exports;
             {start}",
             start = if needs_manual_start {
                 "wasm.__wbindgen_start();\n"
@@ -1080,7 +1111,7 @@ export function initSync(opts = {{}}) {{
 
     const wasmImports = __wbg_get_imports(mem);
     const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    {register_instance}wasm = instance.exports;
     memory = wasmImports['./{module_name}_bg.js'].memory;
 {start_call}
     __initialized = true;
@@ -1094,15 +1125,26 @@ if (isMainThread) {{
 }}
 
 export {{ wasm as __wasm, wasmModule as __wbg_wasm_module, memory as __wbg_memory, __wbg_get_imports }};
-"#
+"#,
+                register_instance = if self.instance_termination_mem.is_some() {
+                    "__wbg_register_instance(instance);\n    "
+                } else {
+                    ""
+                },
             )
         } else {
+            let register_instance = if self.instance_termination_mem.is_some() {
+                "__wbg_register_instance(wasm);\n"
+            } else {
+                ""
+            };
             format!(
                 r#"import {{ readFileSync }} from 'node:fs';
             const wasmUrl = new URL('{module_name}_bg.wasm', import.meta.url);
             const wasmBytes = readFileSync(wasmUrl);
             const wasmModule = new WebAssembly.Module(wasmBytes);
-            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+            {register_instance}wasm = wasm.exports;
             {start}"#,
                 start = if needs_manual_start {
                     "wasm.__wbindgen_start();\n"
@@ -1164,7 +1206,7 @@ exports.initSync = function(opts) {{
 
     const wasmImports = __wbg_get_imports(mem);
     const instance = new WebAssembly.Instance(wasmModule, wasmImports);
-    wasm = instance.exports;
+    {register_instance}wasm = instance.exports;
     memory = wasmImports['./{module_name}_bg.js'].memory;
     exports.__wasm = wasm;
     exports.__wbg_wasm_module = wasmModule;
@@ -1179,14 +1221,25 @@ exports.initSync = function(opts) {{
 if (require('worker_threads').isMainThread) {{
     exports.initSync();
 }}
-"#
+"#,
+                register_instance = if self.instance_termination_mem.is_some() {
+                    "__wbg_register_instance(instance);\n    "
+                } else {
+                    ""
+                },
             )
         } else {
+            let register_instance = if self.instance_termination_mem.is_some() {
+                "__wbg_register_instance(wasm);\n"
+            } else {
+                ""
+            };
             format!(
                 r#"const wasmPath = `${{__dirname}}/{module_name}_bg.wasm`;
             const wasmBytes = require('fs').readFileSync(wasmPath);
             const wasmModule = new WebAssembly.Module(wasmBytes);
-            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
+            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
+            {register_instance}wasm = wasm.exports;
             {start}"#,
                 start = if needs_manual_start {
                     "wasm.__wbindgen_start();\n"
@@ -2970,14 +3023,18 @@ if (require('worker_threads').isMainThread) {{
             reset_statements.push(heap_reset);
         }
 
-        reset_statements.push(
+        let register_instance = if self.instance_termination_mem.is_some() {
+            "\n            __wbg_register_instance(wasm);"
+        } else {
+            ""
+        };
+        reset_statements.push(format!(
             "
-            const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
-            wasm = wasmInstance.exports;
+            wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports());{register_instance}
+            wasm = wasm.exports;
             wasm.__wbindgen_start();
             "
-            .to_string(),
-        );
+        ));
 
         let function_body = format!("() {{\n{}}}", reset_statements.join("\n"));
 
@@ -3230,6 +3287,7 @@ if (require('worker_threads').isMainThread) {{
 
         self.generate_jstag_import();
         self.generate_wrapped_jstag_import();
+        self.generate_instance_termination_registry();
 
         for (id, adapter, kind) in iter_adapter(self.aux, self.wit, self.module) {
             let instrs = match &adapter.kind {
@@ -3378,6 +3436,34 @@ function __wbg_handle_catch(e) {{
         // Use the constant for the import
         self.wasm_import_definitions
             .insert(id, "__wbindgen_wrapped_jstag".to_string());
+    }
+
+    /// Generate a `FinalizationRegistry` that marks the instance as terminated
+    /// when the `WebAssembly.Instance` is garbage collected.  This lets external
+    /// code that holds a reference to the linear memory detect that the instance
+    /// is dead and release its memory reference.
+    fn generate_instance_termination_registry(&mut self) {
+        let memory = crate::wasm_conventions::get_memory(self.module).unwrap();
+        let mem_name = self.export_name_of(memory);
+
+        self.global(&format!(
+            "\
+const __wbg_instance_registry = globalThis.__wbg_instance_registry ||
+    (globalThis.__wbg_instance_registry = (typeof FinalizationRegistry === 'undefined')
+        ? {{ register: () => {{}} }}
+        : new FinalizationRegistry(({{ memory, addr }}) => {{
+            new Int32Array(memory.buffer)[addr / 4] = 1;
+        }}));
+
+function __wbg_register_instance(instance) {{
+    __wbg_instance_registry.register(instance, {{
+        memory: instance.exports.{mem_name},
+        addr: instance.exports.__instance_terminated.value,
+    }});
+}}"
+        ));
+
+        self.instance_termination_mem = Some(mem_name);
     }
 
     /// Registers import names for all `Global` imports first before we actually

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -1133,3 +1133,119 @@ describe('termination with reset state', () => {
         .assert()
         .success();
 }
+
+#[test]
+fn instance_gc_termination() {
+    let mut project = Project::new("instance_gc_termination");
+    project
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                #[wasm_bindgen]
+                pub fn simple_add(a: u32, b: u32) -> u32 {
+                    a + b
+                }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            &format!(
+                "
+                    [package]
+                    name = \"instance_gc_termination\"
+                    authors = []
+                    version = \"1.0.0\"
+                    edition = '2021'
+
+                    [dependencies]
+                    wasm-bindgen = {{ path = '{}' }}
+
+                    [lib]
+                    crate-type = ['cdylib']
+
+                    [workspace]
+                ",
+                REPO_ROOT.display(),
+            ),
+        );
+
+    let out_dir = project.wasm_bindgen("--target nodejs").unwrap();
+
+    // Verify the generated JS contains the FinalizationRegistry and registration code
+    let generated_js = fs::read_to_string(out_dir.join("instance_gc_termination.js")).unwrap();
+    assert!(
+        generated_js.contains("__wbg_instance_registry"),
+        "generated JS should contain __wbg_instance_registry"
+    );
+    assert!(
+        generated_js.contains("__wbg_register_instance"),
+        "generated JS should contain __wbg_register_instance"
+    );
+    assert!(
+        generated_js.contains("globalThis.__wbg_instance_registry"),
+        "registry should be rooted on globalThis"
+    );
+
+    // Test the GC mechanism directly against the wasm module (avoids CJS
+    // module-scope lifetime issues that prevent the Instance from being
+    // collected when loaded via require()).
+    fs::write(
+        out_dir.join("test_instance_gc.js"),
+        r#"
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert/strict');
+
+function forceGC() {
+    gc();
+    for (let i = 0; i < 100; i++) { new Uint8Array(10 * 1024 * 1024); }
+    gc();
+}
+
+const wasmBytes = fs.readFileSync(path.join(__dirname, 'instance_gc_termination_bg.wasm'));
+const wasmMod = new WebAssembly.Module(wasmBytes);
+
+let instance = new WebAssembly.Instance(wasmMod, {
+    './instance_gc_termination_bg.js': {
+        __wbindgen_init_externref_table: () => {}
+    }
+});
+
+// Read the terminated address from the wasm global — just the integer
+const addr = instance.exports.__instance_terminated.value;
+assert.strictEqual(typeof addr, 'number', '__instance_terminated should be an exported global');
+
+// Keep only the raw memory buffer
+const buf = instance.exports.memory.buffer;
+assert.strictEqual(new Int32Array(buf)[addr / 4], 0, 'flag should start at 0');
+assert.strictEqual(instance.exports.simple_add(2, 3), 5, 'exports should work');
+
+// Set up a FinalizationRegistry (same logic the generated JS uses)
+const registry = new FinalizationRegistry(({ buf, addr }) => {
+    new Int32Array(buf)[addr / 4] = 1;
+});
+registry.register(instance, { buf, addr });
+
+// Drop the instance
+instance = null;
+
+forceGC();
+setTimeout(() => {
+    assert.strictEqual(new Int32Array(buf)[addr / 4], 1,
+        'flag should be 1 after instance GC');
+    assert.ok(new Int32Array(buf).length > 0, 'memory should remain accessible');
+}, 50);
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("--expose-gc")
+        .arg("test_instance_gc.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success();
+}

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -609,7 +609,6 @@ pub fn link_mem_intrinsics() {
 #[cfg_attr(target_feature = "atomics", thread_local)]
 static GLOBAL_EXNDATA: ThreadLocalWrapper<Cell<[u32; 2]>> = ThreadLocalWrapper(Cell::new([0; 2]));
 
-#[cfg(panic = "unwind")]
 #[no_mangle]
 pub static mut __instance_terminated: u32 = 0;
 


### PR DESCRIPTION
## Summary
Emit `__instance_terminated` on `panic=abort`, previously only supported for `panic=unwind`. Modules with aborting panics are assumed to still be valid even after an abort - it is only after garbage collection we can say they are dead for certain. This PR writes 1 to `__instance_terminated` from a finalization registry.
## Changes
- Removed #[cfg(panic = "unwind")] from __instance_terminated static so it is compiled unconditionally for all panic strategies.
crates/cli-support/src/js/mod.rs
- Added instance_termination_mem: Option<String> field to Context to track whether the registry was generated and store the resolved memory export name.
- Added generate_instance_termination_registry() method that emits a FinalizationRegistry singleton rooted on globalThis (with typeof guard fallback for environments without it) and a __wbg_register_instance(instance) helper. The registry callback writes 1 to the __instance_terminated address in linear memory when the Instance is collected.
- Added __wbg_register_instance(...) calls in all 8 loading modes:
  - Web / NoModules (__wbg_finalize_init)
  - Module (generate_module_wasm_loading)
  - Deno (generate_deno_wasm_loading)
  - Node ESM with and without threads (generate_node_esm_wasm_loading)
  - Node CJS with and without threads (generate_node_cjs_wasm_loading)
  - Bundler (__wbg_set_wasm accepts optional second instance parameter)
- Added registration call in generate_reset_state() after new instance creation.
- Added instance_gc_termination integration test that:
  - Builds a minimal panic=abort fixture (no nightly required)
  - Verifies the generated JS contains the registry and globalThis rooting
  - Directly instantiates the wasm module, confirms __instance_terminated is exported and starts at 0, registers with a FinalizationRegistry, drops the Instance, forces GC via --expose-gc with allocation pressure, and asserts the flag becomes 1 while memory remains accessible
### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
