### PR TITLE
fix CI: pin clap

### DIFF
--- a/crates/msrv/cli/Cargo.toml
+++ b/crates/msrv/cli/Cargo.toml
@@ -24,6 +24,11 @@ rouille = "=3.6.2"
 # tempfile 3.25+ depends on getrandom 0.4+ which requires edition 2024 (Rust 1.85+)
 tempfile = "=3.24.0"
 
+# clap 4.6.0 raises the MSRV to Rust 1.85, and clap_builder 4.5.61 will
+# otherwise float clap_lex to 1.1.0 which also requires Rust 1.85
+clap = { version = "=4.5.61", features = ["derive"] }
+clap_lex = "=1.0.0"
+
 # enable default feature for icu
 writeable = "0.6.0"
 


### PR DESCRIPTION
# Problem

Yesterday clap 4.6.0 raised MSRV to 1.85, but we need 1.82

# Solution

Pin to the clap version immediately before this change