### PR TITLE
feat: support schedule_reinit() under panic=abort builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@
   is now always a simple boolean (`0` = live, `1` = terminated).
   [#5083](https://github.com/wasm-bindgen/wasm-bindgen/pull/5083)
 
+* `handler::schedule_reinit()` now works under `panic=abort` builds. Previously
+  it was a no-op; it now sets the JS-side reinit flag and the next export call
+  transparently creates a fresh `WebAssembly.Instance`.
+  [#5099](https://github.com/wasm-bindgen/wasm-bindgen/pull/5099)
+
 ### Fixed
 
 * Fixed two CLI issues affecting WASM modules built by rustc 1.94+. First,

--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -96,10 +96,21 @@ pub enum TsReference {
     StringEnum(String),
 }
 
-pub fn wrap_try_catch(call: &str) -> String {
+/// Whether and how to guard an export call against instance termination.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportGuard {
+    /// No guard wrapping needed.
+    None,
+    /// Wrap with termination guard and try-catch for panic=abort with error handling.
+    Abort,
+    /// Wrap with just termination guard for schedule_reinit() support.
+    GuardOnly,
+}
+
+fn wrap_try_catch(call: &str) -> String {
     format!(
         "\
-        __wbg_termination_guard();
+        __wbg_call_guard();
         try {{
             {call};
         }} catch(e) {{
@@ -109,11 +120,20 @@ pub fn wrap_try_catch(call: &str) -> String {
     )
 }
 
-pub fn maybe_wrap_try_catch(call: &str, should_check_aborted: bool) -> String {
-    if should_check_aborted {
-        wrap_try_catch(call)
-    } else {
-        format!("{call};")
+fn wrap_call_guard(call: &str) -> String {
+    format!(
+        "\
+        __wbg_call_guard();
+        {call};
+        "
+    )
+}
+
+pub fn maybe_wrap_export_call(call: &str, guard: ExportGuard) -> String {
+    match guard {
+        ExportGuard::Abort => wrap_try_catch(call),
+        ExportGuard::GuardOnly => wrap_call_guard(call),
+        ExportGuard::None => format!("{call};"),
     }
 }
 
@@ -862,11 +882,17 @@ fn instruction(
         Instruction::CallExport(_)
         | Instruction::CallAdapter(_)
         | Instruction::DeferFree { .. } => {
-            let mut should_check_aborted = js.cx.aux.wrapped_js_tag.is_some()
-                && matches!(
-                    instr,
-                    Instruction::CallExport(_) | Instruction::DeferFree { .. }
-                );
+            let is_export_call = matches!(
+                instr,
+                Instruction::CallExport(_) | Instruction::DeferFree { .. }
+            );
+            let mut guard = if js.cx.aux.wrapped_js_tag.is_some() && is_export_call {
+                ExportGuard::Abort
+            } else if js.cx.generate_reinit && is_export_call {
+                ExportGuard::GuardOnly
+            } else {
+                ExportGuard::None
+            };
             let invoc = Invocation::from(instr, js.cx.module);
             let (mut params, results) = invoc.params_results(js.cx);
 
@@ -899,33 +925,25 @@ fn instruction(
             }
 
             // Call the function through an export of the underlying module.
-            let call = invoc.invoke(
-                js.cx,
-                &args,
-                &mut js.prelude,
-                log_error,
-                &mut should_check_aborted,
-            )?;
+            let call = invoc.invoke(js.cx, &args, &mut js.prelude, log_error, &mut guard)?;
 
             // And then figure out how to actually handle where the call
             // happens. This is pretty conditional depending on the number of
             // return values of the function.
             match (invoc.defer(), results) {
                 (true, 0) => {
-                    js.finally(&maybe_wrap_try_catch(&call, should_check_aborted));
+                    js.finally(&maybe_wrap_export_call(&call, guard));
                 }
                 (true, _) => panic!("deferred calls must have no results"),
-                (false, 0) => js.prelude(&maybe_wrap_try_catch(&call, should_check_aborted)),
+                (false, 0) => js.prelude(&maybe_wrap_export_call(&call, guard)),
                 (false, n) => {
-                    let body = if should_check_aborted {
-                        format!(
-                            "\
-                            let ret;
-                            {}",
-                            &wrap_try_catch(&format!("ret = {call};"))
-                        )
-                    } else {
+                    let body = if matches!(guard, ExportGuard::None) {
                         format!("const ret = {call};")
+                    } else {
+                        format!(
+                            "let ret;\n{}",
+                            &maybe_wrap_export_call(&format!("ret = {call}"), guard)
+                        )
                     };
                     js.prelude(&body);
                     if n == 1 {
@@ -1424,12 +1442,15 @@ fn instruction(
                     // Get the JS identifier for the class, which may be aliased
                     // if the name conflicts with a JS builtin (e.g., `Array` -> `Array2`)
                     let identifier = js.cx.require_class_identifier(class);
+                    // When reinit is enabled, define __wbg_inst as non-enumerable
+                    // and non-configurable so it doesn't appear in serialization
+                    // (e.g. toJSON) but remains writable for instance replacement.
                     let (ptr_assignment, register_data) = if js.cx.generate_reinit {
                         (
                             format!(
                                 "\
                                 this.__wbg_ptr = {val} >>> 0;
-                                this.__wbg_inst = __wbg_instance_id;
+                                Object.defineProperty(this, '__wbg_inst', {{ value: __wbg_instance_id, writable: true }});
                                 "
                             ),
                             format!("{{ ptr: {val} >>> 0, instance: __wbg_instance_id }}"),
@@ -1751,7 +1772,7 @@ impl Invocation {
         args: &[String],
         prelude: &mut String,
         log_error: &mut bool,
-        handle_error: &mut bool,
+        guard: &mut ExportGuard,
     ) -> Result<String, Error> {
         match self {
             Invocation::Core { id, export_id, .. } => {
@@ -1775,7 +1796,7 @@ impl Invocation {
                     *log_error = false;
                 }
                 if cx.import_never_handle_error(import) {
-                    *handle_error = false;
+                    *guard = ExportGuard::None;
                 }
                 cx.invoke_import(import, kind, args, variadic, prelude)
             }

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3,6 +3,7 @@ use crate::intrinsic::Intrinsic;
 use crate::transforms::{
     has_local_exception_tags, threads as threads_xform, unstart_start_function,
 };
+use crate::wasm_conventions::get_memory;
 use crate::wit::{
     Adapter, AdapterId, AdapterJsImportKind, AuxExportedMethodKind, AuxReceiverKind, AuxStringEnum,
     AuxValue,
@@ -10,7 +11,7 @@ use crate::wit::{
 use crate::wit::{AdapterKind, Instruction, InstructionData};
 use crate::wit::{AuxEnum, AuxExport, AuxExportKind, AuxImport, AuxStruct};
 use crate::wit::{JsImport, JsImportName, NonstandardWitSection, WasmBindgenAux};
-use crate::{wasm_conventions, Bindgen, EncodeInto, OutputMode, PLACEHOLDER_MODULE};
+use crate::{Bindgen, EncodeInto, OutputMode, PLACEHOLDER_MODULE};
 use anyhow::{anyhow, bail, Context as _, Error};
 use binding::TsReference;
 use std::borrow::Cow;
@@ -1564,7 +1565,7 @@ if (require('worker_threads').isMainThread) {{
                 (
                     "\
                     obj.__wbg_ptr = ptr;
-                    obj.__wbg_inst = __wbg_instance_id;
+                    Object.defineProperty(obj, '__wbg_inst', { value: __wbg_instance_id, writable: true });
                     ",
                     "{ ptr, instance: __wbg_instance_id }",
                 )
@@ -1678,7 +1679,16 @@ if (require('worker_threads').isMainThread) {{
             "wasm.{}(ptr, 0)",
             wasm_bindgen_shared::free_function(qualified)
         );
-        free = binding::maybe_wrap_try_catch(&free, self.aux.wrapped_js_tag.is_some());
+        free = binding::maybe_wrap_export_call(
+            &free,
+            if self.aux.wrapped_js_tag.is_some() {
+                binding::ExportGuard::Abort
+            } else if self.generate_reinit {
+                binding::ExportGuard::GuardOnly
+            } else {
+                binding::ExportGuard::None
+            },
+        );
         dst.push_str(&format!(
             "\
             __destroy_into_raw() {{
@@ -2787,38 +2797,6 @@ if (require('worker_threads').isMainThread) {{
         self.memview("Float64Array", memory)
     }
 
-    /// Emit a `__wbg_invoke_handler(addr)` JS helper that reads a u32 table
-    /// index from linear memory at `addr` and calls through the Wasm
-    /// indirect-function-table.
-    ///
-    /// Used for both the abort handler and the reinit handler.  No exported
-    /// Wasm function is required — the handler is stored as a plain `u32`
-    /// table index in a `#[no_mangle] static` (exported as a Wasm global),
-    /// so JS can read it directly from linear memory via the global's address.
-    ///
-    /// The indirect-function-table lives entirely outside linear memory, so
-    /// calling through it is safe even when linear memory is corrupt (e.g.
-    /// during a hard abort).  This is the key reason we store handlers as
-    /// table indices rather than heap-allocated closures or fat pointers.
-    fn expose_invoke_handler(&mut self) -> Result<String, Error> {
-        let memory = wasm_conventions::get_memory(self.module)?;
-        let mem_view = self.expose_int32_memory(memory);
-        let table = self.export_function_table()?;
-        self.intrinsic(
-            "invoke_handler".into(),
-            "__wbg_invoke_handler".into(),
-            format!(
-                "\
-                function __wbg_invoke_handler(addr) {{
-                    const idx = {mem_view}()[addr / 4];
-                    if (idx) wasm.{table}.get(idx)();
-                }}"
-            )
-            .into(),
-        );
-        Ok("__wbg_invoke_handler".to_string())
-    }
-
     fn expose_dataview_memory(&mut self, memory: MemoryId) -> MemView {
         self.memview("DataView", memory)
     }
@@ -3387,6 +3365,16 @@ if (require('worker_threads').isMainThread) {{
         });
     }
 
+    fn expose_reinit_scheduled(&mut self) {
+        self.intrinsic(
+            "reinit_scheduled".into(),
+            None,
+            "
+            let __wbg_reinit_scheduled = false;
+            ".into(),
+        );
+    }
+
     /// Emit the `__wbg_reset_state` function and instance-id tracking for the
     /// reinit lifecycle. Called when `schedule_reinit()` is used or
     /// `--experimental-reset-state-function` is passed. The function is private
@@ -3452,9 +3440,11 @@ if (require('worker_threads').isMainThread) {{
 
         let has_catch_handler = self.aux.wrapped_js_tag.is_some();
         let abort_reset = if has_catch_handler {
-            "__wbg_called_abort = false;\n            __wbg_reinit_scheduled = false;"
+            "\
+            __wbg_called_abort = false;
+            __wbg_reinit_scheduled = false;"
         } else {
-            ""
+            "__wbg_reinit_scheduled = false;"
         };
         reset_statements.push(format!(
             "{abort_reset}
@@ -3732,6 +3722,7 @@ if (require('worker_threads').isMainThread) {{
 
         self.generate_jstag_import();
         self.generate_wrapped_jstag_import()?;
+        self.maybe_generate_call_guard()?;
 
         for (id, adapter, kind) in iter_adapter(self.aux, self.wit, self.module) {
             let instrs = match &adapter.kind {
@@ -3854,7 +3845,7 @@ addToLibrary({
     __wbindgen_wrapped_jstag: "(globalThis.__wbindgen_wrapped_jstag = new WebAssembly.Tag({ parameters: ['externref'] }))",
     
     __wbindgen_wrapped_jstag__postset: `
-        function __wbg_termination_guard() {}
+        function __wbg_call_guard() {}
         
         function __wbg_handle_catch(e) {
             if (e instanceof WebAssembly.Exception && e.is(globalThis.__wbindgen_wrapped_jstag)) {
@@ -3873,81 +3864,91 @@ addToLibrary({
             "const __wbindgen_wrapped_jstag = new WebAssembly.Tag({ parameters: ['externref'] });",
         );
 
-        let memory = wasm_conventions::get_memory(self.module).unwrap();
+        let memory = get_memory(self.module).unwrap();
         let mem_view = self.expose_int32_memory(memory);
-
-        self.global("let __wbg_terminated_addr;");
-        self.global("let __wbg_called_abort = false;");
-        if self.generate_reinit {
-            self.global("let __wbg_reinit_scheduled = false;");
-        }
-
-        // Create a helper function to unwrap and rethrow wrapped JS exceptions
-        let invoke_handler = self.expose_invoke_handler()?;
+        let table = self.export_function_table()?;
 
         self.global(&format!(
-            "\
-function __wbg_call_abort_hook() {{
-    __wbg_called_abort = true;
-    try {{ {invoke_handler}(wasm.__abort_handler.value); }} catch(_) {{}}
-}}"
-        ));
+            "
+            let __wbg_terminated_addr;
+            let __wbg_called_abort = false;
+            function __wbg_call_abort_hook() {{
+                __wbg_called_abort = true;
+                try {{ 
+                    const idx = {mem_view}()[wasm.__abort_handler.value / 4];
+                    if (idx) wasm.{table}.get(idx)();
+                }} catch(_) {{}}
+            }}
 
-        let uses_reinit = self.generate_reinit;
-        if uses_reinit {
-            self.global(&format!(
-                "\
-function __wbg_termination_guard() {{
-    __wbg_terminated_addr ??= wasm.__instance_terminated.value / 4;
-    const flag = {mem_view}()[__wbg_terminated_addr];
-    if (flag) {{
-        if (!__wbg_called_abort) {{
-            __wbg_call_abort_hook();
-        }}
-        if (__wbg_reinit_scheduled) {{
-            __wbg_reset_state();
-            return;
-        }}
-        throw new Error('Module terminated');
-    }} else if (__wbg_reinit_scheduled) {{
-        __wbg_reset_state();
-    }}
-}}"
-            ));
-        } else {
-            self.global(&format!(
-                "\
-function __wbg_termination_guard() {{
-    __wbg_terminated_addr ??= wasm.__instance_terminated.value / 4;
-    const flag = {mem_view}()[__wbg_terminated_addr];
-    if (flag) {{
-        if (!__wbg_called_abort) {{
-            __wbg_call_abort_hook();
-        }}
-        throw new Error('Module terminated');
-    }}
-}}"
-            ));
-        }
-
-        self.global(&format!(
-            "\
-function __wbg_handle_catch(e) {{
-    if (e instanceof WebAssembly.Exception && e.is(__wbindgen_wrapped_jstag)) {{
-        throw e.getArg(__wbindgen_wrapped_jstag, 0);
-    }}
-    {mem_view}()[__wbg_terminated_addr] = 1;
-    // Invoke the Rust-registered abort handler (if any). The try/catch ensures
-    // a throwing or panicking handler cannot suppress the original error.
-    __wbg_call_abort_hook();
-    throw e;
-}}"
+            function __wbg_handle_catch(e) {{
+                if (e instanceof WebAssembly.Exception && e.is(__wbindgen_wrapped_jstag)) {{
+                    throw e.getArg(__wbindgen_wrapped_jstag, 0);
+                }}
+                {mem_view}()[__wbg_terminated_addr] = 1;
+                __wbg_call_abort_hook();
+                throw e;
+            }}
+            "
         ));
 
         // Use the constant for the import
         self.wasm_import_definitions
             .insert(id, "__wbindgen_wrapped_jstag".to_string());
 
+        Ok(())
+    }
+
+    /// Emit a `__wbg_call_guard`, handling hard aborts and reinitialization
+    /// - Hard aborts are emitted when we are using js exception tagging.
+    /// - For reinitialization, checks __wbg_reinit_scheduled.
+    /// - If neither features are required, no call guard is emitted.
+    fn maybe_generate_call_guard(&mut self) -> Result<(), Error> {
+        // No call guard needed when we dont have hard aborts or reinit
+        if self.aux.wrapped_js_tag.is_none() && !self.generate_reinit {
+            return Ok(());
+        }
+
+        let mut termination_guard = String::from("function __wbg_call_guard() {");
+        // Exception handling tags -> hard aborts
+        if self.aux.wrapped_js_tag.is_some() {
+            let memory = get_memory(self.module)?;
+            let mem_view = self.expose_int32_memory(memory);
+            termination_guard.push_str(&format!(
+                "
+                __wbg_terminated_addr ??= wasm.__instance_terminated.value / 4;
+                const flag = {mem_view}()[__wbg_terminated_addr];
+                if (flag) {{
+                    if (!__wbg_called_abort) {{
+                        __wbg_call_abort_hook();
+                    }}"
+            ));
+        }
+        // reinit guard
+        if self.generate_reinit {
+            self.expose_reinit_scheduled();
+            termination_guard.push_str(
+                "
+                if (__wbg_reinit_scheduled) {
+                    __wbg_reset_state();
+                    return;
+                }",
+            );
+        }
+        if self.aux.wrapped_js_tag.is_some() {
+            termination_guard.push_str("throw new Error('Module terminated');\n");
+            if self.generate_reinit {
+                termination_guard.push_str(
+                    "
+                    } else if (__wbg_reinit_scheduled) {
+                        __wbg_reset_state();
+                    }",
+                );
+            } else {
+                termination_guard.push_str("}");
+            }
+        }
+        termination_guard.push_str("\n}");
+        self.global(&termination_guard);
         Ok(())
     }
 

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -3371,7 +3371,8 @@ if (require('worker_threads').isMainThread) {{
             None,
             "
             let __wbg_reinit_scheduled = false;
-            ".into(),
+            "
+            .into(),
         );
     }
 
@@ -3944,7 +3945,7 @@ addToLibrary({
                     }",
                 );
             } else {
-                termination_guard.push_str("}");
+                termination_guard.push('}');
             }
         }
         termination_guard.push_str("\n}");

--- a/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
@@ -5,14 +5,16 @@ export function __wbg_reset_state () {
     __wbg_instance_id++;
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
 }
 
 export function exported() {
-    const ret = wasm.exported();
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.exported();
     if (ret[1]) {
         throw takeFromExternrefTable0(ret[0]);
     }
@@ -75,6 +77,14 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
 
 function addToExternrefTable0(obj) {
@@ -104,6 +114,8 @@ function handleError(f, args) {
         wasm.__wbindgen_exn_store(idx);
     }
 }
+
+let __wbg_reinit_scheduled = false;
 
 function takeFromExternrefTable0(idx) {
     const value = wasm.__wbindgen_externrefs.get(idx);

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
@@ -4,7 +4,7 @@ export function __wbg_reset_state () {
     __wbg_instance_id++;
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -16,7 +16,9 @@ export function __wbg_reset_state () {
  * @returns {number}
  */
 export function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 
@@ -47,6 +49,14 @@ function __wbg_get_imports(memory) {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
 
 function getStringFromWasm0(ptr, len) {
@@ -61,6 +71,8 @@ function getUint8ArrayMemory0() {
     }
     return cachedUint8ArrayMemory0;
 }
+
+let __wbg_reinit_scheduled = false;
 
 let cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : undefined);
 if (cachedTextDecoder) cachedTextDecoder.decode();

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
@@ -2,7 +2,7 @@
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -14,7 +14,9 @@ export function __wbg_reset_state () {
  * @returns {number}
  */
 export function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 
@@ -32,7 +34,17 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
+
+let __wbg_reinit_scheduled = false;
 
 import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
@@ -2,7 +2,7 @@
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -14,7 +14,9 @@ export function __wbg_reset_state () {
  * @returns {number}
  */
 export function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 
@@ -41,7 +43,17 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
+
+let __wbg_reinit_scheduled = false;
 
 import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
@@ -4,7 +4,7 @@ function __wbg_reset_state () {
     __wbg_instance_id++;
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -17,7 +17,9 @@ exports.__wbg_reset_state = __wbg_reset_state;
  * @returns {number}
  */
 function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
@@ -49,6 +51,14 @@ function __wbg_get_imports(memory) {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
 
 function getStringFromWasm0(ptr, len) {
@@ -63,6 +73,8 @@ function getUint8ArrayMemory0() {
     }
     return cachedUint8ArrayMemory0;
 }
+
+let __wbg_reinit_scheduled = false;
 
 let cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : undefined);
 if (cachedTextDecoder) cachedTextDecoder.decode();

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
@@ -2,7 +2,7 @@
 
 function __wbg_reset_state () {
     __wbg_instance_id++;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -15,7 +15,9 @@ exports.__wbg_reset_state = __wbg_reset_state;
  * @returns {number}
  */
 function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
@@ -34,7 +36,17 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
+
+let __wbg_reinit_scheduled = false;
 
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
@@ -2,7 +2,7 @@
 
 function __wbg_reset_state () {
     __wbg_instance_id++;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -15,7 +15,9 @@ exports.__wbg_reset_state = __wbg_reset_state;
  * @returns {number}
  */
 function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
@@ -43,7 +45,17 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
+
+let __wbg_reinit_scheduled = false;
 
 const wasmPath = `${__dirname}/reference_test_bg.wasm`;
 const wasmBytes = require('fs').readFileSync(wasmPath);

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
@@ -4,7 +4,7 @@ export function __wbg_reset_state () {
     __wbg_instance_id++;
     cachedUint8ArrayMemory0 = null;
     if (typeof numBytesDecoded !== 'undefined') numBytesDecoded = 0;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -16,7 +16,9 @@ export function __wbg_reset_state () {
  * @returns {number}
  */
 export function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 
@@ -47,6 +49,14 @@ function __wbg_get_imports(memory) {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
 
 function getStringFromWasm0(ptr, len) {
@@ -61,6 +71,8 @@ function getUint8ArrayMemory0() {
     }
     return cachedUint8ArrayMemory0;
 }
+
+let __wbg_reinit_scheduled = false;
 
 let cachedTextDecoder = (typeof TextDecoder !== 'undefined' ? new TextDecoder('utf-8', { ignoreBOM: true, fatal: true }) : undefined);
 if (cachedTextDecoder) cachedTextDecoder.decode();

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
@@ -2,7 +2,7 @@
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -14,7 +14,9 @@ export function __wbg_reset_state () {
  * @returns {number}
  */
 export function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 
@@ -32,7 +34,17 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
+
+let __wbg_reinit_scheduled = false;
 
 let wasmModule, wasm;
 function __wbg_finalize_init(instance, module) {

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
@@ -2,7 +2,7 @@
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
-
+    __wbg_reinit_scheduled = false;
     const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
     wasm = wasmInstance.exports;
     wasm.__wbindgen_start();
@@ -14,7 +14,9 @@ export function __wbg_reset_state () {
  * @returns {number}
  */
 export function add_that_might_fail(a, b) {
-    const ret = wasm.add_that_might_fail(a, b);
+    let ret;
+    __wbg_call_guard();
+    ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
 
@@ -41,7 +43,17 @@ function __wbg_get_imports() {
     };
 }
 
+function __wbg_call_guard() {
+    if (__wbg_reinit_scheduled) {
+        __wbg_reset_state();
+        return;
+    }
+}
+
+
 let __wbg_instance_id = 0;
+
+let __wbg_reinit_scheduled = false;
 
 let wasmModule, wasm;
 function __wbg_finalize_init(instance, module) {

--- a/crates/cli/tests/wasm-bindgen/main.rs
+++ b/crates/cli/tests/wasm-bindgen/main.rs
@@ -1628,6 +1628,124 @@ describe('reinit auto-detection (no --experimental-reset-state-function)', () =>
         .success();
 }
 
+/// Tests that schedule_reinit() works under panic=abort builds.
+#[test]
+fn reinit_panic_abort() {
+    let mut project = Project::new("reinit_panic_abort");
+    project
+        .file(
+            "src/lib.rs",
+            r#"
+                use wasm_bindgen::prelude::*;
+
+                static mut COUNTER: u32 = 0;
+
+                #[wasm_bindgen]
+                pub fn get_counter() -> u32 { unsafe { COUNTER } }
+
+                #[wasm_bindgen]
+                pub fn increment_counter() -> u32 {
+                    unsafe { COUNTER += 1; COUNTER }
+                }
+
+                #[wasm_bindgen]
+                pub fn simple_add(a: u32, b: u32) -> u32 { a + b }
+
+                #[wasm_bindgen]
+                pub fn signal_reinit() {
+                    wasm_bindgen::handler::schedule_reinit();
+                }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            &format!(
+                "
+                [package]
+                name = \"reinit_panic_abort\"
+                authors = []
+                version = \"1.0.0\"
+                edition = '2021'
+
+                [dependencies]
+                wasm-bindgen = {{ path = '{}' }}
+
+                [lib]
+                crate-type = ['cdylib']
+
+                [workspace]
+            ",
+                REPO_ROOT.display(),
+            ),
+        );
+
+    let out_dir = project.wasm_bindgen("--target nodejs").unwrap();
+
+    fs::write(
+        out_dir.join("test_reinit_abort.js"),
+        r#"
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+let instanceCount = 0;
+const OrigInstance = WebAssembly.Instance;
+WebAssembly.Instance = function(module, imports) {
+    instanceCount++;
+    return new OrigInstance(module, imports);
+};
+const wasm = require('./reinit_panic_abort.js');
+assert.strictEqual(instanceCount, 1, 'one instance on load');
+
+describe('schedule_reinit under panic=abort', () => {
+    it('signal_reinit then export call creates a new instance', () => {
+        wasm.signal_reinit();
+        assert.strictEqual(wasm.simple_add(1, 2), 3);
+        assert.strictEqual(instanceCount, 2);
+    });
+
+    it('reinit resets statics', () => {
+        wasm.increment_counter();
+        wasm.increment_counter();
+        assert.ok(wasm.get_counter() > 1);
+        wasm.signal_reinit();
+        wasm.simple_add(0, 0);
+        assert.strictEqual(wasm.get_counter(), 0, 'counter reset to 0');
+        assert.strictEqual(instanceCount, 3);
+    });
+
+    it('counter persists without reinit signal', () => {
+        wasm.increment_counter();
+        wasm.increment_counter();
+        wasm.increment_counter();
+        assert.strictEqual(wasm.get_counter(), 3);
+        wasm.simple_add(0, 0);
+        assert.strictEqual(wasm.get_counter(), 3);
+    });
+
+    it('multiple reinit cycles each produce a fresh instance', () => {
+        const startInstances = instanceCount;
+        for (let i = 0; i < 3; i++) {
+            wasm.increment_counter();
+            wasm.increment_counter();
+            wasm.signal_reinit();
+            wasm.simple_add(0, 0);
+            assert.strictEqual(instanceCount, startInstances + i + 1);
+            assert.strictEqual(wasm.get_counter(), 0);
+        }
+    });
+});
+"#,
+    )
+    .unwrap();
+
+    Command::new("node")
+        .arg("--test")
+        .arg("test_reinit_abort.js")
+        .current_dir(&out_dir)
+        .assert()
+        .success();
+}
+
 #[test]
 fn multiple_start_functions() {
     let out_dir = Project::new("multiple_start_functions")

--- a/crates/msrv/cli/Cargo.toml
+++ b/crates/msrv/cli/Cargo.toml
@@ -38,6 +38,9 @@ clap_lex = "=1.0.0"
 # ureq 3.3.0 requires edition 2024 (Rust 1.85+)
 ureq = "=3.2.0"
 
+# indexmap 2.14.0 depends on hashbrown 0.17.0 which requires edition 2024 (Rust 1.85+)
+indexmap = "=2.13.1"
+
 # enable default feature for icu
 writeable = "0.6.0"
 

--- a/guide/src/reference/handling-aborts.md
+++ b/guide/src/reference/handling-aborts.md
@@ -10,9 +10,10 @@ export call will throw `"Module terminated"`.
 The `wasm_bindgen::handler` module provides hooks for responding to these events
 and optionally recovering by reinitializing the module.
 
-> **Note:** Hard abort detection and the abort handler API currently require
-> `panic=unwind`. Support for `panic=abort` builds may be added in a future
-> release.
+> **Note:** Hard abort detection and the abort handler API (`set_on_abort`)
+> currently require `panic=unwind`. Support for `panic=abort` may be added in
+> a future release. `schedule_reinit()` works with both `panic=unwind` and
+> `panic=abort`.
 
 ## Termination States
 
@@ -63,14 +64,15 @@ means the handler fires on the next export call, giving it a chance to respond
 
 `handler::schedule_reinit()` can be used to reinitialize the WebAssembly instance, while
 keeping the JS wrapper bindings in place, performing a transparent reinitialization
-of the library when state loss is acceptable.
+of the library when state loss is acceptable. Works with both `panic=unwind` and
+`panic=abort` builds.
 
-`schedule_reinit` may be called at any time, including from within the abort hook
-to create a self-recovering abort handler.
+`schedule_reinit` may be called at any time. With `panic=unwind` it can also be
+called from within the abort hook to create a self-recovering abort handler.
 
-When called, `schedule_reinit()` the module for reinitialization. The next call to
-any export detects this, creates a fresh `WebAssembly.Instance` from the same
-module, while keeping the same JS wrapper bindings in place but updated to
+When called, `schedule_reinit()` signals the module for reinitialization. The next
+call to any export detects this, creates a fresh `WebAssembly.Instance` from the
+same module, while keeping the same JS wrapper bindings in place but updated to
 the new instance.
 
 When called during normal execution, the current call completes normally and

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -18,15 +18,15 @@
 //!
 //! # Reinit
 //!
-//! [`schedule_reinit()`] writes a sentinel value into the termination flag.
+//! [`schedule_reinit()`] signals that the instance should be reinitialized.
 //! The next call to any export detects this, creates a fresh
 //! `WebAssembly.Instance` from the same module.
+//!
+//! Works with both `panic=unwind` and `panic=abort` builds.
 //!
 //! The reinit machinery is automatically emitted when [`schedule_reinit()`] is
 //! used — no CLI flag is required. `--experimental-reset-state-function` is
 //! only needed for the public `__wbg_reset_state()` export.
-//!
-//! [`schedule_reinit()`] is a no-op on `panic=abort` builds.
 #[doc(hidden)]
 pub use crate::__rt::schedule_reinit;
 #[doc(hidden)]

--- a/src/rt/mod.rs
+++ b/src/rt/mod.rs
@@ -656,17 +656,11 @@ pub fn set_on_abort(_f: fn()) -> Option<fn()> {
 
 /// Schedule the instance for reinitialization before the next export call.
 ///
-/// Available when built with `panic=unwind`. The reinit machinery is
-/// automatically emitted when this function is used. On `panic=abort` builds
-/// this is a no-op.
-#[cfg(panic = "unwind")]
+/// The reinit machinery is automatically emitted when this function is used.
+/// Works with both `panic=unwind` and `panic=abort` builds.
 pub fn schedule_reinit() {
     crate::__wbindgen_reinit();
 }
-
-/// No-op stub for `panic=abort` builds.
-#[cfg(not(panic = "unwind"))]
-pub fn schedule_reinit() {}
 
 #[no_mangle]
 pub unsafe extern "C" fn __wbindgen_exn_store(idx: u32) {


### PR DESCRIPTION
## Summary

Previously `handler::schedule_reinit()` was a no-op under `panic=abort`. This extends it to work with both panic strategies.

Under `panic=abort` there's no `__instance_terminated` flag or wasm-level catch wrappers, so the full abort detection machinery doesn't apply. But `schedule_reinit()` is independent of abort detection — it just sets a JS-side flag (`__wbg_reinit_scheduled`) that's checked before each export call. This PR adds that minimal path.

* Remove `#[cfg(panic = "unwind")]` gate on `schedule_reinit()` so it calls `__wbindgen_reinit()` in all builds
* Add `generate_reinit_guard()` — emits a simple `__wbg_termination_guard` that only checks `__wbg_reinit_scheduled` (no try/catch, no `__instance_terminated`)
* Refactor `maybe_wrap_try_catch` into `maybe_wrap_export_call` with separate `check_aborted` / `check_reinit` flags — exports under `panic=abort` get the guard prepended without try/catch wrapping
* Fix `__wbg_reset_state` to reset `__wbg_reinit_scheduled` in all builds (not just when `wrapped_js_tag` is present)
* Add `reinit_panic_abort` integration test: builds with `-Cpanic=abort -Zbuild-std=std,panic_abort`, verifies new instance creation, static reset, persistence without signal, and multiple reinit cycles