### PR TITLE
feat: add StaleObjectError class

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -184,7 +184,7 @@ impl<'a, 'b> Builder<'a, 'b> {
                 js.prelude(
                     "
                     if (this.__wbg_inst !== undefined && this.__wbg_inst !== __wbg_instance_id) {
-                        throw new StaleObjectError('Invalid stale object from previous Wasm instance');
+                        throw new __wbg_StaleObjectError('Invalid stale object from previous Wasm instance');
                     }
                     ",
                 );
@@ -770,7 +770,7 @@ impl<'a, 'b> JsBuilder<'a, 'b> {
             self.prelude(&format!(
                 "\
                 if (({arg}).__wbg_inst !== undefined && ({arg}).__wbg_inst !== __wbg_instance_id) {{
-                    throw new StaleObjectError('Invalid stale object from previous Wasm instance');
+                    throw new __wbg_StaleObjectError('Invalid stale object from previous Wasm instance');
                 }}
                 "
             ));

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -2772,7 +2772,7 @@ if (require('worker_threads').isMainThread) {{
                     "const state = { a: arg0, b: arg1, cnt: 1, instance: __wbg_instance_id };",
                     "
                     if (state.instance !== __wbg_instance_id) {
-                        throw new StaleObjectError('Cannot invoke closure from previous WASM instance');
+                        throw new __wbg_StaleObjectError('Cannot invoke closure from previous WASM instance');
                     }
                     ",
                 )
@@ -2828,7 +2828,7 @@ if (require('worker_threads').isMainThread) {{
                     "const state = { a: arg0, b: arg1, cnt: 1, instance: __wbg_instance_id };",
                     "
                     if (state.instance !== __wbg_instance_id) {
-                        throw new StaleObjectError('Cannot invoke closure from previous WASM instance');
+                        throw new __wbg_StaleObjectError('Cannot invoke closure from previous WASM instance');
                     }
                     ",
                 )
@@ -2916,21 +2916,21 @@ if (require('worker_threads').isMainThread) {{
         self.global("let __wbg_instance_id = 0;");
 
         // Export a typed error class so callers can catch stale-object errors
-        // specifically (e.g. via `instanceof StaleObjectError`).
+        // specifically (e.g. via `instanceof __wbg_StaleObjectError`).
         define_export(
             &mut self.exports,
-            "StaleObjectError",
+            "__wbg_StaleObjectError",
             &[],
             ExportEntry::Definition(ExportDefinition {
                 comments: None,
-                identifier: "StaleObjectError".to_string(),
+                identifier: "__wbg_StaleObjectError".to_string(),
                 definition: "\
-                    class StaleObjectError extends Error {}\n\
-                    Object.defineProperty(StaleObjectError.prototype, 'name', {\n\
-                        value: StaleObjectError.name,\n\
+                    class __wbg_StaleObjectError extends Error {}\n\
+                    Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {\n\
+                        value: __wbg_StaleObjectError.name,\n\
                     });\n"
                     .to_string(),
-                ts_definition: "class StaleObjectError extends Error {}\n".to_string(),
+                ts_definition: "class __wbg_StaleObjectError extends Error {}\n".to_string(),
                 ts_comments: None,
                 private: false,
             }),

--- a/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.d.ts
+++ b/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
@@ -1,9 +1,9 @@
 /* @ts-self-types="./reference_test.d.ts" */
 import { default as _default } from 'tests/wasm/import_class.js';
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.d.ts
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
@@ -1,8 +1,8 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.d.ts
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
@@ -1,8 +1,8 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.d.ts
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
@@ -1,8 +1,8 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.d.ts
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
@@ -1,10 +1,10 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
-exports.StaleObjectError = StaleObjectError;
+exports.__wbg_StaleObjectError = __wbg_StaleObjectError;
 
 function __wbg_reset_state () {
     __wbg_instance_id++;

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.d.ts
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
@@ -1,10 +1,10 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
-exports.StaleObjectError = StaleObjectError;
+exports.__wbg_StaleObjectError = __wbg_StaleObjectError;
 
 function __wbg_reset_state () {
     __wbg_instance_id++;

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.d.ts
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
@@ -1,10 +1,10 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
-exports.StaleObjectError = StaleObjectError;
+exports.__wbg_StaleObjectError = __wbg_StaleObjectError;
 
 function __wbg_reset_state () {
     __wbg_instance_id++;

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.d.ts
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
@@ -1,8 +1,8 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.d.ts
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
@@ -1,8 +1,8 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.d.ts
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.d.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export class StaleObjectError extends Error {}
+export class __wbg_StaleObjectError extends Error {}
 
 export function __wbg_reset_state(): void;
 

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
@@ -1,8 +1,8 @@
 /* @ts-self-types="./reference_test.d.ts" */
 
-export class StaleObjectError extends Error {}
-Object.defineProperty(StaleObjectError.prototype, 'name', {
-    value: StaleObjectError.name,
+export class __wbg_StaleObjectError extends Error {}
+Object.defineProperty(__wbg_StaleObjectError.prototype, 'name', {
+    value: __wbg_StaleObjectError.name,
 });
 
 export function __wbg_reset_state () {


### PR DESCRIPTION
### Description
When re-initialization happens, objects created in a previous instance are considered stale, and using them is an error. This error is potentially recoverable. Giving it its own type allows it to be caught in a try-catch block

### Checklist
<!-- Please complete these checks before submitting the PR. -->

<!-- **REQUIRED** for user-facing changes (new features, bug fixes, breaking changes). -->
<!-- **NOT required** for internal refactoring or minor improvements. -->
- [ ] Verified changelog requirement
