### PR TITLE
fix: normalize argument in encode_as_ascii to handle input prediction issues

### DIFF
--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2114,8 +2114,12 @@ if (require('worker_threads').isMainThread) {{
         // This might be not very intuitive, but such calls are usually more
         // expensive in mainstream engines than staying in the JS, and
         // charCodeAt on ASCII strings is usually optimised to raw bytes.
+        //
+        // We also normalize the arg passed in in case tools like Google
+        // Input Tools or input prediction mess up the string.
         let encode_as_ascii = format!(
             "\
+                arg = arg ?? \"\";
                 if (realloc === undefined) {{
                     const buf = cachedTextEncoder.encode(arg);
                     const ptr = malloc(buf.length, 1) >>> 0;


### PR DESCRIPTION
### Description
<!-- Please describe the changes introduced by this PR. -->

This PR adds an extra step in `passStringToWasm` to normalize the string in case if the string is null or undefined. (e.g., when produced by in-browser IME such as Google Input Tools, or input prediction)

Related:

- https://github.com/emilk/egui/issues/7964
- #2746

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [x] Verified changelog requirement
