### PR TITLE
fix: use authenticated GitHub API for geckodriver download in CodSpeed CI

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,12 +34,16 @@ jobs:
           node-version: '25'
 
       - name: Install Firefox and geckodriver
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           sudo apt-get update
           sudo apt-get install -y firefox
           # Download geckodriver for ARM64
-          GECKODRIVER_VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | grep tag_name | cut -d '"' -f 4)
-          curl -sL "https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux-aarch64.tar.gz" | sudo tar -xz -C /usr/local/bin
+          GECKODRIVER_VERSION=$(gh api repos/mozilla/geckodriver/releases/latest --jq '.tag_name')
+          echo "Installing geckodriver ${GECKODRIVER_VERSION}"
+          curl -fSL "https://github.com/mozilla/geckodriver/releases/download/${GECKODRIVER_VERSION}/geckodriver-${GECKODRIVER_VERSION}-linux-aarch64.tar.gz" | sudo tar -xz -C /usr/local/bin
+          geckodriver --version
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

- Fix CodSpeed CI failure caused by GitHub API rate limiting when fetching the latest geckodriver version
- The unauthenticated `curl` to the GitHub API was hitting rate limits on shared CodSpeed runners, causing `GECKODRIVER_VERSION` to be empty and producing a malformed download URL
- `curl -sL` then silently downloaded an HTML error page instead of the tarball, which `tar` failed to decompress (`gzip: stdin: not in gzip format`)

## Changes

- Use `gh api` with `GITHUB_TOKEN` for authenticated API access (avoids rate limits)
- Use `curl -fSL` instead of `curl -sL` so HTTP errors (404, etc.) cause an immediate failure instead of silently piping HTML into `tar`
- Add version echo and `geckodriver --version` for debugging visibility