### PR TITLE
Support per-operation [WbgGeneric] in WebIDL codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@
 
 ### Fixed
 
+* Added support for per-operation `[WbgGeneric]` in WebIDL, restoring typed
+  generic return types (e.g. `Promise<ImageBitmap>`) for `createImageBitmap` on
+  `Window` and `WorkerGlobalScope` that were lost after the `VideoFrame`
+  stabilization.
+  [#5026](https://github.com/wasm-bindgen/wasm-bindgen/pull/5026)
+
 * Fixed `JsOption::new()` to use `undefined` instead of `null`, to be compatible with `Option::None` and JS default parameters.
   [#5023](https://github.com/wasm-bindgen/wasm-bindgen/pull/5023)
 

--- a/crates/web-sys/src/features/gen_Window.rs
+++ b/crates/web-sys/src/features/gen_Window.rs
@@ -2584,50 +2584,50 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `Window`*"]
     pub fn clear_timeout_with_handle(this: &Window, handle: i32);
-    #[cfg(feature = "HtmlImageElement")]
+    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_html_image_element(
         this: &Window,
         a_image: &HtmlImageElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "SvgImageElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "SvgImageElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `SvgImageElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `SvgImageElement`, `Window`*"]
     pub fn create_image_bitmap_with_svg_image_element(
         this: &Window,
         a_image: &SvgImageElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlCanvasElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_html_canvas_element(
         this: &Window,
         a_image: &HtmlCanvasElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlVideoElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_html_video_element(
         this: &Window,
         a_image: &HtmlVideoElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -2638,99 +2638,115 @@ extern "C" {
     pub fn create_image_bitmap_with_image_bitmap(
         this: &Window,
         a_image: &ImageBitmap,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "OffscreenCanvas")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "OffscreenCanvas",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvas`, `Window`*"]
     pub fn create_image_bitmap_with_offscreen_canvas(
         this: &Window,
         a_image: &OffscreenCanvas,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "VideoFrame")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "VideoFrame",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `VideoFrame`, `Window`*"]
     pub fn create_image_bitmap_with_video_frame(
         this: &Window,
         a_image: &VideoFrame,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "Blob")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "Blob", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_blob(
         this: &Window,
         a_image: &Blob,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "ImageData")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "ImageData",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageData`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageData`, `Window`*"]
     pub fn create_image_bitmap_with_image_data(
         this: &Window,
         a_image: &ImageData,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlImageElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_html_image_element_and_image_bitmap_options(
         this: &Window,
         a_image: &HtmlImageElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "SvgImageElement",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "SvgImageElement",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `SvgImageElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `SvgImageElement`, `Window`*"]
     pub fn create_image_bitmap_with_svg_image_element_and_image_bitmap_options(
         this: &Window,
         a_image: &SvgImageElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlCanvasElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_html_canvas_element_and_image_bitmap_options(
         this: &Window,
         a_image: &HtmlCanvasElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlVideoElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_html_video_element_and_image_bitmap_options(
         this: &Window,
         a_image: &HtmlVideoElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(all(feature = "ImageBitmap", feature = "ImageBitmapOptions",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -2742,62 +2758,78 @@ extern "C" {
         this: &Window,
         a_image: &ImageBitmap,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "OffscreenCanvas",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "OffscreenCanvas",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `OffscreenCanvas`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `OffscreenCanvas`, `Window`*"]
     pub fn create_image_bitmap_with_offscreen_canvas_and_image_bitmap_options(
         this: &Window,
         a_image: &OffscreenCanvas,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "VideoFrame",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "VideoFrame",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `VideoFrame`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `VideoFrame`, `Window`*"]
     pub fn create_image_bitmap_with_video_frame_and_image_bitmap_options(
         this: &Window,
         a_image: &VideoFrame,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "Blob", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "Blob",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_blob_and_image_bitmap_options(
         this: &Window,
         a_image: &Blob,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "ImageData",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "ImageData",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `ImageData`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `ImageData`, `Window`*"]
     pub fn create_image_bitmap_with_image_data_and_image_bitmap_options(
         this: &Window,
         a_image: &ImageData,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlImageElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_html_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &HtmlImageElement,
@@ -2805,14 +2837,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "SvgImageElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "SvgImageElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `SvgImageElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `SvgImageElement`, `Window`*"]
     pub fn create_image_bitmap_with_svg_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &SvgImageElement,
@@ -2820,14 +2852,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlCanvasElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_html_canvas_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &HtmlCanvasElement,
@@ -2835,14 +2867,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlVideoElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_html_video_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &HtmlVideoElement,
@@ -2850,7 +2882,7 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -2865,14 +2897,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "OffscreenCanvas")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "OffscreenCanvas",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvas`, `Window`*"]
     pub fn create_image_bitmap_with_offscreen_canvas_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &OffscreenCanvas,
@@ -2880,14 +2912,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "VideoFrame")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "VideoFrame",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `VideoFrame`, `Window`*"]
     pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &VideoFrame,
@@ -2895,14 +2927,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "Blob")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "Blob", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `Window`*"]
     pub fn create_image_bitmap_with_blob_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &Blob,
@@ -2910,14 +2942,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "ImageData")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "ImageData",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageData`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageData`, `Window`*"]
     pub fn create_image_bitmap_with_image_data_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &Window,
         a_image: &ImageData,
@@ -2925,14 +2957,18 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlImageElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_html_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &HtmlImageElement,
@@ -2941,14 +2977,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "SvgImageElement",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "SvgImageElement",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `SvgImageElement`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `SvgImageElement`, `Window`*"]
     pub fn create_image_bitmap_with_svg_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &SvgImageElement,
@@ -2957,14 +2997,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlCanvasElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_html_canvas_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &HtmlCanvasElement,
@@ -2973,14 +3017,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlVideoElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_html_video_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &HtmlVideoElement,
@@ -2989,7 +3037,7 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(all(feature = "ImageBitmap", feature = "ImageBitmapOptions",))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -3005,14 +3053,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "OffscreenCanvas",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "OffscreenCanvas",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `OffscreenCanvas`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `OffscreenCanvas`, `Window`*"]
     pub fn create_image_bitmap_with_offscreen_canvas_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &OffscreenCanvas,
@@ -3021,14 +3073,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "VideoFrame",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "VideoFrame",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `VideoFrame`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `VideoFrame`, `Window`*"]
     pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &VideoFrame,
@@ -3037,14 +3093,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "Blob", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "Blob",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmapOptions`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `ImageBitmapOptions`, `Window`*"]
     pub fn create_image_bitmap_with_blob_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &Blob,
@@ -3053,14 +3113,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "ImageData",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "ImageData",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "Window" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `ImageData`, `Window`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `ImageData`, `Window`*"]
     pub fn create_image_bitmap_with_image_data_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &Window,
         a_image: &ImageData,
@@ -3069,7 +3133,7 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(feature = "Request")]
     # [wasm_bindgen (method , structural , js_class = "Window" , js_name = fetch)]
     #[doc = "The `fetch()` method."]

--- a/crates/web-sys/src/features/gen_WorkerGlobalScope.rs
+++ b/crates/web-sys/src/features/gen_WorkerGlobalScope.rs
@@ -279,50 +279,50 @@ extern "C" {
     #[doc = ""]
     #[doc = "*This API requires the following crate features to be activated: `WorkerGlobalScope`*"]
     pub fn clear_timeout_with_handle(this: &WorkerGlobalScope, handle: i32);
-    #[cfg(feature = "HtmlImageElement")]
+    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_image_element(
         this: &WorkerGlobalScope,
         a_image: &HtmlImageElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "SvgImageElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "SvgImageElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `SvgImageElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `SvgImageElement`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_svg_image_element(
         this: &WorkerGlobalScope,
         a_image: &SvgImageElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlCanvasElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_canvas_element(
         this: &WorkerGlobalScope,
         a_image: &HtmlCanvasElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlVideoElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_video_element(
         this: &WorkerGlobalScope,
         a_image: &HtmlVideoElement,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -333,99 +333,115 @@ extern "C" {
     pub fn create_image_bitmap_with_image_bitmap(
         this: &WorkerGlobalScope,
         a_image: &ImageBitmap,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "OffscreenCanvas")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "OffscreenCanvas",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvas`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_offscreen_canvas(
         this: &WorkerGlobalScope,
         a_image: &OffscreenCanvas,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "VideoFrame")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "VideoFrame",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `VideoFrame`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_video_frame(
         this: &WorkerGlobalScope,
         a_image: &VideoFrame,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "Blob")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "Blob", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_blob(
         this: &WorkerGlobalScope,
         a_image: &Blob,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "ImageData")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "ImageData",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageData`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageData`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_image_data(
         this: &WorkerGlobalScope,
         a_image: &ImageData,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlImageElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_image_element_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &HtmlImageElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "SvgImageElement",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "SvgImageElement",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `SvgImageElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `SvgImageElement`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_svg_image_element_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &SvgImageElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlCanvasElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_canvas_element_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &HtmlCanvasElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlVideoElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_video_element_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &HtmlVideoElement,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(all(feature = "ImageBitmap", feature = "ImageBitmapOptions",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -437,62 +453,78 @@ extern "C" {
         this: &WorkerGlobalScope,
         a_image: &ImageBitmap,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "OffscreenCanvas",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "OffscreenCanvas",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `OffscreenCanvas`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `OffscreenCanvas`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_offscreen_canvas_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &OffscreenCanvas,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "VideoFrame",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "VideoFrame",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `VideoFrame`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `VideoFrame`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_video_frame_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &VideoFrame,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "Blob", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "Blob",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_blob_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &Blob,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "ImageData",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "ImageData",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `ImageData`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `ImageData`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_image_data_and_image_bitmap_options(
         this: &WorkerGlobalScope,
         a_image: &ImageData,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlImageElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &HtmlImageElement,
@@ -500,14 +532,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "SvgImageElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "SvgImageElement",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `SvgImageElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `SvgImageElement`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_svg_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &SvgImageElement,
@@ -515,14 +547,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlCanvasElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_canvas_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &HtmlCanvasElement,
@@ -530,14 +562,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "HtmlVideoElement")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_video_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &HtmlVideoElement,
@@ -545,7 +577,7 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(feature = "ImageBitmap")]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -560,14 +592,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "OffscreenCanvas")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "OffscreenCanvas",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `OffscreenCanvas`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `OffscreenCanvas`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_offscreen_canvas_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &OffscreenCanvas,
@@ -575,14 +607,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "VideoFrame")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "VideoFrame",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `VideoFrame`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `VideoFrame`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &VideoFrame,
@@ -590,14 +622,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "Blob")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "Blob", feature = "ImageBitmap",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_blob_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &Blob,
@@ -605,14 +637,14 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(feature = "ImageData")]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(feature = "ImageBitmap", feature = "ImageData",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageData`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageData`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_image_data_and_a_sx_and_a_sy_and_a_sw_and_a_sh(
         this: &WorkerGlobalScope,
         a_image: &ImageData,
@@ -620,14 +652,18 @@ extern "C" {
         a_sy: i32,
         a_sw: i32,
         a_sh: i32,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlImageElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlImageElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlImageElement`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &HtmlImageElement,
@@ -636,14 +672,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "SvgImageElement",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "SvgImageElement",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `SvgImageElement`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `SvgImageElement`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_svg_image_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &SvgImageElement,
@@ -652,14 +692,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlCanvasElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlCanvasElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlCanvasElement`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_canvas_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &HtmlCanvasElement,
@@ -668,14 +712,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "HtmlVideoElement", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "HtmlVideoElement",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `HtmlVideoElement`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_html_video_element_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &HtmlVideoElement,
@@ -684,7 +732,7 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(all(feature = "ImageBitmap", feature = "ImageBitmapOptions",))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
@@ -700,14 +748,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "OffscreenCanvas",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "OffscreenCanvas",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `OffscreenCanvas`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `OffscreenCanvas`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_offscreen_canvas_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &OffscreenCanvas,
@@ -716,14 +768,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "VideoFrame",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "VideoFrame",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `VideoFrame`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `VideoFrame`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_video_frame_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &VideoFrame,
@@ -732,14 +788,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "Blob", feature = "ImageBitmapOptions",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "Blob",
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `Blob`, `ImageBitmap`, `ImageBitmapOptions`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_blob_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &Blob,
@@ -748,14 +808,18 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
-    #[cfg(all(feature = "ImageBitmapOptions", feature = "ImageData",))]
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
+    #[cfg(all(
+        feature = "ImageBitmap",
+        feature = "ImageBitmapOptions",
+        feature = "ImageData",
+    ))]
     # [wasm_bindgen (catch , method , structural , js_class = "WorkerGlobalScope" , js_name = createImageBitmap)]
     #[doc = "The `createImageBitmap()` method."]
     #[doc = ""]
     #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/createImageBitmap)"]
     #[doc = ""]
-    #[doc = "*This API requires the following crate features to be activated: `ImageBitmapOptions`, `ImageData`, `WorkerGlobalScope`*"]
+    #[doc = "*This API requires the following crate features to be activated: `ImageBitmap`, `ImageBitmapOptions`, `ImageData`, `WorkerGlobalScope`*"]
     pub fn create_image_bitmap_with_image_data_and_a_sx_and_a_sy_and_a_sw_and_a_sh_and_a_options(
         this: &WorkerGlobalScope,
         a_image: &ImageData,
@@ -764,7 +828,7 @@ extern "C" {
         a_sw: i32,
         a_sh: i32,
         a_options: &ImageBitmapOptions,
-    ) -> Result<::js_sys::Promise, JsValue>;
+    ) -> Result<::js_sys::Promise<ImageBitmap>, JsValue>;
     #[cfg(feature = "Request")]
     # [wasm_bindgen (method , structural , js_class = "WorkerGlobalScope" , js_name = fetch)]
     #[doc = "The `fetch()` method."]

--- a/crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl
+++ b/crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl
@@ -36,10 +36,10 @@ interface mixin WindowOrWorkerGlobalScope {
   undefined clearInterval(optional long handle = 0);
 
   // ImageBitmap
-  [Throws]
+  [Throws, WbgGeneric]
   Promise<ImageBitmap> createImageBitmap(ImageBitmapSource aImage,
                                          optional ImageBitmapOptions aOptions = {});
-  [Throws]
+  [Throws, WbgGeneric]
   Promise<ImageBitmap> createImageBitmap(ImageBitmapSource aImage,
                                          long aSx, long aSy, long aSw, long aSh,
                                          optional ImageBitmapOptions aOptions = {});

--- a/crates/webidl/src/lib.rs
+++ b/crates/webidl/src/lib.rs
@@ -797,7 +797,7 @@ impl<'src> FirstPassRecord<'src> {
                 catch: x.catch,
                 variadic: x.variadic,
                 unstable: false,
-                wbg_generic,
+                wbg_generic: x.wbg_generic,
             });
         }
     }

--- a/crates/webidl/src/util.rs
+++ b/crates/webidl/src/util.rs
@@ -361,8 +361,12 @@ impl<'src> FirstPassRecord<'src> {
         for signature in data.signatures.iter() {
             // Signatures from unstable IDL definitions always use typed generics
             // for WbgType expansion (callbacks become typed, etc.)
-            // [WbgGeneric] on the definition also opts into typed generics.
-            if unstable || wbg_generic || signature.stability.is_unstable() {
+            // [WbgGeneric] on the definition or operation also opts into typed generics.
+            if unstable
+                || wbg_generic
+                || signature.stability.is_unstable()
+                || is_wbg_generic(signature.attrs.as_ref())
+            {
                 self.options.next_unstable.set(true);
             }
 
@@ -639,7 +643,14 @@ impl<'src> FirstPassRecord<'src> {
             has_unstable_override: bool,
             wbg_generic: bool,
         ) -> Option<InterfaceMethod<'a>> {
+            // Temporarily set next_unstable so that return type WbgType
+            // expansion uses typed callbacks when wbg_generic or unstable.
+            let saved = first_pass.options.next_unstable.get();
+            if wbg_generic || unstable_flag {
+                first_pass.options.next_unstable.set(true);
+            }
             let ret_ty = signature.orig.ret.to_wbg_type(first_pass);
+            first_pass.options.next_unstable.set(saved);
             let structural =
                 force_structural || is_structural(signature.orig.attrs.as_ref(), container_attrs);
             let catch = force_throws
@@ -751,6 +762,9 @@ impl<'src> FirstPassRecord<'src> {
                     }
                 }
 
+                // [WbgGeneric] on the operation itself also opts into typed generics.
+                let op_wbg_generic = wbg_generic || is_wbg_generic(signature.orig.attrs.as_ref());
+
                 if let Some(method) = create_method(
                     self,
                     signature,
@@ -765,7 +779,7 @@ impl<'src> FirstPassRecord<'src> {
                     container_attrs,
                     unstable_flag,
                     false,
-                    wbg_generic,
+                    op_wbg_generic,
                 ) {
                     methods.push(method.clone());
 


### PR DESCRIPTION
## Summary

- Add support for `[WbgGeneric]` on individual WebIDL operations (not just interface/dictionary/namespace definitions), so that specific methods can opt into typed generics without affecting all sibling methods.
- Fix return type `WbgType` expansion to respect `wbg_generic` for callback-like return types. Previously `next_unstable` was only set temporarily during argument expansion but not when computing the return type in `create_method`.
- Add `[WbgGeneric]` to the two `createImageBitmap` operations in `WindowOrWorkerGlobalScope`, restoring `Promise<ImageBitmap>` return types on `Window` and `WorkerGlobalScope`.

## Motivation

When `VideoFrame` was stabilized in ce535e1a9, the `createImageBitmap` overloads accepting `VideoFrame` on `Window`/`WorkerGlobalScope` lost their typed generic return type (`Promise<ImageBitmap>` became bare `Promise`). Previously these methods were unstable (gated behind `web_sys_unstable_apis`) which automatically gave them generics. After stabilization, the parent `WindowOrWorkerGlobalScope` mixin has no `[WbgGeneric]`, so generics were lost.

Adding `[WbgGeneric]` to the entire mixin was too broad — it changed `setTimeout`, `setInterval`, `fetch`, etc. Per-operation support allows targeting only the affected methods.

## Changes

**`crates/webidl/src/util.rs`**:
- Check `Signature.attrs` for `[WbgGeneric]` and OR it with the parent definition's `wbg_generic` flag in two places: when setting `next_unstable` for argument type expansion, and when passing `wbg_generic` to `create_method`.
- In `create_method`, temporarily set `next_unstable` around the return type `to_wbg_type` call when `wbg_generic` or `unstable_flag` is true, so that callback-like return types also get typed expansion.

**`crates/web-sys/webidls/enabled/WindowOrWorkerGlobalScope.webidl`**: Add `WbgGeneric` to the two `createImageBitmap` operation attributes.

**`crates/web-sys/src/features/gen_Window.rs`**, **`gen_WorkerGlobalScope.rs`**: Regenerated — `createImageBitmap` overloads now return `Promise<ImageBitmap>`.