### PR TITLE
fix: hoist ES module import statements to top of generated JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 
 ### Fixed
 
+* ES module `import` statements are now hoisted to the top of generated JS
+  files, placed right after the `@ts-self-types` directive. This ensures
+  valid ES module output since `import` declarations must precede other
+  statements.
+  [#5103](https://github.com/wasm-bindgen/wasm-bindgen/pull/5103)
+
 * Fixed two CLI issues affecting WASM modules built by rustc 1.94+. First,
   a panic (`failed to find N in function table`) caused by lld emitting element
   segment offsets as `global.get $__table_base` or extended const expressions

--- a/crates/cli-support/src/js/mod.rs
+++ b/crates/cli-support/src/js/mod.rs
@@ -41,6 +41,10 @@ macro_rules! region {
 
 pub struct Context<'a> {
     globals: String,
+    /// ES module `import` statements collected during codegen, emitted at the
+    /// top of the output in `finalize()`. In bundler mode these go into the
+    /// `_bg.js` file; the bundler entry file has its own hardcoded imports.
+    es_module_imports: String,
     intrinsics: Option<BTreeMap<Cow<'static, str>, Cow<'static, str>>>,
     emscripten_library: String,
     imports_post: String,
@@ -224,6 +228,7 @@ impl<'a> Context<'a> {
     ) -> Result<Context<'a>, Error> {
         Ok(Context {
             globals: String::new(),
+            es_module_imports: String::new(),
             intrinsics: Some(Default::default()),
             imports_post: String::new(),
             export_name_list: Vec::new(),
@@ -465,10 +470,7 @@ impl<'a> Context<'a> {
         }
 
         if !self.js_imports.is_empty() {
-            region!(self, "js imports", {
-                let imports = self.js_import_header()?;
-                self.globals.push_str(&imports);
-            });
+            self.js_import_header()?;
         }
 
         if !self.exports.is_empty() {
@@ -583,6 +585,25 @@ impl<'a> Context<'a> {
             }
         }
 
+        // Insert collected ES module imports at the top of the output.
+        if !self.es_module_imports.is_empty() {
+            let mut es_imports = std::mem::take(&mut self.es_module_imports);
+            es_imports.push('\n');
+            if let Some(bg_js) = &mut start {
+                // Bundler: self.globals is the entry file (hardcoded imports),
+                // bg_js is the _bg.js glue file that needs these imports.
+                bg_js.insert_str(0, &es_imports);
+            } else {
+                // Other ESM modes: insert after the @ts-self-types directive.
+                let insert_pos = if self.globals.starts_with("/* @ts-self-types") {
+                    self.globals.find('\n').map(|p| p + 1).unwrap_or(0)
+                } else {
+                    0
+                };
+                self.globals.insert_str(insert_pos, &es_imports);
+            }
+        }
+
         let mut ts = String::new();
 
         if self.config.mode.no_modules() {
@@ -672,11 +693,12 @@ impl<'a> Context<'a> {
         for (i, module) in import_modules.enumerate() {
             let i = i + 1;
             if self.config.mode.uses_es_modules() {
-                imports.push_str(&format!(r#"import * as import{i} from "{module}""#));
+                self.es_module_imports
+                    .push_str(&format!("import * as import{i} from \"{module}\"\n"));
             } else {
                 imports.push_str(&format!(r#"const import{i} = require("{module}");"#));
+                imports.push('\n');
             }
-            imports.push('\n');
 
             return_stmt.push_str(&format!(r#""{module}": import{i},"#));
             return_stmt.push('\n');
@@ -693,7 +715,11 @@ impl<'a> Context<'a> {
         fn_def.push_str(&return_stmt);
         fn_def.push_str("}\n");
 
-        format!("{imports}\n{fn_def}\n")
+        if imports.is_empty() {
+            format!("{fn_def}\n")
+        } else {
+            format!("{imports}\n{fn_def}\n")
+        }
     }
 
     fn generate_bundler_imports(&mut self, module_name: &str) -> String {
@@ -791,11 +817,12 @@ impl<'a> Context<'a> {
         }
     }
 
-    fn js_import_header(&self) -> Result<String, Error> {
-        let mut imports = String::new();
-
+    /// Collects JS module import statements from `self.js_imports`.
+    /// For ESM modes, writes `import { ... }` to `self.es_module_imports`.
+    /// For CJS Node / Emscripten, writes inline to `self.globals`.
+    fn js_import_header(&mut self) -> Result<(), Error> {
         if self.config.omit_imports {
-            return Ok(imports);
+            return Ok(());
         }
 
         match &self.config.mode {
@@ -807,32 +834,37 @@ impl<'a> Context<'a> {
 
             OutputMode::Node { module: false } => {
                 for (module, items) in crate::sorted_iter(&self.js_imports) {
-                    imports.push_str("const { ");
+                    self.globals.push_str("const { ");
                     for (i, (item, rename)) in items.iter().enumerate() {
                         if i > 0 {
-                            imports.push_str(", ");
+                            self.globals.push_str(", ");
                         }
                         if is_valid_ident(item) {
-                            imports.push_str(item);
+                            self.globals.push_str(item);
                         } else {
-                            // Invalid identifiers should already have a valid rename
                             assert!(rename.is_some());
-                            imports.push('\'');
-                            imports.push_str(&escape_string(item));
-                            imports.push('\'');
+                            self.globals.push('\'');
+                            self.globals.push_str(&escape_string(item));
+                            self.globals.push('\'');
                         }
                         if let Some(other) = rename {
-                            imports.push_str(": ");
-                            imports.push_str(other)
+                            self.globals.push_str(": ");
+                            self.globals.push_str(other)
                         }
                     }
                     if module.starts_with('.') || PathBuf::from(module).is_absolute() {
-                        imports.push_str(" } = require(String.raw`");
+                        self.globals.push_str(" } = require(String.raw`");
                     } else {
-                        imports.push_str(" } = require(`");
+                        self.globals.push_str(" } = require(`");
                     }
-                    imports.push_str(module);
-                    imports.push_str("`);\n");
+                    self.globals.push_str(module);
+                    self.globals.push_str("`);\n");
+                }
+            }
+
+            OutputMode::Emscripten => {
+                for (module, items) in crate::sorted_iter(&self.js_imports) {
+                    write_es_import(&mut self.globals, module, items);
                 }
             }
 
@@ -840,33 +872,13 @@ impl<'a> Context<'a> {
             | OutputMode::Node { module: true }
             | OutputMode::Web
             | OutputMode::Module
-            | OutputMode::Deno
-            | OutputMode::Emscripten => {
+            | OutputMode::Deno => {
                 for (module, items) in crate::sorted_iter(&self.js_imports) {
-                    imports.push_str("import { ");
-                    for (i, (item, rename)) in items.iter().enumerate() {
-                        if i > 0 {
-                            imports.push_str(", ");
-                        }
-                        if is_valid_ident(item) {
-                            imports.push_str(item);
-                        } else {
-                            imports.push('\'');
-                            imports.push_str(item);
-                            imports.push('\'');
-                        }
-                        if let Some(other) = rename {
-                            imports.push_str(" as ");
-                            imports.push_str(other);
-                        }
-                    }
-                    imports.push_str(" } from '");
-                    imports.push_str(module);
-                    imports.push_str("';\n");
+                    write_es_import(&mut self.es_module_imports, module, items);
                 }
             }
         }
-        Ok(imports)
+        Ok(())
     }
 
     fn ts_for_init_fn(
@@ -994,15 +1006,20 @@ export const __wbg_memory: WebAssembly.Memory;
         ))
     }
 
-    fn generate_module_wasm_loading(&self, module_name: &str, needs_manual_start: bool) -> String {
+    fn generate_module_wasm_loading(
+        &mut self,
+        module_name: &str,
+        needs_manual_start: bool,
+    ) -> String {
+        self.es_module_imports.push_str(&format!(
+            "import source wasmModule from \"./{module_name}_bg.wasm\";\n"
+        ));
         format!(
-            r#"import source wasmModule from "./{module_name}_bg.wasm";
-            const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
-            let wasm = wasmInstance.exports;
-            {start}
-            "#,
+            "const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());\n\
+             let wasm = wasmInstance.exports;\n\
+             {start}",
             start = if needs_manual_start {
-                "wasm.__wbindgen_start();"
+                "wasm.__wbindgen_start();\n"
             } else {
                 ""
             },
@@ -1025,14 +1042,15 @@ export const __wbg_memory: WebAssembly.Memory;
         if self.config.typescript {
             // jsr-self-types directive
             start.push_str(&format!(r#"/* @ts-self-types="./{module_name}.d.ts" */"#));
-            start.push_str("\n\n");
+            start.push('\n');
         }
 
         start.push_str(&format!(
-            r#"import * as wasm from "./{module_name}_bg.wasm";
-            import {{ __wbg_set_wasm }} from "./{module_name}_bg.js";
+            "\
+            import * as wasm from \"./{module_name}_bg.wasm\";\n\
+            import {{ __wbg_set_wasm }} from \"./{module_name}_bg.js\";\n\n\
             __wbg_set_wasm(wasm);
-        "#
+            "
         ));
 
         if needs_manual_start {
@@ -1232,12 +1250,17 @@ export const __wbg_memory: WebAssembly.Memory;
     }
 
     fn generate_node_esm_wasm_loading(
-        &self,
+        &mut self,
         module_name: &str,
         needs_manual_start: bool,
     ) -> String {
+        self.es_module_imports
+            .push_str("import { readFileSync } from 'node:fs';\n");
+
         if self.threads_enabled {
-            // For threads: generate initSync that accepts custom memory
+            self.es_module_imports
+                .push_str("import { isMainThread } from 'node:worker_threads';\n");
+
             let start_call = if needs_manual_start {
                 format!(
                     r#"
@@ -1253,10 +1276,7 @@ export const __wbg_memory: WebAssembly.Memory;
             };
 
             format!(
-                r#"import {{ readFileSync }} from 'node:fs';
-import {{ isMainThread }} from 'node:worker_threads';
-
-let wasm;
+                r#"let wasm;
 let wasmModule;
 let memory;
 let __initialized = false;
@@ -1297,12 +1317,12 @@ export {{ wasm as __wasm, wasmModule as __wbg_wasm_module, memory as __wbg_memor
             )
         } else {
             format!(
-                r#"import {{ readFileSync }} from 'node:fs';
-            const wasmUrl = new URL('{module_name}_bg.wasm', import.meta.url);
-            const wasmBytes = readFileSync(wasmUrl);
-            const wasmModule = new WebAssembly.Module(wasmBytes);
-            let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;
-            {start}"#,
+                "\
+                const wasmUrl = new URL('{module_name}_bg.wasm', import.meta.url);\n\
+                const wasmBytes = readFileSync(wasmUrl);\n\
+                const wasmModule = new WebAssembly.Module(wasmBytes);\n\
+                let wasm = new WebAssembly.Instance(wasmModule, __wbg_get_imports()).exports;\n\
+                {start}",
                 start = if needs_manual_start {
                     "wasm.__wbindgen_start();\n"
                 } else {
@@ -1437,7 +1457,7 @@ if (require('worker_threads').isMainThread) {{
     }
 
     fn generate_wasm_loading(
-        &self,
+        &mut self,
         module_name: &str,
         needs_manual_start: bool,
         has_memory: bool,
@@ -5889,4 +5909,27 @@ impl fmt::Display for MemView {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}{}", self.name, self.num)
     }
+}
+
+fn write_es_import(dest: &mut String, module: &str, items: &[(String, Option<String>)]) {
+    dest.push_str("import { ");
+    for (i, (item, rename)) in items.iter().enumerate() {
+        if i > 0 {
+            dest.push_str(", ");
+        }
+        if is_valid_ident(item) {
+            dest.push_str(item);
+        } else {
+            dest.push('\'');
+            dest.push_str(item);
+            dest.push('\'');
+        }
+        if let Some(other) = rename {
+            dest.push_str(" as ");
+            dest.push_str(other);
+        }
+    }
+    dest.push_str(" } from '");
+    dest.push_str(module);
+    dest.push_str("';\n");
 }

--- a/crates/cli/tests/reference/add.js
+++ b/crates/cli/tests/reference/add.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/anyref-empty.js
+++ b/crates/cli/tests/reference/anyref-empty.js
@@ -1,6 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/anyref-import-catch.js
+++ b/crates/cli/tests/reference/anyref-import-catch.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/anyref-nop.js
+++ b/crates/cli/tests/reference/anyref-nop.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/async-number.js
+++ b/crates/cli/tests/reference/async-number.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/async-void.js
+++ b/crates/cli/tests/reference/async-void.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/builder.js
+++ b/crates/cli/tests/reference/builder.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/closures.js
+++ b/crates/cli/tests/reference/closures.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/constructor.js
+++ b/crates/cli/tests/reference/constructor.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/custom-section.js
+++ b/crates/cli/tests/reference/custom-section.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/default-class.js
+++ b/crates/cli/tests/reference/default-class.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/default-function.js
+++ b/crates/cli/tests/reference/default-function.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/echo.js
+++ b/crates/cli/tests/reference/echo.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/empty.js
+++ b/crates/cli/tests/reference/empty.js
@@ -1,6 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/enums.js
+++ b/crates/cli/tests/reference/enums.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/function-attrs.js
+++ b/crates/cli/tests/reference/function-attrs.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/getter-setter.js
+++ b/crates/cli/tests/reference/getter-setter.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/import-getter-setter.js
+++ b/crates/cli/tests/reference/import-getter-setter.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/import-target-bundler.bg.js
+++ b/crates/cli/tests/reference/import-target-bundler.bg.js
@@ -1,5 +1,6 @@
 import { default as _default } from 'tests/wasm/import_class.js';
 
+
 export function exported() {
     const ret = wasm.exported();
     if (ret[1]) {

--- a/crates/cli/tests/reference/import-target-bundler.js
+++ b/crates/cli/tests/reference/import-target-bundler.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/import-target-deno.js
+++ b/crates/cli/tests/reference/import-target-deno.js
@@ -1,5 +1,10 @@
 /* @ts-self-types="./reference_test.d.ts" */
 import { default as _default } from 'tests/wasm/import_class.js';
+import * as import1 from "tests/wasm/imports.js"
+import * as import2 from "foo-raw"
+import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
+import * as import4 from "pure-extern"
+
 
 export function exported() {
     const ret = wasm.exported();
@@ -7,11 +12,6 @@ export function exported() {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
-import * as import1 from "tests/wasm/imports.js"
-import * as import2 from "foo-raw"
-import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
-import * as import4 from "pure-extern"
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/import-target-experimental-nodejs-module.js
+++ b/crates/cli/tests/reference/import-target-experimental-nodejs-module.js
@@ -1,5 +1,11 @@
 /* @ts-self-types="./reference_test.d.ts" */
 import { default as _default } from 'tests/wasm/import_class.js';
+import * as import1 from "tests/wasm/imports.js"
+import * as import2 from "foo-raw"
+import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
+import * as import4 from "pure-extern"
+import { readFileSync } from 'node:fs';
+
 
 export function exported() {
     const ret = wasm.exported();
@@ -7,11 +13,6 @@ export function exported() {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
-import * as import1 from "tests/wasm/imports.js"
-import * as import2 from "foo-raw"
-import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
-import * as import4 from "pure-extern"
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -105,7 +106,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-import { readFileSync } from 'node:fs';
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmBytes = readFileSync(wasmUrl);
 const wasmModule = new WebAssembly.Module(wasmBytes);

--- a/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/import-target-module-experimental-reset-state-function.js
@@ -1,5 +1,11 @@
 /* @ts-self-types="./reference_test.d.ts" */
 import { default as _default } from 'tests/wasm/import_class.js';
+import * as import1 from "tests/wasm/imports.js"
+import * as import2 from "foo-raw"
+import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
+import * as import4 from "pure-extern"
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
@@ -19,11 +25,6 @@ export function exported() {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
-import * as import1 from "tests/wasm/imports.js"
-import * as import2 from "foo-raw"
-import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
-import * as import4 from "pure-extern"
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -129,7 +130,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-module.js
+++ b/crates/cli/tests/reference/import-target-module.js
@@ -1,5 +1,11 @@
 /* @ts-self-types="./reference_test.d.ts" */
 import { default as _default } from 'tests/wasm/import_class.js';
+import * as import1 from "tests/wasm/imports.js"
+import * as import2 from "foo-raw"
+import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
+import * as import4 from "pure-extern"
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 export function exported() {
     const ret = wasm.exported();
@@ -7,11 +13,6 @@ export function exported() {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
-import * as import1 from "tests/wasm/imports.js"
-import * as import2 from "foo-raw"
-import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
-import * as import4 from "pure-extern"
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -105,7 +106,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/import-target-web.js
+++ b/crates/cli/tests/reference/import-target-web.js
@@ -1,5 +1,10 @@
 /* @ts-self-types="./reference_test.d.ts" */
 import { default as _default } from 'tests/wasm/import_class.js';
+import * as import1 from "tests/wasm/imports.js"
+import * as import2 from "foo-raw"
+import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
+import * as import4 from "pure-extern"
+
 
 export function exported() {
     const ret = wasm.exported();
@@ -7,11 +12,6 @@ export function exported() {
         throw takeFromExternrefTable0(ret[0]);
     }
 }
-import * as import1 from "tests/wasm/imports.js"
-import * as import2 from "foo-raw"
-import * as import3 from "./snippets/import_reftest-a82831e16a4c30f1/inline0.js"
-import * as import4 from "pure-extern"
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/int128.js
+++ b/crates/cli/tests/reference/int128.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/intrinsic-only.js
+++ b/crates/cli/tests/reference/intrinsic-only.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/js-namespace-export-same-name.js
+++ b/crates/cli/tests/reference/js-namespace-export-same-name.js
@@ -1,6 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/js-namespace-export.js
+++ b/crates/cli/tests/reference/js-namespace-export.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/keyword.js
+++ b/crates/cli/tests/reference/keyword.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/modules.js
+++ b/crates/cli/tests/reference/modules.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/nop.js
+++ b/crates/cli/tests/reference/nop.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/optional-args.js
+++ b/crates/cli/tests/reference/optional-args.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/pointers.js
+++ b/crates/cli/tests/reference/pointers.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/private.js
+++ b/crates/cli/tests/reference/private.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/raw.js
+++ b/crates/cli/tests/reference/raw.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/reexport.bg.js
+++ b/crates/cli/tests/reference/reexport.bg.js
@@ -9,6 +9,7 @@ import { CustomType } from 'types-lib';
 import { original } from 'utils';
 import { 'invalid-name' as invalid_name } from 'weird-exports';
 
+
 export { CustomType }
 
 export { MY_CONSTANT }

--- a/crates/cli/tests/reference/reexport.js
+++ b/crates/cli/tests/reference/reexport.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/reserved-class-name.js
+++ b/crates/cli/tests/reference/reserved-class-name.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/result.js
+++ b/crates/cli/tests/reference/result.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/self-type.js
+++ b/crates/cli/tests/reference/self-type.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/skip-jsdoc.js
+++ b/crates/cli/tests/reference/skip-jsdoc.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/static.js
+++ b/crates/cli/tests/reference/static.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/string-arg.js
+++ b/crates/cli/tests/reference/string-arg.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/targets-target-bundler-atomics.js
+++ b/crates/cli/tests/reference/targets-target-bundler-atomics.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/targets-target-bundler-mvp.js
+++ b/crates/cli/tests/reference/targets-target-bundler-mvp.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 
 export {

--- a/crates/cli/tests/reference/targets-target-bundler.js
+++ b/crates/cli/tests/reference/targets-target-bundler.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/targets-target-deno-atomics.js
+++ b/crates/cli/tests/reference/targets-target-deno-atomics.js
@@ -9,7 +9,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-deno-mvp.js
+++ b/crates/cli/tests/reference/targets-target-deno-mvp.js
@@ -9,7 +9,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-deno.js
+++ b/crates/cli/tests/reference/targets-target-deno.js
@@ -9,7 +9,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-atomics.js
@@ -1,4 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import { readFileSync } from 'node:fs';
+import { isMainThread } from 'node:worker_threads';
+
 
 /**
  * @param {number} a
@@ -9,7 +12,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,
@@ -56,9 +58,6 @@ if (cachedTextDecoder) cachedTextDecoder.decode();
 function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
-
-import { readFileSync } from 'node:fs';
-import { isMainThread } from 'node:worker_threads';
 
 let wasm;
 let wasmModule;

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module-mvp.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module-mvp.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import { readFileSync } from 'node:fs';
+
 
 /**
  * @param {number} a
@@ -9,7 +11,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -24,7 +25,6 @@ function __wbg_get_imports() {
     };
 }
 
-import { readFileSync } from 'node:fs';
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmBytes = readFileSync(wasmUrl);
 const wasmModule = new WebAssembly.Module(wasmBytes);

--- a/crates/cli/tests/reference/targets-target-experimental-nodejs-module.js
+++ b/crates/cli/tests/reference/targets-target-experimental-nodejs-module.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import { readFileSync } from 'node:fs';
+
 
 /**
  * @param {number} a
@@ -9,7 +11,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -33,7 +34,6 @@ function __wbg_get_imports() {
     };
 }
 
-import { readFileSync } from 'node:fs';
 const wasmUrl = new URL('reference_test_bg.wasm', import.meta.url);
 const wasmBytes = readFileSync(wasmUrl);
 const wasmModule = new WebAssembly.Module(wasmBytes);

--- a/crates/cli/tests/reference/targets-target-module-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-atomics.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 /**
  * @param {number} a
@@ -9,7 +11,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,
@@ -57,7 +58,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-atomics.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
@@ -21,7 +23,6 @@ export function add_that_might_fail(a, b) {
     ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,
@@ -81,7 +82,6 @@ function decodeText(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().slice(ptr, ptr + len));
 }
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function-mvp.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
@@ -19,7 +21,6 @@ export function add_that_might_fail(a, b) {
     ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -46,6 +47,5 @@ let __wbg_instance_id = 0;
 
 let __wbg_reinit_scheduled = false;
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-module-experimental-reset-state-function.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 export function __wbg_reset_state () {
     __wbg_instance_id++;
@@ -19,7 +21,6 @@ export function add_that_might_fail(a, b) {
     ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -55,7 +56,6 @@ let __wbg_instance_id = 0;
 
 let __wbg_reinit_scheduled = false;
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-module-mvp.js
+++ b/crates/cli/tests/reference/targets-target-module-mvp.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 /**
  * @param {number} a
@@ -9,7 +11,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -24,6 +25,5 @@ function __wbg_get_imports() {
     };
 }
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;

--- a/crates/cli/tests/reference/targets-target-module.js
+++ b/crates/cli/tests/reference/targets-target-module.js
@@ -1,4 +1,6 @@
 /* @ts-self-types="./reference_test.d.ts" */
+import source wasmModule from "./reference_test_bg.wasm";
+
 
 /**
  * @param {number} a
@@ -9,7 +11,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,
@@ -33,7 +34,6 @@ function __wbg_get_imports() {
     };
 }
 
-import source wasmModule from "./reference_test_bg.wasm";
 const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
 let wasm = wasmInstance.exports;
 wasm.__wbindgen_start();

--- a/crates/cli/tests/reference/targets-target-no-modules-atomics.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-atomics.js
@@ -14,7 +14,6 @@ let wasm_bindgen = (function(exports) {
         return ret >>> 0;
     }
     exports.add_that_might_fail = add_that_might_fail;
-
     function __wbg_get_imports(memory) {
         const import0 = {
             __proto__: null,

--- a/crates/cli/tests/reference/targets-target-no-modules-mvp.js
+++ b/crates/cli/tests/reference/targets-target-no-modules-mvp.js
@@ -14,7 +14,6 @@ let wasm_bindgen = (function(exports) {
         return ret >>> 0;
     }
     exports.add_that_might_fail = add_that_might_fail;
-
     function __wbg_get_imports() {
         const import0 = {
             __proto__: null,

--- a/crates/cli/tests/reference/targets-target-no-modules.js
+++ b/crates/cli/tests/reference/targets-target-no-modules.js
@@ -14,7 +14,6 @@ let wasm_bindgen = (function(exports) {
         return ret >>> 0;
     }
     exports.add_that_might_fail = add_that_might_fail;
-
     function __wbg_get_imports() {
         const import0 = {
             __proto__: null,

--- a/crates/cli/tests/reference/targets-target-nodejs-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-atomics.js
@@ -10,7 +10,6 @@ function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-atomics.js
@@ -23,7 +23,6 @@ function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function-mvp.js
@@ -21,7 +21,6 @@ function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-experimental-reset-state-function.js
@@ -21,7 +21,6 @@ function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-nodejs-mvp.js
+++ b/crates/cli/tests/reference/targets-target-nodejs-mvp.js
@@ -10,7 +10,6 @@ function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-nodejs.js
+++ b/crates/cli/tests/reference/targets-target-nodejs.js
@@ -10,7 +10,6 @@ function add_that_might_fail(a, b) {
     return ret >>> 0;
 }
 exports.add_that_might_fail = add_that_might_fail;
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-web-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-atomics.js
@@ -9,7 +9,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-atomics.js
@@ -21,7 +21,6 @@ export function add_that_might_fail(a, b) {
     ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports(memory) {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function-mvp.js
@@ -19,7 +19,6 @@ export function add_that_might_fail(a, b) {
     ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
+++ b/crates/cli/tests/reference/targets-target-web-experimental-reset-state-function.js
@@ -19,7 +19,6 @@ export function add_that_might_fail(a, b) {
     ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-web-mvp.js
+++ b/crates/cli/tests/reference/targets-target-web-mvp.js
@@ -9,7 +9,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/targets-target-web.js
+++ b/crates/cli/tests/reference/targets-target-web.js
@@ -9,7 +9,6 @@ export function add_that_might_fail(a, b) {
     const ret = wasm.add_that_might_fail(a, b);
     return ret >>> 0;
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/typescript-type.js
+++ b/crates/cli/tests/reference/typescript-type.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {

--- a/crates/cli/tests/reference/wasm-export-colon.js
+++ b/crates/cli/tests/reference/wasm-export-colon.js
@@ -181,7 +181,6 @@ export function __wbgtest_module_signature() {
     const ret = wasm.__wbgtest_module_signature();
     return ret[0] === 0 ? undefined : BigInt.asUintN(64, ret[1]);
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/wasm-export-types.js
+++ b/crates/cli/tests/reference/wasm-export-types.js
@@ -30,7 +30,6 @@ export function example_128(a) {
     const ret = wasm.example_128(a, a >> BigInt(64));
     return ret[0] === 0 ? undefined : (BigInt.asUintN(64, ret[1]) | (BigInt.asUintN(64, ret[2]) << BigInt(64)));
 }
-
 function __wbg_get_imports() {
     const import0 = {
         __proto__: null,

--- a/crates/cli/tests/reference/web-sys.js
+++ b/crates/cli/tests/reference/web-sys.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./reference_test.d.ts" */
-
 import * as wasm from "./reference_test_bg.wasm";
 import { __wbg_set_wasm } from "./reference_test_bg.js";
+
 __wbg_set_wasm(wasm);
 wasm.__wbindgen_start();
 export {


### PR DESCRIPTION
The generated JS output previously had `import` declarations scattered across three locations: the JS import header near the top, wasm `import * as` statements mid-file, and wasm loading imports (like `import source` or `import { readFileSync }`) at the bottom.

While ES engines hoist imports semantically, having them scattered makes output harder to read and can trip up tooling that expects imports at the top of the file.

This adds a `hoist_es_imports()` post-processing step in `finalize()` that collects all `import` lines and emits them together at the top of the file, right after the `@ts-self-types` directive when present. It runs for all ES module output modes (Module, Web, Deno, Node ESM, Bundler).

Before:
```js
/* @ts-self-types="./foo.d.ts" */
import { default as _default } from 'import_class.js';

export function exported() { ... }
import * as import1 from "imports.js"

function __wbg_get_imports() { ... }
...
import source wasmModule from "./foo_bg.wasm";
const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
```

After:
```js
/* @ts-self-types="./foo.d.ts" */
import { default as _default } from 'import_class.js';
import * as import1 from "imports.js"
import source wasmModule from "./foo_bg.wasm";

export function exported() { ... }

function __wbg_get_imports() { ... }
...
const wasmInstance = new WebAssembly.Instance(wasmModule, __wbg_get_imports());
```

All 45 reference tests pass, plus the cli-support unit tests. Snapshot updates are included via `BLESS=1`.