### PR TITLE
fix(js-sys): add missing js_name = "fill" to Float16Array::fill_with_f32

### DIFF
--- a/crates/js-sys/src/lib.rs
+++ b/crates/js-sys/src/lib.rs
@@ -13237,7 +13237,7 @@ extern "C" {
     /// index with a static `f32` value.
     ///
     /// [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill)
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = fill)]
     pub fn fill_with_f32(this: &Float16Array, value: f32, start: u32, end: u32) -> Float16Array;
 
     /// The buffer accessor property represents the `ArrayBuffer` referenced


### PR DESCRIPTION
## Summary

- `Float16Array::fill_with_f32` was missing `js_name = "fill"`, causing it to call a non-existent method literally named `fill_with_f32` on the JS object instead of the native `fill()` method.

Found while investigating #5033 which introduced the Float16Array bindings.