### PR TITLE
fix: remove stale ImmediateClosure references and update closure unwind docs

### DIFF
--- a/crates/cli-support/src/js/binding.rs
+++ b/crates/cli-support/src/js/binding.rs
@@ -1576,7 +1576,7 @@ fn instruction(
                 match dtor {
                     ClosureDtor::OwnClosure => unreachable!(),
                     ClosureDtor::Immediate => {
-                        // Wrapper for ImmediateClosure or raw &dyn FnMut/&dyn Fn closure
+                        // Wrapper for &dyn FnMut/&dyn Fn closure
                         // used as an argument to a JS function. Make sure to null out our
                         // internal pointers when we return back to Rust to
                         // ensure that any lingering references to the closure

--- a/crates/cli-support/src/wit/outgoing.rs
+++ b/crates/cli-support/src/wit/outgoing.rs
@@ -163,7 +163,7 @@ impl InstructionBuilder<'_, '_> {
             Descriptor::Result(d) => self.outgoing_result(d)?,
 
             Descriptor::Function(descriptor) => {
-                // By-value ImmediateClosure<dyn Fn(...)> (immutable)
+                // By-value &dyn Fn(...) (immutable)
                 self.outgoing_function(false, descriptor, None)?;
             }
 
@@ -232,8 +232,8 @@ impl InstructionBuilder<'_, '_> {
                 self.outgoing_function(mutable, descriptor, None)?;
             }
 
-            // ImmediateClosure<dyn FnMut(...)> emits RefMut(Function(...)) to
-            // signal that a reentrancy guard is needed in the JS wrapper.
+            // &mut dyn FnMut(...) emits RefMut(Function(...)) to signal that
+            // a reentrancy guard is needed in the JS wrapper.
             Descriptor::RefMut(inner) => match inner.as_ref() {
                 Descriptor::Function(descriptor) => {
                     self.outgoing_function(true, descriptor, None)?;

--- a/crates/macro-support/src/generics.rs
+++ b/crates/macro-support/src/generics.rs
@@ -723,9 +723,9 @@ mod tests {
         let lifetime_a: syn::Lifetime = syn::parse_quote!('a);
         let lifetimes = [&lifetime_a];
 
-        let ty: syn::Type = syn::parse_quote!(ImmediateClosure<'a, dyn FnMut(T) -> R>);
+        let ty: syn::Type = syn::parse_quote!(ScopedClosure<'a, dyn FnMut(T) -> R>);
         let result = crate::generics::staticize_lifetimes(ty, &lifetimes);
-        let expected: syn::Type = syn::parse_quote!(ImmediateClosure<'static, dyn FnMut(T) -> R>);
+        let expected: syn::Type = syn::parse_quote!(ScopedClosure<'static, dyn FnMut(T) -> R>);
         assert_eq!(
             quote::quote!(#result).to_string(),
             quote::quote!(#expected).to_string()
@@ -779,12 +779,12 @@ mod tests {
         let lifetime_a: syn::Lifetime = syn::parse_quote!('a);
         let lifetimes_to_staticize = [&lifetime_a];
 
-        // ImmediateClosure<'a, dyn FnMut(T)> -> ImmediateClosure<'static, dyn FnMut(JsValue)>
-        let ty: syn::Type = syn::parse_quote!(ImmediateClosure<'a, dyn FnMut(T)>);
+        // ScopedClosure<'a, dyn FnMut(T)> -> ScopedClosure<'static, dyn FnMut(JsValue)>
+        let ty: syn::Type = syn::parse_quote!(ScopedClosure<'a, dyn FnMut(T)>);
         let result =
             crate::generics::generic_to_concrete(ty, &generic_names, &lifetimes_to_staticize)
                 .unwrap();
-        let expected: syn::Type = syn::parse_quote!(ImmediateClosure<'static, dyn FnMut(JsValue)>);
+        let expected: syn::Type = syn::parse_quote!(ScopedClosure<'static, dyn FnMut(JsValue)>);
         assert_eq!(
             quote::quote!(#result).to_string(),
             quote::quote!(#expected).to_string()

--- a/guide/src/examples/closures.md
+++ b/guide/src/examples/closures.md
@@ -10,11 +10,9 @@ demonstrates different `Closure` APIs for various use cases.
 
 ## Choosing a `Closure` API
 
-- **`ImmediateClosure::new`** / **`ImmediateClosure::new_mut`** — For
-  immediate/synchronous callbacks where JavaScript calls the closure right away
-  and doesn't retain it. Lightweight with no JS wrapper overhead. `new` is for
-  immutable `Fn` closures (easier to satisfy unwind safety), `new_mut` is for
-  mutable `FnMut` closures.
+- **`&dyn Fn`** / **`&mut dyn FnMut`** — For immediate/synchronous callbacks
+  where JavaScript calls the closure right away and doesn't retain it.
+  Lightweight with no JS wrapper overhead. These are unwind safe by default.
 
 - **`ScopedClosure::borrow`** / **`ScopedClosure::borrow_mut`** — For known-lifetime
   callbacks where JavaScript may briefly retain the closure but you control when

--- a/guide/src/reference/catch-unwind.md
+++ b/guide/src/reference/catch-unwind.md
@@ -108,27 +108,41 @@ try {
 
 ## Closures
 
-When built with `panic=unwind`, certain `ScopedClosure` and `ImmediateClosure` constructors
-catch panics and convert them to JavaScript `PanicError` exceptions. The panic-catching
-constructors are:
+When built with `panic=unwind`, all closure types catch panics by default and
+convert them to JavaScript `PanicError` exceptions.
 
-- `Closure::new`, `Closure::own`, `Closure::once`, `Closure::once_into_js`
-- `Closure::wrap`, `Closure::wrap_assert_unwind_safe`
-- `Closure::own_assert_unwind_safe`, `Closure::once_assert_unwind_safe`
-- `Closure::borrow` (Fn), `Closure::borrow_mut` (FnMut)
-- `Closure::borrow_assert_unwind_safe`, `Closure::borrow_mut_assert_unwind_safe`
-- `ImmediateClosure::new` (Fn), `ImmediateClosure::new_mut` (FnMut)
-- `ImmediateClosure::new_assert_unwind_safe` (Fn), `ImmediateClosure::new_mut_assert_unwind_safe` (FnMut)
+### Direct closures (`&dyn Fn` / `&mut dyn FnMut`)
 
-The `*_aborting` variants (`own_aborting`, `once_aborting`, `wrap_aborting`, `borrow_aborting`,
-`borrow_mut_aborting`, `ImmediateClosure::new_aborting`, `ImmediateClosure::new_mut_aborting`)
-do NOT catch panics and will abort if the closure panics. These variants also don't require
-the `MaybeUnwindSafe` bound.
+Direct closure arguments (`&dyn Fn` and `&mut dyn FnMut`) are unwind safe by
+default. The `#[wasm_bindgen]` macro auto-injects a `MaybeUnwindSafe` bound,
+so the compiler will require callers to wrap non-unwind-safe captured values
+(e.g. `Cell<T>`, `&mut T`) in `std::panic::AssertUnwindSafe`. See
+[Passing Rust Closures to JavaScript](./passing-rust-closures-to-js.md#unwind-safety)
+for details and examples.
 
-Note: `Closure::new` is an alias for `Closure::own` and catches panics (requires `MaybeUnwindSafe`).
+```rust
+use wasm_bindgen::prelude::*;
 
-Catching panics in closures requires the closure to satisfy the `UnwindSafe` trait,
-or you can use the `*_assert_unwind_safe` variants which skip this check.
+#[wasm_bindgen]
+extern "C" {
+    fn forEach(cb: &mut dyn FnMut(u32));
+}
+
+forEach(&mut |x| {
+    if x == 0 {
+        panic!("zero not allowed!");
+    }
+});
+```
+
+### `ScopedClosure` constructors
+
+All default `ScopedClosure` constructors (`new`/`own`, `wrap`, `once`,
+`once_into_js`, `borrow`, `borrow_mut`) catch panics and require `UnwindSafe`.
+Each has two alternative suffixed variants:
+
+- `*_assert_unwind_safe` — catches panics but skips the `UnwindSafe` check
+- `*_aborting` — does not catch panics (aborts instead) and does not require `UnwindSafe`
 
 ```rust
 use wasm_bindgen::prelude::*;
@@ -152,38 +166,6 @@ try {
     console.log(e.message); // "closure panicked!"
 }
 ```
-
-`ImmediateClosure` also catches panics for immediate/synchronous callbacks:
-
-```rust
-use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-extern "C" {
-    fn forEach(cb: ImmediateClosure<dyn FnMut(u32)>);
-}
-
-forEach(ImmediateClosure::new_mut(&mut |x| {
-    if x == 0 {
-        panic!("zero not allowed!");
-    }
-}));
-```
-
-For closures that should not catch panics (and abort the program instead), use
-the `*_aborting` variants: `Closure::own_aborting`, `Closure::wrap_aborting`,
-`Closure::once_aborting`,
-`ScopedClosure::borrow_aborting`, `ScopedClosure::borrow_mut_aborting`,
-`ImmediateClosure::new_aborting`, and `ImmediateClosure::new_mut_aborting`.
-These do not require `UnwindSafe`.
-
-> **Note**: `&dyn Fn` and `&mut dyn FnMut` arguments are unwind safe when
-> `panic=unwind` is active. The `#[wasm_bindgen]` macro auto-injects a
-> `MaybeUnwindSafe` bound, so the compiler will require callers to wrap
-> non-unwind-safe captured values (e.g. `Cell<T>`, `&mut T`) in
-> `std::panic::AssertUnwindSafe`. See
-> [Passing Rust Closures to JavaScript](./passing-rust-closures-to-js.md#unwind-safety)
-> for details and examples.
 
 See [Passing Rust Closures to JavaScript](./passing-rust-closures-to-js.md) for
 more details on closure APIs and the `UnwindSafe` requirement.

--- a/tests/wasm/closures.js
+++ b/tests/wasm/closures.js
@@ -230,7 +230,7 @@ exports.closure_fn_with_call_arg = (f, value) => {
   f(value);
 };
 
-// Test for ImmediateClosure
+// Test for direct &dyn Fn/&mut dyn FnMut closures
 exports.immediate_closure_call = f => {
   f();
 };


### PR DESCRIPTION
`ImmediateClosure` was removed in 0.2.112 and direct closures (`&dyn Fn` / `&mut dyn FnMut`) now unwind by default. Several docs and code comments still referenced the old type and didn't reflect that direct closures catch panics.

* Remove all `ImmediateClosure` references from the Catching Panics guide, closures example page, and code comments
* Add a "Direct closures" subsection to the Catching Panics guide documenting `&dyn Fn` / `&mut dyn FnMut` unwind behavior
* Simplify the `ScopedClosure` constructor listing to describe the `*_assert_unwind_safe` / `*_aborting` naming convention instead of exhaustively enumerating every variant
* Update `ImmediateClosure` references in `generics.rs` test cases to use `ScopedClosure`

Remaining `ImmediateClosure` references are only in `CHANGELOG.md` (historical records).