### PR TITLE
Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,11 @@ Set `WASM_BINDGEN_KEEP_TEST_BUILD=1` to retain the temp build folder on test fai
 
 Add an entry to `CHANGELOG.md` for any user-facing change.
 
+## PR Process
+
+- PRs must come with sufficient tests
+- After posting the PR, add a CHANGELOG.md entry, this is a PR requirement
+
 ## Release PR
 
 1. Bump all crate versions:


### PR DESCRIPTION
Adds an `AGENTS.md` file to the repo root.

This file is picked up by AI coding tools (like OpenCode, Claude Code, etc.) to give them project-specific context — things like the crate structure, how to run tests, code style rules, and the release process. The idea is to reduce the chance of AI tools doing something obviously wrong (wrong test command, wrong format style, etc.) when working in this repo.

The content is mostly drawn from `CONTRIBUTING.md` and the `justfile`, so nothing new is being documented here — it's just collected in one place that these tools know to look for.

Happy to adjust the content or drop sections if anything looks off.