### PR TITLE
Use Crates.io Trusted Publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -610,6 +610,7 @@ jobs:
   deploy:
     permissions:
       contents: write #  to push changes in repo (jamesives/github-pages-deploy-action)
+      id-token: write #  to use Crates.io trusted publishing
 
     if: github.repository == 'wasm-bindgen/wasm-bindgen' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     needs:
@@ -687,7 +688,9 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
     - run: rustc publish.rs
       if: startsWith(github.ref, 'refs/tags/')
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
     - run: ./publish publish
       if: startsWith(github.ref, 'refs/tags/')
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Use [Crates.io trust publishing](https://crates.io/docs/trusted-publishing) instead of using a secret key.

I've already added the required configuration to Crates.io. After merging we should enable the "Require trusted publishing for all new versions" checkbox for all Crates and delete the secret from GitHub.